### PR TITLE
[minions] feat(ui): per-session worktree header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { ConfirmRoot } from './hooks/useConfirm'
 import { InstallPrompt } from './pwa/InstallPrompt'
 import { useOnlineStatus } from './pwa/useOnlineStatus'
 import { useMediaQuery } from './hooks/useMediaQuery'
+import { WorktreeHeader } from './components/WorktreeHeader'
 import type { ApiSession, MinionCommand, QuickAction } from './api/types'
 
 const showSettings = signal(false)
@@ -238,6 +239,7 @@ function ChatPane({
           </button>
         </div>
       </header>
+      <WorktreeHeader session={session} store={store} />
       <SessionTabs
         tabs={[
           { id: 'chat', label: 'Chat', available: true },

--- a/src/components/WorktreeHeader.tsx
+++ b/src/components/WorktreeHeader.tsx
@@ -1,0 +1,110 @@
+import { useEffect } from 'preact/hooks'
+import type { ApiSession } from '../api/types'
+import type { ConnectionStore, DiffStats } from '../state/types'
+import { hasFeature } from '../api/features'
+
+export function truncateCwd(cwd: string): { display: string; full: string } {
+  const full = cwd
+  const normalized = cwd.replace(/\/+$/, '').replace(/\.git$/, '')
+  if (!normalized) return { display: cwd, full }
+  const segments = normalized.split('/').filter((s) => s.length > 0 && !s.includes(':'))
+  if (segments.length === 0) return { display: cwd, full }
+  if (segments.length <= 2) return { display: segments.join('/'), full }
+  const last = segments.slice(-2).join('/')
+  return { display: last, full }
+}
+
+function StatBadge({ stats }: { stats: DiffStats }) {
+  if (stats.truncated) {
+    return (
+      <span
+        class="font-mono text-[11px] text-slate-500 dark:text-slate-400"
+        title="Diff was truncated — full counts unavailable"
+        data-testid="worktree-stats-truncated"
+      >
+        <span class="text-green-600 dark:text-green-400">+∞</span>{' '}
+        <span class="text-red-600 dark:text-red-400">−∞</span>
+      </span>
+    )
+  }
+  if (stats.filesChanged === 0 && stats.insertions === 0 && stats.deletions === 0) {
+    return (
+      <span
+        class="font-mono text-[11px] text-slate-400 dark:text-slate-500"
+        title="No changes in this worktree"
+        data-testid="worktree-stats"
+      >
+        no changes
+      </span>
+    )
+  }
+  const filesLabel = stats.filesChanged === 1 ? '1 file' : `${stats.filesChanged} files`
+  return (
+    <span
+      class="font-mono text-[11px] text-slate-600 dark:text-slate-300"
+      title={`${filesLabel} changed, +${stats.insertions} −${stats.deletions}`}
+      data-testid="worktree-stats"
+    >
+      <span class="text-green-600 dark:text-green-400">+{stats.insertions}</span>{' '}
+      <span class="text-red-600 dark:text-red-400">−{stats.deletions}</span>
+    </span>
+  )
+}
+
+export function WorktreeHeader({
+  session,
+  store,
+}: {
+  session: ApiSession
+  store: ConnectionStore
+}) {
+  const diffEnabled = hasFeature(store, 'diff-viewer')
+  const stats = store.diffStatsBySessionId.value.get(session.id)
+
+  useEffect(() => {
+    if (!diffEnabled) return
+    if (store.diffStatsBySessionId.value.has(session.id)) return
+    void store.loadDiffStats(session.id)
+  }, [session.id, session.updatedAt, diffEnabled, store])
+
+  if (!session.branch && !session.repo) return null
+
+  const cwd = session.repo ? truncateCwd(session.repo) : null
+
+  return (
+    <div
+      class="flex items-center gap-3 px-4 py-1.5 border-b border-slate-100 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/40 text-xs shrink-0"
+      data-testid="worktree-header"
+    >
+      {session.branch && (
+        <span class="flex items-center gap-1 min-w-0">
+          <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500">branch</span>
+          <span
+            class="font-mono text-slate-700 dark:text-slate-200 truncate"
+            title={session.branch}
+            data-testid="worktree-branch"
+          >
+            {session.branch}
+          </span>
+        </span>
+      )}
+      {cwd && (
+        <span class="flex items-center gap-1 min-w-0">
+          <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500">cwd</span>
+          <span
+            class="font-mono text-slate-700 dark:text-slate-200 truncate"
+            title={cwd.full}
+            data-testid="worktree-cwd"
+          >
+            {cwd.display}
+          </span>
+        </span>
+      )}
+      {diffEnabled && stats && (
+        <span class="ml-auto shrink-0">
+          <StatBadge stats={stats} />
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -2,7 +2,7 @@ import { signal } from '@preact/signals'
 import type { ApiClient } from '../api/client'
 import type { SseEvent } from '../api/types'
 import type { SseStatus } from '../api/sse'
-import type { ConnectionStore } from './types'
+import type { ConnectionStore, DiffStats } from './types'
 import { loadSnapshot, saveSnapshot } from './persist'
 
 export function createConnectionStore(client: ApiClient, connectionId: string): ConnectionStore {
@@ -12,6 +12,28 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
   const error = signal<string | null>(null)
   const version = signal<import('../api/types').VersionInfo | null>(null)
   const stale = signal<boolean>(false)
+  const diffStatsBySessionId = signal<Map<string, DiffStats>>(new Map())
+  const diffStatsInFlight = new Set<string>()
+
+  async function loadDiffStats(sessionId: string): Promise<void> {
+    if (diffStatsInFlight.has(sessionId)) return
+    diffStatsInFlight.add(sessionId)
+    try {
+      const diff = await client.getDiff(sessionId)
+      const next = new Map(diffStatsBySessionId.value)
+      next.set(sessionId, {
+        filesChanged: diff.stats.filesChanged,
+        insertions: diff.stats.insertions,
+        deletions: diff.stats.deletions,
+        truncated: diff.truncated,
+      })
+      diffStatsBySessionId.value = next
+    } catch {
+      // swallow — header falls back to branch/cwd without stats
+    } finally {
+      diffStatsInFlight.delete(sessionId)
+    }
+  }
 
   let snapshotTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -69,12 +91,21 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
           sessions.value = updated
           scheduleSnapshot()
         }
+        if (diffStatsBySessionId.value.has(event.session.id)) {
+          void loadDiffStats(event.session.id)
+        }
         break
       }
-      case 'session_deleted':
+      case 'session_deleted': {
         sessions.value = sessions.value.filter((s) => s.id !== event.sessionId)
+        if (diffStatsBySessionId.value.has(event.sessionId)) {
+          const next = new Map(diffStatsBySessionId.value)
+          next.delete(event.sessionId)
+          diffStatsBySessionId.value = next
+        }
         scheduleSnapshot()
         break
+      }
       case 'dag_created':
         dags.value = [...dags.value, event.dag]
         scheduleSnapshot()
@@ -116,6 +147,8 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
     error,
     version,
     stale,
+    diffStatsBySessionId,
+    loadDiffStats,
     refresh,
     sendCommand(cmd) {
       return client.sendCommand(cmd)

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -5,6 +5,13 @@ import type { ApiClient } from '../api/client'
 
 export type { ReadonlySignal }
 
+export interface DiffStats {
+  filesChanged: number
+  insertions: number
+  deletions: number
+  truncated: boolean
+}
+
 export interface ConnectionStore {
   client: ApiClient
   sessions: ReadonlySignal<ApiSession[]>
@@ -13,6 +20,8 @@ export interface ConnectionStore {
   error: ReadonlySignal<string | null>
   version: ReadonlySignal<VersionInfo | null>
   stale: ReadonlySignal<boolean>
+  diffStatsBySessionId: ReadonlySignal<Map<string, DiffStats>>
+  loadDiffStats(sessionId: string): Promise<void>
   refresh(): Promise<void>
   sendCommand(cmd: MinionCommand): Promise<CommandResult>
   dispose(): void

--- a/test/components/WorktreeHeader.test.tsx
+++ b/test/components/WorktreeHeader.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/preact'
+import { signal } from '@preact/signals'
+import { WorktreeHeader, truncateCwd } from '../../src/components/WorktreeHeader'
+import type { ConnectionStore, DiffStats } from '../../src/state/types'
+import type { ApiSession, VersionInfo } from '../../src/api/types'
+
+function makeSession(over: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 's1',
+    slug: 'brave-fox',
+    status: 'running',
+    command: '/task foo',
+    createdAt: '2026-04-19T00:00:00Z',
+    updatedAt: '2026-04-19T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    branch: 'feature/x',
+    repo: 'https://github.com/acme/widgets',
+    ...over,
+  }
+}
+
+function makeStore(opts: {
+  features?: string[]
+  initialStats?: Map<string, DiffStats>
+  loadDiffStats?: (id: string) => Promise<void>
+} = {}): ConnectionStore {
+  const version = signal<VersionInfo | null>({
+    apiVersion: '1',
+    libraryVersion: '1.0.0',
+    features: opts.features ?? [],
+  })
+  const diffStatsBySessionId = signal<Map<string, DiffStats>>(opts.initialStats ?? new Map())
+  return {
+    client: {} as ConnectionStore['client'],
+    sessions: signal([]),
+    dags: signal([]),
+    status: signal('live'),
+    error: signal(null),
+    version,
+    stale: signal(false),
+    diffStatsBySessionId,
+    loadDiffStats: opts.loadDiffStats ?? (async () => {}),
+    refresh: async () => {},
+    sendCommand: async () => ({ success: true }),
+    dispose: () => {},
+  }
+}
+
+describe('truncateCwd', () => {
+  it('keeps last two segments of a github URL', () => {
+    expect(truncateCwd('https://github.com/acme/widgets').display).toBe('acme/widgets')
+  })
+
+  it('strips .git suffix', () => {
+    expect(truncateCwd('https://github.com/acme/widgets.git').display).toBe('acme/widgets')
+  })
+
+  it('strips trailing slashes', () => {
+    expect(truncateCwd('/workspace/repos/proj/').display).toBe('repos/proj')
+  })
+
+  it('truncates deep paths to last two segments', () => {
+    expect(truncateCwd('/a/b/c/d/e').display).toBe('d/e')
+  })
+
+  it('returns full path in .full regardless', () => {
+    const t = truncateCwd('/a/b/c/d/e')
+    expect(t.full).toBe('/a/b/c/d/e')
+  })
+
+  it('handles single segment', () => {
+    expect(truncateCwd('widgets').display).toBe('widgets')
+  })
+})
+
+describe('WorktreeHeader', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders branch and truncated cwd', () => {
+    const store = makeStore()
+    render(<WorktreeHeader session={makeSession()} store={store} />)
+    expect(screen.getByTestId('worktree-branch').textContent).toBe('feature/x')
+    expect(screen.getByTestId('worktree-cwd').textContent).toBe('acme/widgets')
+  })
+
+  it('puts the full repo path in the cwd title attribute', () => {
+    const store = makeStore()
+    render(<WorktreeHeader session={makeSession()} store={store} />)
+    expect(screen.getByTestId('worktree-cwd').getAttribute('title')).toBe(
+      'https://github.com/acme/widgets'
+    )
+  })
+
+  it('returns null when neither branch nor repo is set', () => {
+    const store = makeStore()
+    const { container } = render(
+      <WorktreeHeader session={makeSession({ branch: undefined, repo: undefined })} store={store} />
+    )
+    expect(container.querySelector('[data-testid="worktree-header"]')).toBeNull()
+  })
+
+  it('omits stats badge when diff-viewer feature is disabled', async () => {
+    const loadDiffStats = vi.fn().mockResolvedValue(undefined)
+    const store = makeStore({ features: [], loadDiffStats })
+    render(<WorktreeHeader session={makeSession()} store={store} />)
+    expect(screen.queryByTestId('worktree-stats')).toBeNull()
+    expect(screen.queryByTestId('worktree-stats-truncated')).toBeNull()
+    await Promise.resolve()
+    expect(loadDiffStats).not.toHaveBeenCalled()
+  })
+
+  it('renders +N −M stats when feature enabled and cache has entry', () => {
+    const stats: DiffStats = { filesChanged: 3, insertions: 12, deletions: 4, truncated: false }
+    const store = makeStore({
+      features: ['diff-viewer'],
+      initialStats: new Map([['s1', stats]]),
+    })
+    render(<WorktreeHeader session={makeSession()} store={store} />)
+    const badge = screen.getByTestId('worktree-stats')
+    expect(badge.textContent).toContain('+12')
+    expect(badge.textContent).toContain('−4')
+    expect(badge.getAttribute('title')).toBe('3 files changed, +12 −4')
+  })
+
+  it('singularizes the files label when exactly one file changed', () => {
+    const stats: DiffStats = { filesChanged: 1, insertions: 2, deletions: 0, truncated: false }
+    const store = makeStore({
+      features: ['diff-viewer'],
+      initialStats: new Map([['s1', stats]]),
+    })
+    render(<WorktreeHeader session={makeSession()} store={store} />)
+    expect(screen.getByTestId('worktree-stats').getAttribute('title')).toBe(
+      '1 file changed, +2 −0'
+    )
+  })
+
+  it('renders "no changes" label when all counters are zero', () => {
+    const stats: DiffStats = { filesChanged: 0, insertions: 0, deletions: 0, truncated: false }
+    const store = makeStore({
+      features: ['diff-viewer'],
+      initialStats: new Map([['s1', stats]]),
+    })
+    render(<WorktreeHeader session={makeSession()} store={store} />)
+    expect(screen.getByTestId('worktree-stats').textContent).toContain('no changes')
+  })
+
+  it('renders +∞ −∞ when the diff is truncated', () => {
+    const stats: DiffStats = { filesChanged: 999, insertions: 0, deletions: 0, truncated: true }
+    const store = makeStore({
+      features: ['diff-viewer'],
+      initialStats: new Map([['s1', stats]]),
+    })
+    render(<WorktreeHeader session={makeSession()} store={store} />)
+    const badge = screen.getByTestId('worktree-stats-truncated')
+    expect(badge.textContent).toContain('+∞')
+    expect(badge.textContent).toContain('−∞')
+    expect(badge.getAttribute('title')).toMatch(/truncated/i)
+  })
+
+  it('calls loadDiffStats on mount when feature enabled and cache is empty', async () => {
+    const loadDiffStats = vi.fn().mockResolvedValue(undefined)
+    const store = makeStore({ features: ['diff-viewer'], loadDiffStats })
+    render(<WorktreeHeader session={makeSession()} store={store} />)
+    await waitFor(() => expect(loadDiffStats).toHaveBeenCalledWith('s1'))
+  })
+
+  it('does not re-fetch when stats are already cached', async () => {
+    const loadDiffStats = vi.fn().mockResolvedValue(undefined)
+    const stats: DiffStats = { filesChanged: 1, insertions: 1, deletions: 0, truncated: false }
+    const store = makeStore({
+      features: ['diff-viewer'],
+      initialStats: new Map([['s1', stats]]),
+      loadDiffStats,
+    })
+    render(<WorktreeHeader session={makeSession()} store={store} />)
+    await Promise.resolve()
+    expect(loadDiffStats).not.toHaveBeenCalled()
+  })
+})

--- a/test/state/diff-stats.test.ts
+++ b/test/state/diff-stats.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createApiClient } from '../../src/api/client'
+import { installMockEventSource, MockEventSource } from '../sse-mock'
+import type { ApiSession, ApiDagGraph, VersionInfo, WorkspaceDiff } from '../../src/api/types'
+
+const BASE_URL = 'https://example.com'
+const TOKEN = 'tok'
+
+const SESSION: ApiSession = {
+  id: 's1',
+  slug: 'fast-cat',
+  status: 'running',
+  command: '/task x',
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+  childIds: [],
+  needsAttention: false,
+  attentionReasons: [],
+  quickActions: [],
+  mode: 'task',
+  conversation: [],
+  branch: 'feature/x',
+  repo: 'https://github.com/acme/widgets',
+}
+const VERSION: VersionInfo = { apiVersion: '1', libraryVersion: '0.1.0', features: ['diff-viewer'] }
+const DAGS: ApiDagGraph[] = []
+
+const DIFF_V1: WorkspaceDiff = {
+  sessionId: 's1',
+  branch: 'feature/x',
+  baseBranch: 'main',
+  patch: '',
+  truncated: false,
+  stats: { filesChanged: 2, insertions: 5, deletions: 1 },
+}
+const DIFF_V2: WorkspaceDiff = {
+  ...DIFF_V1,
+  stats: { filesChanged: 3, insertions: 10, deletions: 2 },
+}
+
+vi.mock('../../src/state/persist', () => ({
+  loadSnapshot: vi.fn().mockResolvedValue(null),
+  saveSnapshot: vi.fn().mockResolvedValue(undefined),
+  clearSnapshot: vi.fn().mockResolvedValue(undefined),
+}))
+
+function stubFetch(diffStack: WorkspaceDiff[]) {
+  return vi.fn().mockImplementation((url: string) => {
+    if (url.includes('/api/version')) {
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: VERSION }) })
+    }
+    if (url.includes('/api/sessions/s1/diff')) {
+      const next = diffStack.shift() ?? DIFF_V1
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: next }) })
+    }
+    if (url.includes('/api/sessions')) {
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: [SESSION] }) })
+    }
+    if (url.includes('/api/dags')) {
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: DAGS }) })
+    }
+    return Promise.resolve({ ok: false, status: 404, statusText: 'NF', json: () => Promise.resolve({ data: null, error: 'Not found' }) })
+  })
+}
+
+describe('createConnectionStore diff stats cache', () => {
+  let mock: ReturnType<typeof installMockEventSource>
+
+  beforeEach(() => {
+    mock = installMockEventSource()
+  })
+
+  afterEach(() => {
+    mock.restore()
+    vi.unstubAllGlobals()
+  })
+
+  it('loadDiffStats populates diffStatsBySessionId and dedupes in-flight calls', async () => {
+    const fetchMock = stubFetch([DIFF_V1])
+    vi.stubGlobal('fetch', fetchMock)
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-diff-1')
+
+    const p1 = store.loadDiffStats('s1')
+    const p2 = store.loadDiffStats('s1')
+    await Promise.all([p1, p2])
+
+    const diffCalls = fetchMock.mock.calls.filter((c) =>
+      (c[0] as string).includes('/api/sessions/s1/diff')
+    )
+    expect(diffCalls.length).toBe(1)
+
+    expect(store.diffStatsBySessionId.value.get('s1')).toEqual({
+      filesChanged: 2,
+      insertions: 5,
+      deletions: 1,
+      truncated: false,
+    })
+    store.dispose()
+  })
+
+  it('swallows errors and leaves the cache unchanged', async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/api/version')) return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: VERSION }) })
+      if (url.includes('/api/sessions/s1/diff')) {
+        return Promise.resolve({ ok: false, status: 500, statusText: 'Err', json: () => Promise.resolve({ data: null, error: 'boom' }) })
+      }
+      if (url.includes('/api/sessions')) return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: [SESSION] }) })
+      if (url.includes('/api/dags')) return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: [] }) })
+      return Promise.resolve({ ok: false, status: 404, statusText: 'NF', json: () => Promise.resolve({ data: null, error: 'Not found' }) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-diff-err')
+
+    await expect(store.loadDiffStats('s1')).resolves.toBeUndefined()
+    expect(store.diffStatsBySessionId.value.has('s1')).toBe(false)
+    store.dispose()
+  })
+
+  it('session_updated SSE event refreshes a cached entry', async () => {
+    const fetchMock = stubFetch([DIFF_V1, DIFF_V2])
+    vi.stubGlobal('fetch', fetchMock)
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-diff-sse')
+
+    const es = mock.instances.get(`${BASE_URL}/api/events?token=${encodeURIComponent(TOKEN)}`)
+    expect(es).toBeInstanceOf(MockEventSource)
+    es?.simulateOpen()
+    await new Promise((r) => setTimeout(r, 0))
+
+    await store.loadDiffStats('s1')
+    expect(store.diffStatsBySessionId.value.get('s1')?.insertions).toBe(5)
+
+    es?.push({
+      type: 'session_updated',
+      session: { ...SESSION, updatedAt: '2024-01-02' },
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(store.diffStatsBySessionId.value.get('s1')?.insertions).toBe(10)
+    store.dispose()
+  })
+
+  it('session_deleted SSE event drops the cache entry', async () => {
+    const fetchMock = stubFetch([DIFF_V1])
+    vi.stubGlobal('fetch', fetchMock)
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-diff-del')
+
+    const es = mock.instances.get(`${BASE_URL}/api/events?token=${encodeURIComponent(TOKEN)}`)
+    es?.simulateOpen()
+    await new Promise((r) => setTimeout(r, 0))
+
+    await store.loadDiffStats('s1')
+    expect(store.diffStatsBySessionId.value.has('s1')).toBe(true)
+
+    es?.push({ type: 'session_deleted', sessionId: 's1' })
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(store.diffStatsBySessionId.value.has('s1')).toBe(false)
+    store.dispose()
+  })
+
+  it('session_updated for an uncached session does not trigger a diff fetch', async () => {
+    const fetchMock = stubFetch([])
+    vi.stubGlobal('fetch', fetchMock)
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-diff-nocache')
+
+    const es = mock.instances.get(`${BASE_URL}/api/events?token=${encodeURIComponent(TOKEN)}`)
+    es?.simulateOpen()
+    await new Promise((r) => setTimeout(r, 0))
+
+    es?.push({
+      type: 'session_updated',
+      session: { ...SESSION, updatedAt: '2024-01-02' },
+    })
+    await new Promise((r) => setTimeout(r, 0))
+
+    const diffCalls = fetchMock.mock.calls.filter((c) =>
+      (c[0] as string).includes('/api/sessions/s1/diff')
+    )
+    expect(diffCalls.length).toBe(0)
+    expect(store.diffStatsBySessionId.value.has('s1')).toBe(false)
+    store.dispose()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a sub-header below the ChatPane header showing `branch`, truncated `cwd`, and `+N −M` diff stats.
- Extends `ConnectionStore` with a `diffStatsBySessionId` cache + `loadDiffStats(sessionId)` loader; calls `GET /api/sessions/:id/diff` lazily on pane open and refreshes cached entries on `session_updated` SSE. Cache drops on `session_deleted`. In-flight de-duped.
- Feature-gates the stats badge on `diff-viewer`; when disabled, the header degrades to branch + cwd only.
- Renders `+∞ −∞` with a tooltip when `diff.truncated` is true, `no changes` when all counters are zero, and a singular/plural \"files changed\" count in the stat tooltip.

## Why
One of the \"free wins\" in the de-Telegramification plan: put repo/worktree context directly in the chat header instead of leaving users to cross-reference branch/PR state elsewhere.

## Assumptions
- `ApiSession` has no `cwd` field today, so `session.repo` is used as the cwd source. The last-two-segments rule handles both file paths (`/a/b/c/d/e` → `d/e`) and git URLs (`github.com/acme/widgets` → `acme/widgets`), with the full string in the `title` attribute.
- `loadDiffStats` failures are silently swallowed — the header falls back to branch + cwd with no stats, per the spec.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — all 278 unit/integration tests pass (31 files)
  - New: `test/components/WorktreeHeader.test.tsx` (16 cases covering `truncateCwd`, feature gating, cached vs uncached render, truncated banner, files-count singular/plural)
  - New: `test/state/diff-stats.test.ts` (5 cases covering in-flight dedup, error swallowing, SSE-driven refresh, cache eviction on delete, no-fetch on uncached update)
- E2E not run (out of scope for this task; plan specifies unit + integration only).

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  api-foundation["✅ API foundation: types, client, features, router"]
  structured-task-creation["✅ Refactor task creation: POST /api/sessions flow"]
  worktree-header["✅ Worktree header: branch, cwd, diff stats"]
  pr-preview-card["✅ PR preview card: title, state, checks, body"]
  session-tabs["✅ Session tabs: diff viewer and screenshots gallery"]
  web-push["✅ Web Push: notifications, subscriptions, service worker"]
  parallel-variants-ui["✅ Parallel variants: N-session group layout and picker"]
  api-foundation --> structured-task-creation
  api-foundation --> worktree-header
  api-foundation --> pr-preview-card
  api-foundation --> session-tabs
  api-foundation --> web-push
  api-foundation --> parallel-variants-ui
  structured-task-creation --> parallel-variants-ui
  class api-foundation done
  class structured-task-creation done
  class worktree-header done
  class worktree-header current
  class pr-preview-card done
  class session-tabs done
  class web-push done
  class parallel-variants-ui done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | API foundation: types, client, features, router | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/4) |
| 2 | Refactor task creation: POST /api/sessions flow | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/5) |
| 3 | **Worktree header: branch, cwd, diff stats** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/6) |
| 4 | PR preview card: title, state, checks, body | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/7) |
| 5 | Session tabs: diff viewer and screenshots gallery | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/8) |
| 6 | Web Push: notifications, subscriptions, service worker | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/10) |
| 7 | Parallel variants: N-session group layout and picker | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/9) |

**Progress:** 7/7 complete

<!-- dag-status-end -->



