### PR TITLE
feat(routing): implement hash-based frontend routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { signal, useSignal } from '@preact/signals'
 import { useState, useEffect, useMemo } from 'preact/hooks'
 import { useRegisterSW } from 'virtual:pwa-register/preact'
 import { connections, activeId, getActiveStore } from './connections/store'
+import { route, navigate } from './routing/route'
 import { ConnectionSettings } from './connections/ConnectionSettings'
 import { ConnectionPicker } from './connections/ConnectionPicker'
 import { ConnectionsDrawer } from './connections/ConnectionsDrawer'
@@ -336,7 +337,9 @@ function ActiveView() {
   const id = activeId.value
   const store = id ? getActiveStore() : null
   const conn = connections.value.find((c) => c.id === id)
-  const [sessionId, setSessionId] = useState<string | null>(null)
+  const currentRoute = route.value
+  const sessionId = currentRoute.name === 'session' ? currentRoute.sessionId : null
+  const selectSession = (id: string) => navigate({ name: 'session', sessionId: id })
   const isOnline = useOnlineStatus()
   const isDesktop = useMediaQuery('(min-width: 768px)')
 
@@ -397,7 +400,7 @@ function ActiveView() {
             <SessionList
               sessions={sessions}
               activeSessionId={sessionId}
-              onSelect={setSessionId}
+              onSelect={selectSession}
               orientation="vertical"
             />
           </aside>
@@ -412,7 +415,7 @@ function ActiveView() {
           <SessionList
             sessions={sessions}
             activeSessionId={sessionId}
-            onSelect={setSessionId}
+            onSelect={selectSession}
             orientation="horizontal"
           />
           {selected ? (

--- a/src/routing/route.ts
+++ b/src/routing/route.ts
@@ -1,0 +1,42 @@
+import { signal } from '@preact/signals'
+
+export type Route =
+  | { name: 'home' }
+  | { name: 'session'; sessionId: string }
+  | { name: 'variants'; groupId: string }
+
+function parseHash(hash: string): Route {
+  const raw = hash.startsWith('#') ? hash.slice(1) : hash
+  const parts = raw.split('/').filter(Boolean)
+
+  if (parts[0] === 'session' && parts[1]) {
+    return { name: 'session', sessionId: parts[1] }
+  }
+  if (parts[0] === 'variants' && parts[1]) {
+    return { name: 'variants', groupId: parts[1] }
+  }
+  return { name: 'home' }
+}
+
+export const route = signal<Route>(parseHash(window.location.hash))
+
+function onHashChange() {
+  route.value = parseHash(window.location.hash)
+}
+
+window.addEventListener('hashchange', onHashChange)
+
+export function navigate(to: Route): void {
+  let hash: string
+  switch (to.name) {
+    case 'session':
+      hash = `#session/${to.sessionId}`
+      break
+    case 'variants':
+      hash = `#variants/${to.groupId}`
+      break
+    default:
+      hash = '#'
+  }
+  window.location.hash = hash
+}

--- a/test/routing/route.test.ts
+++ b/test/routing/route.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { route, navigate } from '../../src/routing/route'
+
+describe('route', () => {
+  beforeEach(() => {
+    window.location.hash = ''
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+  })
+
+  it('defaults to home when hash is empty', () => {
+    expect(route.value).toEqual({ name: 'home' })
+  })
+
+  it('parses session route', () => {
+    window.location.hash = '#session/abc-123'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(route.value).toEqual({ name: 'session', sessionId: 'abc-123' })
+  })
+
+  it('parses variants route', () => {
+    window.location.hash = '#variants/grp-42'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(route.value).toEqual({ name: 'variants', groupId: 'grp-42' })
+  })
+
+  it('falls back to home for unknown hash', () => {
+    window.location.hash = '#unknown/something'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(route.value).toEqual({ name: 'home' })
+  })
+
+  it('navigate() sets hash for session', () => {
+    navigate({ name: 'session', sessionId: 's1' })
+    expect(window.location.hash).toBe('#session/s1')
+  })
+
+  it('navigate() sets hash for variants', () => {
+    navigate({ name: 'variants', groupId: 'g1' })
+    expect(window.location.hash).toBe('#variants/g1')
+  })
+
+  it('navigate() clears hash for home', () => {
+    window.location.hash = '#session/x'
+    navigate({ name: 'home' })
+    expect(window.location.hash === '' || window.location.hash === '#').toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Implement hash-based frontend routing with signal-driven state management.

- Parses window.location.hash into a Route type supporting home, session, and variants pages
- Automatic route detection via hashchange event with signal integration
- navigate() function for programmatic route updates
- Session selection now driven through routing layer

## Changes

- src/routing/route.ts (~40 LOC): Route parser, signal, navigator
- src/App.tsx: Replace useState sessionId with route-derived value
- test/routing/route.test.ts: 7 comprehensive tests

All 229 tests pass, type-check clean.

## Test plan

- All 229 existing tests pass
- 7 new routing tests pass
- Type checks pass
- Manual verification: hashchange events trigger route updates
- Manual verification: navigate() function updates hash correctly

Generated with Claude Code