### PR TITLE
[minions] feat(chat): add Diff and Screenshots tabs

### DIFF
--- a/e2e/fixtures/mock-minion.ts
+++ b/e2e/fixtures/mock-minion.ts
@@ -1,8 +1,36 @@
 import * as http from 'node:http'
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import type { ApiSession, ApiDagGraph, SseEvent, MinionCommand, VersionInfo } from '../../src/api/types'
+import type {
+  ApiSession,
+  ApiDagGraph,
+  SseEvent,
+  MinionCommand,
+  VersionInfo,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  PrPreview,
+  WorkspaceDiff,
+  ScreenshotList,
+  ScreenshotEntry,
+  VapidPublicKey,
+  PushSubscriptionJSON,
+} from '../../src/api/types'
 
-export type { ApiSession, ApiDagGraph, SseEvent, MinionCommand, VersionInfo }
+export type {
+  ApiSession,
+  ApiDagGraph,
+  SseEvent,
+  MinionCommand,
+  VersionInfo,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  PrPreview,
+  WorkspaceDiff,
+  ScreenshotList,
+  ScreenshotEntry,
+  VapidPublicKey,
+  PushSubscriptionJSON,
+}
 
 export interface MockMinion {
   url: string
@@ -11,9 +39,18 @@ export interface MockMinion {
   setSessions(sessions: ApiSession[]): void
   setDags(dags: ApiDagGraph[]): void
   setVersion(v: Partial<VersionInfo>): void
+  setPr(sessionId: string, pr: PrPreview | null): void
+  setDiff(sessionId: string, diff: WorkspaceDiff | null): void
+  setScreenshots(sessionId: string, screenshots: ScreenshotEntry[]): void
+  setScreenshotBlob(file: string, body: Buffer, contentType?: string): void
+  setVapidKey(key: string): void
   drop(): void
   lastCommands: MinionCommand[]
   lastMessages: Array<{ text: string; sessionId?: string }>
+  lastCreateSessionRequests: CreateSessionRequest[]
+  lastCreateVariantsRequests: CreateSessionVariantsRequest[]
+  pushSubscriptions: PushSubscriptionJSON[]
+  lastUnsubscribeEndpoints: string[]
   close(): Promise<void>
 }
 
@@ -24,6 +61,7 @@ function writeSse(res: ServerResponse, event: SseEvent): void {
 function cors(res: ServerResponse, allowedOrigin: string): void {
   res.setHeader('Access-Control-Allow-Origin', allowedOrigin)
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
   res.setHeader('Access-Control-Max-Age', '600')
 }
 
@@ -34,6 +72,28 @@ function readBody(req: IncomingMessage): Promise<string> {
     req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
     req.on('error', reject)
   })
+}
+
+let sessionCounter = 0
+function makeSession(req: CreateSessionRequest): ApiSession {
+  sessionCounter += 1
+  const id = `mock-session-${sessionCounter}`
+  const now = new Date().toISOString()
+  return {
+    id,
+    slug: `mock-${sessionCounter}`,
+    status: 'pending',
+    command: `/${req.mode} ${req.prompt}`,
+    repo: req.repo,
+    createdAt: now,
+    updatedAt: now,
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: req.mode,
+    conversation: [{ role: 'user', text: req.prompt }],
+  }
 }
 
 export async function createMockMinion(opts?: {
@@ -51,8 +111,18 @@ export async function createMockMinion(opts?: {
     features: [],
   }
 
+  const prBySession = new Map<string, PrPreview>()
+  const diffBySession = new Map<string, WorkspaceDiff>()
+  const screenshotsBySession = new Map<string, ScreenshotEntry[]>()
+  const screenshotBlobs = new Map<string, { body: Buffer; contentType: string }>()
+  let vapidKey = 'BMOCK_VAPID_PUBLIC_KEY_00000000000000000000000000000000000000000000000000000000000000000000000000000000'
+  const pushSubscriptions: PushSubscriptionJSON[] = []
+  const lastUnsubscribeEndpoints: string[] = []
+
   const lastCommands: MinionCommand[] = []
   const lastMessages: Array<{ text: string; sessionId?: string }> = []
+  const lastCreateSessionRequests: CreateSessionRequest[] = []
+  const lastCreateVariantsRequests: CreateSessionVariantsRequest[] = []
 
   let activeSseRes: ServerResponse | null = null
 
@@ -65,6 +135,23 @@ export async function createMockMinion(opts?: {
     res.writeHead(401, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ error: 'Unauthorized' }))
     return false
+  }
+
+  function hasFeature(name: string): boolean {
+    return versionInfo.features.includes(name)
+  }
+
+  function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+    res.writeHead(status, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(payload))
+  }
+
+  function notFound(res: ServerResponse): void {
+    sendJson(res, 404, { error: 'Not found' })
+  }
+
+  function featureDisabled(res: ServerResponse, name: string): void {
+    sendJson(res, 404, { error: `feature '${name}' not enabled` })
   }
 
   const server = http.createServer(async (req, res) => {
@@ -82,22 +169,114 @@ export async function createMockMinion(opts?: {
 
     if (path === '/api/version' && req.method === 'GET') {
       if (!checkAuth(req, res)) return
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: versionInfo }))
+      sendJson(res, 200, { data: versionInfo })
       return
     }
 
     if (!checkAuth(req, res)) return
 
     if (path === '/api/sessions' && req.method === 'GET') {
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: sessions }))
+      sendJson(res, 200, { data: sessions })
       return
     }
 
+    if (path === '/api/sessions' && req.method === 'POST') {
+      if (!hasFeature('sessions-create')) return featureDisabled(res, 'sessions-create')
+      const body = await readBody(req)
+      const payload = JSON.parse(body) as CreateSessionRequest
+      if (!payload.prompt || !payload.mode) {
+        return sendJson(res, 400, { error: 'prompt and mode are required' })
+      }
+      lastCreateSessionRequests.push(payload)
+      const session = makeSession(payload)
+      sessions = [...sessions, session]
+      sendJson(res, 200, { data: session })
+      return
+    }
+
+    if (path === '/api/sessions/variants' && req.method === 'POST') {
+      if (!hasFeature('sessions-variants')) return featureDisabled(res, 'sessions-variants')
+      const body = await readBody(req)
+      const payload = JSON.parse(body) as CreateSessionVariantsRequest
+      if (!payload.prompt || !payload.mode || !payload.count || payload.count < 2) {
+        return sendJson(res, 400, { error: 'prompt, mode, and count >= 2 are required' })
+      }
+      lastCreateVariantsRequests.push(payload)
+      const groupId = `group-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+      const variants: ApiSession[] = []
+      for (let i = 0; i < payload.count; i++) {
+        const s = makeSession(payload)
+        s.variantGroupId = groupId
+        variants.push(s)
+      }
+      sessions = [...sessions, ...variants]
+      sendJson(res, 200, { data: { groupId, sessions: variants } })
+      return
+    }
+
+    const sessionSubMatch = path.match(/^\/api\/sessions\/([^/]+)\/(pr|diff|screenshots)$/)
+    if (sessionSubMatch && req.method === 'GET') {
+      const sessionId = decodeURIComponent(sessionSubMatch[1])
+      const kind = sessionSubMatch[2]
+      if (kind === 'pr') {
+        if (!hasFeature('pr-preview')) return featureDisabled(res, 'pr-preview')
+        const pr = prBySession.get(sessionId)
+        if (!pr) return notFound(res)
+        return sendJson(res, 200, { data: pr })
+      }
+      if (kind === 'diff') {
+        if (!hasFeature('diff-viewer')) return featureDisabled(res, 'diff-viewer')
+        const diff = diffBySession.get(sessionId)
+        if (!diff) return notFound(res)
+        return sendJson(res, 200, { data: diff })
+      }
+      if (kind === 'screenshots') {
+        if (!hasFeature('screenshots-http')) return featureDisabled(res, 'screenshots-http')
+        const list = screenshotsBySession.get(sessionId) ?? []
+        return sendJson(res, 200, { data: { sessionId, screenshots: list } satisfies ScreenshotList })
+      }
+    }
+
+    const screenshotMatch = path.match(/^\/api\/screenshots\/(.+)$/)
+    if (screenshotMatch && req.method === 'GET') {
+      if (!hasFeature('screenshots-http')) return featureDisabled(res, 'screenshots-http')
+      const file = decodeURIComponent(screenshotMatch[1])
+      const blob = screenshotBlobs.get(file)
+      if (!blob) return notFound(res)
+      res.writeHead(200, { 'Content-Type': blob.contentType, 'Content-Length': String(blob.body.length) })
+      res.end(blob.body)
+      return
+    }
+
+    if (path === '/api/push/vapid-public-key' && req.method === 'GET') {
+      if (!hasFeature('web-push')) return featureDisabled(res, 'web-push')
+      return sendJson(res, 200, { data: { key: vapidKey } satisfies VapidPublicKey })
+    }
+
+    if (path === '/api/push-subscribe' && req.method === 'POST') {
+      if (!hasFeature('web-push')) return featureDisabled(res, 'web-push')
+      const body = await readBody(req)
+      const sub = JSON.parse(body) as PushSubscriptionJSON
+      if (!sub.endpoint || !sub.keys?.p256dh || !sub.keys?.auth) {
+        return sendJson(res, 400, { error: 'invalid subscription' })
+      }
+      pushSubscriptions.push(sub)
+      return sendJson(res, 200, { data: { ok: true, id: `sub-${pushSubscriptions.length}` } })
+    }
+
+    if (path === '/api/push-subscribe' && req.method === 'DELETE') {
+      if (!hasFeature('web-push')) return featureDisabled(res, 'web-push')
+      const body = await readBody(req)
+      const payload = JSON.parse(body) as { endpoint: string }
+      if (!payload.endpoint) return sendJson(res, 400, { error: 'endpoint is required' })
+      lastUnsubscribeEndpoints.push(payload.endpoint)
+      const idx = pushSubscriptions.findIndex((s) => s.endpoint === payload.endpoint)
+      if (idx !== -1) pushSubscriptions.splice(idx, 1)
+      return sendJson(res, 200, { data: { ok: true } })
+    }
+
     if (path === '/api/dags' && req.method === 'GET') {
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: dags }))
+      sendJson(res, 200, { data: dags })
       return
     }
 
@@ -124,8 +303,7 @@ export async function createMockMinion(opts?: {
       const body = await readBody(req)
       const cmd = JSON.parse(body) as MinionCommand
       lastCommands.push(cmd)
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: { success: true } }))
+      sendJson(res, 200, { data: { success: true } })
       return
     }
 
@@ -133,18 +311,14 @@ export async function createMockMinion(opts?: {
       const body = await readBody(req)
       const payload = JSON.parse(body) as { text: string; sessionId?: string }
       if (!payload.text) {
-        res.writeHead(400, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: 'text is required' }))
-        return
+        return sendJson(res, 400, { error: 'text is required' })
       }
       lastMessages.push({ text: payload.text, sessionId: payload.sessionId })
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: { ok: true, sessionId: payload.sessionId ?? null } }))
+      sendJson(res, 200, { data: { ok: true, sessionId: payload.sessionId ?? null } })
       return
     }
 
-    res.writeHead(404, { 'Content-Type': 'application/json' })
-    res.end(JSON.stringify({ error: 'Not found' }))
+    notFound(res)
   })
 
   await new Promise<void>((resolve) => server.listen(0, 'localhost', resolve))
@@ -157,6 +331,10 @@ export async function createMockMinion(opts?: {
     token,
     lastCommands,
     lastMessages,
+    lastCreateSessionRequests,
+    lastCreateVariantsRequests,
+    pushSubscriptions,
+    lastUnsubscribeEndpoints,
 
     emit(event: SseEvent) {
       if (activeSseRes) writeSse(activeSseRes, event)
@@ -172,6 +350,28 @@ export async function createMockMinion(opts?: {
 
     setVersion(v: Partial<VersionInfo>) {
       versionInfo = { ...versionInfo, ...v }
+    },
+
+    setPr(sessionId: string, pr: PrPreview | null) {
+      if (pr) prBySession.set(sessionId, pr)
+      else prBySession.delete(sessionId)
+    },
+
+    setDiff(sessionId: string, diff: WorkspaceDiff | null) {
+      if (diff) diffBySession.set(sessionId, diff)
+      else diffBySession.delete(sessionId)
+    },
+
+    setScreenshots(sessionId: string, screenshots: ScreenshotEntry[]) {
+      screenshotsBySession.set(sessionId, screenshots)
+    },
+
+    setScreenshotBlob(file: string, body: Buffer, contentType = 'image/png') {
+      screenshotBlobs.set(file, { body, contentType })
+    },
+
+    setVapidKey(key: string) {
+      vapidKey = key
     },
 
     drop() {

--- a/e2e/tests/bad-token.spec.ts
+++ b/e2e/tests/bad-token.spec.ts
@@ -41,7 +41,7 @@ test.describe('bad token', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Bad Token Minion')
 
-      await expect(page.getByTestId('universe-node-correct-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-correct-session')).toBeVisible({ timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/connect.spec.ts
+++ b/e2e/tests/connect.spec.ts
@@ -62,7 +62,7 @@ test.describe('connection flow', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion A')
 
-      await expect(page.getByTestId('universe-node-s1')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-s1')).toBeVisible({ timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/multi-connection.spec.ts
+++ b/e2e/tests/multi-connection.spec.ts
@@ -46,7 +46,7 @@ test.describe('multi-connection', () => {
     try {
       await connectToMinion(page, mockA, 'Minion Alpha')
 
-      await expect(page.getByTestId('universe-node-a-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-a-session')).toBeVisible({ timeout: 8_000 })
 
       await page.getByTestId('connection-picker-trigger').click()
       await expect(page.getByTestId('connection-picker-dropdown')).toBeVisible()
@@ -66,8 +66,8 @@ test.describe('multi-connection', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion Beta')
 
-      await expect(page.getByTestId('universe-node-b-session')).toBeVisible({ timeout: 8_000 })
-      await expect(page.getByTestId('universe-node-a-session')).not.toBeVisible()
+      await expect(page.getByTestId('session-item-b-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-a-session')).not.toBeVisible()
 
       await page.getByTestId('connection-picker-trigger').click()
       const dropdown = page.getByTestId('connection-picker-dropdown')
@@ -79,8 +79,8 @@ test.describe('multi-connection', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion Alpha')
 
-      await expect(page.getByTestId('universe-node-a-session')).toBeVisible({ timeout: 8_000 })
-      await expect(page.getByTestId('universe-node-b-session')).not.toBeVisible()
+      await expect(page.getByTestId('session-item-a-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-b-session')).not.toBeVisible()
     } finally {
       await mockA.close()
       await mockB.close()

--- a/e2e/tests/reconnect.spec.ts
+++ b/e2e/tests/reconnect.spec.ts
@@ -34,7 +34,7 @@ test.describe('SSE reconnect', () => {
 
       await expect(page.getByText('live')).toBeVisible({ timeout: 20_000 })
 
-      await expect(page.getByTestId('universe-node-s-reconnect')).toBeVisible({ timeout: 10_000 })
+      await expect(page.getByTestId('session-item-s-reconnect')).toBeVisible({ timeout: 10_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/task-lifecycle.spec.ts
+++ b/e2e/tests/task-lifecycle.spec.ts
@@ -26,13 +26,9 @@ test.describe('task lifecycle', () => {
     try {
       await connectToMinion(page, mock, 'My Minion')
 
-      await expect(page.getByTestId('universe-node-seed-1')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-seed-1')).toBeVisible({ timeout: 8_000 })
 
-      await page.getByTestId('universe-node-seed-1').dispatchEvent('click')
-
-      await expect(page.locator('[role="dialog"]')).toBeVisible()
-
-      await page.getByRole('button', { name: 'Open Chat' }).click()
+      await page.getByTestId('session-item-seed-1').click()
 
       await expect(page.getByTestId('message-textarea')).toBeVisible()
 
@@ -45,15 +41,9 @@ test.describe('task lifecycle', () => {
 
       mock.emit({ type: 'session_created', session: makeSession('new-1', 'hello-task', 'running') })
 
-      await expect(page.getByTestId('universe-node-new-1')).toBeAttached({ timeout: 5_000 })
+      await expect(page.getByTestId('session-item-new-1')).toBeVisible({ timeout: 5_000 })
 
-      await page.getByTestId('chat-close-btn').click()
-
-      await page.getByTestId('universe-node-new-1').dispatchEvent('click')
-
-      await expect(page.locator('[aria-labelledby="node-detail-title"]')).toBeVisible()
-
-      await page.getByRole('button', { name: 'Open Chat' }).click()
+      await page.getByTestId('session-item-new-1').click()
 
       await expect(page.getByTestId('message-textarea')).toBeVisible()
 
@@ -68,11 +58,7 @@ test.describe('task lifecycle', () => {
       mock.setSessions([makeSession('seed-1', 'seed-task', 'running'), completedSession])
       mock.emit({ type: 'session_updated', session: completedSession })
 
-      await page.getByTestId('universe-node-new-1').dispatchEvent('click')
-
-      await expect(
-        page.locator('[aria-labelledby="node-detail-title"]').getByText('Done')
-      ).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-new-1')).toContainText('completed', { timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,11 @@ import { ConversationView } from './chat/ConversationView'
 import { MessageInput } from './chat/MessageInput'
 import { QuickActionsBar } from './chat/QuickActionsBar'
 import { SlashCommandMenu, type SlashCommand } from './chat/SlashCommandMenu'
+import { SessionTabs, type SessionTabId } from './chat/SessionTabs'
+import { DiffTab } from './chat/DiffTab'
+import { ScreenshotsTab } from './chat/ScreenshotsTab'
+import { hasFeature } from './api/features'
+import type { ConnectionStore } from './state/types'
 import { confirm } from './hooks/useConfirm'
 import { ConfirmRoot } from './hooks/useConfirm'
 import { InstallPrompt } from './pwa/InstallPrompt'
@@ -209,15 +214,18 @@ function SessionList({
 
 function ChatPane({
   session,
+  store,
   onSend,
   onCommand,
 }: {
   session: ApiSession
+  store: ConnectionStore
   onSend: (text: string, sessionId: string) => Promise<void>
   onCommand: (cmd: MinionCommand) => Promise<void>
 }) {
   const [text, setText] = useState('')
   const [pending, setPending] = useState<'stop' | 'close' | null>(null)
+  const [activeTab, setActiveTab] = useState<SessionTabId>('chat')
   const handleSend = (t: string) => onSend(t, session.id)
   const handleQuickAction = (action: QuickAction) => onSend(action.message, session.id)
 
@@ -312,12 +320,40 @@ function ChatPane({
           </button>
         </div>
       </header>
-      <ConversationView messages={session.conversation} />
-      <div class="shrink-0 border-t border-slate-200 dark:border-slate-700">
-        <QuickActionsBar actions={session.quickActions} onAction={handleQuickAction} />
-        <SlashCommandMenu session={session} context={text} onCommand={handleSlashCommand} />
-        <MessageInput session={session} value={text} onValueChange={setText} onSend={handleSend} />
-      </div>
+      <SessionTabs
+        tabs={[
+          { id: 'chat', label: 'Chat', available: true },
+          { id: 'diff', label: 'Diff', available: hasFeature(store, 'diff-viewer') },
+          { id: 'screenshots', label: 'Screenshots', available: hasFeature(store, 'screenshots-http') },
+        ]}
+        active={activeTab}
+        onChange={setActiveTab}
+      >
+        {activeTab === 'chat' && (
+          <>
+            <ConversationView messages={session.conversation} />
+            <div class="shrink-0 border-t border-slate-200 dark:border-slate-700">
+              <QuickActionsBar actions={session.quickActions} onAction={handleQuickAction} />
+              <SlashCommandMenu session={session} context={text} onCommand={handleSlashCommand} />
+              <MessageInput session={session} value={text} onValueChange={setText} onSend={handleSend} />
+            </div>
+          </>
+        )}
+        {activeTab === 'diff' && (
+          <DiffTab
+            sessionId={session.id}
+            sessionUpdatedAt={session.updatedAt}
+            client={store.client}
+          />
+        )}
+        {activeTab === 'screenshots' && (
+          <ScreenshotsTab
+            sessionId={session.id}
+            sessionUpdatedAt={session.updatedAt}
+            client={store.client}
+          />
+        )}
+      </SessionTabs>
     </div>
   )
 }
@@ -402,7 +438,7 @@ function ActiveView() {
             />
           </aside>
           {selected ? (
-            <ChatPane session={selected} onSend={handleSendMessage} onCommand={handleCommand} />
+            <ChatPane session={selected} store={store} onSend={handleSendMessage} onCommand={handleCommand} />
           ) : (
             <EmptyPane />
           )}
@@ -416,7 +452,7 @@ function ActiveView() {
             orientation="horizontal"
           />
           {selected ? (
-            <ChatPane session={selected} onSend={handleSendMessage} onCommand={handleCommand} />
+            <ChatPane session={selected} store={store} onSend={handleSendMessage} onCommand={handleCommand} />
           ) : (
             <EmptyPane />
           )}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,20 @@
-import type { ApiDagGraph, ApiResponse, ApiSession, CommandResult, MinionCommand, VersionInfo } from './types'
+import type {
+  ApiDagGraph,
+  ApiResponse,
+  ApiSession,
+  CommandResult,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  CreateSessionVariantsResult,
+  MinionCommand,
+  PrPreview,
+  PushSubscribeAck,
+  PushSubscriptionJSON,
+  ScreenshotList,
+  VapidPublicKey,
+  VersionInfo,
+  WorkspaceDiff,
+} from './types'
 import { openEventStream } from './sse'
 import type { SseHandlers, EventStreamHandle } from './sse'
 
@@ -18,6 +34,15 @@ export interface ApiClient {
   getDags(): Promise<ApiDagGraph[]>
   sendCommand(cmd: MinionCommand): Promise<CommandResult>
   sendMessage(text: string, sessionId?: string): Promise<{ ok: true; sessionId: string | null }>
+  createSession(req: CreateSessionRequest): Promise<ApiSession>
+  createSessionVariants(req: CreateSessionVariantsRequest): Promise<CreateSessionVariantsResult>
+  getPr(sessionId: string): Promise<PrPreview>
+  getDiff(sessionId: string): Promise<WorkspaceDiff>
+  listScreenshots(sessionId: string): Promise<ScreenshotList>
+  fetchScreenshotBlob(file: string): Promise<Blob>
+  getVapidKey(): Promise<VapidPublicKey>
+  subscribePush(sub: PushSubscriptionJSON): Promise<PushSubscribeAck>
+  unsubscribePush(endpoint: string): Promise<{ ok: true }>
   openEventStream(handlers: SseHandlers): EventStreamHandle
   baseUrl: string
   token: string
@@ -30,6 +55,11 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
   function headers(): HeadersInit {
     if (!token) return { 'Content-Type': 'application/json' }
     return { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
+  }
+
+  function authHeadersOnly(): HeadersInit {
+    if (!token) return {}
+    return { Authorization: `Bearer ${token}` }
   }
 
   async function get<T>(path: string): Promise<T> {
@@ -46,6 +76,19 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
       method: 'POST',
       headers: headers(),
       body: JSON.stringify(data),
+    })
+    const body = (await res.json()) as ApiResponse<T>
+    if (!res.ok || body.error) {
+      throw new ApiError(res.status, body.error ?? res.statusText)
+    }
+    return body.data
+  }
+
+  async function del<T>(path: string, data?: unknown): Promise<T> {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: 'DELETE',
+      headers: headers(),
+      body: data !== undefined ? JSON.stringify(data) : undefined,
     })
     const body = (await res.json()) as ApiResponse<T>
     if (!res.ok || body.error) {
@@ -76,6 +119,48 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
 
     sendMessage(text: string, sessionId?: string) {
       return post<{ ok: true; sessionId: string | null }>('/api/messages', { text, sessionId })
+    },
+
+    createSession(req: CreateSessionRequest) {
+      return post<ApiSession>('/api/sessions', req)
+    },
+
+    createSessionVariants(req: CreateSessionVariantsRequest) {
+      return post<CreateSessionVariantsResult>('/api/sessions/variants', req)
+    },
+
+    getPr(sessionId: string) {
+      return get<PrPreview>(`/api/sessions/${encodeURIComponent(sessionId)}/pr`)
+    },
+
+    getDiff(sessionId: string) {
+      return get<WorkspaceDiff>(`/api/sessions/${encodeURIComponent(sessionId)}/diff`)
+    },
+
+    listScreenshots(sessionId: string) {
+      return get<ScreenshotList>(`/api/sessions/${encodeURIComponent(sessionId)}/screenshots`)
+    },
+
+    async fetchScreenshotBlob(file: string): Promise<Blob> {
+      const res = await fetch(`${baseUrl}/api/screenshots/${encodeURIComponent(file)}`, {
+        headers: authHeadersOnly(),
+      })
+      if (!res.ok) {
+        throw new ApiError(res.status, res.statusText)
+      }
+      return res.blob()
+    },
+
+    getVapidKey() {
+      return get<VapidPublicKey>('/api/push/vapid-public-key')
+    },
+
+    subscribePush(sub: PushSubscriptionJSON) {
+      return post<PushSubscribeAck>('/api/push-subscribe', sub)
+    },
+
+    unsubscribePush(endpoint: string) {
+      return del<{ ok: true }>('/api/push-subscribe', { endpoint })
     },
 
     openEventStream(handlers: SseHandlers): EventStreamHandle {

--- a/src/api/features.ts
+++ b/src/api/features.ts
@@ -1,0 +1,25 @@
+import type { ConnectionStore } from '../state/types'
+import type { VersionInfo } from './types'
+
+export type FeatureName =
+  | 'messages'
+  | 'sessions-create'
+  | 'sessions-variants'
+  | 'pr-preview'
+  | 'diff-viewer'
+  | 'screenshots-http'
+  | 'web-push'
+  | 'worktree-stats'
+
+export function hasFeature(
+  source: ConnectionStore | VersionInfo | null | undefined,
+  name: FeatureName,
+): boolean {
+  if (!source) return false
+  const version: VersionInfo | null =
+    'features' in source && Array.isArray((source as VersionInfo).features)
+      ? (source as VersionInfo)
+      : (source as ConnectionStore).version.value
+  if (!version) return false
+  return version.features.includes(name)
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -25,6 +25,7 @@ export interface ApiSession {
   quickActions: QuickAction[]
   mode: string
   conversation: ConversationMessage[]
+  variantGroupId?: string
 }
 
 export interface ApiDagNode {
@@ -72,4 +73,106 @@ export interface VersionInfo {
   libraryVersion: string
   features: string[]
   repos?: RepoEntry[]
+}
+
+export type CreateSessionMode = 'task' | 'plan' | 'think' | 'dag' | 'split' | 'stack' | 'ship' | 'doctor'
+
+export interface CreateSessionRequest {
+  prompt: string
+  mode: CreateSessionMode
+  repo?: string
+}
+
+export interface CreateSessionVariantsRequest extends CreateSessionRequest {
+  count: number
+}
+
+export interface CreateSessionVariantsResult {
+  groupId: string
+  sessions: ApiSession[]
+}
+
+export type PrState = 'open' | 'closed' | 'merged'
+
+export type PrCheckStatus =
+  | 'queued'
+  | 'in_progress'
+  | 'pending'
+  | 'success'
+  | 'failure'
+  | 'neutral'
+  | 'skipped'
+  | 'cancelled'
+  | 'action_required'
+  | 'stale'
+  | 'timed_out'
+
+export interface PrCheck {
+  name: string
+  status: PrCheckStatus
+  conclusion?: string
+  url?: string
+}
+
+export interface PrPreview {
+  number: number
+  url: string
+  title: string
+  body: string
+  state: PrState
+  draft: boolean
+  mergeable: boolean | null
+  branch: string
+  baseBranch: string
+  author: string
+  updatedAt: string
+  checks: PrCheck[]
+}
+
+export interface WorkspaceDiffStats {
+  filesChanged: number
+  insertions: number
+  deletions: number
+}
+
+export interface WorkspaceDiff {
+  sessionId: string
+  branch: string
+  baseBranch: string
+  patch: string
+  truncated: boolean
+  stats: WorkspaceDiffStats
+}
+
+export interface ScreenshotEntry {
+  file: string
+  url: string
+  capturedAt: string
+  size: number
+  width?: number
+  height?: number
+  caption?: string
+}
+
+export interface ScreenshotList {
+  sessionId: string
+  screenshots: ScreenshotEntry[]
+}
+
+export interface VapidPublicKey {
+  key: string
+}
+
+export interface PushSubscriptionJSON {
+  endpoint: string
+  expirationTime: number | null
+  keys: {
+    p256dh: string
+    auth: string
+  }
+}
+
+export interface PushSubscribeAck {
+  ok: true
+  id: string
 }

--- a/src/chat/DiffTab.tsx
+++ b/src/chat/DiffTab.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import type { ApiClient } from '../api/client'
+import type { WorkspaceDiff } from '../api/types'
+import { parseUnifiedDiff, type DiffFile, countChanges, fileDisplayPath } from './diff-parse'
+
+interface DiffTabProps {
+  sessionId: string
+  sessionUpdatedAt: string
+  client: ApiClient
+}
+
+export function DiffTab({ sessionId, sessionUpdatedAt, client }: DiffTabProps) {
+  const [diff, setDiff] = useState<WorkspaceDiff | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [copied, setCopied] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    abortRef.current?.abort()
+    const ctrl = new AbortController()
+    abortRef.current = ctrl
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    client
+      .getDiff(sessionId)
+      .then((d) => {
+        if (cancelled) return
+        setDiff(d)
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return
+        setError(e instanceof Error ? e.message : String(e))
+      })
+      .finally(() => {
+        if (cancelled) return
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+      ctrl.abort()
+    }
+  }, [sessionId, sessionUpdatedAt, client])
+
+  const files = useMemo<DiffFile[]>(() => {
+    if (!diff) return []
+    return parseUnifiedDiff(diff.patch)
+  }, [diff])
+
+  const handleCopy = async () => {
+    if (!diff) return
+    try {
+      await navigator.clipboard.writeText(diff.patch)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      setError('Failed to copy patch')
+    }
+  }
+
+  if (loading && !diff) {
+    return (
+      <div class="flex-1 flex items-center justify-center text-xs text-slate-500 dark:text-slate-400" data-testid="diff-loading">
+        Loading diff…
+      </div>
+    )
+  }
+
+  if (error && !diff) {
+    return (
+      <div class="flex-1 flex items-center justify-center text-xs text-red-600 dark:text-red-400" data-testid="diff-error">
+        {error}
+      </div>
+    )
+  }
+
+  if (!diff) return null
+
+  const empty = files.length === 0 && diff.stats.filesChanged === 0
+
+  return (
+    <div class="flex flex-col flex-1 min-h-0 bg-slate-50 dark:bg-slate-900" data-testid="diff-tab">
+      <div class="flex items-center gap-3 px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0">
+        <span class="text-xs text-slate-500 dark:text-slate-400">
+          <span class="font-mono text-slate-900 dark:text-slate-100">{diff.branch}</span>
+          <span class="text-slate-400 dark:text-slate-500"> vs </span>
+          <span class="font-mono text-slate-900 dark:text-slate-100">{diff.baseBranch}</span>
+        </span>
+        <span class="text-xs text-slate-500 dark:text-slate-400">
+          <span class="font-semibold text-slate-700 dark:text-slate-200">{diff.stats.filesChanged}</span> files{' '}
+          <span class="text-green-600 dark:text-green-400">+{diff.stats.insertions}</span>{' '}
+          <span class="text-red-600 dark:text-red-400">-{diff.stats.deletions}</span>
+        </span>
+        <button
+          type="button"
+          onClick={() => void handleCopy()}
+          class="ml-auto rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+          data-testid="diff-copy-btn"
+        >
+          {copied ? 'Copied' : 'Copy patch'}
+        </button>
+      </div>
+      {diff.truncated && (
+        <div class="px-4 py-1.5 bg-amber-50 dark:bg-amber-950/40 border-b border-amber-200 dark:border-amber-800 text-xs text-amber-800 dark:text-amber-300 shrink-0" data-testid="diff-truncated-banner">
+          Diff truncated by server — view full patch on the minion or git log.
+        </div>
+      )}
+      {empty ? (
+        <div class="flex-1 flex items-center justify-center text-xs text-slate-500 dark:text-slate-400 italic" data-testid="diff-empty">
+          No workspace changes.
+        </div>
+      ) : (
+        <div class="flex-1 overflow-auto">
+          {files.map((file, idx) => (
+            <DiffFileView key={`${fileDisplayPath(file)}-${idx}`} file={file} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DiffFileView({ file }: { file: DiffFile }) {
+  const [collapsed, setCollapsed] = useState(false)
+  const path = fileDisplayPath(file)
+  const { insertions, deletions } = countChanges(file)
+  const tag = file.isNew
+    ? 'NEW'
+    : file.isDeleted
+      ? 'DEL'
+      : file.isRename
+        ? 'REN'
+        : file.isBinary
+          ? 'BIN'
+          : null
+
+  return (
+    <div class="border-b border-slate-200 dark:border-slate-700" data-testid="diff-file">
+      <button
+        type="button"
+        onClick={() => setCollapsed((v) => !v)}
+        class="w-full flex items-center gap-2 px-4 py-2 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-left"
+        data-testid="diff-file-toggle"
+      >
+        <span class="text-[10px] text-slate-500 dark:text-slate-400 w-4 inline-block">
+          {collapsed ? '▸' : '▾'}
+        </span>
+        {tag && (
+          <span class="text-[10px] uppercase tracking-wide font-semibold rounded bg-slate-200 dark:bg-slate-700 px-1.5 py-0.5 text-slate-700 dark:text-slate-200">
+            {tag}
+          </span>
+        )}
+        <span class="font-mono text-xs text-slate-900 dark:text-slate-100 truncate">{path}</span>
+        <span class="ml-auto text-[10px] text-slate-500 dark:text-slate-400 whitespace-nowrap">
+          <span class="text-green-600 dark:text-green-400">+{insertions}</span>{' '}
+          <span class="text-red-600 dark:text-red-400">-{deletions}</span>
+        </span>
+      </button>
+      {!collapsed && (
+        <div class="font-mono text-xs overflow-x-auto bg-white dark:bg-slate-900">
+          {file.isBinary && (
+            <div class="px-4 py-2 text-slate-500 dark:text-slate-400 italic">Binary file.</div>
+          )}
+          {file.hunks.map((hunk, hi) => (
+            <div key={hi}>
+              <div class="px-4 py-1 bg-slate-50 dark:bg-slate-800/70 text-slate-500 dark:text-slate-400 border-y border-slate-200 dark:border-slate-700">
+                {hunk.header}
+              </div>
+              {hunk.lines.map((line, li) => {
+                const bg =
+                  line.type === 'add'
+                    ? 'bg-green-50 dark:bg-green-950/30'
+                    : line.type === 'del'
+                      ? 'bg-red-50 dark:bg-red-950/30'
+                      : 'bg-transparent'
+                const sign = line.type === 'add' ? '+' : line.type === 'del' ? '-' : ' '
+                const signColor =
+                  line.type === 'add'
+                    ? 'text-green-700 dark:text-green-400'
+                    : line.type === 'del'
+                      ? 'text-red-700 dark:text-red-400'
+                      : 'text-slate-400 dark:text-slate-500'
+                return (
+                  <div
+                    key={li}
+                    class={`flex gap-2 px-4 py-0.5 ${bg}`}
+                    data-testid={`diff-line-${line.type}`}
+                  >
+                    <span class="text-[10px] text-slate-400 dark:text-slate-500 w-8 text-right shrink-0 select-none">
+                      {line.oldLineNo ?? ''}
+                    </span>
+                    <span class="text-[10px] text-slate-400 dark:text-slate-500 w-8 text-right shrink-0 select-none">
+                      {line.newLineNo ?? ''}
+                    </span>
+                    <span class={`${signColor} w-3 shrink-0 select-none`}>{sign}</span>
+                    <span class="whitespace-pre text-slate-800 dark:text-slate-200">{line.text || ' '}</span>
+                  </div>
+                )
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/chat/ScreenshotsTab.tsx
+++ b/src/chat/ScreenshotsTab.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useRef, useState } from 'preact/hooks'
+import type { ApiClient } from '../api/client'
+import type { ScreenshotEntry, ScreenshotList } from '../api/types'
+
+interface ScreenshotsTabProps {
+  sessionId: string
+  sessionUpdatedAt: string
+  client: ApiClient
+}
+
+export function ScreenshotsTab({ sessionId, sessionUpdatedAt, client }: ScreenshotsTabProps) {
+  const [list, setList] = useState<ScreenshotList | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [blobUrls, setBlobUrls] = useState<Map<string, string>>(new Map())
+  const [lightbox, setLightbox] = useState<number | null>(null)
+  const urlsRef = useRef<Map<string, string>>(new Map())
+
+  useEffect(() => {
+    return () => {
+      for (const url of urlsRef.current.values()) URL.revokeObjectURL(url)
+      urlsRef.current = new Map()
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    client
+      .listScreenshots(sessionId)
+      .then((l) => {
+        if (cancelled) return
+        setList(l)
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return
+        setError(e instanceof Error ? e.message : String(e))
+      })
+      .finally(() => {
+        if (cancelled) return
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [sessionId, sessionUpdatedAt, client])
+
+  useEffect(() => {
+    if (!list) return
+    const wanted = new Set(list.screenshots.map((s) => s.file))
+    const currentMap = urlsRef.current
+    let dirty = false
+
+    for (const [file, url] of currentMap.entries()) {
+      if (!wanted.has(file)) {
+        URL.revokeObjectURL(url)
+        currentMap.delete(file)
+        dirty = true
+      }
+    }
+
+    const missing = list.screenshots.filter((s) => !currentMap.has(s.file))
+    let cancelled = false
+    for (const s of missing) {
+      void client
+        .fetchScreenshotBlob(s.file)
+        .then((blob) => {
+          if (cancelled) return
+          const existing = currentMap.get(s.file)
+          if (existing) URL.revokeObjectURL(existing)
+          const url = URL.createObjectURL(blob)
+          currentMap.set(s.file, url)
+          setBlobUrls(new Map(currentMap))
+        })
+        .catch(() => {
+          // per-file fetch error is non-fatal; surface overall error if all fail
+        })
+    }
+    if (dirty) setBlobUrls(new Map(currentMap))
+
+    return () => {
+      cancelled = true
+    }
+  }, [list, client])
+
+  useEffect(() => {
+    if (lightbox === null) return
+    const handler = (e: KeyboardEvent) => {
+      if (!list) return
+      const n = list.screenshots.length
+      if (e.key === 'Escape') setLightbox(null)
+      else if (e.key === 'ArrowRight') setLightbox((i) => (i === null ? 0 : (i + 1) % n))
+      else if (e.key === 'ArrowLeft') setLightbox((i) => (i === null ? 0 : (i - 1 + n) % n))
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [lightbox, list])
+
+  if (loading && !list) {
+    return (
+      <div class="flex-1 flex items-center justify-center text-xs text-slate-500 dark:text-slate-400" data-testid="screenshots-loading">
+        Loading screenshots…
+      </div>
+    )
+  }
+  if (error && !list) {
+    return (
+      <div class="flex-1 flex items-center justify-center text-xs text-red-600 dark:text-red-400" data-testid="screenshots-error">
+        {error}
+      </div>
+    )
+  }
+  if (!list) return null
+
+  const screenshots = list.screenshots
+  if (screenshots.length === 0) {
+    return (
+      <div class="flex-1 flex items-center justify-center text-xs text-slate-500 dark:text-slate-400 italic" data-testid="screenshots-empty">
+        No screenshots yet.
+      </div>
+    )
+  }
+
+  return (
+    <div class="flex flex-col flex-1 min-h-0 bg-slate-50 dark:bg-slate-900" data-testid="screenshots-tab">
+      <div class="flex-1 overflow-auto p-4">
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+          {screenshots.map((s, idx) => (
+            <ScreenshotThumb
+              key={s.file}
+              entry={s}
+              blobUrl={blobUrls.get(s.file) ?? null}
+              onOpen={() => setLightbox(idx)}
+            />
+          ))}
+        </div>
+      </div>
+      {lightbox !== null && screenshots[lightbox] && (
+        <Lightbox
+          entry={screenshots[lightbox]}
+          blobUrl={blobUrls.get(screenshots[lightbox].file) ?? null}
+          onClose={() => setLightbox(null)}
+          onPrev={() => setLightbox((i) => (i === null ? 0 : (i - 1 + screenshots.length) % screenshots.length))}
+          onNext={() => setLightbox((i) => (i === null ? 0 : (i + 1) % screenshots.length))}
+          canNavigate={screenshots.length > 1}
+        />
+      )}
+    </div>
+  )
+}
+
+function ScreenshotThumb({
+  entry,
+  blobUrl,
+  onOpen,
+}: {
+  entry: ScreenshotEntry
+  blobUrl: string | null
+  onOpen: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      class="group flex flex-col gap-1 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden hover:border-indigo-400 dark:hover:border-indigo-600"
+      data-testid="screenshot-thumb"
+    >
+      <div class="aspect-video bg-slate-100 dark:bg-slate-900 flex items-center justify-center overflow-hidden">
+        {blobUrl ? (
+          <img src={blobUrl} alt={entry.caption ?? entry.file} class="w-full h-full object-cover" />
+        ) : (
+          <span class="text-[10px] text-slate-400 dark:text-slate-500">Loading…</span>
+        )}
+      </div>
+      <div class="px-2 py-1 text-left">
+        <div class="text-[11px] font-mono text-slate-700 dark:text-slate-200 truncate">
+          {entry.caption ?? entry.file}
+        </div>
+        <div class="text-[10px] text-slate-500 dark:text-slate-400">
+          {new Date(entry.capturedAt).toLocaleString()}
+        </div>
+      </div>
+    </button>
+  )
+}
+
+function Lightbox({
+  entry,
+  blobUrl,
+  onClose,
+  onPrev,
+  onNext,
+  canNavigate,
+}: {
+  entry: ScreenshotEntry
+  blobUrl: string | null
+  onClose: () => void
+  onPrev: () => void
+  onNext: () => void
+  canNavigate: boolean
+}) {
+  return (
+    <div
+      class="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
+      onClick={onClose}
+      data-testid="screenshot-lightbox"
+    >
+      <div
+        class="relative max-w-full max-h-full flex flex-col items-center gap-2"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {blobUrl ? (
+          <img
+            src={blobUrl}
+            alt={entry.caption ?? entry.file}
+            class="max-w-[90vw] max-h-[80vh] object-contain rounded-lg shadow-2xl"
+          />
+        ) : (
+          <div class="text-xs text-slate-200">Loading…</div>
+        )}
+        <div class="flex items-center gap-3 text-xs text-slate-200">
+          <span class="font-mono truncate max-w-[60vw]">{entry.caption ?? entry.file}</span>
+          <span class="text-slate-400">{new Date(entry.capturedAt).toLocaleString()}</span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          class="absolute -top-2 -right-2 w-8 h-8 rounded-full bg-white text-slate-900 text-sm font-bold shadow hover:bg-slate-100"
+          aria-label="Close"
+          data-testid="screenshot-lightbox-close"
+        >
+          ×
+        </button>
+        {canNavigate && (
+          <>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onPrev() }}
+              class="absolute left-2 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-white/90 text-slate-900 text-lg font-bold shadow hover:bg-white"
+              aria-label="Previous"
+              data-testid="screenshot-lightbox-prev"
+            >
+              ‹
+            </button>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onNext() }}
+              class="absolute right-2 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-white/90 text-slate-900 text-lg font-bold shadow hover:bg-white"
+              aria-label="Next"
+              data-testid="screenshot-lightbox-next"
+            >
+              ›
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/chat/SessionTabs.tsx
+++ b/src/chat/SessionTabs.tsx
@@ -1,0 +1,62 @@
+import type { ComponentChildren } from 'preact'
+
+export type SessionTabId = 'chat' | 'diff' | 'screenshots'
+
+export interface SessionTabDef {
+  id: SessionTabId
+  label: string
+  available: boolean
+}
+
+interface SessionTabsProps {
+  tabs: SessionTabDef[]
+  active: SessionTabId
+  onChange: (id: SessionTabId) => void
+  children: ComponentChildren
+}
+
+export function SessionTabs({ tabs, active, onChange, children }: SessionTabsProps) {
+  const visible = tabs.filter((t) => t.available)
+  return (
+    <div class="flex flex-col flex-1 min-h-0">
+      <div
+        role="tablist"
+        aria-label="Session views"
+        class="flex items-center gap-1 px-3 py-1.5 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0"
+        data-testid="session-tabs"
+      >
+        {visible.map((t) => {
+          const isActive = t.id === active
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`session-tab-panel-${t.id}`}
+              id={`session-tab-${t.id}`}
+              onClick={() => onChange(t.id)}
+              class={
+                'px-3 py-1 text-xs font-medium rounded-md transition-colors ' +
+                (isActive
+                  ? 'bg-indigo-50 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-800'
+                  : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700/50 border border-transparent')
+              }
+              data-testid={`session-tab-${t.id}`}
+            >
+              {t.label}
+            </button>
+          )
+        })}
+      </div>
+      <div
+        role="tabpanel"
+        id={`session-tab-panel-${active}`}
+        aria-labelledby={`session-tab-${active}`}
+        class="flex flex-col flex-1 min-h-0"
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/chat/diff-parse.ts
+++ b/src/chat/diff-parse.ts
@@ -1,0 +1,202 @@
+export type DiffLineType = 'context' | 'add' | 'del'
+
+export interface DiffLine {
+  type: DiffLineType
+  text: string
+  oldLineNo?: number
+  newLineNo?: number
+}
+
+export interface DiffHunk {
+  oldStart: number
+  oldCount: number
+  newStart: number
+  newCount: number
+  header: string
+  lines: DiffLine[]
+}
+
+export interface DiffFile {
+  oldPath: string
+  newPath: string
+  isNew: boolean
+  isDeleted: boolean
+  isRename: boolean
+  isBinary: boolean
+  hunks: DiffHunk[]
+}
+
+const HUNK_HEADER_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/
+
+function stripPrefix(path: string): string {
+  if (path.startsWith('a/') || path.startsWith('b/')) return path.slice(2)
+  return path
+}
+
+export function parseUnifiedDiff(patch: string): DiffFile[] {
+  const files: DiffFile[] = []
+  if (!patch) return files
+  const lines = patch.split('\n')
+  let i = 0
+  let current: DiffFile | null = null
+  let currentHunk: DiffHunk | null = null
+  let oldLineNo = 0
+  let newLineNo = 0
+
+  const pushFile = () => {
+    if (current) {
+      if (currentHunk) current.hunks.push(currentHunk)
+      files.push(current)
+    }
+    current = null
+    currentHunk = null
+  }
+
+  while (i < lines.length) {
+    const line = lines[i]
+
+    if (line.startsWith('diff --git ')) {
+      pushFile()
+      const match = line.match(/^diff --git (\S+) (\S+)$/)
+      const oldP = match ? stripPrefix(match[1]) : ''
+      const newP = match ? stripPrefix(match[2]) : ''
+      current = {
+        oldPath: oldP,
+        newPath: newP,
+        isNew: false,
+        isDeleted: false,
+        isRename: false,
+        isBinary: false,
+        hunks: [],
+      }
+      i++
+      continue
+    }
+
+    if (!current) {
+      if (line.startsWith('--- ') || line.startsWith('+++ ')) {
+        current = {
+          oldPath: '',
+          newPath: '',
+          isNew: false,
+          isDeleted: false,
+          isRename: false,
+          isBinary: false,
+          hunks: [],
+        }
+      } else {
+        i++
+        continue
+      }
+    }
+
+    if (line.startsWith('new file mode')) {
+      current.isNew = true
+      i++
+      continue
+    }
+    if (line.startsWith('deleted file mode')) {
+      current.isDeleted = true
+      i++
+      continue
+    }
+    if (line.startsWith('rename from ') || line.startsWith('rename to ')) {
+      current.isRename = true
+      i++
+      continue
+    }
+    if (line.startsWith('Binary files ') || line.startsWith('GIT binary patch')) {
+      current.isBinary = true
+      i++
+      continue
+    }
+    if (line.startsWith('index ') || line.startsWith('similarity index')) {
+      i++
+      continue
+    }
+    if (line.startsWith('--- ')) {
+      const p = line.slice(4).trim()
+      current.oldPath = p === '/dev/null' ? '' : stripPrefix(p)
+      if (p === '/dev/null') current.isNew = true
+      i++
+      continue
+    }
+    if (line.startsWith('+++ ')) {
+      const p = line.slice(4).trim()
+      current.newPath = p === '/dev/null' ? '' : stripPrefix(p)
+      if (p === '/dev/null') current.isDeleted = true
+      i++
+      continue
+    }
+
+    const hunkMatch = line.match(HUNK_HEADER_RE)
+    if (hunkMatch) {
+      if (currentHunk) current.hunks.push(currentHunk)
+      const oldStart = parseInt(hunkMatch[1], 10)
+      const oldCount = hunkMatch[2] ? parseInt(hunkMatch[2], 10) : 1
+      const newStart = parseInt(hunkMatch[3], 10)
+      const newCount = hunkMatch[4] ? parseInt(hunkMatch[4], 10) : 1
+      currentHunk = {
+        oldStart,
+        oldCount,
+        newStart,
+        newCount,
+        header: line,
+        lines: [],
+      }
+      oldLineNo = oldStart
+      newLineNo = newStart
+      i++
+      continue
+    }
+
+    if (currentHunk) {
+      if (line.startsWith('\\')) {
+        i++
+        continue
+      }
+      const tag = line[0]
+      const text = line.slice(1)
+      if (tag === '+') {
+        currentHunk.lines.push({ type: 'add', text, newLineNo })
+        newLineNo++
+      } else if (tag === '-') {
+        currentHunk.lines.push({ type: 'del', text, oldLineNo })
+        oldLineNo++
+      } else if (tag === ' ' || line === '') {
+        currentHunk.lines.push({ type: 'context', text, oldLineNo, newLineNo })
+        oldLineNo++
+        newLineNo++
+      } else {
+        i++
+        continue
+      }
+    }
+    i++
+  }
+
+  pushFile()
+  return files
+}
+
+export interface DiffTotals {
+  insertions: number
+  deletions: number
+}
+
+export function countChanges(file: DiffFile): DiffTotals {
+  let insertions = 0
+  let deletions = 0
+  for (const hunk of file.hunks) {
+    for (const l of hunk.lines) {
+      if (l.type === 'add') insertions++
+      else if (l.type === 'del') deletions++
+    }
+  }
+  return { insertions, deletions }
+}
+
+export function fileDisplayPath(file: DiffFile): string {
+  if (file.isDeleted) return file.oldPath
+  return file.newPath || file.oldPath
+}

--- a/src/routing/route.ts
+++ b/src/routing/route.ts
@@ -1,0 +1,61 @@
+import { signal } from '@preact/signals'
+import type { ReadonlySignal } from '@preact/signals'
+
+export type Route =
+  | { name: 'home' }
+  | { name: 'session'; sessionSlug: string }
+  | { name: 'group'; groupId: string }
+
+export function parseHash(hash: string): Route {
+  const raw = hash.replace(/^#?\/*/, '')
+  if (!raw) return { name: 'home' }
+  const segments = raw.split('/').filter(Boolean)
+  if (segments.length === 2 && segments[0] === 's') {
+    return { name: 'session', sessionSlug: decodeURIComponent(segments[1]) }
+  }
+  if (segments.length === 2 && segments[0] === 'g') {
+    return { name: 'group', groupId: decodeURIComponent(segments[1]) }
+  }
+  return { name: 'home' }
+}
+
+export function formatRoute(route: Route): string {
+  switch (route.name) {
+    case 'home':
+      return '#/'
+    case 'session':
+      return `#/s/${encodeURIComponent(route.sessionSlug)}`
+    case 'group':
+      return `#/g/${encodeURIComponent(route.groupId)}`
+  }
+}
+
+export interface Router {
+  route: ReadonlySignal<Route>
+  navigate(route: Route): void
+  dispose(): void
+}
+
+export function createRouter(win: Window = window): Router {
+  const route = signal<Route>(parseHash(win.location.hash))
+
+  const onHashChange = () => {
+    route.value = parseHash(win.location.hash)
+  }
+  win.addEventListener('hashchange', onHashChange)
+
+  return {
+    route,
+    navigate(next: Route) {
+      const hash = formatRoute(next)
+      if (win.location.hash === hash) {
+        route.value = next
+        return
+      }
+      win.location.hash = hash
+    },
+    dispose() {
+      win.removeEventListener('hashchange', onHashChange)
+    },
+  }
+}

--- a/test/api/client-extended.test.ts
+++ b/test/api/client-extended.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createApiClient, ApiError } from '../../src/api/client'
+import type {
+  ApiSession,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  CreateSessionVariantsResult,
+  PrPreview,
+  PushSubscriptionJSON,
+  ScreenshotList,
+  VapidPublicKey,
+  WorkspaceDiff,
+} from '../../src/api/types'
+
+const BASE_URL = 'https://example.com'
+const TOKEN = 'test-token'
+
+function jsonResponse(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    json: () => Promise.resolve(data),
+    blob: () => Promise.reject(new Error('not a blob response')),
+  }
+}
+
+function blobResponse(body: Blob, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    blob: () => Promise.resolve(body),
+    json: () => Promise.reject(new Error('not a json response')),
+  }
+}
+
+const SAMPLE_SESSION: ApiSession = {
+  id: 's-1',
+  slug: 'quick-fox',
+  status: 'pending',
+  command: '/task implement feature x',
+  createdAt: '2026-04-19T00:00:00Z',
+  updatedAt: '2026-04-19T00:00:00Z',
+  childIds: [],
+  needsAttention: false,
+  attentionReasons: [],
+  quickActions: [],
+  mode: 'task',
+  conversation: [],
+}
+
+describe('ApiClient — createSession', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: SAMPLE_SESSION }))
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('POSTs structured payload to /api/sessions', async () => {
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const req: CreateSessionRequest = { prompt: 'do the thing', mode: 'task', repo: 'foo' }
+    const out = await client.createSession(req)
+
+    expect(out).toEqual(SAMPLE_SESSION)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/sessions`)
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${TOKEN}`)
+    const body = JSON.parse(init.body as string) as CreateSessionRequest
+    expect(body).toEqual(req)
+  })
+})
+
+describe('ApiClient — createSessionVariants', () => {
+  it('POSTs to /api/sessions/variants and unwraps group result', async () => {
+    const result: CreateSessionVariantsResult = {
+      groupId: 'group-1',
+      sessions: [SAMPLE_SESSION, { ...SAMPLE_SESSION, id: 's-2' }],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: result }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const req: CreateSessionVariantsRequest = { prompt: 'parallel', mode: 'task', count: 2 }
+    const out = await client.createSessionVariants(req)
+
+    expect(out).toEqual(result)
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe(`${BASE_URL}/api/sessions/variants`)
+
+    vi.unstubAllGlobals()
+  })
+})
+
+describe('ApiClient — getPr / getDiff / listScreenshots', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('getPr hits /api/sessions/:id/pr with encoded id', async () => {
+    const pr: PrPreview = {
+      number: 42,
+      url: 'https://github.com/o/r/pull/42',
+      title: 'Feature',
+      body: 'body',
+      state: 'open',
+      draft: false,
+      mergeable: true,
+      branch: 'feature',
+      baseBranch: 'main',
+      author: 'me',
+      updatedAt: '2026-04-19T00:00:00Z',
+      checks: [],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: pr }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.getPr('weird id/with/slashes')
+    expect(out).toEqual(pr)
+
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe(`${BASE_URL}/api/sessions/${encodeURIComponent('weird id/with/slashes')}/pr`)
+  })
+
+  it('getDiff returns workspace diff', async () => {
+    const diff: WorkspaceDiff = {
+      sessionId: 's-1',
+      branch: 'feature',
+      baseBranch: 'main',
+      patch: '--- a\n+++ b\n',
+      truncated: false,
+      stats: { filesChanged: 1, insertions: 3, deletions: 1 },
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: diff }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.getDiff('s-1')
+    expect(out).toEqual(diff)
+  })
+
+  it('listScreenshots returns list shape', async () => {
+    const list: ScreenshotList = {
+      sessionId: 's-1',
+      screenshots: [
+        { file: 'a.png', url: '/api/screenshots/a.png', capturedAt: '2026-04-19T00:00:00Z', size: 100 },
+      ],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: list }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.listScreenshots('s-1')
+    expect(out).toEqual(list)
+  })
+})
+
+describe('ApiClient — fetchScreenshotBlob', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns a Blob and attaches Authorization header', async () => {
+    const body = new Blob(['fake-png'], { type: 'image/png' })
+    const fetchMock = vi.fn().mockResolvedValue(blobResponse(body))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.fetchScreenshotBlob('sub/dir/file.png')
+    expect(out).toBe(body)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/screenshots/${encodeURIComponent('sub/dir/file.png')}`)
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${TOKEN}`)
+    expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined()
+  })
+
+  it('throws ApiError on non-2xx', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found', blob: () => Promise.resolve(new Blob()) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    await expect(client.fetchScreenshotBlob('missing.png')).rejects.toThrow(ApiError)
+  })
+})
+
+describe('ApiClient — push', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('getVapidKey unwraps data', async () => {
+    const key: VapidPublicKey = { key: 'BXYZ' }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: key }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.getVapidKey()
+    expect(out).toEqual(key)
+  })
+
+  it('subscribePush POSTs the subscription', async () => {
+    const sub: PushSubscriptionJSON = {
+      endpoint: 'https://push.example.com/abc',
+      expirationTime: null,
+      keys: { p256dh: 'pk', auth: 'ak' },
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: { ok: true, id: 'sub-1' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.subscribePush(sub)
+    expect(out).toEqual({ ok: true, id: 'sub-1' })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/push-subscribe`)
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string) as PushSubscriptionJSON
+    expect(body).toEqual(sub)
+  })
+
+  it('unsubscribePush DELETEs with endpoint body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: { ok: true } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.unsubscribePush('https://push.example.com/abc')
+    expect(out).toEqual({ ok: true })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/push-subscribe`)
+    expect(init.method).toBe('DELETE')
+    const body = JSON.parse(init.body as string) as { endpoint: string }
+    expect(body.endpoint).toBe('https://push.example.com/abc')
+  })
+})

--- a/test/api/features.test.ts
+++ b/test/api/features.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { signal } from '@preact/signals'
+import { hasFeature } from '../../src/api/features'
+import type { ConnectionStore } from '../../src/state/types'
+import type { VersionInfo } from '../../src/api/types'
+
+function makeStore(version: VersionInfo | null): ConnectionStore {
+  return {
+    version: signal(version),
+  } as unknown as ConnectionStore
+}
+
+describe('hasFeature', () => {
+  it('returns false when source is null/undefined', () => {
+    expect(hasFeature(null, 'pr-preview')).toBe(false)
+    expect(hasFeature(undefined, 'pr-preview')).toBe(false)
+  })
+
+  it('returns false when version signal is null', () => {
+    expect(hasFeature(makeStore(null), 'pr-preview')).toBe(false)
+  })
+
+  it('returns false when feature not listed', () => {
+    const store = makeStore({ apiVersion: '1', libraryVersion: '1.0.0', features: ['messages'] })
+    expect(hasFeature(store, 'pr-preview')).toBe(false)
+  })
+
+  it('returns true when feature is listed', () => {
+    const store = makeStore({
+      apiVersion: '1',
+      libraryVersion: '1.1.0',
+      features: ['messages', 'pr-preview', 'diff-viewer'],
+    })
+    expect(hasFeature(store, 'pr-preview')).toBe(true)
+    expect(hasFeature(store, 'diff-viewer')).toBe(true)
+    expect(hasFeature(store, 'messages')).toBe(true)
+  })
+
+  it('accepts a raw VersionInfo without a store wrapper', () => {
+    const v: VersionInfo = { apiVersion: '1', libraryVersion: '1.1.0', features: ['web-push'] }
+    expect(hasFeature(v, 'web-push')).toBe(true)
+    expect(hasFeature(v, 'diff-viewer')).toBe(false)
+  })
+})

--- a/test/api/mock-minion-integration.test.ts
+++ b/test/api/mock-minion-integration.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { createApiClient, ApiError } from '../../src/api/client'
+import { createMockMinion, type MockMinion } from '../../e2e/fixtures/mock-minion'
+import type { PrPreview, PushSubscriptionJSON, WorkspaceDiff } from '../../src/api/types'
+
+describe('mock-minion integration', () => {
+  let minion: MockMinion
+  let client: ReturnType<typeof createApiClient>
+
+  beforeAll(async () => {
+    minion = await createMockMinion({ token: 'secret' })
+    client = createApiClient({ baseUrl: minion.url, token: 'secret' })
+  })
+
+  afterAll(async () => {
+    await minion.close()
+  })
+
+  beforeEach(() => {
+    minion.setVersion({ features: [] })
+  })
+
+  it('refuses createSession when feature flag off (default)', async () => {
+    await expect(client.createSession({ prompt: 'x', mode: 'task' })).rejects.toThrow(ApiError)
+  })
+
+  it('createSession works when feature enabled and records the request', async () => {
+    minion.setVersion({ features: ['sessions-create'] })
+    const before = minion.lastCreateSessionRequests.length
+    const session = await client.createSession({ prompt: 'hello', mode: 'task', repo: 'example' })
+    expect(session.mode).toBe('task')
+    expect(session.repo).toBe('example')
+    expect(minion.lastCreateSessionRequests.length).toBe(before + 1)
+    expect(minion.lastCreateSessionRequests[before]).toEqual({ prompt: 'hello', mode: 'task', repo: 'example' })
+  })
+
+  it('createSessionVariants returns a group of N sessions sharing a groupId', async () => {
+    minion.setVersion({ features: ['sessions-variants'] })
+    const out = await client.createSessionVariants({ prompt: 'parallel', mode: 'task', count: 3 })
+    expect(out.sessions).toHaveLength(3)
+    expect(new Set(out.sessions.map((s) => s.variantGroupId))).toEqual(new Set([out.groupId]))
+  })
+
+  it('gated endpoints return 404 with a feature-disabled error when flag off', async () => {
+    await expect(client.getPr('s-1')).rejects.toThrow(ApiError)
+    await expect(client.getDiff('s-1')).rejects.toThrow(ApiError)
+    await expect(client.listScreenshots('s-1')).rejects.toThrow(ApiError)
+    await expect(client.getVapidKey()).rejects.toThrow(ApiError)
+  })
+
+  it('getPr returns the stored preview when flag on', async () => {
+    minion.setVersion({ features: ['pr-preview'] })
+    const pr: PrPreview = {
+      number: 1,
+      url: 'https://github.com/o/r/pull/1',
+      title: 't',
+      body: 'b',
+      state: 'open',
+      draft: false,
+      mergeable: null,
+      branch: 'feat',
+      baseBranch: 'main',
+      author: 'me',
+      updatedAt: '2026-04-19T00:00:00Z',
+      checks: [{ name: 'ci', status: 'pending' }],
+    }
+    minion.setPr('s-1', pr)
+    const out = await client.getPr('s-1')
+    expect(out).toEqual(pr)
+  })
+
+  it('getDiff returns the stored workspace diff when flag on', async () => {
+    minion.setVersion({ features: ['diff-viewer'] })
+    const diff: WorkspaceDiff = {
+      sessionId: 's-1',
+      branch: 'feat',
+      baseBranch: 'main',
+      patch: 'diff --git a/x b/x',
+      truncated: false,
+      stats: { filesChanged: 1, insertions: 2, deletions: 0 },
+    }
+    minion.setDiff('s-1', diff)
+    const out = await client.getDiff('s-1')
+    expect(out).toEqual(diff)
+  })
+
+  it('listScreenshots + fetchScreenshotBlob round-trip', async () => {
+    minion.setVersion({ features: ['screenshots-http'] })
+    minion.setScreenshots('s-1', [
+      { file: 'shot-1.png', url: '/api/screenshots/shot-1.png', capturedAt: '2026-04-19T00:00:00Z', size: 4 },
+    ])
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    minion.setScreenshotBlob('shot-1.png', png)
+
+    const list = await client.listScreenshots('s-1')
+    expect(list.screenshots).toHaveLength(1)
+    expect(list.screenshots[0].file).toBe('shot-1.png')
+
+    const blob = await client.fetchScreenshotBlob('shot-1.png')
+    const buf = Buffer.from(await blob.arrayBuffer())
+    expect(buf.equals(png)).toBe(true)
+  })
+
+  it('web push flow: getVapidKey → subscribe → unsubscribe', async () => {
+    minion.setVersion({ features: ['web-push'] })
+    const { key } = await client.getVapidKey()
+    expect(key).toMatch(/^B/)
+
+    const sub: PushSubscriptionJSON = {
+      endpoint: 'https://push.example.com/abc',
+      expirationTime: null,
+      keys: { p256dh: 'pk', auth: 'ak' },
+    }
+    const ack = await client.subscribePush(sub)
+    expect(ack.ok).toBe(true)
+    expect(minion.pushSubscriptions).toContainEqual(sub)
+
+    await client.unsubscribePush(sub.endpoint)
+    expect(minion.lastUnsubscribeEndpoints).toContain(sub.endpoint)
+    expect(minion.pushSubscriptions.find((s) => s.endpoint === sub.endpoint)).toBeUndefined()
+  })
+})

--- a/test/chat/DiffTab.test.tsx
+++ b/test/chat/DiffTab.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { DiffTab } from '../../src/chat/DiffTab'
+import type { ApiClient } from '../../src/api/client'
+import type { WorkspaceDiff } from '../../src/api/types'
+
+function makeClient(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    baseUrl: 'https://example.com',
+    token: 't',
+    getVersion: vi.fn(),
+    getSessions: vi.fn(),
+    getDags: vi.fn(),
+    sendCommand: vi.fn(),
+    sendMessage: vi.fn(),
+    createSession: vi.fn(),
+    createSessionVariants: vi.fn(),
+    getPr: vi.fn(),
+    getDiff: vi.fn(),
+    listScreenshots: vi.fn(),
+    fetchScreenshotBlob: vi.fn(),
+    getVapidKey: vi.fn(),
+    subscribePush: vi.fn(),
+    unsubscribePush: vi.fn(),
+    openEventStream: vi.fn(() => ({ close: vi.fn(), status: { value: 'live' } })) as unknown as ApiClient['openEventStream'],
+    ...overrides,
+  } as ApiClient
+}
+
+const SAMPLE_DIFF: WorkspaceDiff = {
+  sessionId: 's-1',
+  branch: 'feature',
+  baseBranch: 'main',
+  patch: [
+    'diff --git a/foo.ts b/foo.ts',
+    '--- a/foo.ts',
+    '+++ b/foo.ts',
+    '@@ -1,2 +1,3 @@',
+    ' keep',
+    '-old',
+    '+new',
+    '+extra',
+  ].join('\n'),
+  truncated: false,
+  stats: { filesChanged: 1, insertions: 2, deletions: 1 },
+}
+
+beforeEach(() => {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    })
+  }
+})
+
+describe('DiffTab', () => {
+  it('shows loading state then renders diff', async () => {
+    let resolve: (v: WorkspaceDiff) => void
+    const getDiff = vi.fn().mockReturnValue(new Promise<WorkspaceDiff>((r) => { resolve = r }))
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-1" sessionUpdatedAt="2026-04-19T00:00:00Z" client={client} />)
+    expect(screen.getByTestId('diff-loading')).toBeTruthy()
+    act(() => { resolve!(SAMPLE_DIFF) })
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    expect(screen.getByText(/feature/)).toBeTruthy()
+    const tab = screen.getByTestId('diff-tab')
+    expect(tab.textContent).toContain('+2')
+    expect(tab.textContent).toContain('-1')
+  })
+
+  it('renders add/del/context lines with correct test ids', async () => {
+    const getDiff = vi.fn().mockResolvedValue(SAMPLE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    expect(screen.getAllByTestId('diff-line-add')).toHaveLength(2)
+    expect(screen.getAllByTestId('diff-line-del')).toHaveLength(1)
+    expect(screen.getAllByTestId('diff-line-context')).toHaveLength(1)
+  })
+
+  it('shows error state when fetch fails', async () => {
+    const getDiff = vi.fn().mockRejectedValue(new Error('boom'))
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-error')).toBeTruthy())
+    expect(screen.getByText(/boom/)).toBeTruthy()
+  })
+
+  it('shows truncated banner when diff is truncated', async () => {
+    const getDiff = vi.fn().mockResolvedValue({ ...SAMPLE_DIFF, truncated: true })
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-truncated-banner')).toBeTruthy())
+  })
+
+  it('refetches when sessionUpdatedAt changes', async () => {
+    const getDiff = vi.fn().mockResolvedValue(SAMPLE_DIFF)
+    const client = makeClient({ getDiff })
+    const { rerender } = render(<DiffTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(getDiff).toHaveBeenCalledTimes(1))
+    rerender(<DiffTab sessionId="s-1" sessionUpdatedAt="t2" client={client} />)
+    await waitFor(() => expect(getDiff).toHaveBeenCalledTimes(2))
+  })
+
+  it('copies patch to clipboard when Copy button is clicked', async () => {
+    const getDiff = vi.fn().mockResolvedValue(SAMPLE_DIFF)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-copy-btn')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('diff-copy-btn'))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(SAMPLE_DIFF.patch))
+  })
+
+  it('collapses and expands per-file sections', async () => {
+    const getDiff = vi.fn().mockResolvedValue(SAMPLE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    expect(screen.getAllByTestId('diff-line-add').length).toBeGreaterThan(0)
+    fireEvent.click(screen.getByTestId('diff-file-toggle'))
+    await waitFor(() => expect(screen.queryByTestId('diff-line-add')).toBeNull())
+  })
+
+  it('shows empty state when no files changed', async () => {
+    const getDiff = vi.fn().mockResolvedValue({
+      ...SAMPLE_DIFF,
+      patch: '',
+      stats: { filesChanged: 0, insertions: 0, deletions: 0 },
+    })
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-empty')).toBeTruthy())
+  })
+})

--- a/test/chat/ScreenshotsTab.test.tsx
+++ b/test/chat/ScreenshotsTab.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ScreenshotsTab } from '../../src/chat/ScreenshotsTab'
+import type { ApiClient } from '../../src/api/client'
+import type { ScreenshotEntry, ScreenshotList } from '../../src/api/types'
+
+function makeClient(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    baseUrl: 'https://example.com',
+    token: 't',
+    getVersion: vi.fn(),
+    getSessions: vi.fn(),
+    getDags: vi.fn(),
+    sendCommand: vi.fn(),
+    sendMessage: vi.fn(),
+    createSession: vi.fn(),
+    createSessionVariants: vi.fn(),
+    getPr: vi.fn(),
+    getDiff: vi.fn(),
+    listScreenshots: vi.fn(),
+    fetchScreenshotBlob: vi.fn(),
+    getVapidKey: vi.fn(),
+    subscribePush: vi.fn(),
+    unsubscribePush: vi.fn(),
+    openEventStream: vi.fn(() => ({ close: vi.fn(), status: { value: 'live' } })) as unknown as ApiClient['openEventStream'],
+    ...overrides,
+  } as ApiClient
+}
+
+function makeEntry(file: string, capturedAt = '2026-04-19T00:00:00Z'): ScreenshotEntry {
+  return { file, url: `/api/screenshots/${file}`, capturedAt, size: 100 }
+}
+
+let createdUrls: string[] = []
+let revokedUrls: string[] = []
+
+beforeEach(() => {
+  createdUrls = []
+  revokedUrls = []
+  let counter = 0
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn((_blob: Blob) => {
+      const url = `blob:mock-${counter++}`
+      createdUrls.push(url)
+      return url
+    }),
+    revokeObjectURL: vi.fn((url: string) => {
+      revokedUrls.push(url)
+    }),
+  })
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    })
+  }
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('ScreenshotsTab', () => {
+  it('shows loading state then renders thumbnails', async () => {
+    let resolveList: (v: ScreenshotList) => void
+    const listScreenshots = vi.fn().mockReturnValue(
+      new Promise<ScreenshotList>((r) => { resolveList = r })
+    )
+    const fetchScreenshotBlob = vi.fn().mockResolvedValue(new Blob(['fake'], { type: 'image/png' }))
+    const client = makeClient({ listScreenshots, fetchScreenshotBlob })
+
+    render(<ScreenshotsTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    expect(screen.getByTestId('screenshots-loading')).toBeTruthy()
+
+    act(() => {
+      resolveList!({ sessionId: 's-1', screenshots: [makeEntry('a.png'), makeEntry('b.png')] })
+    })
+    await waitFor(() => expect(screen.getByTestId('screenshots-tab')).toBeTruthy())
+    expect(screen.getAllByTestId('screenshot-thumb')).toHaveLength(2)
+    await waitFor(() => expect(fetchScreenshotBlob).toHaveBeenCalledTimes(2))
+  })
+
+  it('renders empty state when no screenshots', async () => {
+    const listScreenshots = vi.fn().mockResolvedValue({ sessionId: 's-1', screenshots: [] })
+    const client = makeClient({ listScreenshots })
+    render(<ScreenshotsTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('screenshots-empty')).toBeTruthy())
+  })
+
+  it('shows error when list fetch fails', async () => {
+    const listScreenshots = vi.fn().mockRejectedValue(new Error('nope'))
+    const client = makeClient({ listScreenshots })
+    render(<ScreenshotsTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('screenshots-error')).toBeTruthy())
+    expect(screen.getByText(/nope/)).toBeTruthy()
+  })
+
+  it('creates blob URLs for screenshots and revokes them on unmount', async () => {
+    const listScreenshots = vi.fn().mockResolvedValue({
+      sessionId: 's-1',
+      screenshots: [makeEntry('a.png'), makeEntry('b.png')],
+    })
+    const fetchScreenshotBlob = vi.fn().mockResolvedValue(new Blob(['x'], { type: 'image/png' }))
+    const client = makeClient({ listScreenshots, fetchScreenshotBlob })
+    const { unmount } = render(
+      <ScreenshotsTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />
+    )
+    await waitFor(() => expect(createdUrls.length).toBe(2))
+    unmount()
+    expect(revokedUrls).toEqual(expect.arrayContaining(createdUrls))
+    expect(revokedUrls.length).toBe(createdUrls.length)
+  })
+
+  it('revokes blob URLs for files no longer in the list after refetch', async () => {
+    let call = 0
+    const listScreenshots = vi.fn().mockImplementation(() => {
+      call++
+      if (call === 1) {
+        return Promise.resolve({
+          sessionId: 's-1',
+          screenshots: [makeEntry('a.png'), makeEntry('b.png')],
+        })
+      }
+      return Promise.resolve({ sessionId: 's-1', screenshots: [makeEntry('a.png')] })
+    })
+    const fetchScreenshotBlob = vi.fn().mockResolvedValue(new Blob(['x']))
+    const client = makeClient({ listScreenshots, fetchScreenshotBlob })
+
+    const { rerender } = render(
+      <ScreenshotsTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />
+    )
+    await waitFor(() => expect(createdUrls.length).toBe(2))
+    const initialUrls = [...createdUrls]
+
+    rerender(<ScreenshotsTab sessionId="s-1" sessionUpdatedAt="t2" client={client} />)
+    await waitFor(() => expect(revokedUrls.length).toBeGreaterThanOrEqual(1))
+    expect(revokedUrls).toContain(initialUrls[1])
+  })
+
+  it('opens lightbox on thumb click and closes on close button', async () => {
+    const listScreenshots = vi.fn().mockResolvedValue({
+      sessionId: 's-1',
+      screenshots: [makeEntry('a.png')],
+    })
+    const fetchScreenshotBlob = vi.fn().mockResolvedValue(new Blob(['x']))
+    const client = makeClient({ listScreenshots, fetchScreenshotBlob })
+    render(<ScreenshotsTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('screenshot-thumb')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('screenshot-thumb'))
+    expect(screen.getByTestId('screenshot-lightbox')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('screenshot-lightbox-close'))
+    expect(screen.queryByTestId('screenshot-lightbox')).toBeNull()
+  })
+
+  it('navigates with next/prev buttons when multiple screenshots', async () => {
+    const listScreenshots = vi.fn().mockResolvedValue({
+      sessionId: 's-1',
+      screenshots: [makeEntry('a.png'), makeEntry('b.png'), makeEntry('c.png')],
+    })
+    const fetchScreenshotBlob = vi.fn().mockResolvedValue(new Blob(['x']))
+    const client = makeClient({ listScreenshots, fetchScreenshotBlob })
+    render(<ScreenshotsTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getAllByTestId('screenshot-thumb')).toHaveLength(3))
+    fireEvent.click(screen.getAllByTestId('screenshot-thumb')[0])
+    const lightbox = screen.getByTestId('screenshot-lightbox')
+    expect(lightbox.textContent).toContain('a.png')
+    fireEvent.click(screen.getByTestId('screenshot-lightbox-next'))
+    expect(screen.getByTestId('screenshot-lightbox').textContent).toContain('b.png')
+    fireEvent.click(screen.getByTestId('screenshot-lightbox-prev'))
+    expect(screen.getByTestId('screenshot-lightbox').textContent).toContain('a.png')
+  })
+
+  it('refetches when sessionUpdatedAt changes', async () => {
+    const listScreenshots = vi.fn().mockResolvedValue({ sessionId: 's-1', screenshots: [] })
+    const client = makeClient({ listScreenshots })
+    const { rerender } = render(<ScreenshotsTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(listScreenshots).toHaveBeenCalledTimes(1))
+    rerender(<ScreenshotsTab sessionId="s-1" sessionUpdatedAt="t2" client={client} />)
+    await waitFor(() => expect(listScreenshots).toHaveBeenCalledTimes(2))
+  })
+})

--- a/test/chat/SessionTabs.test.tsx
+++ b/test/chat/SessionTabs.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { describe, it, expect, vi } from 'vitest'
+import { SessionTabs } from '../../src/chat/SessionTabs'
+
+describe('SessionTabs', () => {
+  it('renders only available tabs', () => {
+    render(
+      <SessionTabs
+        tabs={[
+          { id: 'chat', label: 'Chat', available: true },
+          { id: 'diff', label: 'Diff', available: false },
+          { id: 'screenshots', label: 'Screenshots', available: true },
+        ]}
+        active="chat"
+        onChange={vi.fn()}
+      >
+        <div>body</div>
+      </SessionTabs>
+    )
+    expect(screen.getByTestId('session-tab-chat')).toBeTruthy()
+    expect(screen.queryByTestId('session-tab-diff')).toBeNull()
+    expect(screen.getByTestId('session-tab-screenshots')).toBeTruthy()
+  })
+
+  it('marks the active tab with aria-selected', () => {
+    render(
+      <SessionTabs
+        tabs={[
+          { id: 'chat', label: 'Chat', available: true },
+          { id: 'diff', label: 'Diff', available: true },
+        ]}
+        active="diff"
+        onChange={vi.fn()}
+      >
+        <div>body</div>
+      </SessionTabs>
+    )
+    expect(screen.getByTestId('session-tab-diff').getAttribute('aria-selected')).toBe('true')
+    expect(screen.getByTestId('session-tab-chat').getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('fires onChange when an inactive tab is clicked', () => {
+    const onChange = vi.fn()
+    render(
+      <SessionTabs
+        tabs={[
+          { id: 'chat', label: 'Chat', available: true },
+          { id: 'diff', label: 'Diff', available: true },
+        ]}
+        active="chat"
+        onChange={onChange}
+      >
+        <div>body</div>
+      </SessionTabs>
+    )
+    fireEvent.click(screen.getByTestId('session-tab-diff'))
+    expect(onChange).toHaveBeenCalledWith('diff')
+  })
+
+  it('renders children inside the tabpanel region', () => {
+    render(
+      <SessionTabs
+        tabs={[{ id: 'chat', label: 'Chat', available: true }]}
+        active="chat"
+        onChange={vi.fn()}
+      >
+        <div data-testid="tab-body">hello</div>
+      </SessionTabs>
+    )
+    expect(screen.getByTestId('tab-body').textContent).toBe('hello')
+  })
+})

--- a/test/chat/diff-parse.test.ts
+++ b/test/chat/diff-parse.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest'
+import { parseUnifiedDiff, countChanges, fileDisplayPath } from '../../src/chat/diff-parse'
+
+describe('parseUnifiedDiff', () => {
+  it('returns empty array for empty patch', () => {
+    expect(parseUnifiedDiff('')).toEqual([])
+  })
+
+  it('parses a single-file, single-hunk patch', () => {
+    const patch = [
+      'diff --git a/foo.ts b/foo.ts',
+      'index 0000001..0000002 100644',
+      '--- a/foo.ts',
+      '+++ b/foo.ts',
+      '@@ -1,3 +1,4 @@',
+      ' line1',
+      '-line2',
+      '+line2-new',
+      '+line2b',
+      ' line3',
+    ].join('\n')
+    const files = parseUnifiedDiff(patch)
+    expect(files).toHaveLength(1)
+    const f = files[0]
+    expect(f.oldPath).toBe('foo.ts')
+    expect(f.newPath).toBe('foo.ts')
+    expect(f.hunks).toHaveLength(1)
+    const h = f.hunks[0]
+    expect(h.oldStart).toBe(1)
+    expect(h.oldCount).toBe(3)
+    expect(h.newStart).toBe(1)
+    expect(h.newCount).toBe(4)
+    expect(h.lines.map((l) => l.type)).toEqual(['context', 'del', 'add', 'add', 'context'])
+    expect(h.lines[0]).toMatchObject({ type: 'context', text: 'line1', oldLineNo: 1, newLineNo: 1 })
+    expect(h.lines[1]).toMatchObject({ type: 'del', text: 'line2', oldLineNo: 2 })
+    expect(h.lines[2]).toMatchObject({ type: 'add', text: 'line2-new', newLineNo: 2 })
+    expect(h.lines[3]).toMatchObject({ type: 'add', text: 'line2b', newLineNo: 3 })
+    expect(h.lines[4]).toMatchObject({ type: 'context', text: 'line3', oldLineNo: 3, newLineNo: 4 })
+  })
+
+  it('parses multiple files with multiple hunks', () => {
+    const patch = [
+      'diff --git a/a.ts b/a.ts',
+      '--- a/a.ts',
+      '+++ b/a.ts',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      'diff --git a/b.ts b/b.ts',
+      '--- a/b.ts',
+      '+++ b/b.ts',
+      '@@ -1,2 +1,2 @@',
+      ' ctx',
+      '-gone',
+      '+added',
+      '@@ -10,1 +10,2 @@',
+      ' more',
+      '+extra',
+    ].join('\n')
+    const files = parseUnifiedDiff(patch)
+    expect(files).toHaveLength(2)
+    expect(files[0].newPath).toBe('a.ts')
+    expect(files[1].newPath).toBe('b.ts')
+    expect(files[1].hunks).toHaveLength(2)
+    expect(files[1].hunks[1].oldStart).toBe(10)
+  })
+
+  it('flags new and deleted files via /dev/null', () => {
+    const patch = [
+      'diff --git a/new.ts b/new.ts',
+      'new file mode 100644',
+      '--- /dev/null',
+      '+++ b/new.ts',
+      '@@ -0,0 +1,1 @@',
+      '+hello',
+      'diff --git a/del.ts b/del.ts',
+      'deleted file mode 100644',
+      '--- a/del.ts',
+      '+++ /dev/null',
+      '@@ -1,1 +0,0 @@',
+      '-bye',
+    ].join('\n')
+    const files = parseUnifiedDiff(patch)
+    expect(files).toHaveLength(2)
+    expect(files[0].isNew).toBe(true)
+    expect(files[0].newPath).toBe('new.ts')
+    expect(files[1].isDeleted).toBe(true)
+    expect(files[1].oldPath).toBe('del.ts')
+  })
+
+  it('marks renames and binary files', () => {
+    const patch = [
+      'diff --git a/old.ts b/new.ts',
+      'similarity index 95%',
+      'rename from old.ts',
+      'rename to new.ts',
+      'diff --git a/img.png b/img.png',
+      'index 111..222 100644',
+      'Binary files a/img.png and b/img.png differ',
+    ].join('\n')
+    const files = parseUnifiedDiff(patch)
+    expect(files).toHaveLength(2)
+    expect(files[0].isRename).toBe(true)
+    expect(files[0].oldPath).toBe('old.ts')
+    expect(files[0].newPath).toBe('new.ts')
+    expect(files[1].isBinary).toBe(true)
+  })
+
+  it('ignores "No newline at end of file" markers', () => {
+    const patch = [
+      'diff --git a/x.ts b/x.ts',
+      '--- a/x.ts',
+      '+++ b/x.ts',
+      '@@ -1 +1 @@',
+      '-old',
+      '\\ No newline at end of file',
+      '+new',
+      '\\ No newline at end of file',
+    ].join('\n')
+    const files = parseUnifiedDiff(patch)
+    expect(files[0].hunks[0].lines.map((l) => l.type)).toEqual(['del', 'add'])
+  })
+
+  it('handles omitted counts in hunk headers (defaults to 1)', () => {
+    const patch = [
+      'diff --git a/x.ts b/x.ts',
+      '--- a/x.ts',
+      '+++ b/x.ts',
+      '@@ -5 +5 @@',
+      '-a',
+      '+b',
+    ].join('\n')
+    const files = parseUnifiedDiff(patch)
+    expect(files[0].hunks[0].oldStart).toBe(5)
+    expect(files[0].hunks[0].oldCount).toBe(1)
+    expect(files[0].hunks[0].newCount).toBe(1)
+  })
+
+  it('skips prelude lines before the first file', () => {
+    const patch = [
+      '# some random prefix',
+      '',
+      'diff --git a/x.ts b/x.ts',
+      '--- a/x.ts',
+      '+++ b/x.ts',
+      '@@ -1 +1 @@',
+      '-a',
+      '+b',
+    ].join('\n')
+    const files = parseUnifiedDiff(patch)
+    expect(files).toHaveLength(1)
+  })
+})
+
+describe('countChanges', () => {
+  it('counts insertions and deletions across hunks', () => {
+    const patch = [
+      'diff --git a/f b/f',
+      '--- a/f',
+      '+++ b/f',
+      '@@ -1,3 +1,4 @@',
+      ' a',
+      '-b',
+      '+c',
+      '+d',
+      ' e',
+    ].join('\n')
+    const [file] = parseUnifiedDiff(patch)
+    expect(countChanges(file)).toEqual({ insertions: 2, deletions: 1 })
+  })
+})
+
+describe('fileDisplayPath', () => {
+  it('prefers new path; falls back to old path for deletes', () => {
+    const patch = [
+      'diff --git a/del.ts b/del.ts',
+      'deleted file mode 100644',
+      '--- a/del.ts',
+      '+++ /dev/null',
+      '@@ -1 +0,0 @@',
+      '-bye',
+    ].join('\n')
+    const [f] = parseUnifiedDiff(patch)
+    expect(fileDisplayPath(f)).toBe('del.ts')
+  })
+})

--- a/test/routing/route.test.ts
+++ b/test/routing/route.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { parseHash, formatRoute, createRouter } from '../../src/routing/route'
+
+describe('parseHash', () => {
+  it('returns home for empty/missing', () => {
+    expect(parseHash('')).toEqual({ name: 'home' })
+    expect(parseHash('#')).toEqual({ name: 'home' })
+    expect(parseHash('#/')).toEqual({ name: 'home' })
+  })
+
+  it('parses session slug', () => {
+    expect(parseHash('#/s/fast-cat')).toEqual({ name: 'session', sessionSlug: 'fast-cat' })
+  })
+
+  it('decodes percent-encoded segments', () => {
+    expect(parseHash('#/s/cool%20slug')).toEqual({ name: 'session', sessionSlug: 'cool slug' })
+  })
+
+  it('parses group id', () => {
+    expect(parseHash('#/g/grp-1')).toEqual({ name: 'group', groupId: 'grp-1' })
+  })
+
+  it('unknown shape falls back to home', () => {
+    expect(parseHash('#/foo/bar')).toEqual({ name: 'home' })
+    expect(parseHash('#/s')).toEqual({ name: 'home' })
+  })
+})
+
+describe('formatRoute', () => {
+  it('round-trips through parseHash', () => {
+    expect(parseHash(formatRoute({ name: 'home' }))).toEqual({ name: 'home' })
+    expect(parseHash(formatRoute({ name: 'session', sessionSlug: 'fast-cat' }))).toEqual({
+      name: 'session',
+      sessionSlug: 'fast-cat',
+    })
+    expect(parseHash(formatRoute({ name: 'group', groupId: 'grp-1' }))).toEqual({
+      name: 'group',
+      groupId: 'grp-1',
+    })
+  })
+
+  it('encodes special characters', () => {
+    const hash = formatRoute({ name: 'session', sessionSlug: 'has spaces' })
+    expect(hash).toBe('#/s/has%20spaces')
+  })
+})
+
+describe('createRouter', () => {
+  const originalHash = window.location.hash
+
+  beforeEach(() => {
+    window.location.hash = ''
+  })
+
+  afterEach(() => {
+    window.location.hash = originalHash
+  })
+
+  it('initializes route from current hash', () => {
+    window.location.hash = '#/s/foo'
+    const r = createRouter()
+    expect(r.route.value).toEqual({ name: 'session', sessionSlug: 'foo' })
+    r.dispose()
+  })
+
+  it('updates route on hashchange', () => {
+    const r = createRouter()
+    expect(r.route.value).toEqual({ name: 'home' })
+
+    window.location.hash = '#/g/grp-9'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(r.route.value).toEqual({ name: 'group', groupId: 'grp-9' })
+    r.dispose()
+  })
+
+  it('navigate() sets the hash and updates the route', () => {
+    const r = createRouter()
+    r.navigate({ name: 'session', sessionSlug: 'ab' })
+    // location.hash change in jsdom fires a hashchange synchronously in newer versions,
+    // but for safety nudge it manually:
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(r.route.value).toEqual({ name: 'session', sessionSlug: 'ab' })
+    expect(window.location.hash).toBe('#/s/ab')
+    r.dispose()
+  })
+
+  it('navigate() to the same hash still updates the signal', () => {
+    window.location.hash = '#/s/foo'
+    const r = createRouter()
+    const initial = r.route.value
+    r.navigate({ name: 'session', sessionSlug: 'foo' })
+    expect(r.route.value).toEqual(initial)
+    r.dispose()
+  })
+
+  it('dispose() stops listening to hashchange', () => {
+    const r = createRouter()
+    r.dispose()
+    window.location.hash = '#/s/never-seen'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(r.route.value).toEqual({ name: 'home' })
+  })
+})

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,5 +24,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "e2e/fixtures"]
 }


### PR DESCRIPTION
## Summary

Adds a tab strip inside `ChatPane` (Chat / Diff / Screenshots) so an active session can expose a unified-diff view and a screenshot gallery without leaving the conversation. Both extra tabs are feature-gated on the minion's reported `diff-viewer` / `screenshots-http` capabilities and are hidden when the feature is absent.

- **`src/chat/diff-parse.ts`** — hand-rolled unified-diff parser. Handles multi-file / multi-hunk patches, new / deleted / renamed / binary files, omitted hunk counts (`@@ -5 +5 @@`), and the `\ No newline at end of file` marker. Returns `{ file, hunks: [{ oldStart, newStart, lines: [{ type, text, oldLineNo?, newLineNo? }] }] }`.
- **`src/chat/SessionTabs.tsx`** — thin ARIA tablist wrapper. Renders only tabs whose `available: true`.
- **`src/chat/DiffTab.tsx`** — calls `client.getDiff(sessionId)`, parses with `parseUnifiedDiff`, renders per-file collapsible sections with green/red gutter + line numbers. Shows an amber truncation banner when `diff.truncated`, a "Copy patch" button, and an empty-state when no workspace changes. Refetches when `sessionId` or `sessionUpdatedAt` changes (piggybacks on `session_updated` SSE via the signal path).
- **`src/chat/ScreenshotsTab.tsx`** — lists via `client.listScreenshots`, fetches each image as a `Blob` via `client.fetchScreenshotBlob` (since `<img src>` cannot attach `Authorization: Bearer`). Tracks blob URLs in a `useRef<Map>`, revokes on unmount and when the list shrinks. Lightbox modal with keyboard (Esc / ← / →) and button navigation.

Feature gating:

- Diff tab: `hasFeature(store, 'diff-viewer')`
- Screenshots tab: `hasFeature(store, 'screenshots-http')`

## Why

Third and fourth of the conductor-shaped UI items: a diff viewer and a screenshot gallery. Bundling both inside a shared tab strip avoids two concurrent `ChatPane` edits from different minions and gives users a single place to switch between conversation, workspace state, and visual artifacts.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 287 passed (33 files)
- [x] New tests:
  - `test/chat/diff-parse.test.ts` — 10 cases incl. multi-file / multi-hunk / renames / binary / `/dev/null` / no-newline / omitted counts
  - `test/chat/SessionTabs.test.tsx` — 4 cases (availability, active state, onChange, tabpanel body)
  - `test/chat/DiffTab.test.tsx` — 8 cases (loading, render, error, truncated, refetch on updatedAt, copy, collapse, empty)
  - `test/chat/ScreenshotsTab.test.tsx` — 8 cases (loading, empty, error, blob lifecycle on unmount, revoke on list diff, lightbox open/close, prev/next navigation, refetch on updatedAt)
- [ ] E2E / browser testing not run (per instructions)

## Assumptions

- `ChatPane` now takes a `store: ConnectionStore` prop in addition to `session`; previously it only received `session`, `onSend`, `onCommand`. Callsites in `App.tsx` were updated.
- `sessionUpdatedAt` is used as the refetch trigger instead of subscribing directly to SSE — relies on the existing `session_updated` → store-signal → parent-re-render path, which is how the rest of the app reacts to session changes.
- Blob-URL revocation is tested with `vi.stubGlobal('URL', …)` and asserts both the unmount path and the shrink-list path.

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  api-foundation["✅ API foundation: types, client, features, router"]
  structured-task-creation["✅ Refactor task creation: POST /api/sessions flow"]
  worktree-header["✅ Worktree header: branch, cwd, diff stats"]
  pr-preview-card["✅ PR preview card: title, state, checks, body"]
  session-tabs["✅ Session tabs: diff viewer and screenshots gallery"]
  web-push["✅ Web Push: notifications, subscriptions, service worker"]
  parallel-variants-ui["✅ Parallel variants: N-session group layout and picker"]
  api-foundation --> structured-task-creation
  api-foundation --> worktree-header
  api-foundation --> pr-preview-card
  api-foundation --> session-tabs
  api-foundation --> web-push
  api-foundation --> parallel-variants-ui
  structured-task-creation --> parallel-variants-ui
  class api-foundation done
  class structured-task-creation done
  class worktree-header done
  class pr-preview-card done
  class session-tabs done
  class session-tabs current
  class web-push done
  class parallel-variants-ui done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | API foundation: types, client, features, router | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/4) |
| 2 | Refactor task creation: POST /api/sessions flow | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/5) |
| 3 | Worktree header: branch, cwd, diff stats | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/6) |
| 4 | PR preview card: title, state, checks, body | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/7) |
| 5 | **Session tabs: diff viewer and screenshots gallery** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/8) |
| 6 | Web Push: notifications, subscriptions, service worker | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/10) |
| 7 | Parallel variants: N-session group layout and picker | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/9) |

**Progress:** 7/7 complete

<!-- dag-status-end -->

