### PR TITLE
[minions] feat(pwa): web push subscriptions gated on VITE_ENABLE_PUSH

### DIFF
--- a/docs/push.md
+++ b/docs/push.md
@@ -1,0 +1,87 @@
+# Web Push notifications
+
+`minions-ui` can subscribe to a minion's Web Push channel so the browser shows a
+notification (and focuses the app on click) when the minion has news — typically
+when a session needs attention or a long-running task finishes.
+
+The flow is opt-in per connection and gated behind a build flag, because the
+Web Push API throws `SecurityError` on non-HTTPS origins.
+
+## Build-time flag
+
+The "Enable notifications" UI only renders when the app is built with:
+
+```sh
+VITE_ENABLE_PUSH=1 npm run build
+```
+
+For local development against a real minion over HTTPS:
+
+```sh
+VITE_ENABLE_PUSH=1 npm run dev
+```
+
+When the flag is **off** (the default), the UI is hidden entirely. This avoids
+shipping a button that silently fails on `http://localhost`.
+
+## Server requirements
+
+The connected minion must:
+
+1. Advertise the `web-push` capability in `GET /api/version` →
+   `features: [..., "web-push"]`.
+2. Expose the VAPID public key at `GET /api/push/vapid-public-key` →
+   `{ data: { key: "<base64url>" } }`.
+3. Accept a `PushSubscriptionJSON` payload at `POST /api/push-subscribe` and
+   return `{ data: { ok: true, id: "<sub-id>" } }`.
+4. Accept `DELETE /api/push-subscribe` with `{ "endpoint": "<endpoint>" }` to
+   remove a subscription.
+
+If `web-push` is missing from `features`, the UI shows
+"This minion does not advertise the web-push feature" instead of the toggle.
+
+## Client flow
+
+1. User opens a connection in **Settings → Edit connection**.
+2. The Notifications panel calls `Notification.requestPermission()`.
+3. On `granted`, the client fetches the VAPID public key and subscribes via
+   `registration.pushManager.subscribe({ userVisibleOnly: true, ... })`.
+4. The resulting `PushSubscriptionJSON` is POSTed to `/api/push-subscribe`.
+5. To turn notifications off, the client calls `DELETE /api/push-subscribe`
+   with the endpoint and `subscription.unsubscribe()`.
+
+## Notification payload
+
+The service worker (`src/sw.ts`) treats the push payload as JSON:
+
+```json
+{
+  "title": "Session needs attention",
+  "body":  "fluffy-otter is waiting for feedback",
+  "tag":   "session:abc-123",
+  "url":   "/#/s/fluffy-otter",
+  "icon":  "/icons/icon-192.png",
+  "badge": "/icons/icon-192.png"
+}
+```
+
+`title` and `body` are optional; missing fields fall back to a generic title and
+the default app icon. `url` controls where `notificationclick` focuses or opens
+the app — open windows pointing at the same URL are reused, then re-navigated,
+then opened fresh as a last resort.
+
+## Why HTTPS only?
+
+Per the W3C Web Push spec, `PushManager.subscribe` rejects with `SecurityError`
+on non-secure origins. We could detect this at runtime and show an inline
+message, but that still leaves a "broken button" trail on `localhost`. The
+build-time flag means notifications never render in dev unless you've
+deliberately opted in (e.g., behind `https://localhost` via `mkcert` or a
+reverse proxy that terminates TLS).
+
+## Testing
+
+Unit tests live in `test/pwa/push.test.ts` and cover the URL-base64 conversion,
+support detection, and the subscribe/unsubscribe flow against a mocked
+service-worker registration. End-to-end tests skip push by default — toggling
+`VITE_ENABLE_PUSH=1` in a Playwright project runs the panel checks.

--- a/e2e/fixtures/mock-minion.ts
+++ b/e2e/fixtures/mock-minion.ts
@@ -1,8 +1,36 @@
 import * as http from 'node:http'
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import type { ApiSession, ApiDagGraph, SseEvent, MinionCommand, VersionInfo } from '../../src/api/types'
+import type {
+  ApiSession,
+  ApiDagGraph,
+  SseEvent,
+  MinionCommand,
+  VersionInfo,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  PrPreview,
+  WorkspaceDiff,
+  ScreenshotList,
+  ScreenshotEntry,
+  VapidPublicKey,
+  PushSubscriptionJSON,
+} from '../../src/api/types'
 
-export type { ApiSession, ApiDagGraph, SseEvent, MinionCommand, VersionInfo }
+export type {
+  ApiSession,
+  ApiDagGraph,
+  SseEvent,
+  MinionCommand,
+  VersionInfo,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  PrPreview,
+  WorkspaceDiff,
+  ScreenshotList,
+  ScreenshotEntry,
+  VapidPublicKey,
+  PushSubscriptionJSON,
+}
 
 export interface MockMinion {
   url: string
@@ -11,9 +39,18 @@ export interface MockMinion {
   setSessions(sessions: ApiSession[]): void
   setDags(dags: ApiDagGraph[]): void
   setVersion(v: Partial<VersionInfo>): void
+  setPr(sessionId: string, pr: PrPreview | null): void
+  setDiff(sessionId: string, diff: WorkspaceDiff | null): void
+  setScreenshots(sessionId: string, screenshots: ScreenshotEntry[]): void
+  setScreenshotBlob(file: string, body: Buffer, contentType?: string): void
+  setVapidKey(key: string): void
   drop(): void
   lastCommands: MinionCommand[]
   lastMessages: Array<{ text: string; sessionId?: string }>
+  lastCreateSessionRequests: CreateSessionRequest[]
+  lastCreateVariantsRequests: CreateSessionVariantsRequest[]
+  pushSubscriptions: PushSubscriptionJSON[]
+  lastUnsubscribeEndpoints: string[]
   close(): Promise<void>
 }
 
@@ -24,6 +61,7 @@ function writeSse(res: ServerResponse, event: SseEvent): void {
 function cors(res: ServerResponse, allowedOrigin: string): void {
   res.setHeader('Access-Control-Allow-Origin', allowedOrigin)
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
   res.setHeader('Access-Control-Max-Age', '600')
 }
 
@@ -34,6 +72,28 @@ function readBody(req: IncomingMessage): Promise<string> {
     req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
     req.on('error', reject)
   })
+}
+
+let sessionCounter = 0
+function makeSession(req: CreateSessionRequest): ApiSession {
+  sessionCounter += 1
+  const id = `mock-session-${sessionCounter}`
+  const now = new Date().toISOString()
+  return {
+    id,
+    slug: `mock-${sessionCounter}`,
+    status: 'pending',
+    command: `/${req.mode} ${req.prompt}`,
+    repo: req.repo,
+    createdAt: now,
+    updatedAt: now,
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: req.mode,
+    conversation: [{ role: 'user', text: req.prompt }],
+  }
 }
 
 export async function createMockMinion(opts?: {
@@ -51,8 +111,18 @@ export async function createMockMinion(opts?: {
     features: [],
   }
 
+  const prBySession = new Map<string, PrPreview>()
+  const diffBySession = new Map<string, WorkspaceDiff>()
+  const screenshotsBySession = new Map<string, ScreenshotEntry[]>()
+  const screenshotBlobs = new Map<string, { body: Buffer; contentType: string }>()
+  let vapidKey = 'BMOCK_VAPID_PUBLIC_KEY_00000000000000000000000000000000000000000000000000000000000000000000000000000000'
+  const pushSubscriptions: PushSubscriptionJSON[] = []
+  const lastUnsubscribeEndpoints: string[] = []
+
   const lastCommands: MinionCommand[] = []
   const lastMessages: Array<{ text: string; sessionId?: string }> = []
+  const lastCreateSessionRequests: CreateSessionRequest[] = []
+  const lastCreateVariantsRequests: CreateSessionVariantsRequest[] = []
 
   let activeSseRes: ServerResponse | null = null
 
@@ -65,6 +135,23 @@ export async function createMockMinion(opts?: {
     res.writeHead(401, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ error: 'Unauthorized' }))
     return false
+  }
+
+  function hasFeature(name: string): boolean {
+    return versionInfo.features.includes(name)
+  }
+
+  function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+    res.writeHead(status, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(payload))
+  }
+
+  function notFound(res: ServerResponse): void {
+    sendJson(res, 404, { error: 'Not found' })
+  }
+
+  function featureDisabled(res: ServerResponse, name: string): void {
+    sendJson(res, 404, { error: `feature '${name}' not enabled` })
   }
 
   const server = http.createServer(async (req, res) => {
@@ -82,22 +169,114 @@ export async function createMockMinion(opts?: {
 
     if (path === '/api/version' && req.method === 'GET') {
       if (!checkAuth(req, res)) return
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: versionInfo }))
+      sendJson(res, 200, { data: versionInfo })
       return
     }
 
     if (!checkAuth(req, res)) return
 
     if (path === '/api/sessions' && req.method === 'GET') {
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: sessions }))
+      sendJson(res, 200, { data: sessions })
       return
     }
 
+    if (path === '/api/sessions' && req.method === 'POST') {
+      if (!hasFeature('sessions-create')) return featureDisabled(res, 'sessions-create')
+      const body = await readBody(req)
+      const payload = JSON.parse(body) as CreateSessionRequest
+      if (!payload.prompt || !payload.mode) {
+        return sendJson(res, 400, { error: 'prompt and mode are required' })
+      }
+      lastCreateSessionRequests.push(payload)
+      const session = makeSession(payload)
+      sessions = [...sessions, session]
+      sendJson(res, 200, { data: session })
+      return
+    }
+
+    if (path === '/api/sessions/variants' && req.method === 'POST') {
+      if (!hasFeature('sessions-variants')) return featureDisabled(res, 'sessions-variants')
+      const body = await readBody(req)
+      const payload = JSON.parse(body) as CreateSessionVariantsRequest
+      if (!payload.prompt || !payload.mode || !payload.count || payload.count < 2) {
+        return sendJson(res, 400, { error: 'prompt, mode, and count >= 2 are required' })
+      }
+      lastCreateVariantsRequests.push(payload)
+      const groupId = `group-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+      const variants: ApiSession[] = []
+      for (let i = 0; i < payload.count; i++) {
+        const s = makeSession(payload)
+        s.variantGroupId = groupId
+        variants.push(s)
+      }
+      sessions = [...sessions, ...variants]
+      sendJson(res, 200, { data: { groupId, sessions: variants } })
+      return
+    }
+
+    const sessionSubMatch = path.match(/^\/api\/sessions\/([^/]+)\/(pr|diff|screenshots)$/)
+    if (sessionSubMatch && req.method === 'GET') {
+      const sessionId = decodeURIComponent(sessionSubMatch[1])
+      const kind = sessionSubMatch[2]
+      if (kind === 'pr') {
+        if (!hasFeature('pr-preview')) return featureDisabled(res, 'pr-preview')
+        const pr = prBySession.get(sessionId)
+        if (!pr) return notFound(res)
+        return sendJson(res, 200, { data: pr })
+      }
+      if (kind === 'diff') {
+        if (!hasFeature('diff-viewer')) return featureDisabled(res, 'diff-viewer')
+        const diff = diffBySession.get(sessionId)
+        if (!diff) return notFound(res)
+        return sendJson(res, 200, { data: diff })
+      }
+      if (kind === 'screenshots') {
+        if (!hasFeature('screenshots-http')) return featureDisabled(res, 'screenshots-http')
+        const list = screenshotsBySession.get(sessionId) ?? []
+        return sendJson(res, 200, { data: { sessionId, screenshots: list } satisfies ScreenshotList })
+      }
+    }
+
+    const screenshotMatch = path.match(/^\/api\/screenshots\/(.+)$/)
+    if (screenshotMatch && req.method === 'GET') {
+      if (!hasFeature('screenshots-http')) return featureDisabled(res, 'screenshots-http')
+      const file = decodeURIComponent(screenshotMatch[1])
+      const blob = screenshotBlobs.get(file)
+      if (!blob) return notFound(res)
+      res.writeHead(200, { 'Content-Type': blob.contentType, 'Content-Length': String(blob.body.length) })
+      res.end(blob.body)
+      return
+    }
+
+    if (path === '/api/push/vapid-public-key' && req.method === 'GET') {
+      if (!hasFeature('web-push')) return featureDisabled(res, 'web-push')
+      return sendJson(res, 200, { data: { key: vapidKey } satisfies VapidPublicKey })
+    }
+
+    if (path === '/api/push-subscribe' && req.method === 'POST') {
+      if (!hasFeature('web-push')) return featureDisabled(res, 'web-push')
+      const body = await readBody(req)
+      const sub = JSON.parse(body) as PushSubscriptionJSON
+      if (!sub.endpoint || !sub.keys?.p256dh || !sub.keys?.auth) {
+        return sendJson(res, 400, { error: 'invalid subscription' })
+      }
+      pushSubscriptions.push(sub)
+      return sendJson(res, 200, { data: { ok: true, id: `sub-${pushSubscriptions.length}` } })
+    }
+
+    if (path === '/api/push-subscribe' && req.method === 'DELETE') {
+      if (!hasFeature('web-push')) return featureDisabled(res, 'web-push')
+      const body = await readBody(req)
+      const payload = JSON.parse(body) as { endpoint: string }
+      if (!payload.endpoint) return sendJson(res, 400, { error: 'endpoint is required' })
+      lastUnsubscribeEndpoints.push(payload.endpoint)
+      const idx = pushSubscriptions.findIndex((s) => s.endpoint === payload.endpoint)
+      if (idx !== -1) pushSubscriptions.splice(idx, 1)
+      return sendJson(res, 200, { data: { ok: true } })
+    }
+
     if (path === '/api/dags' && req.method === 'GET') {
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: dags }))
+      sendJson(res, 200, { data: dags })
       return
     }
 
@@ -124,8 +303,7 @@ export async function createMockMinion(opts?: {
       const body = await readBody(req)
       const cmd = JSON.parse(body) as MinionCommand
       lastCommands.push(cmd)
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: { success: true } }))
+      sendJson(res, 200, { data: { success: true } })
       return
     }
 
@@ -133,18 +311,14 @@ export async function createMockMinion(opts?: {
       const body = await readBody(req)
       const payload = JSON.parse(body) as { text: string; sessionId?: string }
       if (!payload.text) {
-        res.writeHead(400, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: 'text is required' }))
-        return
+        return sendJson(res, 400, { error: 'text is required' })
       }
       lastMessages.push({ text: payload.text, sessionId: payload.sessionId })
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ data: { ok: true, sessionId: payload.sessionId ?? null } }))
+      sendJson(res, 200, { data: { ok: true, sessionId: payload.sessionId ?? null } })
       return
     }
 
-    res.writeHead(404, { 'Content-Type': 'application/json' })
-    res.end(JSON.stringify({ error: 'Not found' }))
+    notFound(res)
   })
 
   await new Promise<void>((resolve) => server.listen(0, 'localhost', resolve))
@@ -157,6 +331,10 @@ export async function createMockMinion(opts?: {
     token,
     lastCommands,
     lastMessages,
+    lastCreateSessionRequests,
+    lastCreateVariantsRequests,
+    pushSubscriptions,
+    lastUnsubscribeEndpoints,
 
     emit(event: SseEvent) {
       if (activeSseRes) writeSse(activeSseRes, event)
@@ -172,6 +350,28 @@ export async function createMockMinion(opts?: {
 
     setVersion(v: Partial<VersionInfo>) {
       versionInfo = { ...versionInfo, ...v }
+    },
+
+    setPr(sessionId: string, pr: PrPreview | null) {
+      if (pr) prBySession.set(sessionId, pr)
+      else prBySession.delete(sessionId)
+    },
+
+    setDiff(sessionId: string, diff: WorkspaceDiff | null) {
+      if (diff) diffBySession.set(sessionId, diff)
+      else diffBySession.delete(sessionId)
+    },
+
+    setScreenshots(sessionId: string, screenshots: ScreenshotEntry[]) {
+      screenshotsBySession.set(sessionId, screenshots)
+    },
+
+    setScreenshotBlob(file: string, body: Buffer, contentType = 'image/png') {
+      screenshotBlobs.set(file, { body, contentType })
+    },
+
+    setVapidKey(key: string) {
+      vapidKey = key
     },
 
     drop() {

--- a/e2e/tests/bad-token.spec.ts
+++ b/e2e/tests/bad-token.spec.ts
@@ -41,7 +41,7 @@ test.describe('bad token', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Bad Token Minion')
 
-      await expect(page.getByTestId('universe-node-correct-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-correct-session')).toBeVisible({ timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/connect.spec.ts
+++ b/e2e/tests/connect.spec.ts
@@ -62,7 +62,7 @@ test.describe('connection flow', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion A')
 
-      await expect(page.getByTestId('universe-node-s1')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-s1')).toBeVisible({ timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/multi-connection.spec.ts
+++ b/e2e/tests/multi-connection.spec.ts
@@ -46,7 +46,7 @@ test.describe('multi-connection', () => {
     try {
       await connectToMinion(page, mockA, 'Minion Alpha')
 
-      await expect(page.getByTestId('universe-node-a-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-a-session')).toBeVisible({ timeout: 8_000 })
 
       await page.getByTestId('connection-picker-trigger').click()
       await expect(page.getByTestId('connection-picker-dropdown')).toBeVisible()
@@ -66,8 +66,8 @@ test.describe('multi-connection', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion Beta')
 
-      await expect(page.getByTestId('universe-node-b-session')).toBeVisible({ timeout: 8_000 })
-      await expect(page.getByTestId('universe-node-a-session')).not.toBeVisible()
+      await expect(page.getByTestId('session-item-b-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-a-session')).not.toBeVisible()
 
       await page.getByTestId('connection-picker-trigger').click()
       const dropdown = page.getByTestId('connection-picker-dropdown')
@@ -79,8 +79,8 @@ test.describe('multi-connection', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion Alpha')
 
-      await expect(page.getByTestId('universe-node-a-session')).toBeVisible({ timeout: 8_000 })
-      await expect(page.getByTestId('universe-node-b-session')).not.toBeVisible()
+      await expect(page.getByTestId('session-item-a-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-b-session')).not.toBeVisible()
     } finally {
       await mockA.close()
       await mockB.close()

--- a/e2e/tests/reconnect.spec.ts
+++ b/e2e/tests/reconnect.spec.ts
@@ -34,7 +34,7 @@ test.describe('SSE reconnect', () => {
 
       await expect(page.getByText('live')).toBeVisible({ timeout: 20_000 })
 
-      await expect(page.getByTestId('universe-node-s-reconnect')).toBeVisible({ timeout: 10_000 })
+      await expect(page.getByTestId('session-item-s-reconnect')).toBeVisible({ timeout: 10_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/task-lifecycle.spec.ts
+++ b/e2e/tests/task-lifecycle.spec.ts
@@ -26,13 +26,9 @@ test.describe('task lifecycle', () => {
     try {
       await connectToMinion(page, mock, 'My Minion')
 
-      await expect(page.getByTestId('universe-node-seed-1')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-seed-1')).toBeVisible({ timeout: 8_000 })
 
-      await page.getByTestId('universe-node-seed-1').dispatchEvent('click')
-
-      await expect(page.locator('[role="dialog"]')).toBeVisible()
-
-      await page.getByRole('button', { name: 'Open Chat' }).click()
+      await page.getByTestId('session-item-seed-1').click()
 
       await expect(page.getByTestId('message-textarea')).toBeVisible()
 
@@ -45,15 +41,9 @@ test.describe('task lifecycle', () => {
 
       mock.emit({ type: 'session_created', session: makeSession('new-1', 'hello-task', 'running') })
 
-      await expect(page.getByTestId('universe-node-new-1')).toBeAttached({ timeout: 5_000 })
+      await expect(page.getByTestId('session-item-new-1')).toBeVisible({ timeout: 5_000 })
 
-      await page.getByTestId('chat-close-btn').click()
-
-      await page.getByTestId('universe-node-new-1').dispatchEvent('click')
-
-      await expect(page.locator('[aria-labelledby="node-detail-title"]')).toBeVisible()
-
-      await page.getByRole('button', { name: 'Open Chat' }).click()
+      await page.getByTestId('session-item-new-1').click()
 
       await expect(page.getByTestId('message-textarea')).toBeVisible()
 
@@ -68,11 +58,7 @@ test.describe('task lifecycle', () => {
       mock.setSessions([makeSession('seed-1', 'seed-task', 'running'), completedSession])
       mock.emit({ type: 'session_updated', session: completedSession })
 
-      await page.getByTestId('universe-node-new-1').dispatchEvent('click')
-
-      await expect(
-        page.locator('[aria-labelledby="node-detail-title"]').getByText('Done')
-      ).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-new-1')).toContainText('completed', { timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,20 @@
-import type { ApiDagGraph, ApiResponse, ApiSession, CommandResult, MinionCommand, VersionInfo } from './types'
+import type {
+  ApiDagGraph,
+  ApiResponse,
+  ApiSession,
+  CommandResult,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  CreateSessionVariantsResult,
+  MinionCommand,
+  PrPreview,
+  PushSubscribeAck,
+  PushSubscriptionJSON,
+  ScreenshotList,
+  VapidPublicKey,
+  VersionInfo,
+  WorkspaceDiff,
+} from './types'
 import { openEventStream } from './sse'
 import type { SseHandlers, EventStreamHandle } from './sse'
 
@@ -18,6 +34,15 @@ export interface ApiClient {
   getDags(): Promise<ApiDagGraph[]>
   sendCommand(cmd: MinionCommand): Promise<CommandResult>
   sendMessage(text: string, sessionId?: string): Promise<{ ok: true; sessionId: string | null }>
+  createSession(req: CreateSessionRequest): Promise<ApiSession>
+  createSessionVariants(req: CreateSessionVariantsRequest): Promise<CreateSessionVariantsResult>
+  getPr(sessionId: string): Promise<PrPreview>
+  getDiff(sessionId: string): Promise<WorkspaceDiff>
+  listScreenshots(sessionId: string): Promise<ScreenshotList>
+  fetchScreenshotBlob(file: string): Promise<Blob>
+  getVapidKey(): Promise<VapidPublicKey>
+  subscribePush(sub: PushSubscriptionJSON): Promise<PushSubscribeAck>
+  unsubscribePush(endpoint: string): Promise<{ ok: true }>
   openEventStream(handlers: SseHandlers): EventStreamHandle
   baseUrl: string
   token: string
@@ -30,6 +55,11 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
   function headers(): HeadersInit {
     if (!token) return { 'Content-Type': 'application/json' }
     return { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
+  }
+
+  function authHeadersOnly(): HeadersInit {
+    if (!token) return {}
+    return { Authorization: `Bearer ${token}` }
   }
 
   async function get<T>(path: string): Promise<T> {
@@ -46,6 +76,19 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
       method: 'POST',
       headers: headers(),
       body: JSON.stringify(data),
+    })
+    const body = (await res.json()) as ApiResponse<T>
+    if (!res.ok || body.error) {
+      throw new ApiError(res.status, body.error ?? res.statusText)
+    }
+    return body.data
+  }
+
+  async function del<T>(path: string, data?: unknown): Promise<T> {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: 'DELETE',
+      headers: headers(),
+      body: data !== undefined ? JSON.stringify(data) : undefined,
     })
     const body = (await res.json()) as ApiResponse<T>
     if (!res.ok || body.error) {
@@ -76,6 +119,48 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
 
     sendMessage(text: string, sessionId?: string) {
       return post<{ ok: true; sessionId: string | null }>('/api/messages', { text, sessionId })
+    },
+
+    createSession(req: CreateSessionRequest) {
+      return post<ApiSession>('/api/sessions', req)
+    },
+
+    createSessionVariants(req: CreateSessionVariantsRequest) {
+      return post<CreateSessionVariantsResult>('/api/sessions/variants', req)
+    },
+
+    getPr(sessionId: string) {
+      return get<PrPreview>(`/api/sessions/${encodeURIComponent(sessionId)}/pr`)
+    },
+
+    getDiff(sessionId: string) {
+      return get<WorkspaceDiff>(`/api/sessions/${encodeURIComponent(sessionId)}/diff`)
+    },
+
+    listScreenshots(sessionId: string) {
+      return get<ScreenshotList>(`/api/sessions/${encodeURIComponent(sessionId)}/screenshots`)
+    },
+
+    async fetchScreenshotBlob(file: string): Promise<Blob> {
+      const res = await fetch(`${baseUrl}/api/screenshots/${encodeURIComponent(file)}`, {
+        headers: authHeadersOnly(),
+      })
+      if (!res.ok) {
+        throw new ApiError(res.status, res.statusText)
+      }
+      return res.blob()
+    },
+
+    getVapidKey() {
+      return get<VapidPublicKey>('/api/push/vapid-public-key')
+    },
+
+    subscribePush(sub: PushSubscriptionJSON) {
+      return post<PushSubscribeAck>('/api/push-subscribe', sub)
+    },
+
+    unsubscribePush(endpoint: string) {
+      return del<{ ok: true }>('/api/push-subscribe', { endpoint })
     },
 
     openEventStream(handlers: SseHandlers): EventStreamHandle {

--- a/src/api/features.ts
+++ b/src/api/features.ts
@@ -1,0 +1,25 @@
+import type { ConnectionStore } from '../state/types'
+import type { VersionInfo } from './types'
+
+export type FeatureName =
+  | 'messages'
+  | 'sessions-create'
+  | 'sessions-variants'
+  | 'pr-preview'
+  | 'diff-viewer'
+  | 'screenshots-http'
+  | 'web-push'
+  | 'worktree-stats'
+
+export function hasFeature(
+  source: ConnectionStore | VersionInfo | null | undefined,
+  name: FeatureName,
+): boolean {
+  if (!source) return false
+  const version: VersionInfo | null =
+    'features' in source && Array.isArray((source as VersionInfo).features)
+      ? (source as VersionInfo)
+      : (source as ConnectionStore).version.value
+  if (!version) return false
+  return version.features.includes(name)
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -25,6 +25,7 @@ export interface ApiSession {
   quickActions: QuickAction[]
   mode: string
   conversation: ConversationMessage[]
+  variantGroupId?: string
 }
 
 export interface ApiDagNode {
@@ -72,4 +73,106 @@ export interface VersionInfo {
   libraryVersion: string
   features: string[]
   repos?: RepoEntry[]
+}
+
+export type CreateSessionMode = 'task' | 'plan' | 'think' | 'dag' | 'split' | 'stack' | 'ship' | 'doctor'
+
+export interface CreateSessionRequest {
+  prompt: string
+  mode: CreateSessionMode
+  repo?: string
+}
+
+export interface CreateSessionVariantsRequest extends CreateSessionRequest {
+  count: number
+}
+
+export interface CreateSessionVariantsResult {
+  groupId: string
+  sessions: ApiSession[]
+}
+
+export type PrState = 'open' | 'closed' | 'merged'
+
+export type PrCheckStatus =
+  | 'queued'
+  | 'in_progress'
+  | 'pending'
+  | 'success'
+  | 'failure'
+  | 'neutral'
+  | 'skipped'
+  | 'cancelled'
+  | 'action_required'
+  | 'stale'
+  | 'timed_out'
+
+export interface PrCheck {
+  name: string
+  status: PrCheckStatus
+  conclusion?: string
+  url?: string
+}
+
+export interface PrPreview {
+  number: number
+  url: string
+  title: string
+  body: string
+  state: PrState
+  draft: boolean
+  mergeable: boolean | null
+  branch: string
+  baseBranch: string
+  author: string
+  updatedAt: string
+  checks: PrCheck[]
+}
+
+export interface WorkspaceDiffStats {
+  filesChanged: number
+  insertions: number
+  deletions: number
+}
+
+export interface WorkspaceDiff {
+  sessionId: string
+  branch: string
+  baseBranch: string
+  patch: string
+  truncated: boolean
+  stats: WorkspaceDiffStats
+}
+
+export interface ScreenshotEntry {
+  file: string
+  url: string
+  capturedAt: string
+  size: number
+  width?: number
+  height?: number
+  caption?: string
+}
+
+export interface ScreenshotList {
+  sessionId: string
+  screenshots: ScreenshotEntry[]
+}
+
+export interface VapidPublicKey {
+  key: string
+}
+
+export interface PushSubscriptionJSON {
+  endpoint: string
+  expirationTime: number | null
+  keys: {
+    p256dh: string
+    auth: string
+  }
+}
+
+export interface PushSubscribeAck {
+  ok: true
+  id: string
 }

--- a/src/connections/ConnectionSettings.tsx
+++ b/src/connections/ConnectionSettings.tsx
@@ -1,8 +1,11 @@
+import { useMemo, useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { createApiClient, ApiError } from '../api/client'
 import { addConnection, updateConnection, setActive } from './store'
 import type { Connection } from './types'
 import { CONNECTION_PALETTE } from '../theme/colors'
+import { EnableNotifications } from '../pwa/EnableNotifications'
+import { isPushFlagEnabled } from '../pwa/push'
 
 interface Props {
   onClose: () => void
@@ -21,6 +24,38 @@ export function ConnectionSettings({ onClose, existing, embedded }: Props) {
   const err = useSignal<string | null>(null)
   const loading = useSignal(false)
   const features = useSignal<string[]>([])
+
+  const showPushPanel = Boolean(existing) && isPushFlagEnabled()
+  const editClient = useMemo(
+    () =>
+      showPushPanel && existing
+        ? createApiClient({ baseUrl: existing.baseUrl, token: existing.token })
+        : null,
+    [showPushPanel, existing?.id, existing?.baseUrl, existing?.token],
+  )
+  const editFeatures = useSignal<string[] | null>(null)
+  const editFeaturesError = useSignal<string | null>(null)
+
+  useEffect(() => {
+    if (!editClient) return
+    let cancelled = false
+    editFeatures.value = null
+    editFeaturesError.value = null
+    void editClient
+      .getVersion()
+      .then((info) => {
+        if (cancelled) return
+        editFeatures.value = info.features
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return
+        editFeatures.value = []
+        editFeaturesError.value = e instanceof Error ? e.message : 'Could not fetch features'
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [editClient])
 
   async function submit(e: Event) {
     e.preventDefault()
@@ -164,6 +199,23 @@ export function ConnectionSettings({ onClose, existing, embedded }: Props) {
                 {f}
               </span>
             ))}
+          </div>
+        )}
+        {showPushPanel && editClient && (
+          <div class="flex flex-col gap-2 border-t border-slate-200 dark:border-slate-700 pt-3" data-testid="push-section">
+            <span class="text-xs font-medium text-slate-600 dark:text-slate-400">Notifications</span>
+            {editFeatures.value === null ? (
+              <p class="text-xs text-slate-500 dark:text-slate-400">Checking server features…</p>
+            ) : editFeaturesError.value ? (
+              <p class="text-xs text-red-600 dark:text-red-400" data-testid="push-features-error">
+                {editFeaturesError.value}
+              </p>
+            ) : (
+              <EnableNotifications
+                client={editClient}
+                hasFeature={editFeatures.value.includes('web-push')}
+              />
+            )}
           </div>
         )}
         <div class="flex gap-2 mt-1">

--- a/src/pwa/EnableNotifications.tsx
+++ b/src/pwa/EnableNotifications.tsx
@@ -1,0 +1,169 @@
+import { useSignal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import type { ApiClient } from '../api/client'
+import {
+  detectPushSupport,
+  disablePush,
+  enablePush,
+  getCurrentSubscription,
+  getNotificationPermission,
+  isPushFlagEnabled,
+  type PushSupport,
+} from './push'
+
+interface Props {
+  client: ApiClient
+  hasFeature: boolean
+}
+
+function reasonText(support: PushSupport): string {
+  switch (support.kind) {
+    case 'flag-disabled':
+      return 'Push notifications are disabled in this build (set VITE_ENABLE_PUSH=1).'
+    case 'insecure-context':
+      return 'Push notifications require HTTPS — open this app on a secure origin.'
+    case 'no-service-worker':
+      return 'This browser does not expose service workers.'
+    case 'no-push-manager':
+      return 'This browser does not support the Web Push API.'
+    case 'no-notifications':
+      return 'This browser does not support the Notifications API.'
+    case 'supported':
+      return ''
+  }
+}
+
+export function EnableNotifications({ client, hasFeature }: Props) {
+  if (!isPushFlagEnabled()) return null
+
+  const support = useSignal<PushSupport>(detectPushSupport())
+  const subscribed = useSignal<boolean>(false)
+  const checking = useSignal<boolean>(true)
+  const busy = useSignal<boolean>(false)
+  const error = useSignal<string | null>(null)
+  const status = useSignal<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void getCurrentSubscription()
+      .then((sub) => {
+        if (cancelled) return
+        subscribed.value = sub !== null
+      })
+      .catch(() => {
+        if (cancelled) return
+        subscribed.value = false
+      })
+      .finally(() => {
+        if (!cancelled) checking.value = false
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (!hasFeature) {
+    return (
+      <div
+        class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 p-3 text-xs text-slate-600 dark:text-slate-400"
+        data-testid="push-feature-missing"
+      >
+        This minion does not advertise the <code>web-push</code> feature. Update the library on the server to enable notifications.
+      </div>
+    )
+  }
+
+  if (support.value.kind !== 'supported') {
+    return (
+      <div
+        class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 p-3 text-xs text-slate-600 dark:text-slate-400"
+        data-testid="push-unsupported"
+      >
+        {reasonText(support.value)}
+      </div>
+    )
+  }
+
+  const permission = getNotificationPermission()
+  const denied = permission === 'denied'
+
+  const handleEnable = async () => {
+    busy.value = true
+    error.value = null
+    status.value = null
+    try {
+      const result = await enablePush(client)
+      if (result.ok) {
+        subscribed.value = true
+        status.value = 'Notifications enabled.'
+      } else if (result.reason === 'permission-denied') {
+        error.value = 'Notification permission was denied. Re-enable it in your browser settings.'
+      } else if (result.reason === 'permission-default') {
+        error.value = 'Notification permission was dismissed.'
+      } else {
+        error.value = result.error ? `Could not enable notifications: ${result.error}` : 'Could not enable notifications.'
+      }
+    } finally {
+      busy.value = false
+    }
+  }
+
+  const handleDisable = async () => {
+    busy.value = true
+    error.value = null
+    status.value = null
+    try {
+      const result = await disablePush(client)
+      if (result.ok) {
+        subscribed.value = false
+        status.value = 'Notifications disabled.'
+      } else {
+        error.value = `Could not disable notifications: ${result.error}`
+      }
+    } finally {
+      busy.value = false
+    }
+  }
+
+  return (
+    <div class="flex flex-col gap-2" data-testid="push-controls">
+      <div class="flex items-center gap-2">
+        {subscribed.value ? (
+          <button
+            type="button"
+            onClick={() => void handleDisable()}
+            disabled={busy.value || checking.value}
+            data-testid="push-disable-btn"
+            class="rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-1.5 text-xs font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 disabled:opacity-50"
+          >
+            {busy.value ? 'Disabling…' : 'Disable notifications'}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void handleEnable()}
+            disabled={busy.value || checking.value || denied}
+            data-testid="push-enable-btn"
+            class="rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {busy.value ? 'Enabling…' : 'Enable notifications'}
+          </button>
+        )}
+        <span class="text-xs text-slate-500 dark:text-slate-400" data-testid="push-permission">
+          permission: {permission}
+        </span>
+      </div>
+      {denied && !subscribed.value && (
+        <p class="text-xs text-amber-700 dark:text-amber-300" data-testid="push-denied-hint">
+          Browser permission is blocked. Re-enable it in your browser settings, then retry.
+        </p>
+      )}
+      {error.value && (
+        <p class="text-xs text-red-600 dark:text-red-400" data-testid="push-error">{error.value}</p>
+      )}
+      {status.value && (
+        <p class="text-xs text-emerald-700 dark:text-emerald-400" data-testid="push-status">{status.value}</p>
+      )}
+    </div>
+  )
+}

--- a/src/pwa/push.ts
+++ b/src/pwa/push.ts
@@ -1,0 +1,149 @@
+import type { ApiClient } from '../api/client'
+import type { PushSubscriptionJSON } from '../api/types'
+
+export type PushSupport =
+  | { kind: 'supported' }
+  | { kind: 'flag-disabled' }
+  | { kind: 'no-service-worker' }
+  | { kind: 'no-push-manager' }
+  | { kind: 'no-notifications' }
+  | { kind: 'insecure-context' }
+
+export type PushPermission = NotificationPermission | 'unsupported'
+
+export type SubscribeResult =
+  | { ok: true; subscription: PushSubscriptionJSON }
+  | { ok: false; reason: 'permission-denied' | 'permission-default' | 'unsupported' | 'error'; error?: string }
+
+export function isPushFlagEnabled(): boolean {
+  const raw: unknown = import.meta.env?.VITE_ENABLE_PUSH
+  if (raw === true) return true
+  if (typeof raw === 'string') {
+    const v = raw.toLowerCase()
+    return v === '1' || v === 'true' || v === 'yes' || v === 'on'
+  }
+  return false
+}
+
+export function detectPushSupport(win: typeof globalThis = globalThis): PushSupport {
+  if (!isPushFlagEnabled()) return { kind: 'flag-disabled' }
+  const w = win as typeof globalThis & {
+    isSecureContext?: boolean
+    Notification?: typeof Notification
+    PushManager?: typeof PushManager
+    navigator?: Navigator
+  }
+  if (w.isSecureContext === false) return { kind: 'insecure-context' }
+  if (!w.navigator || !('serviceWorker' in w.navigator)) return { kind: 'no-service-worker' }
+  if (typeof w.PushManager === 'undefined') return { kind: 'no-push-manager' }
+  if (typeof w.Notification === 'undefined') return { kind: 'no-notifications' }
+  return { kind: 'supported' }
+}
+
+export function getNotificationPermission(): PushPermission {
+  if (typeof Notification === 'undefined') return 'unsupported'
+  return Notification.permission
+}
+
+export function urlBase64ToUint8Array(base64: string): Uint8Array<ArrayBuffer> {
+  const trimmed = base64.replace(/\s+/g, '')
+  if (!trimmed) throw new Error('VAPID key is empty')
+  const padding = '='.repeat((4 - (trimmed.length % 4)) % 4)
+  const normalized = (trimmed + padding).replace(/-/g, '+').replace(/_/g, '/')
+  if (!/^[A-Za-z0-9+/=]+$/.test(normalized)) {
+    throw new Error('VAPID key is not valid base64url')
+  }
+  const raw = atob(normalized)
+  const buffer = new ArrayBuffer(raw.length)
+  const out = new Uint8Array(buffer)
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i)
+  return out
+}
+
+export function toPushSubscriptionJSON(sub: PushSubscription): PushSubscriptionJSON {
+  const json = sub.toJSON() as {
+    endpoint?: string
+    expirationTime?: number | null
+    keys?: { p256dh?: string; auth?: string }
+  }
+  if (!json.endpoint) throw new Error('Subscription is missing endpoint')
+  if (!json.keys?.p256dh || !json.keys?.auth) {
+    throw new Error('Subscription is missing p256dh/auth keys')
+  }
+  return {
+    endpoint: json.endpoint,
+    expirationTime: json.expirationTime ?? null,
+    keys: { p256dh: json.keys.p256dh, auth: json.keys.auth },
+  }
+}
+
+async function getRegistration(): Promise<ServiceWorkerRegistration | null> {
+  if (!('serviceWorker' in navigator)) return null
+  const reg = await navigator.serviceWorker.ready
+  return reg ?? null
+}
+
+export async function getCurrentSubscription(): Promise<PushSubscription | null> {
+  const reg = await getRegistration()
+  if (!reg) return null
+  return reg.pushManager.getSubscription()
+}
+
+export async function requestPermission(): Promise<NotificationPermission> {
+  if (typeof Notification === 'undefined') return 'denied'
+  if (Notification.permission !== 'default') return Notification.permission
+  return Notification.requestPermission()
+}
+
+export async function enablePush(client: ApiClient): Promise<SubscribeResult> {
+  const support = detectPushSupport()
+  if (support.kind !== 'supported') {
+    return { ok: false, reason: 'unsupported', error: support.kind }
+  }
+
+  const permission = await requestPermission()
+  if (permission === 'denied') return { ok: false, reason: 'permission-denied' }
+  if (permission !== 'granted') return { ok: false, reason: 'permission-default' }
+
+  const reg = await getRegistration()
+  if (!reg) return { ok: false, reason: 'unsupported', error: 'no-registration' }
+
+  try {
+    const { key } = await client.getVapidKey()
+    const applicationServerKey = urlBase64ToUint8Array(key)
+    const existing = await reg.pushManager.getSubscription()
+    if (existing) {
+      try {
+        await existing.unsubscribe()
+      } catch {
+        // ignore: a stale subscription may already be invalid; we'll re-subscribe below
+      }
+    }
+    const sub = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey,
+    })
+    const json = toPushSubscriptionJSON(sub)
+    await client.subscribePush(json)
+    return { ok: true, subscription: json }
+  } catch (e) {
+    return { ok: false, reason: 'error', error: e instanceof Error ? e.message : String(e) }
+  }
+}
+
+export async function disablePush(client: ApiClient): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const sub = await getCurrentSubscription()
+    if (!sub) return { ok: true }
+    const json = toPushSubscriptionJSON(sub)
+    try {
+      await client.unsubscribePush(json.endpoint)
+    } catch {
+      // ignore: the server may already have purged the subscription; still drop it client-side
+    }
+    await sub.unsubscribe()
+    return { ok: true }
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) }
+  }
+}

--- a/src/routing/route.ts
+++ b/src/routing/route.ts
@@ -1,0 +1,61 @@
+import { signal } from '@preact/signals'
+import type { ReadonlySignal } from '@preact/signals'
+
+export type Route =
+  | { name: 'home' }
+  | { name: 'session'; sessionSlug: string }
+  | { name: 'group'; groupId: string }
+
+export function parseHash(hash: string): Route {
+  const raw = hash.replace(/^#?\/*/, '')
+  if (!raw) return { name: 'home' }
+  const segments = raw.split('/').filter(Boolean)
+  if (segments.length === 2 && segments[0] === 's') {
+    return { name: 'session', sessionSlug: decodeURIComponent(segments[1]) }
+  }
+  if (segments.length === 2 && segments[0] === 'g') {
+    return { name: 'group', groupId: decodeURIComponent(segments[1]) }
+  }
+  return { name: 'home' }
+}
+
+export function formatRoute(route: Route): string {
+  switch (route.name) {
+    case 'home':
+      return '#/'
+    case 'session':
+      return `#/s/${encodeURIComponent(route.sessionSlug)}`
+    case 'group':
+      return `#/g/${encodeURIComponent(route.groupId)}`
+  }
+}
+
+export interface Router {
+  route: ReadonlySignal<Route>
+  navigate(route: Route): void
+  dispose(): void
+}
+
+export function createRouter(win: Window = window): Router {
+  const route = signal<Route>(parseHash(win.location.hash))
+
+  const onHashChange = () => {
+    route.value = parseHash(win.location.hash)
+  }
+  win.addEventListener('hashchange', onHashChange)
+
+  return {
+    route,
+    navigate(next: Route) {
+      const hash = formatRoute(next)
+      if (win.location.hash === hash) {
+        route.value = next
+        return
+      }
+      win.location.hash = hash
+    },
+    dispose() {
+      win.removeEventListener('hashchange', onHashChange)
+    },
+  }
+}

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -4,6 +4,32 @@ import { registerRoute, NavigationRoute } from 'workbox-routing'
 
 declare const self: ServiceWorkerGlobalScope
 
+interface PushPayload {
+  title?: string
+  body?: string
+  tag?: string
+  url?: string
+  icon?: string
+  badge?: string
+  renotify?: boolean
+}
+
+const DEFAULT_TITLE = 'Minion update'
+const DEFAULT_ICON = '/icons/icon-192.png'
+const DEFAULT_BADGE = '/icons/icon-192.png'
+
+function parsePushPayload(event: PushEvent): PushPayload {
+  if (!event.data) return {}
+  try {
+    const json = event.data.json() as unknown
+    if (json && typeof json === 'object') return json as PushPayload
+    return {}
+  } catch {
+    const text = event.data.text()
+    return text ? { body: text } : {}
+  }
+}
+
 precacheAndRoute(self.__WB_MANIFEST)
 
 registerRoute(
@@ -14,4 +40,49 @@ registerRoute(
 
 self.addEventListener('message', (event) => {
   if (event.data?.type === 'SKIP_WAITING') self.skipWaiting()
+})
+
+self.addEventListener('push', (event) => {
+  const payload = parsePushPayload(event)
+  const title = payload.title?.trim() || DEFAULT_TITLE
+  const options: NotificationOptions & { renotify?: boolean } = {
+    body: payload.body ?? '',
+    tag: payload.tag,
+    icon: payload.icon ?? DEFAULT_ICON,
+    badge: payload.badge ?? DEFAULT_BADGE,
+    data: { url: payload.url ?? '/' },
+    renotify: payload.tag ? (payload.renotify ?? true) : undefined,
+  }
+  event.waitUntil(self.registration.showNotification(title, options))
+})
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const target = (event.notification.data as { url?: string } | undefined)?.url ?? '/'
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then(async (windows) => {
+        const targetUrl = new URL(target, self.location.origin).href
+        for (const w of windows) {
+          if (w.url === targetUrl && 'focus' in w) {
+            return w.focus()
+          }
+        }
+        for (const w of windows) {
+          if ('navigate' in w && 'focus' in w) {
+            try {
+              await w.navigate(targetUrl)
+              return w.focus()
+            } catch {
+              // fall through to opening a fresh window
+            }
+          }
+        }
+        if (self.clients.openWindow) {
+          return self.clients.openWindow(targetUrl)
+        }
+        return null
+      }),
+  )
 })

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,10 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/preact" />
+
+interface ImportMetaEnv {
+  readonly VITE_ENABLE_PUSH?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/test/api/client-extended.test.ts
+++ b/test/api/client-extended.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createApiClient, ApiError } from '../../src/api/client'
+import type {
+  ApiSession,
+  CreateSessionRequest,
+  CreateSessionVariantsRequest,
+  CreateSessionVariantsResult,
+  PrPreview,
+  PushSubscriptionJSON,
+  ScreenshotList,
+  VapidPublicKey,
+  WorkspaceDiff,
+} from '../../src/api/types'
+
+const BASE_URL = 'https://example.com'
+const TOKEN = 'test-token'
+
+function jsonResponse(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    json: () => Promise.resolve(data),
+    blob: () => Promise.reject(new Error('not a blob response')),
+  }
+}
+
+function blobResponse(body: Blob, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    blob: () => Promise.resolve(body),
+    json: () => Promise.reject(new Error('not a json response')),
+  }
+}
+
+const SAMPLE_SESSION: ApiSession = {
+  id: 's-1',
+  slug: 'quick-fox',
+  status: 'pending',
+  command: '/task implement feature x',
+  createdAt: '2026-04-19T00:00:00Z',
+  updatedAt: '2026-04-19T00:00:00Z',
+  childIds: [],
+  needsAttention: false,
+  attentionReasons: [],
+  quickActions: [],
+  mode: 'task',
+  conversation: [],
+}
+
+describe('ApiClient — createSession', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: SAMPLE_SESSION }))
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('POSTs structured payload to /api/sessions', async () => {
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const req: CreateSessionRequest = { prompt: 'do the thing', mode: 'task', repo: 'foo' }
+    const out = await client.createSession(req)
+
+    expect(out).toEqual(SAMPLE_SESSION)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/sessions`)
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${TOKEN}`)
+    const body = JSON.parse(init.body as string) as CreateSessionRequest
+    expect(body).toEqual(req)
+  })
+})
+
+describe('ApiClient — createSessionVariants', () => {
+  it('POSTs to /api/sessions/variants and unwraps group result', async () => {
+    const result: CreateSessionVariantsResult = {
+      groupId: 'group-1',
+      sessions: [SAMPLE_SESSION, { ...SAMPLE_SESSION, id: 's-2' }],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: result }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const req: CreateSessionVariantsRequest = { prompt: 'parallel', mode: 'task', count: 2 }
+    const out = await client.createSessionVariants(req)
+
+    expect(out).toEqual(result)
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe(`${BASE_URL}/api/sessions/variants`)
+
+    vi.unstubAllGlobals()
+  })
+})
+
+describe('ApiClient — getPr / getDiff / listScreenshots', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('getPr hits /api/sessions/:id/pr with encoded id', async () => {
+    const pr: PrPreview = {
+      number: 42,
+      url: 'https://github.com/o/r/pull/42',
+      title: 'Feature',
+      body: 'body',
+      state: 'open',
+      draft: false,
+      mergeable: true,
+      branch: 'feature',
+      baseBranch: 'main',
+      author: 'me',
+      updatedAt: '2026-04-19T00:00:00Z',
+      checks: [],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: pr }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.getPr('weird id/with/slashes')
+    expect(out).toEqual(pr)
+
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe(`${BASE_URL}/api/sessions/${encodeURIComponent('weird id/with/slashes')}/pr`)
+  })
+
+  it('getDiff returns workspace diff', async () => {
+    const diff: WorkspaceDiff = {
+      sessionId: 's-1',
+      branch: 'feature',
+      baseBranch: 'main',
+      patch: '--- a\n+++ b\n',
+      truncated: false,
+      stats: { filesChanged: 1, insertions: 3, deletions: 1 },
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: diff }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.getDiff('s-1')
+    expect(out).toEqual(diff)
+  })
+
+  it('listScreenshots returns list shape', async () => {
+    const list: ScreenshotList = {
+      sessionId: 's-1',
+      screenshots: [
+        { file: 'a.png', url: '/api/screenshots/a.png', capturedAt: '2026-04-19T00:00:00Z', size: 100 },
+      ],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: list }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.listScreenshots('s-1')
+    expect(out).toEqual(list)
+  })
+})
+
+describe('ApiClient — fetchScreenshotBlob', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns a Blob and attaches Authorization header', async () => {
+    const body = new Blob(['fake-png'], { type: 'image/png' })
+    const fetchMock = vi.fn().mockResolvedValue(blobResponse(body))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.fetchScreenshotBlob('sub/dir/file.png')
+    expect(out).toBe(body)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/screenshots/${encodeURIComponent('sub/dir/file.png')}`)
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${TOKEN}`)
+    expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined()
+  })
+
+  it('throws ApiError on non-2xx', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found', blob: () => Promise.resolve(new Blob()) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    await expect(client.fetchScreenshotBlob('missing.png')).rejects.toThrow(ApiError)
+  })
+})
+
+describe('ApiClient — push', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('getVapidKey unwraps data', async () => {
+    const key: VapidPublicKey = { key: 'BXYZ' }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: key }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.getVapidKey()
+    expect(out).toEqual(key)
+  })
+
+  it('subscribePush POSTs the subscription', async () => {
+    const sub: PushSubscriptionJSON = {
+      endpoint: 'https://push.example.com/abc',
+      expirationTime: null,
+      keys: { p256dh: 'pk', auth: 'ak' },
+    }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: { ok: true, id: 'sub-1' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.subscribePush(sub)
+    expect(out).toEqual({ ok: true, id: 'sub-1' })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/push-subscribe`)
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string) as PushSubscriptionJSON
+    expect(body).toEqual(sub)
+  })
+
+  it('unsubscribePush DELETEs with endpoint body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: { ok: true } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.unsubscribePush('https://push.example.com/abc')
+    expect(out).toEqual({ ok: true })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/push-subscribe`)
+    expect(init.method).toBe('DELETE')
+    const body = JSON.parse(init.body as string) as { endpoint: string }
+    expect(body.endpoint).toBe('https://push.example.com/abc')
+  })
+})

--- a/test/api/features.test.ts
+++ b/test/api/features.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { signal } from '@preact/signals'
+import { hasFeature } from '../../src/api/features'
+import type { ConnectionStore } from '../../src/state/types'
+import type { VersionInfo } from '../../src/api/types'
+
+function makeStore(version: VersionInfo | null): ConnectionStore {
+  return {
+    version: signal(version),
+  } as unknown as ConnectionStore
+}
+
+describe('hasFeature', () => {
+  it('returns false when source is null/undefined', () => {
+    expect(hasFeature(null, 'pr-preview')).toBe(false)
+    expect(hasFeature(undefined, 'pr-preview')).toBe(false)
+  })
+
+  it('returns false when version signal is null', () => {
+    expect(hasFeature(makeStore(null), 'pr-preview')).toBe(false)
+  })
+
+  it('returns false when feature not listed', () => {
+    const store = makeStore({ apiVersion: '1', libraryVersion: '1.0.0', features: ['messages'] })
+    expect(hasFeature(store, 'pr-preview')).toBe(false)
+  })
+
+  it('returns true when feature is listed', () => {
+    const store = makeStore({
+      apiVersion: '1',
+      libraryVersion: '1.1.0',
+      features: ['messages', 'pr-preview', 'diff-viewer'],
+    })
+    expect(hasFeature(store, 'pr-preview')).toBe(true)
+    expect(hasFeature(store, 'diff-viewer')).toBe(true)
+    expect(hasFeature(store, 'messages')).toBe(true)
+  })
+
+  it('accepts a raw VersionInfo without a store wrapper', () => {
+    const v: VersionInfo = { apiVersion: '1', libraryVersion: '1.1.0', features: ['web-push'] }
+    expect(hasFeature(v, 'web-push')).toBe(true)
+    expect(hasFeature(v, 'diff-viewer')).toBe(false)
+  })
+})

--- a/test/api/mock-minion-integration.test.ts
+++ b/test/api/mock-minion-integration.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { createApiClient, ApiError } from '../../src/api/client'
+import { createMockMinion, type MockMinion } from '../../e2e/fixtures/mock-minion'
+import type { PrPreview, PushSubscriptionJSON, WorkspaceDiff } from '../../src/api/types'
+
+describe('mock-minion integration', () => {
+  let minion: MockMinion
+  let client: ReturnType<typeof createApiClient>
+
+  beforeAll(async () => {
+    minion = await createMockMinion({ token: 'secret' })
+    client = createApiClient({ baseUrl: minion.url, token: 'secret' })
+  })
+
+  afterAll(async () => {
+    await minion.close()
+  })
+
+  beforeEach(() => {
+    minion.setVersion({ features: [] })
+  })
+
+  it('refuses createSession when feature flag off (default)', async () => {
+    await expect(client.createSession({ prompt: 'x', mode: 'task' })).rejects.toThrow(ApiError)
+  })
+
+  it('createSession works when feature enabled and records the request', async () => {
+    minion.setVersion({ features: ['sessions-create'] })
+    const before = minion.lastCreateSessionRequests.length
+    const session = await client.createSession({ prompt: 'hello', mode: 'task', repo: 'example' })
+    expect(session.mode).toBe('task')
+    expect(session.repo).toBe('example')
+    expect(minion.lastCreateSessionRequests.length).toBe(before + 1)
+    expect(minion.lastCreateSessionRequests[before]).toEqual({ prompt: 'hello', mode: 'task', repo: 'example' })
+  })
+
+  it('createSessionVariants returns a group of N sessions sharing a groupId', async () => {
+    minion.setVersion({ features: ['sessions-variants'] })
+    const out = await client.createSessionVariants({ prompt: 'parallel', mode: 'task', count: 3 })
+    expect(out.sessions).toHaveLength(3)
+    expect(new Set(out.sessions.map((s) => s.variantGroupId))).toEqual(new Set([out.groupId]))
+  })
+
+  it('gated endpoints return 404 with a feature-disabled error when flag off', async () => {
+    await expect(client.getPr('s-1')).rejects.toThrow(ApiError)
+    await expect(client.getDiff('s-1')).rejects.toThrow(ApiError)
+    await expect(client.listScreenshots('s-1')).rejects.toThrow(ApiError)
+    await expect(client.getVapidKey()).rejects.toThrow(ApiError)
+  })
+
+  it('getPr returns the stored preview when flag on', async () => {
+    minion.setVersion({ features: ['pr-preview'] })
+    const pr: PrPreview = {
+      number: 1,
+      url: 'https://github.com/o/r/pull/1',
+      title: 't',
+      body: 'b',
+      state: 'open',
+      draft: false,
+      mergeable: null,
+      branch: 'feat',
+      baseBranch: 'main',
+      author: 'me',
+      updatedAt: '2026-04-19T00:00:00Z',
+      checks: [{ name: 'ci', status: 'pending' }],
+    }
+    minion.setPr('s-1', pr)
+    const out = await client.getPr('s-1')
+    expect(out).toEqual(pr)
+  })
+
+  it('getDiff returns the stored workspace diff when flag on', async () => {
+    minion.setVersion({ features: ['diff-viewer'] })
+    const diff: WorkspaceDiff = {
+      sessionId: 's-1',
+      branch: 'feat',
+      baseBranch: 'main',
+      patch: 'diff --git a/x b/x',
+      truncated: false,
+      stats: { filesChanged: 1, insertions: 2, deletions: 0 },
+    }
+    minion.setDiff('s-1', diff)
+    const out = await client.getDiff('s-1')
+    expect(out).toEqual(diff)
+  })
+
+  it('listScreenshots + fetchScreenshotBlob round-trip', async () => {
+    minion.setVersion({ features: ['screenshots-http'] })
+    minion.setScreenshots('s-1', [
+      { file: 'shot-1.png', url: '/api/screenshots/shot-1.png', capturedAt: '2026-04-19T00:00:00Z', size: 4 },
+    ])
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    minion.setScreenshotBlob('shot-1.png', png)
+
+    const list = await client.listScreenshots('s-1')
+    expect(list.screenshots).toHaveLength(1)
+    expect(list.screenshots[0].file).toBe('shot-1.png')
+
+    const blob = await client.fetchScreenshotBlob('shot-1.png')
+    const buf = Buffer.from(await blob.arrayBuffer())
+    expect(buf.equals(png)).toBe(true)
+  })
+
+  it('web push flow: getVapidKey → subscribe → unsubscribe', async () => {
+    minion.setVersion({ features: ['web-push'] })
+    const { key } = await client.getVapidKey()
+    expect(key).toMatch(/^B/)
+
+    const sub: PushSubscriptionJSON = {
+      endpoint: 'https://push.example.com/abc',
+      expirationTime: null,
+      keys: { p256dh: 'pk', auth: 'ak' },
+    }
+    const ack = await client.subscribePush(sub)
+    expect(ack.ok).toBe(true)
+    expect(minion.pushSubscriptions).toContainEqual(sub)
+
+    await client.unsubscribePush(sub.endpoint)
+    expect(minion.lastUnsubscribeEndpoints).toContain(sub.endpoint)
+    expect(minion.pushSubscriptions.find((s) => s.endpoint === sub.endpoint)).toBeUndefined()
+  })
+})

--- a/test/connections/ConnectionSettings.test.tsx
+++ b/test/connections/ConnectionSettings.test.tsx
@@ -25,6 +25,10 @@ vi.mock('../../src/api/client', () => ({
   },
 }))
 
+vi.mock('../../src/pwa/EnableNotifications', () => ({
+  EnableNotifications: () => <div data-testid="push-controls" />,
+}))
+
 function setInputValue(input: HTMLInputElement, value: string) {
   Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(input, value)
   fireEvent.input(input)
@@ -129,5 +133,31 @@ describe('ConnectionSettings', () => {
     setInputValue(hexInput, 'notahex')
     const firstSwatch = screen.getByTestId('swatch-#3b82f6')
     expect(firstSwatch.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('hides push panel when VITE_ENABLE_PUSH is off', async () => {
+    vi.stubEnv('VITE_ENABLE_PUSH', '')
+    await renderSettings({
+      existing: { id: 'e1', label: 'Old', baseUrl: 'https://old.example.com', token: 'tok', color: '#10b981' },
+    })
+    expect(screen.queryByTestId('push-section')).toBeNull()
+    vi.unstubAllEnvs()
+  })
+
+  it('shows push panel for existing connection when VITE_ENABLE_PUSH is on', async () => {
+    vi.stubEnv('VITE_ENABLE_PUSH', '1')
+    await renderSettings({
+      existing: { id: 'e1', label: 'Old', baseUrl: 'https://old.example.com', token: 'tok', color: '#10b981' },
+    })
+    expect(screen.getByTestId('push-section')).toBeTruthy()
+    await waitFor(() => expect(screen.getByTestId('push-controls')).toBeTruthy())
+    vi.unstubAllEnvs()
+  })
+
+  it('hides push panel for new (unsaved) connection even when flag is on', async () => {
+    vi.stubEnv('VITE_ENABLE_PUSH', '1')
+    await renderSettings()
+    expect(screen.queryByTestId('push-section')).toBeNull()
+    vi.unstubAllEnvs()
   })
 })

--- a/test/pwa/EnableNotifications.test.tsx
+++ b/test/pwa/EnableNotifications.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/preact'
+
+const enablePushMock = vi.fn()
+const disablePushMock = vi.fn()
+const getCurrentSubscriptionMock = vi.fn()
+const detectPushSupportMock = vi.fn()
+const isPushFlagEnabledMock = vi.fn()
+const getNotificationPermissionMock = vi.fn()
+
+vi.mock('../../src/pwa/push', () => ({
+  enablePush: enablePushMock,
+  disablePush: disablePushMock,
+  getCurrentSubscription: getCurrentSubscriptionMock,
+  detectPushSupport: detectPushSupportMock,
+  isPushFlagEnabled: isPushFlagEnabledMock,
+  getNotificationPermission: getNotificationPermissionMock,
+}))
+
+const fakeClient = {} as never
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isPushFlagEnabledMock.mockReturnValue(true)
+  detectPushSupportMock.mockReturnValue({ kind: 'supported' })
+  getCurrentSubscriptionMock.mockResolvedValue(null)
+  getNotificationPermissionMock.mockReturnValue('default')
+})
+
+afterEach(() => {
+  vi.resetModules()
+})
+
+describe('EnableNotifications', () => {
+  it('renders nothing when flag is disabled', async () => {
+    isPushFlagEnabledMock.mockReturnValue(false)
+    const { EnableNotifications } = await import('../../src/pwa/EnableNotifications')
+    const { container } = render(<EnableNotifications client={fakeClient} hasFeature={true} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows feature-missing message when hasFeature=false', async () => {
+    const { EnableNotifications } = await import('../../src/pwa/EnableNotifications')
+    render(<EnableNotifications client={fakeClient} hasFeature={false} />)
+    expect(screen.getByTestId('push-feature-missing')).toBeTruthy()
+  })
+
+  it('shows unsupported message when not supported', async () => {
+    detectPushSupportMock.mockReturnValue({ kind: 'no-push-manager' })
+    const { EnableNotifications } = await import('../../src/pwa/EnableNotifications')
+    render(<EnableNotifications client={fakeClient} hasFeature={true} />)
+    expect(screen.getByTestId('push-unsupported').textContent).toContain('Web Push API')
+  })
+
+  it('shows Enable button when no current subscription', async () => {
+    const { EnableNotifications } = await import('../../src/pwa/EnableNotifications')
+    render(<EnableNotifications client={fakeClient} hasFeature={true} />)
+    await waitFor(() => expect(screen.getByTestId('push-enable-btn')).toBeTruthy())
+    expect(screen.queryByTestId('push-disable-btn')).toBeNull()
+  })
+
+  it('shows Disable button when already subscribed', async () => {
+    getCurrentSubscriptionMock.mockResolvedValue({
+      endpoint: 'https://push.example.com/x',
+    })
+    const { EnableNotifications } = await import('../../src/pwa/EnableNotifications')
+    render(<EnableNotifications client={fakeClient} hasFeature={true} />)
+    await waitFor(() => expect(screen.getByTestId('push-disable-btn')).toBeTruthy())
+  })
+
+  it('calls enablePush and shows status on success', async () => {
+    enablePushMock.mockResolvedValue({ ok: true, subscription: { endpoint: 'x' } })
+    const { EnableNotifications } = await import('../../src/pwa/EnableNotifications')
+    render(<EnableNotifications client={fakeClient} hasFeature={true} />)
+    await waitFor(() => expect(screen.getByTestId('push-enable-btn')).toBeTruthy())
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('push-enable-btn'))
+    })
+    await waitFor(() => expect(screen.getByTestId('push-status')).toBeTruthy())
+    expect(enablePushMock).toHaveBeenCalledWith(fakeClient)
+    expect(screen.getByTestId('push-status').textContent).toContain('enabled')
+    expect(screen.getByTestId('push-disable-btn')).toBeTruthy()
+  })
+
+  it('shows error message when permission is denied via enablePush result', async () => {
+    enablePushMock.mockResolvedValue({ ok: false, reason: 'permission-denied' })
+    const { EnableNotifications } = await import('../../src/pwa/EnableNotifications')
+    render(<EnableNotifications client={fakeClient} hasFeature={true} />)
+    await waitFor(() => expect(screen.getByTestId('push-enable-btn')).toBeTruthy())
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('push-enable-btn'))
+    })
+    await waitFor(() => expect(screen.getByTestId('push-error')).toBeTruthy())
+    expect(screen.getByTestId('push-error').textContent).toMatch(/denied/i)
+  })
+
+  it('disables Enable button and shows hint when permission is already denied', async () => {
+    getNotificationPermissionMock.mockReturnValue('denied')
+    const { EnableNotifications } = await import('../../src/pwa/EnableNotifications')
+    render(<EnableNotifications client={fakeClient} hasFeature={true} />)
+    await waitFor(() => expect(screen.getByTestId('push-enable-btn')).toBeTruthy())
+    expect((screen.getByTestId('push-enable-btn') as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByTestId('push-denied-hint')).toBeTruthy()
+  })
+
+  it('calls disablePush when Disable is clicked', async () => {
+    getCurrentSubscriptionMock.mockResolvedValue({ endpoint: 'x' })
+    disablePushMock.mockResolvedValue({ ok: true })
+    const { EnableNotifications } = await import('../../src/pwa/EnableNotifications')
+    render(<EnableNotifications client={fakeClient} hasFeature={true} />)
+    await waitFor(() => expect(screen.getByTestId('push-disable-btn')).toBeTruthy())
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('push-disable-btn'))
+    })
+    await waitFor(() => expect(screen.getByTestId('push-status')).toBeTruthy())
+    expect(disablePushMock).toHaveBeenCalledWith(fakeClient)
+    expect(screen.getByTestId('push-enable-btn')).toBeTruthy()
+  })
+})

--- a/test/pwa/push.test.ts
+++ b/test/pwa/push.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const NotificationStub = {
+  permission: 'default' as NotificationPermission,
+  requestPermission: vi.fn().mockResolvedValue('granted' as NotificationPermission),
+}
+
+const PushManagerStub = function PushManager() {}
+
+function setEnv(value: string | undefined) {
+  if (value === undefined) vi.unstubAllEnvs()
+  else vi.stubEnv('VITE_ENABLE_PUSH', value)
+}
+
+function stubBrowserGlobals() {
+  vi.stubGlobal('Notification', NotificationStub)
+  vi.stubGlobal('PushManager', PushManagerStub)
+  vi.stubGlobal('isSecureContext', true)
+}
+
+beforeEach(() => {
+  NotificationStub.permission = 'default'
+  NotificationStub.requestPermission = vi.fn().mockResolvedValue('granted')
+  setEnv('1')
+  stubBrowserGlobals()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  setEnv(undefined)
+  vi.resetModules()
+})
+
+describe('isPushFlagEnabled', () => {
+  it('returns true for "1", "true", "yes", "on"', async () => {
+    const { isPushFlagEnabled } = await import('../../src/pwa/push')
+    for (const v of ['1', 'true', 'TRUE', 'yes', 'on']) {
+      setEnv(v)
+      expect(isPushFlagEnabled()).toBe(true)
+    }
+  })
+
+  it('returns false when undefined or off-like', async () => {
+    const { isPushFlagEnabled } = await import('../../src/pwa/push')
+    for (const v of [undefined, '', '0', 'false', 'no', 'off']) {
+      setEnv(v)
+      expect(isPushFlagEnabled()).toBe(false)
+    }
+  })
+})
+
+describe('detectPushSupport', () => {
+  it('returns flag-disabled when env flag is off', async () => {
+    setEnv('0')
+    const { detectPushSupport } = await import('../../src/pwa/push')
+    expect(detectPushSupport().kind).toBe('flag-disabled')
+  })
+
+  it('returns insecure-context when not secure', async () => {
+    const { detectPushSupport } = await import('../../src/pwa/push')
+    expect(
+      detectPushSupport({
+        isSecureContext: false,
+        navigator: { serviceWorker: {} } as unknown as Navigator,
+        Notification: NotificationStub,
+        PushManager: PushManagerStub,
+      } as unknown as typeof globalThis).kind,
+    ).toBe('insecure-context')
+  })
+
+  it('returns no-service-worker when navigator lacks SW', async () => {
+    const { detectPushSupport } = await import('../../src/pwa/push')
+    expect(
+      detectPushSupport({
+        isSecureContext: true,
+        navigator: {} as Navigator,
+        Notification: NotificationStub,
+        PushManager: PushManagerStub,
+      } as unknown as typeof globalThis).kind,
+    ).toBe('no-service-worker')
+  })
+
+  it('returns no-push-manager when window lacks PushManager', async () => {
+    const { detectPushSupport } = await import('../../src/pwa/push')
+    expect(
+      detectPushSupport({
+        isSecureContext: true,
+        navigator: { serviceWorker: {} } as unknown as Navigator,
+        Notification: NotificationStub,
+      } as unknown as typeof globalThis).kind,
+    ).toBe('no-push-manager')
+  })
+
+  it('returns no-notifications when window lacks Notification', async () => {
+    const { detectPushSupport } = await import('../../src/pwa/push')
+    expect(
+      detectPushSupport({
+        isSecureContext: true,
+        navigator: { serviceWorker: {} } as unknown as Navigator,
+        PushManager: PushManagerStub,
+      } as unknown as typeof globalThis).kind,
+    ).toBe('no-notifications')
+  })
+
+  it('returns supported when everything is in place', async () => {
+    const { detectPushSupport } = await import('../../src/pwa/push')
+    expect(
+      detectPushSupport({
+        isSecureContext: true,
+        navigator: { serviceWorker: {} } as unknown as Navigator,
+        Notification: NotificationStub,
+        PushManager: PushManagerStub,
+      } as unknown as typeof globalThis).kind,
+    ).toBe('supported')
+  })
+})
+
+describe('urlBase64ToUint8Array', () => {
+  it('decodes a known base64url VAPID-style key', async () => {
+    const { urlBase64ToUint8Array } = await import('../../src/pwa/push')
+    const out = urlBase64ToUint8Array('BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM')
+    expect(out).toBeInstanceOf(Uint8Array)
+    expect(out.byteLength).toBe(65)
+    expect(out[0]).toBe(0x04)
+  })
+
+  it('handles base64url with - and _ and missing padding', async () => {
+    const { urlBase64ToUint8Array } = await import('../../src/pwa/push')
+    const standard = atob('Hi+/')
+    const expected = Uint8Array.from(standard, (c) => c.charCodeAt(0))
+    const out = urlBase64ToUint8Array('Hi-_')
+    expect(out.byteLength).toBe(expected.byteLength)
+    expect(Array.from(out)).toEqual(Array.from(expected))
+  })
+
+  it('throws on empty input', async () => {
+    const { urlBase64ToUint8Array } = await import('../../src/pwa/push')
+    expect(() => urlBase64ToUint8Array('')).toThrow(/empty/)
+    expect(() => urlBase64ToUint8Array('   ')).toThrow(/empty/)
+  })
+
+  it('throws on invalid base64', async () => {
+    const { urlBase64ToUint8Array } = await import('../../src/pwa/push')
+    expect(() => urlBase64ToUint8Array('not*valid*chars')).toThrow(/base64url/)
+  })
+})
+
+describe('toPushSubscriptionJSON', () => {
+  it('normalizes a PushSubscription.toJSON()', async () => {
+    const { toPushSubscriptionJSON } = await import('../../src/pwa/push')
+    const sub = {
+      toJSON: () => ({
+        endpoint: 'https://push.example.com/abc',
+        expirationTime: null,
+        keys: { p256dh: 'pk', auth: 'ak' },
+      }),
+    } as unknown as PushSubscription
+    expect(toPushSubscriptionJSON(sub)).toEqual({
+      endpoint: 'https://push.example.com/abc',
+      expirationTime: null,
+      keys: { p256dh: 'pk', auth: 'ak' },
+    })
+  })
+
+  it('throws on missing endpoint or keys', async () => {
+    const { toPushSubscriptionJSON } = await import('../../src/pwa/push')
+    expect(() =>
+      toPushSubscriptionJSON({ toJSON: () => ({}) } as unknown as PushSubscription),
+    ).toThrow(/endpoint/)
+    expect(() =>
+      toPushSubscriptionJSON({
+        toJSON: () => ({ endpoint: 'x', keys: {} }),
+      } as unknown as PushSubscription),
+    ).toThrow(/keys/)
+  })
+})
+
+describe('enablePush', () => {
+  function makeRegistration({
+    existing,
+    subscribe,
+  }: {
+    existing?: unknown
+    subscribe?: ReturnType<typeof vi.fn>
+  } = {}) {
+    return {
+      pushManager: {
+        getSubscription: vi.fn().mockResolvedValue(existing ?? null),
+        subscribe: subscribe ?? vi.fn().mockResolvedValue({
+          toJSON: () => ({
+            endpoint: 'https://push.example.com/new',
+            expirationTime: null,
+            keys: { p256dh: 'pk', auth: 'ak' },
+          }),
+        }),
+      },
+    }
+  }
+
+  function installServiceWorker(reg: ReturnType<typeof makeRegistration>) {
+    Object.defineProperty(globalThis.navigator, 'serviceWorker', {
+      configurable: true,
+      value: {
+        ready: Promise.resolve(reg as unknown as ServiceWorkerRegistration),
+      },
+    })
+  }
+
+  afterEach(() => {
+    delete (globalThis.navigator as { serviceWorker?: unknown }).serviceWorker
+  })
+
+  function makeClient(overrides: Record<string, unknown> = {}) {
+    return {
+      getVapidKey: vi.fn().mockResolvedValue({ key: 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM' }),
+      subscribePush: vi.fn().mockResolvedValue({ ok: true, id: 'sub-1' }),
+      unsubscribePush: vi.fn().mockResolvedValue({ ok: true }),
+      ...overrides,
+    }
+  }
+
+  it('returns unsupported when flag is disabled', async () => {
+    setEnv('0')
+    const { enablePush } = await import('../../src/pwa/push')
+    const result = await enablePush(makeClient() as never)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('unsupported')
+  })
+
+  it('returns permission-denied when user denies', async () => {
+    NotificationStub.permission = 'default'
+    NotificationStub.requestPermission = vi.fn().mockResolvedValue('denied')
+    const reg = makeRegistration()
+    installServiceWorker(reg)
+    const { enablePush } = await import('../../src/pwa/push')
+    const result = await enablePush(makeClient() as never)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('permission-denied')
+  })
+
+  it('returns permission-default when user dismisses', async () => {
+    NotificationStub.permission = 'default'
+    NotificationStub.requestPermission = vi.fn().mockResolvedValue('default')
+    installServiceWorker(makeRegistration())
+    const { enablePush } = await import('../../src/pwa/push')
+    const result = await enablePush(makeClient() as never)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('permission-default')
+  })
+
+  it('subscribes and POSTs JSON when permission is granted', async () => {
+    NotificationStub.permission = 'granted'
+    const reg = makeRegistration()
+    installServiceWorker(reg)
+    const client = makeClient()
+    const { enablePush } = await import('../../src/pwa/push')
+    const result = await enablePush(client as never)
+    expect(result.ok).toBe(true)
+    expect(client.getVapidKey).toHaveBeenCalled()
+    expect(reg.pushManager.subscribe).toHaveBeenCalledWith(
+      expect.objectContaining({ userVisibleOnly: true }),
+    )
+    expect(client.subscribePush).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: 'https://push.example.com/new' }),
+    )
+  })
+
+  it('replaces an existing subscription before subscribing', async () => {
+    NotificationStub.permission = 'granted'
+    const unsubscribe = vi.fn().mockResolvedValue(true)
+    const reg = makeRegistration({
+      existing: {
+        endpoint: 'https://push.example.com/old',
+        unsubscribe,
+        toJSON: () => ({
+          endpoint: 'https://push.example.com/old',
+          keys: { p256dh: 'pk', auth: 'ak' },
+        }),
+      },
+    })
+    installServiceWorker(reg)
+    const { enablePush } = await import('../../src/pwa/push')
+    await enablePush(makeClient() as never)
+    expect(unsubscribe).toHaveBeenCalled()
+    expect(reg.pushManager.subscribe).toHaveBeenCalled()
+  })
+
+  it('returns error when subscribe throws', async () => {
+    NotificationStub.permission = 'granted'
+    const reg = makeRegistration({
+      subscribe: vi.fn().mockRejectedValue(new Error('boom')),
+    })
+    installServiceWorker(reg)
+    const { enablePush } = await import('../../src/pwa/push')
+    const result = await enablePush(makeClient() as never)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toBe('error')
+      expect(result.error).toContain('boom')
+    }
+  })
+})
+
+describe('disablePush', () => {
+  function installSwReady(ready: Promise<unknown>) {
+    Object.defineProperty(globalThis.navigator, 'serviceWorker', {
+      configurable: true,
+      value: { ready },
+    })
+  }
+
+  afterEach(() => {
+    delete (globalThis.navigator as { serviceWorker?: unknown }).serviceWorker
+  })
+
+  it('returns ok when no subscription exists', async () => {
+    installSwReady(
+      Promise.resolve({
+        pushManager: { getSubscription: vi.fn().mockResolvedValue(null) },
+      } as unknown as ServiceWorkerRegistration),
+    )
+    const { disablePush } = await import('../../src/pwa/push')
+    const client = { unsubscribePush: vi.fn() }
+    const result = await disablePush(client as never)
+    expect(result.ok).toBe(true)
+    expect(client.unsubscribePush).not.toHaveBeenCalled()
+  })
+
+  it('calls server DELETE then subscription.unsubscribe', async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(true)
+    const sub = {
+      endpoint: 'https://push.example.com/abc',
+      unsubscribe,
+      toJSON: () => ({
+        endpoint: 'https://push.example.com/abc',
+        keys: { p256dh: 'pk', auth: 'ak' },
+      }),
+    }
+    installSwReady(
+      Promise.resolve({
+        pushManager: { getSubscription: vi.fn().mockResolvedValue(sub) },
+      } as unknown as ServiceWorkerRegistration),
+    )
+    const { disablePush } = await import('../../src/pwa/push')
+    const client = { unsubscribePush: vi.fn().mockResolvedValue({ ok: true }) }
+    const result = await disablePush(client as never)
+    expect(result.ok).toBe(true)
+    expect(client.unsubscribePush).toHaveBeenCalledWith('https://push.example.com/abc')
+    expect(unsubscribe).toHaveBeenCalled()
+  })
+
+  it('still unsubscribes locally even if server DELETE fails', async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(true)
+    const sub = {
+      endpoint: 'https://push.example.com/abc',
+      unsubscribe,
+      toJSON: () => ({
+        endpoint: 'https://push.example.com/abc',
+        keys: { p256dh: 'pk', auth: 'ak' },
+      }),
+    }
+    installSwReady(
+      Promise.resolve({
+        pushManager: { getSubscription: vi.fn().mockResolvedValue(sub) },
+      } as unknown as ServiceWorkerRegistration),
+    )
+    const { disablePush } = await import('../../src/pwa/push')
+    const client = { unsubscribePush: vi.fn().mockRejectedValue(new Error('500')) }
+    const result = await disablePush(client as never)
+    expect(result.ok).toBe(true)
+    expect(unsubscribe).toHaveBeenCalled()
+  })
+})

--- a/test/routing/route.test.ts
+++ b/test/routing/route.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { parseHash, formatRoute, createRouter } from '../../src/routing/route'
+
+describe('parseHash', () => {
+  it('returns home for empty/missing', () => {
+    expect(parseHash('')).toEqual({ name: 'home' })
+    expect(parseHash('#')).toEqual({ name: 'home' })
+    expect(parseHash('#/')).toEqual({ name: 'home' })
+  })
+
+  it('parses session slug', () => {
+    expect(parseHash('#/s/fast-cat')).toEqual({ name: 'session', sessionSlug: 'fast-cat' })
+  })
+
+  it('decodes percent-encoded segments', () => {
+    expect(parseHash('#/s/cool%20slug')).toEqual({ name: 'session', sessionSlug: 'cool slug' })
+  })
+
+  it('parses group id', () => {
+    expect(parseHash('#/g/grp-1')).toEqual({ name: 'group', groupId: 'grp-1' })
+  })
+
+  it('unknown shape falls back to home', () => {
+    expect(parseHash('#/foo/bar')).toEqual({ name: 'home' })
+    expect(parseHash('#/s')).toEqual({ name: 'home' })
+  })
+})
+
+describe('formatRoute', () => {
+  it('round-trips through parseHash', () => {
+    expect(parseHash(formatRoute({ name: 'home' }))).toEqual({ name: 'home' })
+    expect(parseHash(formatRoute({ name: 'session', sessionSlug: 'fast-cat' }))).toEqual({
+      name: 'session',
+      sessionSlug: 'fast-cat',
+    })
+    expect(parseHash(formatRoute({ name: 'group', groupId: 'grp-1' }))).toEqual({
+      name: 'group',
+      groupId: 'grp-1',
+    })
+  })
+
+  it('encodes special characters', () => {
+    const hash = formatRoute({ name: 'session', sessionSlug: 'has spaces' })
+    expect(hash).toBe('#/s/has%20spaces')
+  })
+})
+
+describe('createRouter', () => {
+  const originalHash = window.location.hash
+
+  beforeEach(() => {
+    window.location.hash = ''
+  })
+
+  afterEach(() => {
+    window.location.hash = originalHash
+  })
+
+  it('initializes route from current hash', () => {
+    window.location.hash = '#/s/foo'
+    const r = createRouter()
+    expect(r.route.value).toEqual({ name: 'session', sessionSlug: 'foo' })
+    r.dispose()
+  })
+
+  it('updates route on hashchange', () => {
+    const r = createRouter()
+    expect(r.route.value).toEqual({ name: 'home' })
+
+    window.location.hash = '#/g/grp-9'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(r.route.value).toEqual({ name: 'group', groupId: 'grp-9' })
+    r.dispose()
+  })
+
+  it('navigate() sets the hash and updates the route', () => {
+    const r = createRouter()
+    r.navigate({ name: 'session', sessionSlug: 'ab' })
+    // location.hash change in jsdom fires a hashchange synchronously in newer versions,
+    // but for safety nudge it manually:
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(r.route.value).toEqual({ name: 'session', sessionSlug: 'ab' })
+    expect(window.location.hash).toBe('#/s/ab')
+    r.dispose()
+  })
+
+  it('navigate() to the same hash still updates the signal', () => {
+    window.location.hash = '#/s/foo'
+    const r = createRouter()
+    const initial = r.route.value
+    r.navigate({ name: 'session', sessionSlug: 'foo' })
+    expect(r.route.value).toEqual(initial)
+    r.dispose()
+  })
+
+  it('dispose() stops listening to hashchange', () => {
+    const r = createRouter()
+    r.dispose()
+    window.location.hash = '#/s/never-seen'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+    expect(r.route.value).toEqual({ name: 'home' })
+  })
+})

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,5 +24,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "e2e/fixtures"]
 }


### PR DESCRIPTION
## Summary

Adds the client-side Web Push slice of the de-Telegramification work. Users can opt in to browser notifications per connection; the service worker now handles `push` and `notificationclick` events.

## What changed

- `src/pwa/push.ts` — VAPID base64url decoding, support detection, `enablePush` / `disablePush` driving `Notification.requestPermission` → `pushManager.subscribe` → `client.subscribePush`
- `src/pwa/EnableNotifications.tsx` — toggle panel with permission and unsupported-state messaging
- `src/sw.ts` — `push` handler (parses `{title, body, tag, url, icon, badge}` JSON, falls back to defaults) and `notificationclick` handler that focuses an existing window at `url`, navigates one if reusable, or opens fresh
- `src/connections/ConnectionSettings.tsx` — mounts the panel for existing connections only, gated on the build flag and the server's `web-push` feature
- `docs/push.md` — flow + server requirements + payload shape + HTTPS rationale

## API consumed

- `GET /api/push/vapid-public-key`
- `POST /api/push-subscribe` (PushSubscriptionJSON)
- `DELETE /api/push-subscribe` (`{ endpoint }`)
- Feature gate: `web-push` in `/api/version.features`

## Build flag

`VITE_ENABLE_PUSH=1` is required at build time. Without it the UI is hidden entirely — Web Push throws `SecurityError` on non-HTTPS origins, so a runtime "broken button" on `localhost` would just confuse developers.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 292/292 pass (35 new cases: push module, EnableNotifications, ConnectionSettings push panel)
- [x] `npm run build` — both app bundle and `sw.js` build clean
- [ ] E2E not run — requires an HTTPS origin and a real VAPID key

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  api-foundation["✅ API foundation: types, client, features, router"]
  structured-task-creation["✅ Refactor task creation: POST /api/sessions flow"]
  worktree-header["✅ Worktree header: branch, cwd, diff stats"]
  pr-preview-card["✅ PR preview card: title, state, checks, body"]
  session-tabs["✅ Session tabs: diff viewer and screenshots gallery"]
  web-push["✅ Web Push: notifications, subscriptions, service worker"]
  parallel-variants-ui["✅ Parallel variants: N-session group layout and picker"]
  api-foundation --> structured-task-creation
  api-foundation --> worktree-header
  api-foundation --> pr-preview-card
  api-foundation --> session-tabs
  api-foundation --> web-push
  api-foundation --> parallel-variants-ui
  structured-task-creation --> parallel-variants-ui
  class api-foundation done
  class structured-task-creation done
  class worktree-header done
  class pr-preview-card done
  class session-tabs done
  class web-push done
  class web-push current
  class parallel-variants-ui done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | API foundation: types, client, features, router | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/4) |
| 2 | Refactor task creation: POST /api/sessions flow | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/5) |
| 3 | Worktree header: branch, cwd, diff stats | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/6) |
| 4 | PR preview card: title, state, checks, body | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/7) |
| 5 | Session tabs: diff viewer and screenshots gallery | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/8) |
| 6 | **Web Push: notifications, subscriptions, service worker** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/10) |
| 7 | Parallel variants: N-session group layout and picker | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/9) |

**Progress:** 7/7 complete

<!-- dag-status-end -->