### PR TITLE
[minions] feat(groups): parallel variants group view and picker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import { InstallPrompt } from './pwa/InstallPrompt'
 import { useOnlineStatus } from './pwa/useOnlineStatus'
 import { useMediaQuery } from './hooks/useMediaQuery'
 import { WorktreeHeader } from './components/WorktreeHeader'
+import { currentRoute } from './routing/current'
+import { VariantGroupView } from './groups/VariantGroupView'
 import type { ApiSession, MinionCommand, QuickAction } from './api/types'
 
 const showSettings = signal(false)
@@ -303,16 +305,24 @@ function ActiveView() {
   const [sessionId, setSessionId] = useState<string | null>(null)
   const isOnline = useOnlineStatus()
   const isDesktop = useMediaQuery('(min-width: 768px)')
+  const route = currentRoute.value
 
   useEffect(() => {
     const color = conn?.color ?? '#3b82f6'
     document.documentElement.style.setProperty('--accent', color)
   }, [conn?.color])
 
+  useEffect(() => {
+    if (route.name !== 'session') return
+    const match = store?.sessions.value.find((s) => s.slug === route.sessionSlug)
+    if (match && match.id !== sessionId) setSessionId(match.id)
+  }, [route, store, sessionId])
+
   if (!store || !conn) return null
 
   const sessions = store.sessions.value
   const selected = sessionId ? sessions.find((s) => s.id === sessionId) ?? null : null
+  const isGroupRoute = route.name === 'group'
 
   const handleSendMessage = async (text: string, sid: string) => {
     await store.client.sendMessage(text, sid)
@@ -351,7 +361,9 @@ function ActiveView() {
         </div>
       )}
       <NewTaskBar store={store} />
-      {isDesktop.value ? (
+      {isGroupRoute ? (
+        <VariantGroupView store={store} groupId={route.groupId} />
+      ) : isDesktop.value ? (
         <div class="flex flex-1 min-h-0">
           <aside class="w-72 border-r border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 overflow-y-auto shrink-0">
             <SessionList

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -3,6 +3,7 @@ import type { ConnectionStore } from '../state/types'
 import type { CreateSessionMode } from '../api/types'
 import { hasFeature } from '../api/features'
 import { formatRoute } from '../routing/route'
+import { recordVariantGroup } from '../groups/store'
 
 export interface ModeOption {
   value: CreateSessionMode
@@ -78,6 +79,14 @@ export function NewTaskBar({ store, navigate = defaultNavigate }: NewTaskBarProp
           mode: mode.value,
           repo: selectedRepo,
           count: variantCount.value,
+        })
+        recordVariantGroup(store.connectionId, {
+          groupId: out.groupId,
+          prompt: p,
+          mode: mode.value,
+          repo: selectedRepo,
+          variantSessionIds: out.sessions.map((s) => s.id),
+          createdAt: new Date().toISOString(),
         })
         prompt.value = ''
         navigate(formatRoute({ name: 'group', groupId: out.groupId }))

--- a/src/groups/VariantGroupView.tsx
+++ b/src/groups/VariantGroupView.tsx
@@ -1,0 +1,285 @@
+import { useMemo, useState } from 'preact/hooks'
+import { useComputed } from '@preact/signals'
+import type { ApiSession, MinionCommand } from '../api/types'
+import type { ConnectionStore } from '../state/types'
+import { ConversationView } from '../chat/ConversationView'
+import { confirm } from '../hooks/useConfirm'
+import { hasFeature } from '../api/features'
+import { formatRoute } from '../routing/route'
+import { variantGroupsSignal, setVariantWinner } from './store'
+import type { VariantGroup } from './types'
+
+interface VariantGroupViewProps {
+  store: ConnectionStore
+  groupId: string
+  navigate?: (hash: string) => void
+}
+
+function defaultNavigate(hash: string): void {
+  if (typeof window !== 'undefined') {
+    window.location.hash = hash
+  }
+}
+
+function statusDot(status: ApiSession['status']): string {
+  if (status === 'running') return 'bg-blue-500 animate-pulse'
+  if (status === 'completed') return 'bg-green-500'
+  if (status === 'failed') return 'bg-red-500'
+  return 'bg-slate-400'
+}
+
+export function VariantGroupView({ store, groupId, navigate = defaultNavigate }: VariantGroupViewProps) {
+  const groupsSignal = useMemo(() => variantGroupsSignal(store.connectionId), [store.connectionId])
+  const groupSignal = useComputed<VariantGroup | null>(
+    () => groupsSignal.value.find((g) => g.groupId === groupId) ?? null
+  )
+  const group = groupSignal.value
+  const allSessions = store.sessions.value
+
+  const featureOn = hasFeature(store, 'sessions-variants')
+
+  if (!featureOn) {
+    return (
+      <div
+        class="flex-1 flex items-center justify-center p-8 bg-slate-50 dark:bg-slate-900"
+        data-testid="variant-group-gated"
+      >
+        <div class="text-center text-sm text-slate-500 dark:text-slate-400 max-w-md">
+          <div class="font-semibold text-slate-700 dark:text-slate-300 mb-1">Parallel variants unavailable</div>
+          <div>This connection's library does not support variant groups. Needs library ≥ 1.111.</div>
+          <button
+            type="button"
+            onClick={() => navigate(formatRoute({ name: 'home' }))}
+            class="mt-3 rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-3 py-1.5 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+            data-testid="variant-group-back"
+          >
+            ← Back
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!group) {
+    return (
+      <div
+        class="flex-1 flex items-center justify-center p-8 bg-slate-50 dark:bg-slate-900"
+        data-testid="variant-group-missing"
+      >
+        <div class="text-center text-sm text-slate-500 dark:text-slate-400 max-w-md">
+          <div class="font-semibold text-slate-700 dark:text-slate-300 mb-1">Variant group not found</div>
+          <div>
+            Group <code class="font-mono text-xs bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded">{groupId}</code>{' '}
+            isn't recorded for this connection.
+          </div>
+          <button
+            type="button"
+            onClick={() => navigate(formatRoute({ name: 'home' }))}
+            class="mt-3 rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-3 py-1.5 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+            data-testid="variant-group-back"
+          >
+            ← Back
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const variants: Array<{ id: string; session: ApiSession | null }> = group.variantSessionIds.map((id) => ({
+    id,
+    session: allSessions.find((s) => s.id === id) ?? null,
+  }))
+
+  return (
+    <div class="flex flex-col flex-1 min-h-0 bg-white dark:bg-slate-800" data-testid="variant-group-view">
+      <VariantGroupHeader group={group} onBack={() => navigate(formatRoute({ name: 'home' }))} />
+      <VariantColumns
+        store={store}
+        group={group}
+        variants={variants}
+        navigate={navigate}
+      />
+    </div>
+  )
+}
+
+function VariantGroupHeader({ group, onBack }: { group: VariantGroup; onBack: () => void }) {
+  return (
+    <header
+      class="flex flex-col gap-1 px-4 py-3 border-b border-slate-200 dark:border-slate-700 shrink-0 bg-slate-50 dark:bg-slate-900"
+      data-testid="variant-group-header"
+    >
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onBack}
+          class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+          data-testid="variant-group-back"
+        >
+          ← Back
+        </button>
+        <span class="text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">Variants</span>
+        <span class="font-mono text-xs text-slate-600 dark:text-slate-300">{group.groupId}</span>
+        <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500">{group.mode}</span>
+        {group.repo && (
+          <span class="text-[10px] font-mono rounded bg-slate-100 dark:bg-slate-700 px-1.5 py-0.5 text-slate-600 dark:text-slate-300">
+            {group.repo}
+          </span>
+        )}
+        <span class="ml-auto text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          ×{group.variantSessionIds.length}
+        </span>
+      </div>
+      <div
+        class="text-sm text-slate-800 dark:text-slate-200 whitespace-pre-wrap break-words"
+        data-testid="variant-group-prompt"
+      >
+        {group.prompt}
+      </div>
+    </header>
+  )
+}
+
+interface VariantColumnsProps {
+  store: ConnectionStore
+  group: VariantGroup
+  variants: Array<{ id: string; session: ApiSession | null }>
+  navigate: (hash: string) => void
+}
+
+function VariantColumns({ store, group, variants, navigate }: VariantColumnsProps) {
+  const pickWinner = async (winner: ApiSession) => {
+    const siblings = variants.filter((v) => v.id !== winner.id)
+    const siblingCount = siblings.length
+    const ok = await confirm({
+      title: `Pick ${winner.slug} as winner?`,
+      message:
+        siblingCount > 0
+          ? `Stops the other ${siblingCount} sibling session${siblingCount === 1 ? '' : 's'}. The winner keeps running and is promoted to the normal session list.`
+          : 'Promotes this session to the normal list.',
+      destructive: true,
+      confirmLabel: 'Pick winner',
+    })
+    if (!ok) return
+
+    for (const sib of siblings) {
+      if (!sib.session) continue
+      const s = sib.session
+      if (s.status === 'running' || s.status === 'pending') {
+        await store.sendCommand({ action: 'stop', sessionId: s.id } satisfies MinionCommand)
+      }
+      if (s.status !== 'completed' && s.status !== 'failed') {
+        await store.sendCommand({ action: 'close', sessionId: s.id } satisfies MinionCommand)
+      }
+    }
+
+    setVariantWinner(store.connectionId, group.groupId, winner.id)
+    navigate(formatRoute({ name: 'session', sessionSlug: winner.slug }))
+  }
+
+  return (
+    <div
+      class="flex-1 grid gap-px bg-slate-200 dark:bg-slate-700 overflow-hidden md:overflow-x-auto"
+      style={{
+        gridTemplateColumns: `repeat(${Math.max(variants.length, 1)}, minmax(320px, 1fr))`,
+      }}
+      data-testid="variant-columns"
+    >
+      {variants.map((v) => (
+        <VariantColumn
+          key={v.id}
+          id={v.id}
+          session={v.session}
+          group={group}
+          onPickWinner={pickWinner}
+          onOpen={() => {
+            if (v.session) navigate(formatRoute({ name: 'session', sessionSlug: v.session.slug }))
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+interface VariantColumnProps {
+  id: string
+  session: ApiSession | null
+  group: VariantGroup
+  onPickWinner: (s: ApiSession) => Promise<void>
+  onOpen: () => void
+}
+
+function VariantColumn({ id, session, group, onPickWinner, onOpen }: VariantColumnProps) {
+  const [picking, setPicking] = useState(false)
+  const isWinner = group.winnerId === id
+  const winnerLocked = typeof group.winnerId === 'string'
+
+  return (
+    <section
+      class={`flex flex-col min-h-0 min-w-0 bg-white dark:bg-slate-800 ${isWinner ? 'ring-2 ring-inset ring-indigo-500' : ''}`}
+      data-testid={`variant-column-${id}`}
+      data-winner={isWinner ? 'true' : 'false'}
+    >
+      <div class="flex items-center gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700 shrink-0">
+        {session ? (
+          <>
+            <span class={`inline-block h-2 w-2 rounded-full ${statusDot(session.status)}`} />
+            <button
+              type="button"
+              onClick={onOpen}
+              class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate hover:underline"
+              data-testid={`variant-open-${id}`}
+            >
+              {session.slug}
+            </button>
+            <span class="text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              {session.status}
+            </span>
+          </>
+        ) : (
+          <>
+            <span class="inline-block h-2 w-2 rounded-full bg-slate-400" />
+            <span class="font-mono text-xs text-slate-500 dark:text-slate-400 truncate">waiting…</span>
+          </>
+        )}
+        <button
+          type="button"
+          disabled={!session || picking || winnerLocked}
+          onClick={async () => {
+            if (!session) return
+            setPicking(true)
+            try {
+              await onPickWinner(session)
+            } finally {
+              setPicking(false)
+            }
+          }}
+          title={
+            winnerLocked
+              ? isWinner
+                ? 'Already picked'
+                : 'Winner already chosen'
+              : 'Stop siblings and promote this session'
+          }
+          class={`ml-auto rounded-md border px-2 py-1 text-xs font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+            isWinner
+              ? 'bg-indigo-600 border-indigo-700 text-white'
+              : 'border-indigo-300 dark:border-indigo-700 text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-950/40 hover:bg-indigo-100 dark:hover:bg-indigo-900/50'
+          }`}
+          data-testid={`variant-pick-${id}`}
+        >
+          {isWinner ? 'Winner' : picking ? 'Picking…' : 'Pick winner'}
+        </button>
+      </div>
+      <div class="flex-1 min-h-0 overflow-hidden flex flex-col">
+        {session ? (
+          <ConversationView messages={session.conversation} />
+        ) : (
+          <div class="flex-1 flex items-center justify-center text-xs text-slate-400 dark:text-slate-500 italic p-6">
+            Variant hasn't landed yet.
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/groups/store.ts
+++ b/src/groups/store.ts
@@ -1,0 +1,116 @@
+import { signal, computed } from '@preact/signals'
+import type { ReadonlySignal } from '@preact/signals'
+import type { VariantGroup, VariantGroupsState } from './types'
+
+const STORAGE_KEY = 'minions-ui:variant-groups:v1'
+
+function migrate(raw: unknown): VariantGroupsState {
+  if (
+    raw !== null &&
+    typeof raw === 'object' &&
+    (raw as Record<string, unknown>).version === 1 &&
+    typeof (raw as Record<string, unknown>).byConnection === 'object'
+  ) {
+    return raw as VariantGroupsState
+  }
+  return { version: 1, byConnection: {} }
+}
+
+function load(): VariantGroupsState {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return { version: 1, byConnection: {} }
+    return migrate(JSON.parse(stored) as unknown)
+  } catch {
+    return { version: 1, byConnection: {} }
+  }
+}
+
+function persist(state: VariantGroupsState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // storage quota, private mode — skip silently
+  }
+}
+
+const state = signal<VariantGroupsState>(load())
+
+export const variantGroupsState: ReadonlySignal<VariantGroupsState> = state
+
+export function groupsForConnection(connectionId: string): VariantGroup[] {
+  return state.value.byConnection[connectionId] ?? []
+}
+
+export function variantGroupsSignal(connectionId: string): ReadonlySignal<VariantGroup[]> {
+  return computed(() => state.value.byConnection[connectionId] ?? [])
+}
+
+export function getVariantGroup(connectionId: string, groupId: string): VariantGroup | null {
+  const list = groupsForConnection(connectionId)
+  return list.find((g) => g.groupId === groupId) ?? null
+}
+
+export function recordVariantGroup(connectionId: string, group: VariantGroup): void {
+  const current = state.value
+  const existing = current.byConnection[connectionId] ?? []
+  const idx = existing.findIndex((g) => g.groupId === group.groupId)
+  const next = idx === -1 ? [...existing, group] : existing.map((g) => (g.groupId === group.groupId ? group : g))
+  const nextState: VariantGroupsState = {
+    version: 1,
+    byConnection: { ...current.byConnection, [connectionId]: next },
+  }
+  state.value = nextState
+  persist(nextState)
+}
+
+export function setVariantWinner(connectionId: string, groupId: string, winnerId: string): void {
+  const current = state.value
+  const existing = current.byConnection[connectionId] ?? []
+  const idx = existing.findIndex((g) => g.groupId === groupId)
+  if (idx === -1) return
+  const group = existing[idx]
+  if (!group.variantSessionIds.includes(winnerId)) return
+  const updated: VariantGroup = { ...group, winnerId }
+  const next = existing.map((g) => (g.groupId === groupId ? updated : g))
+  const nextState: VariantGroupsState = {
+    version: 1,
+    byConnection: { ...current.byConnection, [connectionId]: next },
+  }
+  state.value = nextState
+  persist(nextState)
+}
+
+export function removeVariantGroup(connectionId: string, groupId: string): void {
+  const current = state.value
+  const existing = current.byConnection[connectionId] ?? []
+  const next = existing.filter((g) => g.groupId !== groupId)
+  if (next.length === existing.length) return
+  const nextState: VariantGroupsState = {
+    version: 1,
+    byConnection: { ...current.byConnection, [connectionId]: next },
+  }
+  state.value = nextState
+  persist(nextState)
+}
+
+export function clearConnectionGroups(connectionId: string): void {
+  const current = state.value
+  if (!(connectionId in current.byConnection)) return
+  const rest: Record<string, VariantGroup[]> = {}
+  for (const [cid, list] of Object.entries(current.byConnection)) {
+    if (cid !== connectionId) rest[cid] = list
+  }
+  const nextState: VariantGroupsState = { version: 1, byConnection: rest }
+  state.value = nextState
+  persist(nextState)
+}
+
+export function resetVariantGroupsForTests(): void {
+  state.value = { version: 1, byConnection: {} }
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    return
+  }
+}

--- a/src/groups/types.ts
+++ b/src/groups/types.ts
@@ -1,0 +1,16 @@
+import type { CreateSessionMode } from '../api/types'
+
+export interface VariantGroup {
+  groupId: string
+  prompt: string
+  mode: CreateSessionMode
+  repo?: string
+  variantSessionIds: string[]
+  winnerId?: string
+  createdAt: string
+}
+
+export interface VariantGroupsState {
+  version: 1
+  byConnection: Record<string, VariantGroup[]>
+}

--- a/src/routing/current.ts
+++ b/src/routing/current.ts
@@ -1,0 +1,16 @@
+import { signal } from '@preact/signals'
+import type { ReadonlySignal } from '@preact/signals'
+import { parseHash } from './route'
+import type { Route } from './route'
+
+const internal = signal<Route>(
+  typeof window !== 'undefined' ? parseHash(window.location.hash) : { name: 'home' }
+)
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('hashchange', () => {
+    internal.value = parseHash(window.location.hash)
+  })
+}
+
+export const currentRoute: ReadonlySignal<Route> = internal

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -140,6 +140,7 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
   void refresh()
 
   return {
+    connectionId,
     client,
     sessions,
     dags,

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -13,6 +13,7 @@ export interface DiffStats {
 }
 
 export interface ConnectionStore {
+  connectionId: string
   client: ApiClient
   sessions: ReadonlySignal<ApiSession[]>
   dags: ReadonlySignal<ApiDagGraph[]>

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -105,6 +105,61 @@ describe('App', () => {
     expect(within(conv).getByText('hello')).toBeTruthy()
   })
 
+  it('renders the variant group view when the hash is #/g/:groupId', async () => {
+    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
+      version: 1,
+      connections: [
+        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+      ],
+      activeId: 'c1',
+    }))
+    localStorage.setItem(
+      'minions-ui:variant-groups:v1',
+      JSON.stringify({
+        version: 1,
+        byConnection: {
+          c1: [{
+            groupId: 'g-route',
+            prompt: 'routed prompt',
+            mode: 'task',
+            variantSessionIds: ['s1', 's2'],
+            createdAt: '2026-04-19T00:00:00Z',
+          }],
+        },
+      })
+    )
+    const versionWithVariants: VersionInfo = {
+      apiVersion: '1',
+      libraryVersion: '1.111.0',
+      features: ['sessions-create', 'sessions-variants'],
+    }
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/api/version')) {
+        return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: versionWithVariants }) })
+      }
+      if (url.includes('/api/sessions')) {
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          json: () => Promise.resolve({ data: [session({ id: 's1', slug: 'brave-fox' }), session({ id: 's2', slug: 'swift-cat' })] }),
+        })
+      }
+      if (url.includes('/api/dags')) {
+        return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: [] }) })
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'NF', json: () => Promise.resolve({ data: null }) })
+    }))
+    window.location.hash = '#/g/g-route'
+    try {
+      const App = (await import('../src/App')).default
+      render(<App />)
+      const view = await screen.findByTestId('variant-group-view')
+      expect(view).toBeTruthy()
+      expect(screen.getByTestId('variant-group-prompt').textContent).toBe('routed prompt')
+    } finally {
+      window.location.hash = ''
+    }
+  })
+
   it('switching sessions swaps the conversation pane', async () => {
     localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
       version: 1,

--- a/test/chat/NewTaskBar.test.tsx
+++ b/test/chat/NewTaskBar.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/preact'
 import { signal } from '@preact/signals'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NewTaskBar } from '../../src/chat/NewTaskBar'
+import { getVariantGroup, resetVariantGroupsForTests } from '../../src/groups/store'
 import type { ConnectionStore } from '../../src/state/types'
 import type {
   ApiDagGraph,
@@ -69,6 +70,7 @@ function makeStore(opts: {
   }
 
   const store: ConnectionStore = {
+    connectionId: 'test-conn',
     client: client as unknown as ConnectionStore['client'],
     sessions: signal<ApiSession[]>([]),
     dags: signal<ApiDagGraph[]>([]),
@@ -85,6 +87,8 @@ function makeStore(opts: {
 
 describe('NewTaskBar', () => {
   beforeEach(() => {
+    localStorage.clear()
+    resetVariantGroupsForTests()
     if (!window.matchMedia) {
       Object.defineProperty(window, 'matchMedia', {
         writable: true,
@@ -216,6 +220,27 @@ describe('NewTaskBar', () => {
 
     const err = await screen.findByTestId('new-task-error')
     expect(err.textContent).toContain('bad request')
+  })
+
+  it('records the variant group client-side on successful variant creation', async () => {
+    const { store } = makeStore({
+      features: ['sessions-create', 'sessions-variants'],
+      repos: [{ alias: 'primary', url: 'https://github.com/org/primary' }],
+    })
+    const navigate = vi.fn<(hash: string) => void>()
+    render(<NewTaskBar store={store} navigate={navigate} />)
+    fireEvent.click(screen.getByTestId('variant-2'))
+    const textarea = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'compare approaches' } })
+    fireEvent.click(screen.getByTestId('new-task-send'))
+
+    await waitFor(() => expect(navigate).toHaveBeenCalled())
+    const recorded = getVariantGroup('test-conn', 'g-xyz')
+    expect(recorded).not.toBeNull()
+    expect(recorded?.prompt).toBe('compare approaches')
+    expect(recorded?.mode).toBe('task')
+    expect(recorded?.repo).toBe('primary')
+    expect(recorded?.variantSessionIds).toHaveLength(2)
   })
 
   it('Launch button label reflects variant count', async () => {

--- a/test/groups/VariantGroupView.test.tsx
+++ b/test/groups/VariantGroupView.test.tsx
@@ -1,0 +1,274 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/preact'
+import { signal } from '@preact/signals'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { VariantGroupView } from '../../src/groups/VariantGroupView'
+import {
+  recordVariantGroup,
+  getVariantGroup,
+  resetVariantGroupsForTests,
+} from '../../src/groups/store'
+import { ConfirmRoot } from '../../src/hooks/useConfirm'
+import type { ConnectionStore } from '../../src/state/types'
+import type {
+  ApiDagGraph,
+  ApiSession,
+  CommandResult,
+  MinionCommand,
+  VersionInfo,
+} from '../../src/api/types'
+import type { VariantGroup } from '../../src/groups/types'
+
+function session(over: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 's1',
+    slug: 'brave-fox',
+    status: 'running',
+    command: '/task x',
+    createdAt: '2026-04-19T00:00:00Z',
+    updatedAt: '2026-04-19T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...over,
+  }
+}
+
+function makeStore(opts: {
+  features?: string[]
+  sessions?: ApiSession[]
+  sendCommandImpl?: (cmd: MinionCommand) => Promise<CommandResult>
+} = {}): ConnectionStore {
+  const version: VersionInfo = {
+    apiVersion: '1',
+    libraryVersion: '1.111.0',
+    features: opts.features ?? ['sessions-create', 'sessions-variants'],
+  }
+  return {
+    connectionId: 'conn-test',
+    client: {} as ConnectionStore['client'],
+    sessions: signal<ApiSession[]>(opts.sessions ?? []),
+    dags: signal<ApiDagGraph[]>([]),
+    status: signal('live'),
+    error: signal<string | null>(null),
+    version: signal<VersionInfo | null>(version),
+    stale: signal(false),
+    refresh: vi.fn(async () => {}),
+    sendCommand: vi
+      .fn<(cmd: MinionCommand) => Promise<CommandResult>>()
+      .mockImplementation(opts.sendCommandImpl ?? (async () => ({ success: true }))),
+    dispose: vi.fn(),
+  }
+}
+
+function exampleGroup(over: Partial<VariantGroup> = {}): VariantGroup {
+  return {
+    groupId: 'g-xyz',
+    prompt: 'ship the feature',
+    mode: 'task',
+    variantSessionIds: ['sv-1', 'sv-2', 'sv-3'],
+    createdAt: '2026-04-19T00:00:00Z',
+    ...over,
+  }
+}
+
+describe('VariantGroupView', () => {
+  beforeEach(() => {
+    resetVariantGroupsForTests()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    resetVariantGroupsForTests()
+    localStorage.clear()
+  })
+
+  it('renders gated message when sessions-variants feature is missing', () => {
+    const store = makeStore({ features: ['sessions-create'] })
+    recordVariantGroup('conn-test', exampleGroup())
+    render(<VariantGroupView store={store} groupId="g-xyz" />)
+    expect(screen.getByTestId('variant-group-gated')).toBeTruthy()
+    expect(screen.getByTestId('variant-group-gated').textContent).toContain('Needs library ≥ 1.111')
+  })
+
+  it('renders a friendly missing state when the group is unknown', () => {
+    const store = makeStore()
+    render(<VariantGroupView store={store} groupId="g-nope" />)
+    expect(screen.getByTestId('variant-group-missing')).toBeTruthy()
+    expect(screen.getByTestId('variant-group-missing').textContent).toContain('g-nope')
+  })
+
+  it('renders header with prompt, mode, repo and variant count', () => {
+    const store = makeStore()
+    recordVariantGroup(
+      'conn-test',
+      exampleGroup({ repo: 'primary', mode: 'plan', prompt: 'build auth service' })
+    )
+    render(<VariantGroupView store={store} groupId="g-xyz" />)
+    const header = screen.getByTestId('variant-group-header')
+    expect(header.textContent).toContain('plan')
+    expect(header.textContent).toContain('primary')
+    expect(header.textContent).toContain('×3')
+    expect(screen.getByTestId('variant-group-prompt').textContent).toBe('build auth service')
+  })
+
+  it('renders one column per variant id with session status when available', () => {
+    const sessions = [
+      session({ id: 'sv-1', slug: 'brave-fox', status: 'running' }),
+      session({ id: 'sv-2', slug: 'swift-cat', status: 'completed' }),
+    ]
+    const store = makeStore({ sessions })
+    recordVariantGroup(
+      'conn-test',
+      exampleGroup({ variantSessionIds: ['sv-1', 'sv-2', 'sv-3'] })
+    )
+    render(<VariantGroupView store={store} groupId="g-xyz" />)
+    expect(screen.getByTestId('variant-column-sv-1')).toBeTruthy()
+    expect(screen.getByTestId('variant-column-sv-2')).toBeTruthy()
+    expect(screen.getByTestId('variant-column-sv-3')).toBeTruthy()
+
+    const col1 = screen.getByTestId('variant-column-sv-1')
+    expect(within(col1).getByText('brave-fox')).toBeTruthy()
+    expect(within(col1).getByText('running')).toBeTruthy()
+
+    const col3 = screen.getByTestId('variant-column-sv-3')
+    expect(col3.textContent).toContain('waiting')
+    const pickBtn3 = within(col3).getByTestId('variant-pick-sv-3') as HTMLButtonElement
+    expect(pickBtn3.disabled).toBe(true)
+  })
+
+  it('pick-winner stops and closes siblings, marks winner, and navigates to the session route', async () => {
+    const sessions = [
+      session({ id: 'sv-1', slug: 'brave-fox', status: 'running' }),
+      session({ id: 'sv-2', slug: 'swift-cat', status: 'running' }),
+      session({ id: 'sv-3', slug: 'quiet-owl', status: 'pending' }),
+    ]
+    const store = makeStore({ sessions })
+    const navigate = vi.fn<(hash: string) => void>()
+    recordVariantGroup(
+      'conn-test',
+      exampleGroup({ variantSessionIds: ['sv-1', 'sv-2', 'sv-3'] })
+    )
+
+    render(
+      <>
+        <VariantGroupView store={store} groupId="g-xyz" navigate={navigate} />
+        <ConfirmRoot />
+      </>
+    )
+
+    fireEvent.click(screen.getByTestId('variant-pick-sv-2'))
+    await screen.findByRole('dialog')
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(within(dialog).getByText('Pick winner'))
+
+    await waitFor(() => expect(store.sendCommand).toHaveBeenCalled())
+    const calls = (store.sendCommand as unknown as { mock: { calls: [MinionCommand][] } }).mock.calls.map((c) => c[0])
+    const stopTargets = calls.filter((c) => c.action === 'stop').map((c) => c.sessionId)
+    const closeTargets = calls.filter((c) => c.action === 'close').map((c) => c.sessionId)
+    expect(stopTargets.sort()).toEqual(['sv-1', 'sv-3'])
+    expect(closeTargets.sort()).toEqual(['sv-1', 'sv-3'])
+    expect(stopTargets).not.toContain('sv-2')
+    expect(closeTargets).not.toContain('sv-2')
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('#/s/swift-cat'))
+
+    const after = getVariantGroup('conn-test', 'g-xyz')
+    expect(after?.winnerId).toBe('sv-2')
+  })
+
+  it('pick-winner aborts when the confirm modal is cancelled', async () => {
+    const sessions = [
+      session({ id: 'sv-1', slug: 'brave-fox', status: 'running' }),
+      session({ id: 'sv-2', slug: 'swift-cat', status: 'running' }),
+    ]
+    const store = makeStore({ sessions })
+    const navigate = vi.fn<(hash: string) => void>()
+    recordVariantGroup(
+      'conn-test',
+      exampleGroup({ variantSessionIds: ['sv-1', 'sv-2'] })
+    )
+
+    render(
+      <>
+        <VariantGroupView store={store} groupId="g-xyz" navigate={navigate} />
+        <ConfirmRoot />
+      </>
+    )
+
+    fireEvent.click(screen.getByTestId('variant-pick-sv-1'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByText('Cancel'))
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(store.sendCommand).not.toHaveBeenCalled()
+    expect(navigate).not.toHaveBeenCalled()
+    expect(getVariantGroup('conn-test', 'g-xyz')?.winnerId).toBeUndefined()
+  })
+
+  it('pick-winner skips commands for terminal siblings', async () => {
+    const sessions = [
+      session({ id: 'sv-1', slug: 'brave-fox', status: 'completed' }),
+      session({ id: 'sv-2', slug: 'swift-cat', status: 'running' }),
+    ]
+    const store = makeStore({ sessions })
+    const navigate = vi.fn<(hash: string) => void>()
+    recordVariantGroup(
+      'conn-test',
+      exampleGroup({ variantSessionIds: ['sv-1', 'sv-2'] })
+    )
+
+    render(
+      <>
+        <VariantGroupView store={store} groupId="g-xyz" navigate={navigate} />
+        <ConfirmRoot />
+      </>
+    )
+
+    fireEvent.click(screen.getByTestId('variant-pick-sv-2'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByText('Pick winner'))
+
+    await waitFor(() => expect(navigate).toHaveBeenCalled())
+    expect(store.sendCommand).not.toHaveBeenCalled()
+    expect(getVariantGroup('conn-test', 'g-xyz')?.winnerId).toBe('sv-2')
+  })
+
+  it('locks out subsequent pick-winner clicks once a winner is set', () => {
+    const sessions = [
+      session({ id: 'sv-1', slug: 'brave-fox', status: 'running' }),
+      session({ id: 'sv-2', slug: 'swift-cat', status: 'running' }),
+    ]
+    const store = makeStore({ sessions })
+    recordVariantGroup(
+      'conn-test',
+      exampleGroup({ variantSessionIds: ['sv-1', 'sv-2'], winnerId: 'sv-1' })
+    )
+
+    render(<VariantGroupView store={store} groupId="g-xyz" />)
+
+    const winnerBtn = screen.getByTestId('variant-pick-sv-1') as HTMLButtonElement
+    const loserBtn = screen.getByTestId('variant-pick-sv-2') as HTMLButtonElement
+    expect(winnerBtn.textContent).toBe('Winner')
+    expect(winnerBtn.disabled).toBe(true)
+    expect(loserBtn.disabled).toBe(true)
+    expect(screen.getByTestId('variant-column-sv-1').getAttribute('data-winner')).toBe('true')
+  })
+
+  it('navigates to the session when the column title is clicked', () => {
+    const sessions = [session({ id: 'sv-1', slug: 'brave-fox', status: 'running' })]
+    const store = makeStore({ sessions })
+    const navigate = vi.fn<(hash: string) => void>()
+    recordVariantGroup(
+      'conn-test',
+      exampleGroup({ variantSessionIds: ['sv-1'] })
+    )
+
+    render(<VariantGroupView store={store} groupId="g-xyz" navigate={navigate} />)
+
+    fireEvent.click(screen.getByTestId('variant-open-sv-1'))
+    expect(navigate).toHaveBeenCalledWith('#/s/brave-fox')
+  })
+})

--- a/test/groups/store.test.ts
+++ b/test/groups/store.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { VariantGroup } from '../../src/groups/types'
+
+function group(over: Partial<VariantGroup> = {}): VariantGroup {
+  return {
+    groupId: 'g1',
+    prompt: 'do the thing',
+    mode: 'task',
+    variantSessionIds: ['s1', 's2'],
+    createdAt: '2026-04-19T00:00:00Z',
+    ...over,
+  }
+}
+
+describe('variant groups store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('records a group for a connection and retrieves it', async () => {
+    const m = await import('../../src/groups/store')
+    m.recordVariantGroup('conn-a', group())
+    expect(m.groupsForConnection('conn-a')).toHaveLength(1)
+    expect(m.getVariantGroup('conn-a', 'g1')?.prompt).toBe('do the thing')
+  })
+
+  it('persists to localStorage on record', async () => {
+    const m = await import('../../src/groups/store')
+    m.recordVariantGroup('conn-a', group({ groupId: 'g-persist' }))
+    const raw = localStorage.getItem('minions-ui:variant-groups:v1')
+    expect(raw).toBeTruthy()
+    const parsed = JSON.parse(raw ?? '{}') as { byConnection: Record<string, VariantGroup[]> }
+    expect(parsed.byConnection['conn-a'][0].groupId).toBe('g-persist')
+  })
+
+  it('rehydrates from localStorage on fresh module load', async () => {
+    localStorage.setItem(
+      'minions-ui:variant-groups:v1',
+      JSON.stringify({
+        version: 1,
+        byConnection: { 'conn-a': [group({ groupId: 'g-rehydrated' })] },
+      })
+    )
+    const m = await import('../../src/groups/store')
+    expect(m.getVariantGroup('conn-a', 'g-rehydrated')?.prompt).toBe('do the thing')
+  })
+
+  it('scopes groups by connection id', async () => {
+    const m = await import('../../src/groups/store')
+    m.recordVariantGroup('conn-a', group({ groupId: 'ga' }))
+    m.recordVariantGroup('conn-b', group({ groupId: 'gb' }))
+    expect(m.getVariantGroup('conn-a', 'gb')).toBeNull()
+    expect(m.getVariantGroup('conn-b', 'ga')).toBeNull()
+    expect(m.getVariantGroup('conn-b', 'gb')?.groupId).toBe('gb')
+  })
+
+  it('updates an existing group when recording the same id twice', async () => {
+    const m = await import('../../src/groups/store')
+    m.recordVariantGroup('conn-a', group({ prompt: 'first' }))
+    m.recordVariantGroup('conn-a', group({ prompt: 'second' }))
+    const list = m.groupsForConnection('conn-a')
+    expect(list).toHaveLength(1)
+    expect(list[0].prompt).toBe('second')
+  })
+
+  it('setVariantWinner marks the winner and refuses unknown ids', async () => {
+    const m = await import('../../src/groups/store')
+    m.recordVariantGroup('conn-a', group({ variantSessionIds: ['s1', 's2', 's3'] }))
+    m.setVariantWinner('conn-a', 'g1', 'not-a-variant')
+    expect(m.getVariantGroup('conn-a', 'g1')?.winnerId).toBeUndefined()
+    m.setVariantWinner('conn-a', 'g1', 's2')
+    expect(m.getVariantGroup('conn-a', 'g1')?.winnerId).toBe('s2')
+  })
+
+  it('removeVariantGroup deletes only the targeted group', async () => {
+    const m = await import('../../src/groups/store')
+    m.recordVariantGroup('conn-a', group({ groupId: 'g1' }))
+    m.recordVariantGroup('conn-a', group({ groupId: 'g2' }))
+    m.removeVariantGroup('conn-a', 'g1')
+    expect(m.groupsForConnection('conn-a').map((g) => g.groupId)).toEqual(['g2'])
+  })
+
+  it('clearConnectionGroups drops all groups for a connection', async () => {
+    const m = await import('../../src/groups/store')
+    m.recordVariantGroup('conn-a', group({ groupId: 'ga' }))
+    m.recordVariantGroup('conn-b', group({ groupId: 'gb' }))
+    m.clearConnectionGroups('conn-a')
+    expect(m.groupsForConnection('conn-a')).toHaveLength(0)
+    expect(m.groupsForConnection('conn-b')).toHaveLength(1)
+  })
+
+  it('variantGroupsSignal reflects updates reactively', async () => {
+    const m = await import('../../src/groups/store')
+    const sig = m.variantGroupsSignal('conn-a')
+    expect(sig.value).toHaveLength(0)
+    m.recordVariantGroup('conn-a', group())
+    expect(sig.value).toHaveLength(1)
+  })
+
+  it('survives malformed localStorage by falling back to empty state', async () => {
+    localStorage.setItem('minions-ui:variant-groups:v1', '{not json')
+    const m = await import('../../src/groups/store')
+    expect(m.groupsForConnection('conn-a')).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- New `VariantGroupView` layout: shared prompt header + N side-by-side columns (one per variant session), each with a compact status header + conversation view.
- Client-side variant group store (`src/groups/store.ts`) persisting `{groupId, prompt, mode, repo, variantSessionIds, winnerId, createdAt}` to localStorage, keyed by connection id.
- `NewTaskBar` now records the group on successful `createSessionVariants` and keeps routing to `#/g/:groupId`.
- App wired to render the group view when the hash is `#/g/:id`, via a new `currentRoute` signal.
- Per-column **Pick winner** button: confirm modal → stop + close non-terminal siblings → mark winner → navigate to the kept session. One-way door (winner lock).
- Gated on the existing `sessions-variants` feature flag; renders a clear "needs library ≥ 1.111" panel when disabled, and a "group not found" panel when the id is unknown for the active connection.

## Why
Part of the de-Telegramification push toward a Conductor-shaped UX. Task creation can already fan out to N siblings; this PR turns that response into a side-by-side comparison + picker, instead of just dropping all N into the flat session list.

## Design notes
- localStorage (client-only) over a server-owned variant group registry — scope constraint specified this as the cheaper first pass. Easy to promote to a `/api/variant-groups` endpoint later if multi-device sync becomes important.
- Used `sessions-variants` feature flag rather than introducing a new `parallel-variants` name — matches the existing `FeatureName` union in `src/api/features.ts` and what `NewTaskBar` already gates on.
- Exposed `connectionId` on `ConnectionStore` so the groups store can key per-connection without threading props.
- Grid with `minmax(320px, 1fr)` columns so desktop stretches and narrow viewports horizontally scroll — no separate mobile branch.

## Tests
- `test/groups/store.test.ts` — 10 tests: record/read/update/remove, scope-by-connection, reactive signal, localStorage round-trip, malformed-JSON recovery.
- `test/groups/VariantGroupView.test.tsx` — 9 tests: gated render, missing group render, header content, column composition, pick-winner happy path (stop+close siblings, winner mark, navigate), cancel modal, terminal-sibling skip, winner lock, column-title navigate.
- `test/chat/NewTaskBar.test.tsx` — added coverage for `recordVariantGroup` side effect.
- `test/App.test.tsx` — integration test that `#/g/:id` routes to the group view.

All 288 unit/component tests pass. Typecheck and lint are clean. E2E suite not run per task guidance.

## Assumptions
- `sessions-variants` library feature implies `POST /api/sessions/variants` accepts `count` and returns `{groupId, sessions[]}` — matches what `NewTaskBar` and its existing tests already rely on.
- Session-slug-based navigation (`#/s/:slug`) is the intended route for promoting a winner; no new session-by-id route was added.

## Test plan
- [ ] Launch ×2 on a library ≥1.111 minion, land on `#/g/:id`, confirm both columns render the shared prompt and live conversation.
- [ ] Click **Pick winner** on one column: siblings transition to stopped/closed, winner gets the ring highlight, hash moves to `#/s/:slug`, kept session appears in the normal list.
- [ ] Reload on `#/g/:id` — group view still renders with the recorded prompt (localStorage rehydrate).
- [ ] Launch ×1 — no group is recorded, no navigation to `/g/`, behavior unchanged.
- [ ] Connect to a library < 1.111 — new-task bar stays gated, variant buttons >1 disabled, direct `#/g/:id` navigation shows the gated panel.

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  api-foundation["✅ API foundation: types, client, features, router"]
  structured-task-creation["✅ Refactor task creation: POST /api/sessions flow"]
  worktree-header["✅ Worktree header: branch, cwd, diff stats"]
  pr-preview-card["✅ PR preview card: title, state, checks, body"]
  session-tabs["✅ Session tabs: diff viewer and screenshots gallery"]
  web-push["✅ Web Push: notifications, subscriptions, service worker"]
  parallel-variants-ui["✅ Parallel variants: N-session group layout and picker"]
  api-foundation --> structured-task-creation
  api-foundation --> worktree-header
  api-foundation --> pr-preview-card
  api-foundation --> session-tabs
  api-foundation --> web-push
  api-foundation --> parallel-variants-ui
  structured-task-creation --> parallel-variants-ui
  class api-foundation done
  class structured-task-creation done
  class worktree-header done
  class pr-preview-card done
  class session-tabs done
  class web-push done
  class parallel-variants-ui done
  class parallel-variants-ui current
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | API foundation: types, client, features, router | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/4) |
| 2 | Refactor task creation: POST /api/sessions flow | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/5) |
| 3 | Worktree header: branch, cwd, diff stats | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/6) |
| 4 | PR preview card: title, state, checks, body | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/7) |
| 5 | Session tabs: diff viewer and screenshots gallery | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/8) |
| 6 | Web Push: notifications, subscriptions, service worker | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/10) |
| 7 | **Parallel variants: N-session group layout and picker** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/9) |

**Progress:** 7/7 complete

<!-- dag-status-end -->
