### PR TITLE
[minions] feat(ui): inline PR preview card in ChatPane

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { SlashCommandMenu, type SlashCommand } from './chat/SlashCommandMenu'
 import { SessionTabs, type SessionTabId } from './chat/SessionTabs'
 import { DiffTab } from './chat/DiffTab'
 import { ScreenshotsTab } from './chat/ScreenshotsTab'
+import { PrPreviewCard } from './components/PrPreviewCard'
 import { hasFeature } from './api/features'
 import type { ConnectionStore } from './state/types'
 import { confirm } from './hooks/useConfirm'
@@ -249,6 +250,13 @@ function ChatPane({
       >
         {activeTab === 'chat' && (
           <>
+            {session.prUrl && hasFeature(store, 'pr-preview') && (
+              <PrPreviewCard
+                sessionId={session.id}
+                prUrl={session.prUrl}
+                client={store.client}
+              />
+            )}
             <ConversationView messages={session.conversation} />
             <div class="shrink-0 border-t border-slate-200 dark:border-slate-700">
               <QuickActionsBar actions={session.quickActions} onAction={handleQuickAction} />

--- a/src/chat/ConversationView.tsx
+++ b/src/chat/ConversationView.tsx
@@ -1,25 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
-import { marked } from 'marked'
-import DOMPurify from 'dompurify'
 import type { ConversationMessage } from '../api/types'
-
-marked.setOptions({ gfm: true, breaks: true })
+import { renderMarkdown } from '../components/markdown'
 
 interface ConversationViewProps {
   messages: ConversationMessage[]
-}
-
-function renderMarkdown(text: string): string {
-  const raw = marked.parse(text, { async: false }) as string
-  return DOMPurify.sanitize(raw, {
-    ALLOWED_TAGS: [
-      'p', 'br', 'strong', 'em', 'code', 'pre', 'blockquote',
-      'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-      'a', 'hr', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
-      'del', 'ins', 'span', 'div',
-    ],
-    ALLOWED_ATTR: ['href', 'target', 'rel', 'class'],
-  })
 }
 
 function AssistantMessage({ text }: { text: string }) {

--- a/src/components/PrPreviewCard.tsx
+++ b/src/components/PrPreviewCard.tsx
@@ -1,0 +1,307 @@
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import type { ApiClient } from '../api/client'
+import type { PrCheck, PrCheckStatus, PrPreview, PrState } from '../api/types'
+import { renderMarkdown } from './markdown'
+
+export const PR_PREVIEW_POLL_MS = 30_000
+
+interface PrPreviewCardProps {
+  sessionId: string
+  prUrl: string
+  client: ApiClient
+}
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; pr: PrPreview }
+
+export interface ChecksRollup {
+  pass: number
+  fail: number
+  pending: number
+  neutral: number
+  total: number
+}
+
+export function rollupChecks(checks: PrCheck[]): ChecksRollup {
+  const rollup: ChecksRollup = { pass: 0, fail: 0, pending: 0, neutral: 0, total: checks.length }
+  for (const c of checks) rollup[bucketForStatus(c.status)] += 1
+  return rollup
+}
+
+function bucketForStatus(status: PrCheckStatus): 'pass' | 'fail' | 'pending' | 'neutral' {
+  switch (status) {
+    case 'success':
+      return 'pass'
+    case 'failure':
+    case 'action_required':
+    case 'timed_out':
+    case 'cancelled':
+      return 'fail'
+    case 'queued':
+    case 'in_progress':
+    case 'pending':
+      return 'pending'
+    case 'neutral':
+    case 'skipped':
+    case 'stale':
+      return 'neutral'
+  }
+}
+
+function isTerminalState(state: PrState): boolean {
+  return state === 'merged' || state === 'closed'
+}
+
+function stateBadgeClasses(state: PrState): string {
+  if (state === 'merged') return 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300'
+  if (state === 'closed') return 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300'
+  return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300'
+}
+
+function stateLabel(state: PrState): string {
+  return state.toUpperCase()
+}
+
+function ChecksSummary({ rollup }: { rollup: ChecksRollup }) {
+  if (rollup.total === 0) {
+    return (
+      <span class="text-xs text-slate-500 dark:text-slate-400" data-testid="pr-checks-empty">
+        no checks
+      </span>
+    )
+  }
+  return (
+    <span class="flex items-center gap-2 text-xs" data-testid="pr-checks-summary">
+      {rollup.pass > 0 && (
+        <span class="flex items-center gap-1 text-green-700 dark:text-green-400" data-testid="pr-checks-pass">
+          <span class="inline-block h-1.5 w-1.5 rounded-full bg-green-500" />
+          {rollup.pass} pass
+        </span>
+      )}
+      {rollup.fail > 0 && (
+        <span class="flex items-center gap-1 text-red-700 dark:text-red-400" data-testid="pr-checks-fail">
+          <span class="inline-block h-1.5 w-1.5 rounded-full bg-red-500" />
+          {rollup.fail} fail
+        </span>
+      )}
+      {rollup.pending > 0 && (
+        <span class="flex items-center gap-1 text-amber-700 dark:text-amber-400" data-testid="pr-checks-pending">
+          <span class="inline-block h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
+          {rollup.pending} pending
+        </span>
+      )}
+      {rollup.neutral > 0 && (
+        <span class="flex items-center gap-1 text-slate-500 dark:text-slate-400" data-testid="pr-checks-neutral">
+          <span class="inline-block h-1.5 w-1.5 rounded-full bg-slate-400" />
+          {rollup.neutral}
+        </span>
+      )}
+    </span>
+  )
+}
+
+function AuthorChip({ login }: { login: string }) {
+  const avatar = `https://github.com/${encodeURIComponent(login)}.png?size=32`
+  return (
+    <span class="inline-flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-300" data-testid="pr-author">
+      <img
+        src={avatar}
+        alt=""
+        width={16}
+        height={16}
+        class="h-4 w-4 rounded-full bg-slate-200 dark:bg-slate-700"
+        referrerpolicy="no-referrer"
+        onError={(e) => {
+          (e.currentTarget as HTMLImageElement).style.visibility = 'hidden'
+        }}
+      />
+      <span class="font-medium">{login}</span>
+    </span>
+  )
+}
+
+function LoadingCard() {
+  return (
+    <div
+      class="mx-3 mt-3 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-xs text-slate-500 dark:text-slate-400"
+      data-testid="pr-preview-loading"
+    >
+      Loading PR preview…
+    </div>
+  )
+}
+
+function ErrorCard({ message, prUrl, onRetry }: { message: string; prUrl: string; onRetry: () => void }) {
+  return (
+    <div
+      class="mx-3 mt-3 rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/40 px-3 py-2 flex items-center gap-2"
+      data-testid="pr-preview-error"
+    >
+      <span class="text-xs text-red-700 dark:text-red-300 flex-1 min-w-0 truncate">{message}</span>
+      <button
+        type="button"
+        onClick={onRetry}
+        class="text-xs font-medium underline text-red-700 dark:text-red-300"
+        data-testid="pr-preview-retry"
+      >
+        Retry
+      </button>
+      <a
+        href={prUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-xs font-medium underline text-red-700 dark:text-red-300"
+      >
+        Open on GitHub
+      </a>
+    </div>
+  )
+}
+
+export function PrPreviewCard({ sessionId, prUrl, client }: PrPreviewCardProps) {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' })
+  const [expanded, setExpanded] = useState(false)
+  const [reloadNonce, setReloadNonce] = useState(0)
+  const aliveRef = useRef(true)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    aliveRef.current = true
+    setState({ kind: 'loading' })
+
+    function clearTimer() {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+
+    async function load() {
+      try {
+        const pr = await client.getPr(sessionId)
+        if (!aliveRef.current) return
+        setState({ kind: 'ready', pr })
+        clearTimer()
+        if (!isTerminalState(pr.state)) {
+          timerRef.current = setTimeout(load, PR_PREVIEW_POLL_MS)
+        }
+      } catch (e) {
+        if (!aliveRef.current) return
+        const message = e instanceof Error ? e.message : String(e)
+        setState({ kind: 'error', message })
+        clearTimer()
+        timerRef.current = setTimeout(load, PR_PREVIEW_POLL_MS)
+      }
+    }
+
+    void load()
+
+    return () => {
+      aliveRef.current = false
+      clearTimer()
+    }
+  }, [sessionId, client, reloadNonce])
+
+  const bodyHtml = useMemo(() => {
+    if (state.kind !== 'ready') return ''
+    const body = state.pr.body?.trim()
+    return body ? renderMarkdown(body) : ''
+  }, [state])
+
+  if (state.kind === 'loading') return <LoadingCard />
+  if (state.kind === 'error') {
+    return (
+      <ErrorCard
+        message={state.message}
+        prUrl={prUrl}
+        onRetry={() => {
+          setState({ kind: 'loading' })
+          setReloadNonce((n) => n + 1)
+        }}
+      />
+    )
+  }
+
+  const pr = state.pr
+  const rollup = rollupChecks(pr.checks)
+
+  return (
+    <section
+      class="mx-3 mt-3 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden"
+      data-testid="pr-preview-card"
+    >
+      <header class="flex flex-wrap items-center gap-2 px-3 py-2 border-b border-slate-100 dark:border-slate-700">
+        <span
+          class={`px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide ${stateBadgeClasses(pr.state)}`}
+          data-testid="pr-state-badge"
+        >
+          {stateLabel(pr.state)}
+        </span>
+        {pr.draft && (
+          <span
+            class="px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-300"
+            data-testid="pr-draft-pill"
+          >
+            Draft
+          </span>
+        )}
+        <a
+          href={pr.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900 dark:text-slate-100 hover:underline"
+          data-testid="pr-title"
+        >
+          {pr.title}
+        </a>
+        <a
+          href={pr.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-xs font-mono text-slate-500 dark:text-slate-400 hover:underline"
+          data-testid="pr-number"
+        >
+          #{pr.number}
+        </a>
+      </header>
+      <div class="flex flex-wrap items-center gap-x-4 gap-y-1 px-3 py-2 text-xs text-slate-600 dark:text-slate-300">
+        <span class="font-mono truncate" data-testid="pr-branches">
+          <span class="text-slate-500 dark:text-slate-400">{pr.baseBranch}</span>
+          <span class="mx-1">←</span>
+          <span>{pr.branch}</span>
+        </span>
+        <AuthorChip login={pr.author} />
+        <ChecksSummary rollup={rollup} />
+        {pr.mergeable === false && (
+          <span
+            class="text-[10px] font-medium uppercase tracking-wide text-red-700 dark:text-red-400"
+            data-testid="pr-mergeable-conflict"
+          >
+            conflicts
+          </span>
+        )}
+      </div>
+      {bodyHtml && (
+        <div class="border-t border-slate-100 dark:border-slate-700">
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            class="w-full px-3 py-1.5 text-left text-xs font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50"
+            data-testid="pr-body-toggle"
+          >
+            {expanded ? 'Hide description' : 'Show description'}
+          </button>
+          {expanded && (
+            <div
+              class="px-3 pb-3 prose prose-sm dark:prose-invert max-w-none prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-pre:rounded prose-pre:px-2 prose-pre:py-1 prose-pre:text-xs prose-code:before:content-none prose-code:after:content-none prose-code:bg-slate-100 dark:prose-code:bg-slate-800 prose-code:px-1 prose-code:rounded text-slate-700 dark:text-slate-200"
+              dangerouslySetInnerHTML={{ __html: bodyHtml }}
+              data-testid="pr-body"
+            />
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/markdown.ts
+++ b/src/components/markdown.ts
@@ -1,0 +1,18 @@
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
+
+marked.setOptions({ gfm: true, breaks: true })
+
+const ALLOWED_TAGS = [
+  'p', 'br', 'strong', 'em', 'code', 'pre', 'blockquote',
+  'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'a', 'hr', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  'del', 'ins', 'span', 'div',
+]
+
+const ALLOWED_ATTR = ['href', 'target', 'rel', 'class']
+
+export function renderMarkdown(text: string): string {
+  const raw = marked.parse(text, { async: false }) as string
+  return DOMPurify.sanitize(raw, { ALLOWED_TAGS, ALLOWED_ATTR })
+}

--- a/test/components/PrPreviewCard.test.tsx
+++ b/test/components/PrPreviewCard.test.tsx
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor, act } from '@testing-library/preact'
+import { PrPreviewCard, rollupChecks, PR_PREVIEW_POLL_MS } from '../../src/components/PrPreviewCard'
+import type { PrCheck, PrPreview } from '../../src/api/types'
+import type { ApiClient } from '../../src/api/client'
+
+function makePr(overrides: Partial<PrPreview> = {}): PrPreview {
+  return {
+    number: 42,
+    url: 'https://github.com/acme/widgets/pull/42',
+    title: 'Add shiny feature',
+    body: 'Fixes the **bug** everyone cares about.',
+    state: 'open',
+    draft: false,
+    mergeable: true,
+    branch: 'feature/shiny',
+    baseBranch: 'main',
+    author: 'octocat',
+    updatedAt: '2026-04-19T00:00:00Z',
+    checks: [],
+    ...overrides,
+  }
+}
+
+function makeClient(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    baseUrl: 'https://example.com',
+    token: 't',
+    getVersion: vi.fn(),
+    getSessions: vi.fn(),
+    getDags: vi.fn(),
+    sendCommand: vi.fn(),
+    sendMessage: vi.fn(),
+    createSession: vi.fn(),
+    createSessionVariants: vi.fn(),
+    getPr: vi.fn(),
+    getDiff: vi.fn(),
+    listScreenshots: vi.fn(),
+    fetchScreenshotBlob: vi.fn(),
+    getVapidKey: vi.fn(),
+    subscribePush: vi.fn(),
+    unsubscribePush: vi.fn(),
+    openEventStream: vi.fn(),
+    ...overrides,
+  } as ApiClient
+}
+
+describe('rollupChecks', () => {
+  it('buckets every PrCheckStatus into pass/fail/pending/neutral', () => {
+    const checks: PrCheck[] = [
+      { name: 'a', status: 'success' },
+      { name: 'b', status: 'failure' },
+      { name: 'c', status: 'action_required' },
+      { name: 'd', status: 'timed_out' },
+      { name: 'e', status: 'cancelled' },
+      { name: 'f', status: 'queued' },
+      { name: 'g', status: 'in_progress' },
+      { name: 'h', status: 'pending' },
+      { name: 'i', status: 'neutral' },
+      { name: 'j', status: 'skipped' },
+      { name: 'k', status: 'stale' },
+    ]
+    expect(rollupChecks(checks)).toEqual({ pass: 1, fail: 4, pending: 3, neutral: 3, total: 11 })
+  })
+
+  it('returns zero rollup on empty input', () => {
+    expect(rollupChecks([])).toEqual({ pass: 0, fail: 0, pending: 0, neutral: 0, total: 0 })
+  })
+})
+
+describe('PrPreviewCard — loading', () => {
+  afterEach(() => cleanup())
+
+  it('shows loading card before fetch resolves', () => {
+    const client = makeClient({ getPr: vi.fn(() => new Promise<PrPreview>(() => {})) })
+    render(<PrPreviewCard sessionId="s-1" prUrl="https://github.com/a/b/pull/1" client={client} />)
+    expect(screen.getByTestId('pr-preview-loading')).toBeTruthy()
+  })
+})
+
+describe('PrPreviewCard — ready state', () => {
+  afterEach(() => cleanup())
+
+  it('renders title, number, state badge, and base←head', async () => {
+    const pr = makePr()
+    const client = makeClient({ getPr: vi.fn(async () => pr) })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+
+    await waitFor(() => expect(screen.getByTestId('pr-preview-card')).toBeTruthy())
+    expect(screen.getByTestId('pr-title').textContent).toBe('Add shiny feature')
+    expect(screen.getByTestId('pr-number').textContent).toBe('#42')
+    expect(screen.getByTestId('pr-state-badge').textContent).toBe('OPEN')
+    const branches = screen.getByTestId('pr-branches').textContent ?? ''
+    expect(branches).toContain('main')
+    expect(branches).toContain('feature/shiny')
+  })
+
+  it('shows DRAFT pill when draft=true', async () => {
+    const pr = makePr({ draft: true })
+    const client = makeClient({ getPr: vi.fn(async () => pr) })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+    await waitFor(() => expect(screen.getByTestId('pr-draft-pill')).toBeTruthy())
+  })
+
+  it('renders MERGED badge for merged state', async () => {
+    const pr = makePr({ state: 'merged' })
+    const client = makeClient({ getPr: vi.fn(async () => pr) })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+    await waitFor(() => expect(screen.getByTestId('pr-state-badge').textContent).toBe('MERGED'))
+  })
+
+  it('renders CLOSED badge for closed state', async () => {
+    const pr = makePr({ state: 'closed' })
+    const client = makeClient({ getPr: vi.fn(async () => pr) })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+    await waitFor(() => expect(screen.getByTestId('pr-state-badge').textContent).toBe('CLOSED'))
+  })
+
+  it('surfaces conflicts when mergeable is false', async () => {
+    const pr = makePr({ mergeable: false })
+    const client = makeClient({ getPr: vi.fn(async () => pr) })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+    await waitFor(() => expect(screen.getByTestId('pr-mergeable-conflict')).toBeTruthy())
+  })
+
+  it('renders author login', async () => {
+    const pr = makePr({ author: 'hubot' })
+    const client = makeClient({ getPr: vi.fn(async () => pr) })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+    await waitFor(() => expect(screen.getByTestId('pr-author').textContent).toContain('hubot'))
+  })
+
+  it('renders checks roll-up', async () => {
+    const pr = makePr({
+      checks: [
+        { name: 'lint', status: 'success' },
+        { name: 'test', status: 'success' },
+        { name: 'build', status: 'failure' },
+        { name: 'deploy', status: 'in_progress' },
+      ],
+    })
+    const client = makeClient({ getPr: vi.fn(async () => pr) })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+    await waitFor(() => expect(screen.getByTestId('pr-checks-summary')).toBeTruthy())
+    expect(screen.getByTestId('pr-checks-pass').textContent).toContain('2 pass')
+    expect(screen.getByTestId('pr-checks-fail').textContent).toContain('1 fail')
+    expect(screen.getByTestId('pr-checks-pending').textContent).toContain('1 pending')
+  })
+
+  it('renders "no checks" when none attached', async () => {
+    const pr = makePr({ checks: [] })
+    const client = makeClient({ getPr: vi.fn(async () => pr) })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+    await waitFor(() => expect(screen.getByTestId('pr-checks-empty')).toBeTruthy())
+  })
+
+  it('toggles the PR body (markdown-rendered) when expand button clicked', async () => {
+    const pr = makePr({ body: 'Fixes the **bug** everyone cares about.' })
+    const client = makeClient({ getPr: vi.fn(async () => pr) })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+    await waitFor(() => expect(screen.getByTestId('pr-body-toggle')).toBeTruthy())
+    expect(screen.queryByTestId('pr-body')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('pr-body-toggle'))
+    const body = screen.getByTestId('pr-body')
+    expect(body.innerHTML).toContain('<strong>bug</strong>')
+  })
+
+  it('omits the body toggle when the body is empty', async () => {
+    const pr = makePr({ body: '' })
+    const client = makeClient({ getPr: vi.fn(async () => pr) })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+    await waitFor(() => expect(screen.getByTestId('pr-preview-card')).toBeTruthy())
+    expect(screen.queryByTestId('pr-body-toggle')).toBeNull()
+  })
+})
+
+describe('PrPreviewCard — error state', () => {
+  afterEach(() => cleanup())
+
+  it('renders an error card and retry link when getPr rejects', async () => {
+    const client = makeClient({ getPr: vi.fn(async () => { throw new Error('boom') }) })
+    render(<PrPreviewCard sessionId="s-1" prUrl="https://github.com/a/b/pull/1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('pr-preview-error')).toBeTruthy())
+    expect(screen.getByTestId('pr-preview-error').textContent).toContain('boom')
+    expect(screen.getByTestId('pr-preview-retry')).toBeTruthy()
+  })
+
+  it('retry re-invokes getPr and can transition to ready state', async () => {
+    let calls = 0
+    const pr = makePr()
+    const getPr = vi.fn(async () => {
+      calls += 1
+      if (calls === 1) throw new Error('nope')
+      return pr
+    })
+    const client = makeClient({ getPr })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+    await waitFor(() => expect(screen.getByTestId('pr-preview-error')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('pr-preview-retry'))
+    await waitFor(() => expect(screen.getByTestId('pr-preview-card')).toBeTruthy())
+    expect(getPr).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('PrPreviewCard — polling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    cleanup()
+  })
+
+  it('re-polls every PR_PREVIEW_POLL_MS while the PR is open', async () => {
+    const pr = makePr({ state: 'open' })
+    const getPr = vi.fn(async () => pr)
+    const client = makeClient({ getPr })
+    render(<PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />)
+
+    await vi.waitFor(() => expect(getPr).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PR_PREVIEW_POLL_MS)
+    })
+    expect(getPr).toHaveBeenCalledTimes(2)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PR_PREVIEW_POLL_MS)
+    })
+    expect(getPr).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops polling once the PR transitions to merged', async () => {
+    let callCount = 0
+    const getPr = vi.fn(async () => {
+      callCount += 1
+      return makePr({ state: callCount >= 2 ? 'merged' : 'open' })
+    })
+    const client = makeClient({ getPr })
+    render(<PrPreviewCard sessionId="s-1" prUrl="https://github.com/a/b/pull/1" client={client} />)
+
+    await vi.waitFor(() => expect(getPr).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PR_PREVIEW_POLL_MS)
+    })
+    expect(getPr).toHaveBeenCalledTimes(2)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PR_PREVIEW_POLL_MS * 3)
+    })
+    expect(getPr).toHaveBeenCalledTimes(2)
+  })
+
+  it('teardown on unmount aborts pending polls', async () => {
+    const pr = makePr({ state: 'open' })
+    const getPr = vi.fn(async () => pr)
+    const client = makeClient({ getPr })
+    const { unmount } = render(
+      <PrPreviewCard sessionId="s-1" prUrl={pr.url} client={client} />
+    )
+    await vi.waitFor(() => expect(getPr).toHaveBeenCalledTimes(1))
+    unmount()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PR_PREVIEW_POLL_MS * 5)
+    })
+    expect(getPr).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/components/markdown.test.ts
+++ b/test/components/markdown.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { renderMarkdown } from '../../src/components/markdown'
+
+describe('renderMarkdown', () => {
+  it('renders bold and italic', () => {
+    const out = renderMarkdown('hello **world** and *moon*')
+    expect(out).toContain('<strong>world</strong>')
+    expect(out).toContain('<em>moon</em>')
+  })
+
+  it('renders fenced code blocks', () => {
+    const out = renderMarkdown('```\nconst x = 1\n```')
+    expect(out).toContain('<pre>')
+    expect(out).toContain('const x = 1')
+  })
+
+  it('strips <script> tags (XSS)', () => {
+    const out = renderMarkdown('ok <script>alert(1)</script> still ok')
+    expect(out).not.toContain('<script>')
+    expect(out).not.toContain('alert(1)')
+  })
+
+  it('strips unsafe attributes like onerror', () => {
+    const out = renderMarkdown('<img src=x onerror=alert(1)>')
+    expect(out.toLowerCase()).not.toContain('onerror')
+  })
+
+  it('strips <img> tags — only explicitly allowed tags remain', () => {
+    const out = renderMarkdown('![alt](http://example.com/x.png)')
+    expect(out).not.toContain('<img')
+  })
+
+  it('preserves GFM tables', () => {
+    const md = '| a | b |\n| --- | --- |\n| 1 | 2 |'
+    const out = renderMarkdown(md)
+    expect(out).toContain('<table>')
+    expect(out).toContain('<th>a</th>')
+  })
+
+  it('preserves anchor tags with href', () => {
+    const out = renderMarkdown('[link](https://example.com)')
+    expect(out).toContain('<a href="https://example.com">link</a>')
+  })
+})


### PR DESCRIPTION
## Summary

- New `PrPreviewCard` mounts below the ChatPane header whenever `session.prUrl` is set and the connected minion advertises `pr-preview` in `/api/version.features`.
- Shows PR title, `#number`, state badge (`OPEN` / `MERGED` / `CLOSED`), `DRAFT` pill, base←head branches, author avatar+login, and a pass/fail/pending/neutral rollup over `PrCheck.status`.
- Polls `GET /api/sessions/:id/pr` every 30s while the PR state is `open`; stops once it goes to `merged` / `closed`. Errors surface a Retry + direct GitHub link; polling continues through transient failures so the card self-heals.
- The expandable PR body is rendered via a shared `renderMarkdown` extracted from `ConversationView` into `src/components/markdown.ts`, keeping one allow-list for sanitized HTML.

## Why

Step 2 of the Conductor-shaped PWA roll-out: when an agent opens a PR, the chat pane should surface its status without bouncing the user to GitHub. Gated on `hasFeature('pr-preview')` so older library versions degrade to just the existing PR link.

## Scope

Owns `src/components/PrPreviewCard.tsx`, `src/components/markdown.ts`, their tests, and a single mount point inside `ChatPane` in `src/App.tsx`. Also refactors `src/chat/ConversationView.tsx` to import the shared sanitizer (no behavior change).

## Test plan

- [x] `npx vitest run` — 282/282 pass (7 new markdown tests, 18 new PrPreviewCard tests covering loading / error / ready / retry / polling / unmount teardown / state transitions to merged).
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint src test` clean.
- [ ] Manual smoke in the PWA (requires a minion that advertises `pr-preview`) — not run here, depends on library upgrade.

## Notes

- `pr-preview` endpoint and feature flag land in the upstream API scaffold (commit `d9e0b2b`) and are already stubbed in `e2e/fixtures/mock-minion.ts`.
- Depends on the API scaffold PR from `minion/salt-cap`; this branch stacks on top of it.

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  api-foundation["✅ API foundation: types, client, features, router"]
  structured-task-creation["✅ Refactor task creation: POST /api/sessions flow"]
  worktree-header["✅ Worktree header: branch, cwd, diff stats"]
  pr-preview-card["✅ PR preview card: title, state, checks, body"]
  session-tabs["✅ Session tabs: diff viewer and screenshots gallery"]
  web-push["✅ Web Push: notifications, subscriptions, service worker"]
  parallel-variants-ui["✅ Parallel variants: N-session group layout and picker"]
  api-foundation --> structured-task-creation
  api-foundation --> worktree-header
  api-foundation --> pr-preview-card
  api-foundation --> session-tabs
  api-foundation --> web-push
  api-foundation --> parallel-variants-ui
  structured-task-creation --> parallel-variants-ui
  class api-foundation done
  class structured-task-creation done
  class worktree-header done
  class pr-preview-card done
  class pr-preview-card current
  class session-tabs done
  class web-push done
  class parallel-variants-ui done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | API foundation: types, client, features, router | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/4) |
| 2 | Refactor task creation: POST /api/sessions flow | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/5) |
| 3 | Worktree header: branch, cwd, diff stats | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/6) |
| 4 | **PR preview card: title, state, checks, body** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/7) |
| 5 | Session tabs: diff viewer and screenshots gallery | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/8) |
| 6 | Web Push: notifications, subscriptions, service worker | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/10) |
| 7 | Parallel variants: N-session group layout and picker | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/9) |

**Progress:** 7/7 complete

<!-- dag-status-end -->


