### PR TITLE
[minions] feat(chat): auto-scroll with jump-to-latest button

### DIFF
--- a/src/chat/ConversationView.tsx
+++ b/src/chat/ConversationView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'preact/hooks'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import type { ConversationMessage } from '../api/types'
@@ -47,9 +47,18 @@ function UserMessage({ text }: { text: string }) {
   )
 }
 
+const NEAR_BOTTOM_PX = 120
+
 export function ConversationView({ messages }: ConversationViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const prevLengthRef = useRef(messages.length)
+  const [following, setFollowing] = useState(true)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [])
 
   useEffect(() => {
     const el = scrollRef.current
@@ -57,27 +66,57 @@ export function ConversationView({ messages }: ConversationViewProps) {
     const prevLen = prevLengthRef.current
     prevLengthRef.current = messages.length
     if (messages.length <= prevLen) return
-    const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 120
-    if (nearBottom) el.scrollTop = el.scrollHeight
-  }, [messages.length])
+    if (following) el.scrollTop = el.scrollHeight
+  }, [messages.length, following])
+
+  function handleScroll() {
+    const el = scrollRef.current
+    if (!el) return
+    const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - NEAR_BOTTOM_PX
+    if (nearBottom !== following) setFollowing(nearBottom)
+  }
+
+  function jumpToLatest() {
+    const el = scrollRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+    setFollowing(true)
+  }
 
   return (
-    <div
-      ref={scrollRef}
-      class="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-4 bg-slate-50 dark:bg-slate-900"
-      data-testid="conversation-view"
-    >
-      {messages.length === 0 && (
-        <div class="text-xs text-slate-500 dark:text-slate-400 italic text-center py-8">
-          No messages yet.
-        </div>
-      )}
-      {messages.map((msg, idx) =>
-        msg.role === 'assistant' ? (
-          <AssistantMessage key={idx} text={msg.text} />
-        ) : (
-          <UserMessage key={idx} text={msg.text} />
-        )
+    <div class="relative flex-1 flex min-h-0">
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        class="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-4 bg-slate-50 dark:bg-slate-900"
+        data-testid="conversation-view"
+      >
+        {messages.length === 0 && (
+          <div class="text-xs text-slate-500 dark:text-slate-400 italic text-center py-8">
+            No messages yet.
+          </div>
+        )}
+        {messages.map((msg, idx) =>
+          msg.role === 'assistant' ? (
+            <AssistantMessage key={idx} text={msg.text} />
+          ) : (
+            <UserMessage key={idx} text={msg.text} />
+          )
+        )}
+      </div>
+      {!following && messages.length > 0 && (
+        <button
+          type="button"
+          onClick={jumpToLatest}
+          data-testid="jump-to-latest"
+          aria-label="Jump to latest messages"
+          class="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-1.5 rounded-full border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-1.5 text-xs font-medium text-slate-700 dark:text-slate-200 shadow-md hover:bg-slate-50 dark:hover:bg-slate-700"
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5" aria-hidden="true">
+            <path fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v10.69l3.72-3.72a.75.75 0 1 1 1.06 1.06l-5 5a.75.75 0 0 1-1.06 0l-5-5a.75.75 0 1 1 1.06-1.06l3.72 3.72V3.75A.75.75 0 0 1 10 3Z" clip-rule="evenodd" />
+          </svg>
+          Jump to latest
+        </button>
       )}
     </div>
   )

--- a/test/chat/ConversationView.test.tsx
+++ b/test/chat/ConversationView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/preact'
+import { render, screen, fireEvent } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ConversationView } from '../../src/chat/ConversationView'
 import type { ConversationMessage } from '../../src/api/types'
@@ -74,14 +74,17 @@ describe('ConversationView', () => {
     expect(scrollToBottomSpy).toHaveBeenCalled()
   })
 
-  it('does not scroll when user is scrolled up', () => {
-    const scrollToBottomSpy = vi.fn()
+  it('does not scroll when user has scrolled up', () => {
     const { rerender } = render(
       <ConversationView messages={[{ role: 'user', text: 'first' }]} />
     )
     const container = screen.getByTestId('conversation-view')
     Object.defineProperty(container, 'clientHeight', { writable: true, configurable: true, value: 200 })
     Object.defineProperty(container, 'scrollHeight', { writable: true, configurable: true, value: 800 })
+    Object.defineProperty(container, 'scrollTop', { writable: true, configurable: true, value: 0 })
+    fireEvent.scroll(container)
+
+    const scrollToBottomSpy = vi.fn()
     Object.defineProperty(container, 'scrollTop', {
       set: scrollToBottomSpy,
       get: () => 0,
@@ -94,5 +97,74 @@ describe('ConversationView', () => {
     ]} />)
 
     expect(scrollToBottomSpy).not.toHaveBeenCalled()
+  })
+
+  it('shows jump-to-latest button when user scrolls up', () => {
+    render(<ConversationView messages={makeMessages([{ role: 'user', text: 'first' }])} />)
+    const container = screen.getByTestId('conversation-view')
+    Object.defineProperty(container, 'clientHeight', { writable: true, configurable: true, value: 200 })
+    Object.defineProperty(container, 'scrollHeight', { writable: true, configurable: true, value: 800 })
+    Object.defineProperty(container, 'scrollTop', { writable: true, configurable: true, value: 0 })
+
+    expect(screen.queryByTestId('jump-to-latest')).toBeNull()
+    fireEvent.scroll(container)
+    expect(screen.getByTestId('jump-to-latest')).toBeTruthy()
+  })
+
+  it('hides jump-to-latest button when user is near bottom', () => {
+    render(<ConversationView messages={makeMessages([{ role: 'user', text: 'first' }])} />)
+    const container = screen.getByTestId('conversation-view')
+    Object.defineProperty(container, 'clientHeight', { writable: true, configurable: true, value: 200 })
+    Object.defineProperty(container, 'scrollHeight', { writable: true, configurable: true, value: 800 })
+    Object.defineProperty(container, 'scrollTop', { writable: true, configurable: true, value: 0 })
+
+    fireEvent.scroll(container)
+    expect(screen.getByTestId('jump-to-latest')).toBeTruthy()
+
+    Object.defineProperty(container, 'scrollTop', { writable: true, configurable: true, value: 600 })
+    fireEvent.scroll(container)
+    expect(screen.queryByTestId('jump-to-latest')).toBeNull()
+  })
+
+  it('jump-to-latest button scrolls to bottom and resumes auto-follow', () => {
+    const { rerender } = render(
+      <ConversationView messages={makeMessages([{ role: 'user', text: 'first' }])} />
+    )
+    const container = screen.getByTestId('conversation-view')
+    Object.defineProperty(container, 'clientHeight', { writable: true, configurable: true, value: 200 })
+    Object.defineProperty(container, 'scrollHeight', { writable: true, configurable: true, value: 800 })
+    let currentScrollTop = 0
+    const scrollSpy = vi.fn((v: number) => { currentScrollTop = v })
+    Object.defineProperty(container, 'scrollTop', {
+      configurable: true,
+      get: () => currentScrollTop,
+      set: scrollSpy,
+    })
+
+    fireEvent.scroll(container)
+    const button = screen.getByTestId('jump-to-latest')
+    fireEvent.click(button)
+
+    expect(scrollSpy).toHaveBeenCalledWith(800)
+    expect(screen.queryByTestId('jump-to-latest')).toBeNull()
+
+    scrollSpy.mockClear()
+    Object.defineProperty(container, 'scrollHeight', { writable: true, configurable: true, value: 1200 })
+    rerender(<ConversationView messages={[
+      { role: 'user', text: 'first' },
+      { role: 'assistant', text: 'second' },
+    ]} />)
+
+    expect(scrollSpy).toHaveBeenCalledWith(1200)
+  })
+
+  it('does not show jump-to-latest button when there are no messages', () => {
+    render(<ConversationView messages={[]} />)
+    const container = screen.getByTestId('conversation-view')
+    Object.defineProperty(container, 'clientHeight', { writable: true, configurable: true, value: 200 })
+    Object.defineProperty(container, 'scrollHeight', { writable: true, configurable: true, value: 800 })
+    Object.defineProperty(container, 'scrollTop', { writable: true, configurable: true, value: 0 })
+    fireEvent.scroll(container)
+    expect(screen.queryByTestId('jump-to-latest')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- Chat now auto-scrolls to the latest message by default — including on initial mount.
- Scrolling up pauses auto-follow; a floating **Jump to latest** pill appears at the bottom of the conversation pane.
- Clicking the pill scrolls to the bottom and resumes auto-follow.

## Why
Previously the chat only scrolled when the user happened to be near the bottom *at the moment* a message arrived. With streaming/long messages, the bottom moves out from under you, so the heuristic silently dropped follow-mode. The new model captures user intent explicitly: a `following` flag is flipped only by scroll events, so as long as you stay near the bottom you keep getting new messages, and once you scroll up you stay where you are until you opt back in.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (226 passed, including 5 new ConversationView cases)
- [ ] Manual: open a session with many messages, confirm initial render lands at the bottom; scroll up and verify the pill appears; click the pill and verify the view jumps down and continues following new messages.

## Notes
- `useState` (local) is used for `following` rather than a signal — it is purely component-scoped UI state.
- The 120px `nearBottom` threshold from the previous implementation is preserved.
- The existing "does not scroll when user is scrolled up" test was updated to fire a `scroll` event before re-rendering, since the new model derives intent from scroll events instead of inferring it at message-arrival time.