### PR TITLE
[minions] refactor(chat): structured task creation via POST /api/sessions

### DIFF
--- a/e2e/fixtures/mock-minion.ts
+++ b/e2e/fixtures/mock-minion.ts
@@ -1,8 +1,36 @@
 import * as http from 'node:http'
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import type { ApiSession, ApiDagGraph, SseEvent, MinionCommand, VersionInfo } from '../../src/api/types'
+import type {
+  ApiSession,
+  ApiDagGraph,
+  SseEvent,
+  MinionCommand,
+  VersionInfo,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  PrPreview,
+  WorkspaceDiff,
+  ScreenshotList,
+  ScreenshotEntry,
+  VapidPublicKey,
+  PushSubscriptionJSON,
+} from '../../src/api/types'
 
-export type { ApiSession, ApiDagGraph, SseEvent, MinionCommand, VersionInfo }
+export type {
+  ApiSession,
+  ApiDagGraph,
+  SseEvent,
+  MinionCommand,
+  VersionInfo,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  PrPreview,
+  WorkspaceDiff,
+  ScreenshotList,
+  ScreenshotEntry,
+  VapidPublicKey,
+  PushSubscriptionJSON,
+}
 
 export interface MockMinion {
   url: string
@@ -11,9 +39,18 @@ export interface MockMinion {
   setSessions(sessions: ApiSession[]): void
   setDags(dags: ApiDagGraph[]): void
   setVersion(v: Partial<VersionInfo>): void
+  setPr(sessionId: string, pr: PrPreview | null): void
+  setDiff(sessionId: string, diff: WorkspaceDiff | null): void
+  setScreenshots(sessionId: string, screenshots: ScreenshotEntry[]): void
+  setScreenshotBlob(file: string, body: Buffer, contentType?: string): void
+  setVapidKey(key: string): void
   drop(): void
   lastCommands: MinionCommand[]
   lastMessages: Array<{ text: string; sessionId?: string }>
+  lastCreateSessionRequests: CreateSessionRequest[]
+  lastCreateVariantsRequests: CreateSessionVariantsRequest[]
+  pushSubscriptions: PushSubscriptionJSON[]
+  lastUnsubscribeEndpoints: string[]
   close(): Promise<void>
 }
 
@@ -24,6 +61,7 @@ function writeSse(res: ServerResponse, event: SseEvent): void {
 function cors(res: ServerResponse, allowedOrigin: string): void {
   res.setHeader('Access-Control-Allow-Origin', allowedOrigin)
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
   res.setHeader('Access-Control-Max-Age', '600')
 }
 
@@ -34,6 +72,28 @@ function readBody(req: IncomingMessage): Promise<string> {
     req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
     req.on('error', reject)
   })
+}
+
+let sessionCounter = 0
+function makeSession(req: CreateSessionRequest): ApiSession {
+  sessionCounter += 1
+  const id = `mock-session-${sessionCounter}`
+  const now = new Date().toISOString()
+  return {
+    id,
+    slug: `mock-${sessionCounter}`,
+    status: 'pending',
+    command: `/${req.mode} ${req.prompt}`,
+    repo: req.repo,
+    createdAt: now,
+    updatedAt: now,
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: req.mode,
+    conversation: [{ role: 'user', text: req.prompt }],
+  }
 }
 
 export async function createMockMinion(opts?: {
@@ -51,8 +111,18 @@ export async function createMockMinion(opts?: {
     features: [],
   }
 
+  const prBySession = new Map<string, PrPreview>()
+  const diffBySession = new Map<string, WorkspaceDiff>()
+  const screenshotsBySession = new Map<string, ScreenshotEntry[]>()
+  const screenshotBlobs = new Map<string, { body: Buffer; contentType: string }>()
+  let vapidKey = 'BMOCK_VAPID_PUBLIC_KEY_00000000000000000000000000000000000000000000000000000000000000000000000000000000'
+  const pushSubscriptions: PushSubscriptionJSON[] = []
+  const lastUnsubscribeEndpoints: string[] = []
+
   const lastCommands: MinionCommand[] = []
   const lastMessages: Array<{ text: string; sessionId?: string }> = []
+  const lastCreateSessionRequests: CreateSessionRequest[] = []
+  const lastCreateVariantsRequests: CreateSessionVariantsRequest[] = []
 
   let activeSseRes: ServerResponse | null = null
 
@@ -65,6 +135,23 @@ export async function createMockMinion(opts?: {
     res.writeHead(401, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ error: 'Unauthorized' }))
     return false
+  }
+
+  function hasFeature(name: string): boolean {
+    return versionInfo.features.includes(name)
+  }
+
+  function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+    res.writeHead(status, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(payload))
+  }
+
+  function notFound(res: ServerResponse): void {
+    sendJson(res, 404, { error: 'Not found' })
+  }
+
+  function featureDisabled(res: ServerResponse, name: string): void {
+    sendJson(res, 404, { error: `feature '${name}' not enabled` })
   }
 
   const server = http.createServer(async (req, res) => {
@@ -82,22 +169,114 @@ export async function createMockMinion(opts?: {
 
     if (path === '/api/version' && req.method === 'GET') {
       if (!checkAuth(req, res)) return
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: versionInfo }))
+      sendJson(res, 200, { data: versionInfo })
       return
     }
 
     if (!checkAuth(req, res)) return
 
     if (path === '/api/sessions' && req.method === 'GET') {
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: sessions }))
+      sendJson(res, 200, { data: sessions })
       return
     }
 
+    if (path === '/api/sessions' && req.method === 'POST') {
+      if (!hasFeature('sessions-create')) return featureDisabled(res, 'sessions-create')
+      const body = await readBody(req)
+      const payload = JSON.parse(body) as CreateSessionRequest
+      if (!payload.prompt || !payload.mode) {
+        return sendJson(res, 400, { error: 'prompt and mode are required' })
+      }
+      lastCreateSessionRequests.push(payload)
+      const session = makeSession(payload)
+      sessions = [...sessions, session]
+      sendJson(res, 200, { data: session })
+      return
+    }
+
+    if (path === '/api/sessions/variants' && req.method === 'POST') {
+      if (!hasFeature('sessions-variants')) return featureDisabled(res, 'sessions-variants')
+      const body = await readBody(req)
+      const payload = JSON.parse(body) as CreateSessionVariantsRequest
+      if (!payload.prompt || !payload.mode || !payload.count || payload.count < 2) {
+        return sendJson(res, 400, { error: 'prompt, mode, and count >= 2 are required' })
+      }
+      lastCreateVariantsRequests.push(payload)
+      const groupId = `group-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+      const variants: ApiSession[] = []
+      for (let i = 0; i < payload.count; i++) {
+        const s = makeSession(payload)
+        s.variantGroupId = groupId
+        variants.push(s)
+      }
+      sessions = [...sessions, ...variants]
+      sendJson(res, 200, { data: { groupId, sessions: variants } })
+      return
+    }
+
+    const sessionSubMatch = path.match(/^\/api\/sessions\/([^/]+)\/(pr|diff|screenshots)$/)
+    if (sessionSubMatch && req.method === 'GET') {
+      const sessionId = decodeURIComponent(sessionSubMatch[1])
+      const kind = sessionSubMatch[2]
+      if (kind === 'pr') {
+        if (!hasFeature('pr-preview')) return featureDisabled(res, 'pr-preview')
+        const pr = prBySession.get(sessionId)
+        if (!pr) return notFound(res)
+        return sendJson(res, 200, { data: pr })
+      }
+      if (kind === 'diff') {
+        if (!hasFeature('diff-viewer')) return featureDisabled(res, 'diff-viewer')
+        const diff = diffBySession.get(sessionId)
+        if (!diff) return notFound(res)
+        return sendJson(res, 200, { data: diff })
+      }
+      if (kind === 'screenshots') {
+        if (!hasFeature('screenshots-http')) return featureDisabled(res, 'screenshots-http')
+        const list = screenshotsBySession.get(sessionId) ?? []
+        return sendJson(res, 200, { data: { sessionId, screenshots: list } satisfies ScreenshotList })
+      }
+    }
+
+    const screenshotMatch = path.match(/^\/api\/screenshots\/(.+)$/)
+    if (screenshotMatch && req.method === 'GET') {
+      if (!hasFeature('screenshots-http')) return featureDisabled(res, 'screenshots-http')
+      const file = decodeURIComponent(screenshotMatch[1])
+      const blob = screenshotBlobs.get(file)
+      if (!blob) return notFound(res)
+      res.writeHead(200, { 'Content-Type': blob.contentType, 'Content-Length': String(blob.body.length) })
+      res.end(blob.body)
+      return
+    }
+
+    if (path === '/api/push/vapid-public-key' && req.method === 'GET') {
+      if (!hasFeature('web-push')) return featureDisabled(res, 'web-push')
+      return sendJson(res, 200, { data: { key: vapidKey } satisfies VapidPublicKey })
+    }
+
+    if (path === '/api/push-subscribe' && req.method === 'POST') {
+      if (!hasFeature('web-push')) return featureDisabled(res, 'web-push')
+      const body = await readBody(req)
+      const sub = JSON.parse(body) as PushSubscriptionJSON
+      if (!sub.endpoint || !sub.keys?.p256dh || !sub.keys?.auth) {
+        return sendJson(res, 400, { error: 'invalid subscription' })
+      }
+      pushSubscriptions.push(sub)
+      return sendJson(res, 200, { data: { ok: true, id: `sub-${pushSubscriptions.length}` } })
+    }
+
+    if (path === '/api/push-subscribe' && req.method === 'DELETE') {
+      if (!hasFeature('web-push')) return featureDisabled(res, 'web-push')
+      const body = await readBody(req)
+      const payload = JSON.parse(body) as { endpoint: string }
+      if (!payload.endpoint) return sendJson(res, 400, { error: 'endpoint is required' })
+      lastUnsubscribeEndpoints.push(payload.endpoint)
+      const idx = pushSubscriptions.findIndex((s) => s.endpoint === payload.endpoint)
+      if (idx !== -1) pushSubscriptions.splice(idx, 1)
+      return sendJson(res, 200, { data: { ok: true } })
+    }
+
     if (path === '/api/dags' && req.method === 'GET') {
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: dags }))
+      sendJson(res, 200, { data: dags })
       return
     }
 
@@ -124,8 +303,7 @@ export async function createMockMinion(opts?: {
       const body = await readBody(req)
       const cmd = JSON.parse(body) as MinionCommand
       lastCommands.push(cmd)
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: { success: true } }))
+      sendJson(res, 200, { data: { success: true } })
       return
     }
 
@@ -133,18 +311,14 @@ export async function createMockMinion(opts?: {
       const body = await readBody(req)
       const payload = JSON.parse(body) as { text: string; sessionId?: string }
       if (!payload.text) {
-        res.writeHead(400, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: 'text is required' }))
-        return
+        return sendJson(res, 400, { error: 'text is required' })
       }
       lastMessages.push({ text: payload.text, sessionId: payload.sessionId })
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: { ok: true, sessionId: payload.sessionId ?? null } }))
+      sendJson(res, 200, { data: { ok: true, sessionId: payload.sessionId ?? null } })
       return
     }
 
-    res.writeHead(404, { 'Content-Type': 'application/json' })
-    res.end(JSON.stringify({ error: 'Not found' }))
+    notFound(res)
   })
 
   await new Promise<void>((resolve) => server.listen(0, 'localhost', resolve))
@@ -157,6 +331,10 @@ export async function createMockMinion(opts?: {
     token,
     lastCommands,
     lastMessages,
+    lastCreateSessionRequests,
+    lastCreateVariantsRequests,
+    pushSubscriptions,
+    lastUnsubscribeEndpoints,
 
     emit(event: SseEvent) {
       if (activeSseRes) writeSse(activeSseRes, event)
@@ -172,6 +350,28 @@ export async function createMockMinion(opts?: {
 
     setVersion(v: Partial<VersionInfo>) {
       versionInfo = { ...versionInfo, ...v }
+    },
+
+    setPr(sessionId: string, pr: PrPreview | null) {
+      if (pr) prBySession.set(sessionId, pr)
+      else prBySession.delete(sessionId)
+    },
+
+    setDiff(sessionId: string, diff: WorkspaceDiff | null) {
+      if (diff) diffBySession.set(sessionId, diff)
+      else diffBySession.delete(sessionId)
+    },
+
+    setScreenshots(sessionId: string, screenshots: ScreenshotEntry[]) {
+      screenshotsBySession.set(sessionId, screenshots)
+    },
+
+    setScreenshotBlob(file: string, body: Buffer, contentType = 'image/png') {
+      screenshotBlobs.set(file, { body, contentType })
+    },
+
+    setVapidKey(key: string) {
+      vapidKey = key
     },
 
     drop() {

--- a/e2e/tests/bad-token.spec.ts
+++ b/e2e/tests/bad-token.spec.ts
@@ -41,7 +41,7 @@ test.describe('bad token', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Bad Token Minion')
 
-      await expect(page.getByTestId('universe-node-correct-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-correct-session')).toBeVisible({ timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/connect.spec.ts
+++ b/e2e/tests/connect.spec.ts
@@ -62,7 +62,7 @@ test.describe('connection flow', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion A')
 
-      await expect(page.getByTestId('universe-node-s1')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-s1')).toBeVisible({ timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/multi-connection.spec.ts
+++ b/e2e/tests/multi-connection.spec.ts
@@ -46,7 +46,7 @@ test.describe('multi-connection', () => {
     try {
       await connectToMinion(page, mockA, 'Minion Alpha')
 
-      await expect(page.getByTestId('universe-node-a-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-a-session')).toBeVisible({ timeout: 8_000 })
 
       await page.getByTestId('connection-picker-trigger').click()
       await expect(page.getByTestId('connection-picker-dropdown')).toBeVisible()
@@ -66,8 +66,8 @@ test.describe('multi-connection', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion Beta')
 
-      await expect(page.getByTestId('universe-node-b-session')).toBeVisible({ timeout: 8_000 })
-      await expect(page.getByTestId('universe-node-a-session')).not.toBeVisible()
+      await expect(page.getByTestId('session-item-b-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-a-session')).not.toBeVisible()
 
       await page.getByTestId('connection-picker-trigger').click()
       const dropdown = page.getByTestId('connection-picker-dropdown')
@@ -79,8 +79,8 @@ test.describe('multi-connection', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion Alpha')
 
-      await expect(page.getByTestId('universe-node-a-session')).toBeVisible({ timeout: 8_000 })
-      await expect(page.getByTestId('universe-node-b-session')).not.toBeVisible()
+      await expect(page.getByTestId('session-item-a-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-b-session')).not.toBeVisible()
     } finally {
       await mockA.close()
       await mockB.close()

--- a/e2e/tests/reconnect.spec.ts
+++ b/e2e/tests/reconnect.spec.ts
@@ -34,7 +34,7 @@ test.describe('SSE reconnect', () => {
 
       await expect(page.getByText('live')).toBeVisible({ timeout: 20_000 })
 
-      await expect(page.getByTestId('universe-node-s-reconnect')).toBeVisible({ timeout: 10_000 })
+      await expect(page.getByTestId('session-item-s-reconnect')).toBeVisible({ timeout: 10_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/task-lifecycle.spec.ts
+++ b/e2e/tests/task-lifecycle.spec.ts
@@ -26,13 +26,9 @@ test.describe('task lifecycle', () => {
     try {
       await connectToMinion(page, mock, 'My Minion')
 
-      await expect(page.getByTestId('universe-node-seed-1')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-seed-1')).toBeVisible({ timeout: 8_000 })
 
-      await page.getByTestId('universe-node-seed-1').dispatchEvent('click')
-
-      await expect(page.locator('[role="dialog"]')).toBeVisible()
-
-      await page.getByRole('button', { name: 'Open Chat' }).click()
+      await page.getByTestId('session-item-seed-1').click()
 
       await expect(page.getByTestId('message-textarea')).toBeVisible()
 
@@ -45,15 +41,9 @@ test.describe('task lifecycle', () => {
 
       mock.emit({ type: 'session_created', session: makeSession('new-1', 'hello-task', 'running') })
 
-      await expect(page.getByTestId('universe-node-new-1')).toBeAttached({ timeout: 5_000 })
+      await expect(page.getByTestId('session-item-new-1')).toBeVisible({ timeout: 5_000 })
 
-      await page.getByTestId('chat-close-btn').click()
-
-      await page.getByTestId('universe-node-new-1').dispatchEvent('click')
-
-      await expect(page.locator('[aria-labelledby="node-detail-title"]')).toBeVisible()
-
-      await page.getByRole('button', { name: 'Open Chat' }).click()
+      await page.getByTestId('session-item-new-1').click()
 
       await expect(page.getByTestId('message-textarea')).toBeVisible()
 
@@ -68,11 +58,7 @@ test.describe('task lifecycle', () => {
       mock.setSessions([makeSession('seed-1', 'seed-task', 'running'), completedSession])
       mock.emit({ type: 'session_updated', session: completedSession })
 
-      await page.getByTestId('universe-node-new-1').dispatchEvent('click')
-
-      await expect(
-        page.locator('[aria-labelledby="node-detail-title"]').getByText('Done')
-      ).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-new-1')).toContainText('completed', { timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { signal, useSignal } from '@preact/signals'
+import { signal } from '@preact/signals'
 import { useState, useEffect, useMemo } from 'preact/hooks'
 import { useRegisterSW } from 'virtual:pwa-register/preact'
 import { connections, activeId, getActiveStore } from './connections/store'
@@ -7,6 +7,7 @@ import { ConnectionPicker } from './connections/ConnectionPicker'
 import { ConnectionsDrawer } from './connections/ConnectionsDrawer'
 import { ConversationView } from './chat/ConversationView'
 import { MessageInput } from './chat/MessageInput'
+import { NewTaskBar } from './chat/NewTaskBar'
 import { QuickActionsBar } from './chat/QuickActionsBar'
 import { SlashCommandMenu, type SlashCommand } from './chat/SlashCommandMenu'
 import { confirm } from './hooks/useConfirm'
@@ -14,7 +15,7 @@ import { ConfirmRoot } from './hooks/useConfirm'
 import { InstallPrompt } from './pwa/InstallPrompt'
 import { useOnlineStatus } from './pwa/useOnlineStatus'
 import { useMediaQuery } from './hooks/useMediaQuery'
-import type { ApiSession, MinionCommand, QuickAction, RepoEntry } from './api/types'
+import type { ApiSession, MinionCommand, QuickAction } from './api/types'
 
 const showSettings = signal(false)
 const showDrawer = signal(false)
@@ -41,89 +42,6 @@ function statusDot(status: ApiSession['status']): string {
   if (status === 'completed') return 'bg-green-500'
   if (status === 'failed') return 'bg-red-500'
   return 'bg-slate-400'
-}
-
-const TASK_LIKE_COMMANDS = ['/task', '/plan', '/think', '/dag', '/split', '/stack', '/ship', '/doctor']
-
-function injectRepo(text: string, repo: string): string {
-  const trimmed = text.trimStart()
-  const spaceIdx = trimmed.indexOf(' ')
-  if (spaceIdx === -1) return text
-  const head = trimmed.slice(0, spaceIdx)
-  const rest = trimmed.slice(spaceIdx + 1)
-  if (!TASK_LIKE_COMMANDS.includes(head)) return text
-  const restTrimmed = rest.trimStart()
-  const firstToken = restTrimmed.split(' ', 1)[0] ?? ''
-  if (firstToken === repo) return `${head} ${restTrimmed}`
-  return `${head} ${repo} ${restTrimmed}`
-}
-
-function NewTaskBar({
-  repos,
-  onSend,
-}: {
-  repos: RepoEntry[]
-  onSend: (text: string) => Promise<void>
-}) {
-  const text = useSignal('')
-  const sending = useSignal(false)
-  const error = useSignal<string | null>(null)
-  const selectedRepo = useSignal<string>(repos.length > 0 ? repos[0].alias : '')
-
-  const submit = async () => {
-    const raw = text.value.trim()
-    if (!raw || sending.value) return
-    const value = selectedRepo.value ? injectRepo(raw, selectedRepo.value) : raw
-    sending.value = true
-    error.value = null
-    try {
-      await onSend(value)
-      text.value = ''
-    } catch (e) {
-      error.value = e instanceof Error ? e.message : 'Send failed'
-    } finally {
-      sending.value = false
-    }
-  }
-
-  return (
-    <div class="flex flex-col gap-1 px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
-      <div class="flex items-center gap-2">
-        {repos.length > 0 && (
-          <select
-            value={selectedRepo.value}
-            onChange={(e) => { selectedRepo.value = (e.currentTarget as HTMLSelectElement).value }}
-            disabled={sending.value}
-            title="Repo to run the task against (auto-inserted after the slash command)"
-            class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-2 py-2 text-sm text-slate-900 dark:text-slate-100 disabled:opacity-50"
-            data-testid="new-task-repo-select"
-          >
-            {repos.map((r) => (
-              <option key={r.alias} value={r.alias}>{r.alias}</option>
-            ))}
-            <option value="">(no repo)</option>
-          </select>
-        )}
-        <input
-          type="text"
-          value={text.value}
-          onInput={(e) => { text.value = (e.currentTarget as HTMLInputElement).value }}
-          onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); void submit() } }}
-          disabled={sending.value}
-          placeholder="New task: /task <prompt>, /plan, /think, /dag, /split, /stack, /doctor, /ship"
-          class="flex-1 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 placeholder:text-slate-400 disabled:opacity-50"
-        />
-        <button
-          onClick={() => void submit()}
-          disabled={sending.value || !text.value.trim()}
-          class="rounded-lg bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
-        >
-          {sending.value ? '…' : 'Send'}
-        </button>
-      </div>
-      {error.value && <div class="text-xs text-red-600 dark:text-red-400">{error.value}</div>}
-    </div>
-  )
 }
 
 function SessionItem({ session, active, onSelect }: { session: ApiSession; active: boolean; onSelect: () => void }) {
@@ -174,7 +92,7 @@ function SessionList({
   if (sorted.length === 0) {
     return (
       <div class="text-xs text-slate-500 dark:text-slate-400 p-3 italic">
-        No sessions yet. Send a /task above.
+        No sessions yet. Launch one from the task bar above.
       </div>
     )
   }
@@ -358,10 +276,6 @@ function ActiveView() {
     await store.sendCommand(cmd)
   }
 
-  const handleNewTask = async (text: string) => {
-    await store.client.sendMessage(text)
-  }
-
   const showOfflineBanner = !isOnline.value && store.stale.value
 
   return (
@@ -390,7 +304,7 @@ function ActiveView() {
           <button onClick={() => void store.refresh()} class="text-xs font-medium underline">Retry</button>
         </div>
       )}
-      <NewTaskBar repos={store.version.value?.repos ?? []} onSend={handleNewTask} />
+      <NewTaskBar store={store} />
       {isDesktop.value ? (
         <div class="flex flex-1 min-h-0">
           <aside class="w-72 border-r border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 overflow-y-auto shrink-0">

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,20 @@
-import type { ApiDagGraph, ApiResponse, ApiSession, CommandResult, MinionCommand, VersionInfo } from './types'
+import type {
+  ApiDagGraph,
+  ApiResponse,
+  ApiSession,
+  CommandResult,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  CreateSessionVariantsResult,
+  MinionCommand,
+  PrPreview,
+  PushSubscribeAck,
+  PushSubscriptionJSON,
+  ScreenshotList,
+  VapidPublicKey,
+  VersionInfo,
+  WorkspaceDiff,
+} from './types'
 import { openEventStream } from './sse'
 import type { SseHandlers, EventStreamHandle } from './sse'
 
@@ -18,6 +34,15 @@ export interface ApiClient {
   getDags(): Promise<ApiDagGraph[]>
   sendCommand(cmd: MinionCommand): Promise<CommandResult>
   sendMessage(text: string, sessionId?: string): Promise<{ ok: true; sessionId: string | null }>
+  createSession(req: CreateSessionRequest): Promise<ApiSession>
+  createSessionVariants(req: CreateSessionVariantsRequest): Promise<CreateSessionVariantsResult>
+  getPr(sessionId: string): Promise<PrPreview>
+  getDiff(sessionId: string): Promise<WorkspaceDiff>
+  listScreenshots(sessionId: string): Promise<ScreenshotList>
+  fetchScreenshotBlob(file: string): Promise<Blob>
+  getVapidKey(): Promise<VapidPublicKey>
+  subscribePush(sub: PushSubscriptionJSON): Promise<PushSubscribeAck>
+  unsubscribePush(endpoint: string): Promise<{ ok: true }>
   openEventStream(handlers: SseHandlers): EventStreamHandle
   baseUrl: string
   token: string
@@ -30,6 +55,11 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
   function headers(): HeadersInit {
     if (!token) return { 'Content-Type': 'application/json' }
     return { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
+  }
+
+  function authHeadersOnly(): HeadersInit {
+    if (!token) return {}
+    return { Authorization: `Bearer ${token}` }
   }
 
   async function get<T>(path: string): Promise<T> {
@@ -46,6 +76,19 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
       method: 'POST',
       headers: headers(),
       body: JSON.stringify(data),
+    })
+    const body = (await res.json()) as ApiResponse<T>
+    if (!res.ok || body.error) {
+      throw new ApiError(res.status, body.error ?? res.statusText)
+    }
+    return body.data
+  }
+
+  async function del<T>(path: string, data?: unknown): Promise<T> {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: 'DELETE',
+      headers: headers(),
+      body: data !== undefined ? JSON.stringify(data) : undefined,
     })
     const body = (await res.json()) as ApiResponse<T>
     if (!res.ok || body.error) {
@@ -76,6 +119,48 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
 
     sendMessage(text: string, sessionId?: string) {
       return post<{ ok: true; sessionId: string | null }>('/api/messages', { text, sessionId })
+    },
+
+    createSession(req: CreateSessionRequest) {
+      return post<ApiSession>('/api/sessions', req)
+    },
+
+    createSessionVariants(req: CreateSessionVariantsRequest) {
+      return post<CreateSessionVariantsResult>('/api/sessions/variants', req)
+    },
+
+    getPr(sessionId: string) {
+      return get<PrPreview>(`/api/sessions/${encodeURIComponent(sessionId)}/pr`)
+    },
+
+    getDiff(sessionId: string) {
+      return get<WorkspaceDiff>(`/api/sessions/${encodeURIComponent(sessionId)}/diff`)
+    },
+
+    listScreenshots(sessionId: string) {
+      return get<ScreenshotList>(`/api/sessions/${encodeURIComponent(sessionId)}/screenshots`)
+    },
+
+    async fetchScreenshotBlob(file: string): Promise<Blob> {
+      const res = await fetch(`${baseUrl}/api/screenshots/${encodeURIComponent(file)}`, {
+        headers: authHeadersOnly(),
+      })
+      if (!res.ok) {
+        throw new ApiError(res.status, res.statusText)
+      }
+      return res.blob()
+    },
+
+    getVapidKey() {
+      return get<VapidPublicKey>('/api/push/vapid-public-key')
+    },
+
+    subscribePush(sub: PushSubscriptionJSON) {
+      return post<PushSubscribeAck>('/api/push-subscribe', sub)
+    },
+
+    unsubscribePush(endpoint: string) {
+      return del<{ ok: true }>('/api/push-subscribe', { endpoint })
     },
 
     openEventStream(handlers: SseHandlers): EventStreamHandle {

--- a/src/api/features.ts
+++ b/src/api/features.ts
@@ -1,0 +1,25 @@
+import type { ConnectionStore } from '../state/types'
+import type { VersionInfo } from './types'
+
+export type FeatureName =
+  | 'messages'
+  | 'sessions-create'
+  | 'sessions-variants'
+  | 'pr-preview'
+  | 'diff-viewer'
+  | 'screenshots-http'
+  | 'web-push'
+  | 'worktree-stats'
+
+export function hasFeature(
+  source: ConnectionStore | VersionInfo | null | undefined,
+  name: FeatureName,
+): boolean {
+  if (!source) return false
+  const version: VersionInfo | null =
+    'features' in source && Array.isArray((source as VersionInfo).features)
+      ? (source as VersionInfo)
+      : (source as ConnectionStore).version.value
+  if (!version) return false
+  return version.features.includes(name)
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -25,6 +25,7 @@ export interface ApiSession {
   quickActions: QuickAction[]
   mode: string
   conversation: ConversationMessage[]
+  variantGroupId?: string
 }
 
 export interface ApiDagNode {
@@ -72,4 +73,106 @@ export interface VersionInfo {
   libraryVersion: string
   features: string[]
   repos?: RepoEntry[]
+}
+
+export type CreateSessionMode = 'task' | 'plan' | 'think' | 'dag' | 'split' | 'stack' | 'ship' | 'doctor'
+
+export interface CreateSessionRequest {
+  prompt: string
+  mode: CreateSessionMode
+  repo?: string
+}
+
+export interface CreateSessionVariantsRequest extends CreateSessionRequest {
+  count: number
+}
+
+export interface CreateSessionVariantsResult {
+  groupId: string
+  sessions: ApiSession[]
+}
+
+export type PrState = 'open' | 'closed' | 'merged'
+
+export type PrCheckStatus =
+  | 'queued'
+  | 'in_progress'
+  | 'pending'
+  | 'success'
+  | 'failure'
+  | 'neutral'
+  | 'skipped'
+  | 'cancelled'
+  | 'action_required'
+  | 'stale'
+  | 'timed_out'
+
+export interface PrCheck {
+  name: string
+  status: PrCheckStatus
+  conclusion?: string
+  url?: string
+}
+
+export interface PrPreview {
+  number: number
+  url: string
+  title: string
+  body: string
+  state: PrState
+  draft: boolean
+  mergeable: boolean | null
+  branch: string
+  baseBranch: string
+  author: string
+  updatedAt: string
+  checks: PrCheck[]
+}
+
+export interface WorkspaceDiffStats {
+  filesChanged: number
+  insertions: number
+  deletions: number
+}
+
+export interface WorkspaceDiff {
+  sessionId: string
+  branch: string
+  baseBranch: string
+  patch: string
+  truncated: boolean
+  stats: WorkspaceDiffStats
+}
+
+export interface ScreenshotEntry {
+  file: string
+  url: string
+  capturedAt: string
+  size: number
+  width?: number
+  height?: number
+  caption?: string
+}
+
+export interface ScreenshotList {
+  sessionId: string
+  screenshots: ScreenshotEntry[]
+}
+
+export interface VapidPublicKey {
+  key: string
+}
+
+export interface PushSubscriptionJSON {
+  endpoint: string
+  expirationTime: number | null
+  keys: {
+    p256dh: string
+    auth: string
+  }
+}
+
+export interface PushSubscribeAck {
+  ok: true
+  id: string
 }

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -1,0 +1,217 @@
+import { useSignal, useComputed } from '@preact/signals'
+import type { ConnectionStore } from '../state/types'
+import type { CreateSessionMode } from '../api/types'
+import { hasFeature } from '../api/features'
+import { formatRoute } from '../routing/route'
+
+export interface ModeOption {
+  value: CreateSessionMode
+  label: string
+  hint: string
+}
+
+export const NEW_TASK_MODES: ModeOption[] = [
+  { value: 'task', label: 'Task', hint: 'Execute end-to-end' },
+  { value: 'plan', label: 'Plan', hint: 'Produce a plan; no execution' },
+  { value: 'think', label: 'Think', hint: 'Deliberate; no side effects' },
+  { value: 'ship', label: 'Ship', hint: 'Finish with a PR' },
+]
+
+export const VARIANT_COUNTS: ReadonlyArray<number> = [1, 2, 3, 4]
+
+export interface NewTaskBarProps {
+  store: ConnectionStore
+  navigate?: (hash: string) => void
+}
+
+function defaultNavigate(hash: string): void {
+  if (typeof window !== 'undefined') {
+    window.location.hash = hash
+  }
+}
+
+export function NewTaskBar({ store, navigate = defaultNavigate }: NewTaskBarProps) {
+  const mode = useSignal<CreateSessionMode>('task')
+  const prompt = useSignal('')
+  const repo = useSignal('')
+  const variantCount = useSignal(1)
+  const sending = useSignal(false)
+  const error = useSignal<string | null>(null)
+
+  const version = store.version.value
+  const repos = version?.repos ?? []
+  if (repos.length > 0 && !repo.value) {
+    repo.value = repos[0].alias
+  }
+
+  const canCreate = hasFeature(store, 'sessions-create')
+  const canVariants = hasFeature(store, 'sessions-variants')
+  const wantVariants = useComputed(() => variantCount.value > 1)
+
+  if (!canCreate) {
+    return (
+      <div
+        class="flex items-center gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 text-xs text-slate-500 dark:text-slate-400"
+        data-testid="new-task-bar"
+        data-gated="true"
+      >
+        <span class="font-medium text-slate-600 dark:text-slate-300">Structured task creation disabled</span>
+        <span>needs library ≥ 1.111</span>
+      </div>
+    )
+  }
+
+  const submit = async () => {
+    const p = prompt.value.trim()
+    if (!p || sending.value) return
+    if (wantVariants.value && !canVariants) {
+      error.value = 'Parallel variants need library ≥ 1.111'
+      return
+    }
+    sending.value = true
+    error.value = null
+    try {
+      const selectedRepo = repo.value || undefined
+      if (wantVariants.value) {
+        const out = await store.client.createSessionVariants({
+          prompt: p,
+          mode: mode.value,
+          repo: selectedRepo,
+          count: variantCount.value,
+        })
+        prompt.value = ''
+        navigate(formatRoute({ name: 'group', groupId: out.groupId }))
+      } else {
+        await store.client.createSession({
+          prompt: p,
+          mode: mode.value,
+          repo: selectedRepo,
+        })
+        prompt.value = ''
+      }
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Send failed'
+    } finally {
+      sending.value = false
+    }
+  }
+
+  const canSubmit = !sending.value && prompt.value.trim().length > 0 && !(wantVariants.value && !canVariants)
+  const launchLabel = sending.value
+    ? '…'
+    : wantVariants.value
+      ? `Launch ×${variantCount.value}`
+      : 'Launch'
+
+  return (
+    <div
+      class="flex flex-col gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
+      data-testid="new-task-bar"
+    >
+      <div class="flex flex-wrap items-center gap-2">
+        <div class="flex gap-1" role="radiogroup" aria-label="Task mode" data-testid="mode-picker">
+          {NEW_TASK_MODES.map((m) => {
+            const active = mode.value === m.value
+            const btnClass = active
+              ? 'bg-indigo-600 text-white border-indigo-700'
+              : 'bg-slate-50 dark:bg-slate-900 text-slate-700 dark:text-slate-200 border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700'
+            return (
+              <button
+                key={m.value}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                title={m.hint}
+                disabled={sending.value}
+                onClick={() => { mode.value = m.value }}
+                data-testid={`mode-${m.value}`}
+                class={`rounded-full border px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${btnClass}`}
+              >
+                {m.label}
+              </button>
+            )
+          })}
+        </div>
+
+        {repos.length > 0 && (
+          <select
+            value={repo.value}
+            onChange={(e) => { repo.value = (e.currentTarget as HTMLSelectElement).value }}
+            disabled={sending.value}
+            title="Repo to run the task against"
+            class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-2 py-1.5 text-xs text-slate-900 dark:text-slate-100 disabled:opacity-50"
+            data-testid="new-task-repo-select"
+          >
+            {repos.map((r) => (
+              <option key={r.alias} value={r.alias}>{r.alias}</option>
+            ))}
+            <option value="">(no repo)</option>
+          </select>
+        )}
+
+        <div
+          class="flex items-center gap-1 ml-auto"
+          role="group"
+          aria-label="Variant count"
+          data-testid="variant-count"
+        >
+          <span class="text-xs text-slate-500 dark:text-slate-400">×</span>
+          {VARIANT_COUNTS.map((n) => {
+            const active = variantCount.value === n
+            const gated = n > 1 && !canVariants
+            const btnClass = active
+              ? 'bg-indigo-600 text-white border-indigo-700'
+              : 'bg-slate-50 dark:bg-slate-900 text-slate-700 dark:text-slate-200 border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700'
+            return (
+              <button
+                key={n}
+                type="button"
+                onClick={() => { variantCount.value = n }}
+                disabled={sending.value || gated}
+                title={gated ? 'Parallel variants need library ≥ 1.111' : n === 1 ? 'Single session' : `${n} parallel variants`}
+                data-testid={`variant-${n}`}
+                aria-pressed={active}
+                class={`h-7 min-w-7 rounded-full border px-2 text-xs font-medium transition-colors disabled:opacity-40 ${btnClass}`}
+              >
+                {n}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div class="flex items-end gap-2">
+        <textarea
+          value={prompt.value}
+          onInput={(e) => { prompt.value = (e.currentTarget as HTMLTextAreaElement).value }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault()
+              void submit()
+            }
+          }}
+          disabled={sending.value}
+          rows={2}
+          placeholder={`New ${mode.value}: describe what you want…`}
+          class="flex-1 resize-y rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 placeholder:text-slate-400 disabled:opacity-50"
+          data-testid="new-task-prompt"
+        />
+        <button
+          type="button"
+          onClick={() => void submit()}
+          disabled={!canSubmit}
+          class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          data-testid="new-task-send"
+        >
+          {launchLabel}
+        </button>
+      </div>
+
+      {error.value && (
+        <div class="text-xs text-red-600 dark:text-red-400" data-testid="new-task-error">
+          {error.value}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -264,7 +264,7 @@ export function UniverseCanvas({
           <div class="text-4xl mb-3 opacity-40">~</div>
           <div class="text-lg font-medium">No active sessions</div>
           <div class="text-sm mt-1 opacity-70">
-            Send a /task command to get started
+            Launch a task from the bar above to get started
           </div>
         </div>
       </div>

--- a/src/routing/route.ts
+++ b/src/routing/route.ts
@@ -1,0 +1,61 @@
+import { signal } from '@preact/signals'
+import type { ReadonlySignal } from '@preact/signals'
+
+export type Route =
+  | { name: 'home' }
+  | { name: 'session'; sessionSlug: string }
+  | { name: 'group'; groupId: string }
+
+export function parseHash(hash: string): Route {
+  const raw = hash.replace(/^#?\/*/, '')
+  if (!raw) return { name: 'home' }
+  const segments = raw.split('/').filter(Boolean)
+  if (segments.length === 2 && segments[0] === 's') {
+    return { name: 'session', sessionSlug: decodeURIComponent(segments[1]) }
+  }
+  if (segments.length === 2 && segments[0] === 'g') {
+    return { name: 'group', groupId: decodeURIComponent(segments[1]) }
+  }
+  return { name: 'home' }
+}
+
+export function formatRoute(route: Route): string {
+  switch (route.name) {
+    case 'home':
+      return '#/'
+    case 'session':
+      return `#/s/${encodeURIComponent(route.sessionSlug)}`
+    case 'group':
+      return `#/g/${encodeURIComponent(route.groupId)}`
+  }
+}
+
+export interface Router {
+  route: ReadonlySignal<Route>
+  navigate(route: Route): void
+  dispose(): void
+}
+
+export function createRouter(win: Window = window): Router {
+  const route = signal<Route>(parseHash(win.location.hash))
+
+  const onHashChange = () => {
+    route.value = parseHash(win.location.hash)
+  }
+  win.addEventListener('hashchange', onHashChange)
+
+  return {
+    route,
+    navigate(next: Route) {
+      const hash = formatRoute(next)
+      if (win.location.hash === hash) {
+        route.value = next
+        return
+      }
+      win.location.hash = hash
+    },
+    dispose() {
+      win.removeEventListener('hashchange', onHashChange)
+    },
+  }
+}

--- a/test/api/client-extended.test.ts
+++ b/test/api/client-extended.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createApiClient, ApiError } from '../../src/api/client'
+import type {
+  ApiSession,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  CreateSessionVariantsResult,
+  PrPreview,
+  PushSubscriptionJSON,
+  ScreenshotList,
+  VapidPublicKey,
+  WorkspaceDiff,
+} from '../../src/api/types'
+
+const BASE_URL = 'https://example.com'
+const TOKEN = 'test-token'
+
+function jsonResponse(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    json: () => Promise.resolve(data),
+    blob: () => Promise.reject(new Error('not a blob response')),
+  }
+}
+
+function blobResponse(body: Blob, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    blob: () => Promise.resolve(body),
+    json: () => Promise.reject(new Error('not a json response')),
+  }
+}
+
+const SAMPLE_SESSION: ApiSession = {
+  id: 's-1',
+  slug: 'quick-fox',
+  status: 'pending',
+  command: '/task implement feature x',
+  createdAt: '2026-04-19T00:00:00Z',
+  updatedAt: '2026-04-19T00:00:00Z',
+  childIds: [],
+  needsAttention: false,
+  attentionReasons: [],
+  quickActions: [],
+  mode: 'task',
+  conversation: [],
+}
+
+describe('ApiClient — createSession', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: SAMPLE_SESSION }))
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('POSTs structured payload to /api/sessions', async () => {
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const req: CreateSessionRequest = { prompt: 'do the thing', mode: 'task', repo: 'foo' }
+    const out = await client.createSession(req)
+
+    expect(out).toEqual(SAMPLE_SESSION)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/sessions`)
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${TOKEN}`)
+    const body = JSON.parse(init.body as string) as CreateSessionRequest
+    expect(body).toEqual(req)
+  })
+})
+
+describe('ApiClient — createSessionVariants', () => {
+  it('POSTs to /api/sessions/variants and unwraps group result', async () => {
+    const result: CreateSessionVariantsResult = {
+      groupId: 'group-1',
+      sessions: [SAMPLE_SESSION, { ...SAMPLE_SESSION, id: 's-2' }],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: result }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const req: CreateSessionVariantsRequest = { prompt: 'parallel', mode: 'task', count: 2 }
+    const out = await client.createSessionVariants(req)
+
+    expect(out).toEqual(result)
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe(`${BASE_URL}/api/sessions/variants`)
+
+    vi.unstubAllGlobals()
+  })
+})
+
+describe('ApiClient — getPr / getDiff / listScreenshots', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('getPr hits /api/sessions/:id/pr with encoded id', async () => {
+    const pr: PrPreview = {
+      number: 42,
+      url: 'https://github.com/o/r/pull/42',
+      title: 'Feature',
+      body: 'body',
+      state: 'open',
+      draft: false,
+      mergeable: true,
+      branch: 'feature',
+      baseBranch: 'main',
+      author: 'me',
+      updatedAt: '2026-04-19T00:00:00Z',
+      checks: [],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: pr }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.getPr('weird id/with/slashes')
+    expect(out).toEqual(pr)
+
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe(`${BASE_URL}/api/sessions/${encodeURIComponent('weird id/with/slashes')}/pr`)
+  })
+
+  it('getDiff returns workspace diff', async () => {
+    const diff: WorkspaceDiff = {
+      sessionId: 's-1',
+      branch: 'feature',
+      baseBranch: 'main',
+      patch: '--- a\n+++ b\n',
+      truncated: false,
+      stats: { filesChanged: 1, insertions: 3, deletions: 1 },
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: diff }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.getDiff('s-1')
+    expect(out).toEqual(diff)
+  })
+
+  it('listScreenshots returns list shape', async () => {
+    const list: ScreenshotList = {
+      sessionId: 's-1',
+      screenshots: [
+        { file: 'a.png', url: '/api/screenshots/a.png', capturedAt: '2026-04-19T00:00:00Z', size: 100 },
+      ],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: list }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.listScreenshots('s-1')
+    expect(out).toEqual(list)
+  })
+})
+
+describe('ApiClient — fetchScreenshotBlob', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns a Blob and attaches Authorization header', async () => {
+    const body = new Blob(['fake-png'], { type: 'image/png' })
+    const fetchMock = vi.fn().mockResolvedValue(blobResponse(body))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.fetchScreenshotBlob('sub/dir/file.png')
+    expect(out).toBe(body)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/screenshots/${encodeURIComponent('sub/dir/file.png')}`)
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${TOKEN}`)
+    expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined()
+  })
+
+  it('throws ApiError on non-2xx', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found', blob: () => Promise.resolve(new Blob()) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    await expect(client.fetchScreenshotBlob('missing.png')).rejects.toThrow(ApiError)
+  })
+})
+
+describe('ApiClient — push', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('getVapidKey unwraps data', async () => {
+    const key: VapidPublicKey = { key: 'BXYZ' }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: key }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.getVapidKey()
+    expect(out).toEqual(key)
+  })
+
+  it('subscribePush POSTs the subscription', async () => {
+    const sub: PushSubscriptionJSON = {
+      endpoint: 'https://push.example.com/abc',
+      expirationTime: null,
+      keys: { p256dh: 'pk', auth: 'ak' },
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: { ok: true, id: 'sub-1' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.subscribePush(sub)
+    expect(out).toEqual({ ok: true, id: 'sub-1' })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/push-subscribe`)
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string) as PushSubscriptionJSON
+    expect(body).toEqual(sub)
+  })
+
+  it('unsubscribePush DELETEs with endpoint body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: { ok: true } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.unsubscribePush('https://push.example.com/abc')
+    expect(out).toEqual({ ok: true })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/push-subscribe`)
+    expect(init.method).toBe('DELETE')
+    const body = JSON.parse(init.body as string) as { endpoint: string }
+    expect(body.endpoint).toBe('https://push.example.com/abc')
+  })
+})

--- a/test/api/features.test.ts
+++ b/test/api/features.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { signal } from '@preact/signals'
+import { hasFeature } from '../../src/api/features'
+import type { ConnectionStore } from '../../src/state/types'
+import type { VersionInfo } from '../../src/api/types'
+
+function makeStore(version: VersionInfo | null): ConnectionStore {
+  return {
+    version: signal(version),
+  } as unknown as ConnectionStore
+}
+
+describe('hasFeature', () => {
+  it('returns false when source is null/undefined', () => {
+    expect(hasFeature(null, 'pr-preview')).toBe(false)
+    expect(hasFeature(undefined, 'pr-preview')).toBe(false)
+  })
+
+  it('returns false when version signal is null', () => {
+    expect(hasFeature(makeStore(null), 'pr-preview')).toBe(false)
+  })
+
+  it('returns false when feature not listed', () => {
+    const store = makeStore({ apiVersion: '1', libraryVersion: '1.0.0', features: ['messages'] })
+    expect(hasFeature(store, 'pr-preview')).toBe(false)
+  })
+
+  it('returns true when feature is listed', () => {
+    const store = makeStore({
+      apiVersion: '1',
+      libraryVersion: '1.1.0',
+      features: ['messages', 'pr-preview', 'diff-viewer'],
+    })
+    expect(hasFeature(store, 'pr-preview')).toBe(true)
+    expect(hasFeature(store, 'diff-viewer')).toBe(true)
+    expect(hasFeature(store, 'messages')).toBe(true)
+  })
+
+  it('accepts a raw VersionInfo without a store wrapper', () => {
+    const v: VersionInfo = { apiVersion: '1', libraryVersion: '1.1.0', features: ['web-push'] }
+    expect(hasFeature(v, 'web-push')).toBe(true)
+    expect(hasFeature(v, 'diff-viewer')).toBe(false)
+  })
+})

--- a/test/api/mock-minion-integration.test.ts
+++ b/test/api/mock-minion-integration.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { createApiClient, ApiError } from '../../src/api/client'
+import { createMockMinion, type MockMinion } from '../../e2e/fixtures/mock-minion'
+import type { PrPreview, PushSubscriptionJSON, WorkspaceDiff } from '../../src/api/types'
+
+describe('mock-minion integration', () => {
+  let minion: MockMinion
+  let client: ReturnType<typeof createApiClient>
+
+  beforeAll(async () => {
+    minion = await createMockMinion({ token: 'secret' })
+    client = createApiClient({ baseUrl: minion.url, token: 'secret' })
+  })
+
+  afterAll(async () => {
+    await minion.close()
+  })
+
+  beforeEach(() => {
+    minion.setVersion({ features: [] })
+  })
+
+  it('refuses createSession when feature flag off (default)', async () => {
+    await expect(client.createSession({ prompt: 'x', mode: 'task' })).rejects.toThrow(ApiError)
+  })
+
+  it('createSession works when feature enabled and records the request', async () => {
+    minion.setVersion({ features: ['sessions-create'] })
+    const before = minion.lastCreateSessionRequests.length
+    const session = await client.createSession({ prompt: 'hello', mode: 'task', repo: 'example' })
+    expect(session.mode).toBe('task')
+    expect(session.repo).toBe('example')
+    expect(minion.lastCreateSessionRequests.length).toBe(before + 1)
+    expect(minion.lastCreateSessionRequests[before]).toEqual({ prompt: 'hello', mode: 'task', repo: 'example' })
+  })
+
+  it('createSessionVariants returns a group of N sessions sharing a groupId', async () => {
+    minion.setVersion({ features: ['sessions-variants'] })
+    const out = await client.createSessionVariants({ prompt: 'parallel', mode: 'task', count: 3 })
+    expect(out.sessions).toHaveLength(3)
+    expect(new Set(out.sessions.map((s) => s.variantGroupId))).toEqual(new Set([out.groupId]))
+  })
+
+  it('gated endpoints return 404 with a feature-disabled error when flag off', async () => {
+    await expect(client.getPr('s-1')).rejects.toThrow(ApiError)
+    await expect(client.getDiff('s-1')).rejects.toThrow(ApiError)
+    await expect(client.listScreenshots('s-1')).rejects.toThrow(ApiError)
+    await expect(client.getVapidKey()).rejects.toThrow(ApiError)
+  })
+
+  it('getPr returns the stored preview when flag on', async () => {
+    minion.setVersion({ features: ['pr-preview'] })
+    const pr: PrPreview = {
+      number: 1,
+      url: 'https://github.com/o/r/pull/1',
+      title: 't',
+      body: 'b',
+      state: 'open',
+      draft: false,
+      mergeable: null,
+      branch: 'feat',
+      baseBranch: 'main',
+      author: 'me',
+      updatedAt: '2026-04-19T00:00:00Z',
+      checks: [{ name: 'ci', status: 'pending' }],
+    }
+    minion.setPr('s-1', pr)
+    const out = await client.getPr('s-1')
+    expect(out).toEqual(pr)
+  })
+
+  it('getDiff returns the stored workspace diff when flag on', async () => {
+    minion.setVersion({ features: ['diff-viewer'] })
+    const diff: WorkspaceDiff = {
+      sessionId: 's-1',
+      branch: 'feat',
+      baseBranch: 'main',
+      patch: 'diff --git a/x b/x',
+      truncated: false,
+      stats: { filesChanged: 1, insertions: 2, deletions: 0 },
+    }
+    minion.setDiff('s-1', diff)
+    const out = await client.getDiff('s-1')
+    expect(out).toEqual(diff)
+  })
+
+  it('listScreenshots + fetchScreenshotBlob round-trip', async () => {
+    minion.setVersion({ features: ['screenshots-http'] })
+    minion.setScreenshots('s-1', [
+      { file: 'shot-1.png', url: '/api/screenshots/shot-1.png', capturedAt: '2026-04-19T00:00:00Z', size: 4 },
+    ])
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    minion.setScreenshotBlob('shot-1.png', png)
+
+    const list = await client.listScreenshots('s-1')
+    expect(list.screenshots).toHaveLength(1)
+    expect(list.screenshots[0].file).toBe('shot-1.png')
+
+    const blob = await client.fetchScreenshotBlob('shot-1.png')
+    const buf = Buffer.from(await blob.arrayBuffer())
+    expect(buf.equals(png)).toBe(true)
+  })
+
+  it('web push flow: getVapidKey → subscribe → unsubscribe', async () => {
+    minion.setVersion({ features: ['web-push'] })
+    const { key } = await client.getVapidKey()
+    expect(key).toMatch(/^B/)
+
+    const sub: PushSubscriptionJSON = {
+      endpoint: 'https://push.example.com/abc',
+      expirationTime: null,
+      keys: { p256dh: 'pk', auth: 'ak' },
+    }
+    const ack = await client.subscribePush(sub)
+    expect(ack.ok).toBe(true)
+    expect(minion.pushSubscriptions).toContainEqual(sub)
+
+    await client.unsubscribePush(sub.endpoint)
+    expect(minion.lastUnsubscribeEndpoints).toContain(sub.endpoint)
+    expect(minion.pushSubscriptions.find((s) => s.endpoint === sub.endpoint)).toBeUndefined()
+  })
+})

--- a/test/chat/NewTaskBar.test.tsx
+++ b/test/chat/NewTaskBar.test.tsx
@@ -1,0 +1,230 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/preact'
+import { signal } from '@preact/signals'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NewTaskBar } from '../../src/chat/NewTaskBar'
+import type { ConnectionStore } from '../../src/state/types'
+import type {
+  ApiDagGraph,
+  ApiSession,
+  CommandResult,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  CreateSessionVariantsResult,
+  MinionCommand,
+  VersionInfo,
+} from '../../src/api/types'
+
+type StubClient = {
+  createSession: ReturnType<typeof vi.fn>
+  createSessionVariants: ReturnType<typeof vi.fn>
+  sendCommand: ReturnType<typeof vi.fn>
+}
+
+function makeSession(over: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 's1',
+    slug: 'brave-fox',
+    status: 'pending',
+    command: '/task x',
+    createdAt: '2026-04-19T00:00:00Z',
+    updatedAt: '2026-04-19T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...over,
+  }
+}
+
+function makeStore(opts: {
+  features?: string[]
+  repos?: Array<{ alias: string; url: string }>
+  createSessionImpl?: (req: CreateSessionRequest) => Promise<ApiSession>
+  createVariantsImpl?: (req: CreateSessionVariantsRequest) => Promise<CreateSessionVariantsResult>
+}): { store: ConnectionStore; client: StubClient } {
+  const version: VersionInfo = {
+    apiVersion: '1',
+    libraryVersion: '1.111.0',
+    features: opts.features ?? [],
+    repos: opts.repos,
+  }
+  const client: StubClient = {
+    createSession: vi
+      .fn<(req: CreateSessionRequest) => Promise<ApiSession>>()
+      .mockImplementation(opts.createSessionImpl ?? (async () => makeSession())),
+    createSessionVariants: vi
+      .fn<(req: CreateSessionVariantsRequest) => Promise<CreateSessionVariantsResult>>()
+      .mockImplementation(
+        opts.createVariantsImpl ??
+          (async (req) => ({
+            groupId: 'g-xyz',
+            sessions: Array.from({ length: req.count }, (_, i) =>
+              makeSession({ id: `sv-${i + 1}`, variantGroupId: 'g-xyz' })
+            ),
+          }))
+      ),
+    sendCommand: vi.fn<(cmd: MinionCommand) => Promise<CommandResult>>(),
+  }
+
+  const store: ConnectionStore = {
+    client: client as unknown as ConnectionStore['client'],
+    sessions: signal<ApiSession[]>([]),
+    dags: signal<ApiDagGraph[]>([]),
+    status: signal('live'),
+    error: signal<string | null>(null),
+    version: signal<VersionInfo | null>(version),
+    stale: signal(false),
+    refresh: vi.fn(async () => {}),
+    sendCommand: vi.fn(async () => ({ success: true })),
+    dispose: vi.fn(),
+  }
+  return { store, client }
+}
+
+describe('NewTaskBar', () => {
+  beforeEach(() => {
+    if (!window.matchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+      })
+    }
+  })
+
+  it('renders disabled gated bar when sessions-create feature is missing', () => {
+    const { store, client } = makeStore({ features: [] })
+    render(<NewTaskBar store={store} />)
+    const bar = screen.getByTestId('new-task-bar')
+    expect(bar.getAttribute('data-gated')).toBe('true')
+    expect(bar.textContent).toContain('needs library ≥ 1.111')
+    expect(screen.queryByTestId('new-task-prompt')).toBeNull()
+    expect(client.createSession).not.toHaveBeenCalled()
+  })
+
+  it('renders all four modes as radio buttons when feature enabled', () => {
+    const { store } = makeStore({ features: ['sessions-create'] })
+    render(<NewTaskBar store={store} />)
+    expect(screen.getByTestId('mode-task')).toBeTruthy()
+    expect(screen.getByTestId('mode-plan')).toBeTruthy()
+    expect(screen.getByTestId('mode-think')).toBeTruthy()
+    expect(screen.getByTestId('mode-ship')).toBeTruthy()
+    expect(screen.getByTestId('mode-task').getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('switches the selected mode when a mode button is clicked', () => {
+    const { store } = makeStore({ features: ['sessions-create'] })
+    render(<NewTaskBar store={store} />)
+    fireEvent.click(screen.getByTestId('mode-plan'))
+    expect(screen.getByTestId('mode-plan').getAttribute('aria-checked')).toBe('true')
+    expect(screen.getByTestId('mode-task').getAttribute('aria-checked')).toBe('false')
+    const textarea = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
+    expect(textarea.placeholder).toContain('plan')
+  })
+
+  it('submits a structured createSession payload with prompt, mode, and repo', async () => {
+    const { store, client } = makeStore({
+      features: ['sessions-create'],
+      repos: [
+        { alias: 'primary', url: 'https://github.com/org/primary' },
+        { alias: 'other', url: 'https://github.com/org/other' },
+      ],
+    })
+    render(<NewTaskBar store={store} />)
+    fireEvent.click(screen.getByTestId('mode-plan'))
+    const textarea = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'build the thing' } })
+    fireEvent.click(screen.getByTestId('new-task-send'))
+
+    await waitFor(() => expect(client.createSession).toHaveBeenCalled())
+    expect(client.createSession).toHaveBeenCalledWith({
+      prompt: 'build the thing',
+      mode: 'plan',
+      repo: 'primary',
+    })
+    expect(client.createSessionVariants).not.toHaveBeenCalled()
+    await waitFor(() => expect(textarea.value).toBe(''))
+  })
+
+  it('omits repo field from payload when no repos are configured', async () => {
+    const { store, client } = makeStore({ features: ['sessions-create'], repos: [] })
+    render(<NewTaskBar store={store} />)
+    const textarea = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'no repo task' } })
+    fireEvent.click(screen.getByTestId('new-task-send'))
+
+    await waitFor(() => expect(client.createSession).toHaveBeenCalled())
+    const payload = client.createSession.mock.calls[0][0] as CreateSessionRequest
+    expect(payload.repo).toBeUndefined()
+    expect(payload.prompt).toBe('no repo task')
+    expect(payload.mode).toBe('task')
+  })
+
+  it('does not submit when prompt is empty or whitespace', () => {
+    const { store, client } = makeStore({ features: ['sessions-create'] })
+    render(<NewTaskBar store={store} />)
+    const send = screen.getByTestId('new-task-send') as HTMLButtonElement
+    expect(send.disabled).toBe(true)
+    fireEvent.click(send)
+    expect(client.createSession).not.toHaveBeenCalled()
+  })
+
+  it('disables variant buttons >1 when sessions-variants feature is missing', () => {
+    const { store } = makeStore({ features: ['sessions-create'] })
+    render(<NewTaskBar store={store} />)
+    expect((screen.getByTestId('variant-1') as HTMLButtonElement).disabled).toBe(false)
+    expect((screen.getByTestId('variant-2') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('variant-3') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('variant-4') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('calls createSessionVariants and navigates to #/g/:groupId when count > 1', async () => {
+    const { store, client } = makeStore({
+      features: ['sessions-create', 'sessions-variants'],
+      repos: [{ alias: 'primary', url: 'https://github.com/org/primary' }],
+    })
+    const navigate = vi.fn<(hash: string) => void>()
+    render(<NewTaskBar store={store} navigate={navigate} />)
+    fireEvent.click(screen.getByTestId('variant-3'))
+    const textarea = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'split it' } })
+    fireEvent.click(screen.getByTestId('new-task-send'))
+
+    await waitFor(() => expect(client.createSessionVariants).toHaveBeenCalled())
+    expect(client.createSessionVariants).toHaveBeenCalledWith({
+      prompt: 'split it',
+      mode: 'task',
+      repo: 'primary',
+      count: 3,
+    })
+    expect(client.createSession).not.toHaveBeenCalled()
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('#/g/g-xyz'))
+  })
+
+  it('shows server error when createSession rejects', async () => {
+    const { store } = makeStore({
+      features: ['sessions-create'],
+      createSessionImpl: async () => {
+        throw new Error('bad request')
+      },
+    })
+    render(<NewTaskBar store={store} />)
+    const textarea = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'oops' } })
+    fireEvent.click(screen.getByTestId('new-task-send'))
+
+    const err = await screen.findByTestId('new-task-error')
+    expect(err.textContent).toContain('bad request')
+  })
+
+  it('Launch button label reflects variant count', async () => {
+    const { store } = makeStore({
+      features: ['sessions-create', 'sessions-variants'],
+    })
+    render(<NewTaskBar store={store} />)
+    expect(screen.getByTestId('new-task-send').textContent).toBe('Launch')
+    fireEvent.click(screen.getByTestId('variant-4'))
+    expect(screen.getByTestId('new-task-send').textContent).toBe('Launch ×4')
+  })
+})

--- a/test/components/UniverseCanvas.test.tsx
+++ b/test/components/UniverseCanvas.test.tsx
@@ -143,7 +143,7 @@ describe('UniverseCanvas', () => {
   it('shows empty state when no sessions or DAGs', () => {
     render(<UniverseCanvas {...defaultProps} />)
     expect(document.body.innerHTML).toContain('No active sessions')
-    expect(document.body.innerHTML).toContain('/task')
+    expect(document.body.innerHTML).toContain('Launch a task')
   })
 
   it('shows loading state', () => {

--- a/test/routing/route.test.ts
+++ b/test/routing/route.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { parseHash, formatRoute, createRouter } from '../../src/routing/route'
+
+describe('parseHash', () => {
+  it('returns home for empty/missing', () => {
+    expect(parseHash('')).toEqual({ name: 'home' })
+    expect(parseHash('#')).toEqual({ name: 'home' })
+    expect(parseHash('#/')).toEqual({ name: 'home' })
+  })
+
+  it('parses session slug', () => {
+    expect(parseHash('#/s/fast-cat')).toEqual({ name: 'session', sessionSlug: 'fast-cat' })
+  })
+
+  it('decodes percent-encoded segments', () => {
+    expect(parseHash('#/s/cool%20slug')).toEqual({ name: 'session', sessionSlug: 'cool slug' })
+  })
+
+  it('parses group id', () => {
+    expect(parseHash('#/g/grp-1')).toEqual({ name: 'group', groupId: 'grp-1' })
+  })
+
+  it('unknown shape falls back to home', () => {
+    expect(parseHash('#/foo/bar')).toEqual({ name: 'home' })
+    expect(parseHash('#/s')).toEqual({ name: 'home' })
+  })
+})
+
+describe('formatRoute', () => {
+  it('round-trips through parseHash', () => {
+    expect(parseHash(formatRoute({ name: 'home' }))).toEqual({ name: 'home' })
+    expect(parseHash(formatRoute({ name: 'session', sessionSlug: 'fast-cat' }))).toEqual({
+      name: 'session',
+      sessionSlug: 'fast-cat',
+    })
+    expect(parseHash(formatRoute({ name: 'group', groupId: 'grp-1' }))).toEqual({
+      name: 'group',
+      groupId: 'grp-1',
+    })
+  })
+
+  it('encodes special characters', () => {
+    const hash = formatRoute({ name: 'session', sessionSlug: 'has spaces' })
+    expect(hash).toBe('#/s/has%20spaces')
+  })
+})
+
+describe('createRouter', () => {
+  const originalHash = window.location.hash
+
+  beforeEach(() => {
+    window.location.hash = ''
+  })
+
+  afterEach(() => {
+    window.location.hash = originalHash
+  })
+
+  it('initializes route from current hash', () => {
+    window.location.hash = '#/s/foo'
+    const r = createRouter()
+    expect(r.route.value).toEqual({ name: 'session', sessionSlug: 'foo' })
+    r.dispose()
+  })
+
+  it('updates route on hashchange', () => {
+    const r = createRouter()
+    expect(r.route.value).toEqual({ name: 'home' })
+
+    window.location.hash = '#/g/grp-9'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(r.route.value).toEqual({ name: 'group', groupId: 'grp-9' })
+    r.dispose()
+  })
+
+  it('navigate() sets the hash and updates the route', () => {
+    const r = createRouter()
+    r.navigate({ name: 'session', sessionSlug: 'ab' })
+    // location.hash change in jsdom fires a hashchange synchronously in newer versions,
+    // but for safety nudge it manually:
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(r.route.value).toEqual({ name: 'session', sessionSlug: 'ab' })
+    expect(window.location.hash).toBe('#/s/ab')
+    r.dispose()
+  })
+
+  it('navigate() to the same hash still updates the signal', () => {
+    window.location.hash = '#/s/foo'
+    const r = createRouter()
+    const initial = r.route.value
+    r.navigate({ name: 'session', sessionSlug: 'foo' })
+    expect(r.route.value).toEqual(initial)
+    r.dispose()
+  })
+
+  it('dispose() stops listening to hashchange', () => {
+    const r = createRouter()
+    r.dispose()
+    window.location.hash = '#/s/never-seen'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(r.route.value).toEqual({ name: 'home' })
+  })
+})

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,5 +24,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "e2e/fixtures"]
 }


### PR DESCRIPTION
## Summary
- Replaces the string-parsed NewTaskBar with a Conductor-shaped mode picker + repo select + variant-count toggle + prompt textarea in `src/chat/NewTaskBar.tsx`.
- Submit now POSTs structured payloads: `createSession` for count===1 and `createSessionVariants` for count>1 (navigates to `#/g/:groupId` via an injectable `navigate` prop, defaulting to `window.location.hash`).
- Gated end-to-end on the `sessions-create` feature; count>1 variant buttons are additionally gated on `sessions-variants`. When the feature is absent, the bar renders a disabled "needs library ≥ 1.111" strip.
- Removes `/task`-era copy from `SessionList` and `UniverseCanvas` empty states.

## Why
De-Telegramification pass toward Conductor parity: structured session creation over free-text slash commands so downstream features (variant groups, PR preview, diff viewer, screenshots, push) have a single well-typed entry point.

## Notes
- `QuickActionsBar` is intentionally untouched — its labels and `message` fields are server-driven and never contained a literal `/task` token.
- No new npm deps. No changes to API types (already in place from the API-foundation commit).
- Tests: added `test/chat/NewTaskBar.test.tsx` (10 cases) covering feature gating, mode switching, structured payload shape, repo optionality, variant gating, group navigation, and error surface. `UniverseCanvas` test assertion updated for the new copy.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 267 passed
- [ ] E2E not run in this environment (skipped per task guidance).

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  api-foundation["✅ API foundation: types, client, features, router"]
  structured-task-creation["✅ Refactor task creation: POST /api/sessions flow"]
  worktree-header["✅ Worktree header: branch, cwd, diff stats"]
  pr-preview-card["✅ PR preview card: title, state, checks, body"]
  session-tabs["✅ Session tabs: diff viewer and screenshots gallery"]
  web-push["✅ Web Push: notifications, subscriptions, service worker"]
  parallel-variants-ui["✅ Parallel variants: N-session group layout and picker"]
  api-foundation --> structured-task-creation
  api-foundation --> worktree-header
  api-foundation --> pr-preview-card
  api-foundation --> session-tabs
  api-foundation --> web-push
  api-foundation --> parallel-variants-ui
  structured-task-creation --> parallel-variants-ui
  class api-foundation done
  class structured-task-creation done
  class structured-task-creation current
  class worktree-header done
  class pr-preview-card done
  class session-tabs done
  class web-push done
  class parallel-variants-ui done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | API foundation: types, client, features, router | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/4) |
| 2 | **Refactor task creation: POST /api/sessions flow** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/5) |
| 3 | Worktree header: branch, cwd, diff stats | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/6) |
| 4 | PR preview card: title, state, checks, body | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/7) |
| 5 | Session tabs: diff viewer and screenshots gallery | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/8) |
| 6 | Web Push: notifications, subscriptions, service worker | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/10) |
| 7 | Parallel variants: N-session group layout and picker | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/9) |

**Progress:** 7/7 complete

<!-- dag-status-end -->




