### PR TITLE
[minions] refactor: strengthen typing in useTheme hook

### DIFF
--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -26,7 +26,11 @@ function resolveAndApply(pref: ThemePref): void {
   applyTheme(resolved)
 }
 
-let currentPref: ThemePref = (localStorage.getItem(STORAGE_KEY) as ThemePref | null) ?? 'system'
+function parseThemePref(raw: string | null): ThemePref {
+  return raw === 'light' || raw === 'dark' || raw === 'system' ? raw : 'system'
+}
+
+let currentPref: ThemePref = parseThemePref(localStorage.getItem(STORAGE_KEY))
 resolveAndApply(currentPref)
 
 const mq = window.matchMedia('(prefers-color-scheme: dark)')


### PR DESCRIPTION
## Summary
- Replaced an unchecked `as ThemePref | null` type assertion in `src/hooks/useTheme.ts` with a `parseThemePref` narrowing function.
- `localStorage.getItem` returns an arbitrary `string | null` (user-editable storage), so asserting directly to `ThemePref` was unsound — any bogus value would silently flow into `resolveAndApply`.
- The new guard validates against the `'light' | 'dark' | 'system'` union and falls back to `'system'`, preserving the prior behavior for valid prefs and the missing-key default.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (25 files, 222 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)