### PR TITLE
[minions] extract session classification to shared module

### DIFF
--- a/src/components/universe-layout.ts
+++ b/src/components/universe-layout.ts
@@ -2,6 +2,7 @@ import dagre from 'dagre'
 import type { Node, Edge } from '@reactflow/core'
 import { MarkerType } from '@reactflow/core'
 import type { ApiSession, ApiDagGraph, ApiDagNode } from '../api/types'
+import { classifySessions } from '../state/hierarchy'
 
 export const NODE_WIDTH = 240
 export const NODE_HEIGHT = 100
@@ -31,80 +32,6 @@ interface LayoutGroup {
   edges: Edge[]
   width: number
   height: number
-}
-
-function classifySessions(
-  sessions: ApiSession[],
-  dags: ApiDagGraph[],
-): { dagOwned: Set<string>; parentChildRoots: ApiSession[]; standalone: ApiSession[] } {
-  const dagOwned = new Set<string>()
-
-  for (const dag of dags) {
-    for (const node of Object.values(dag.nodes)) {
-      if (node.session) {
-        dagOwned.add(node.session.id)
-      }
-    }
-  }
-
-  const sessionById = new Map<string, ApiSession>()
-  for (const s of sessions) {
-    sessionById.set(s.id, s)
-  }
-
-  const inParentChildTree = new Set<string>()
-  const parentChildRoots: ApiSession[] = []
-
-  for (const s of sessions) {
-    if (dagOwned.has(s.id)) continue
-    if (inParentChildTree.has(s.id)) continue
-
-    if (s.childIds.length > 0 && !s.parentId) {
-      parentChildRoots.push(s)
-      inParentChildTree.add(s.id)
-      collectChildren(s, sessionById, inParentChildTree)
-    }
-  }
-
-  const standalone: ApiSession[] = []
-  for (const s of sessions) {
-    if (!dagOwned.has(s.id) && !inParentChildTree.has(s.id)) {
-      if (s.parentId && sessionById.has(s.parentId)) {
-        const parent = sessionById.get(s.parentId)!
-        if (parent.childIds.includes(s.id) && !dagOwned.has(parent.id)) {
-          let root = parent
-          while (root.parentId && sessionById.has(root.parentId) && !dagOwned.has(root.parentId)) {
-            root = sessionById.get(root.parentId)!
-          }
-          if (!inParentChildTree.has(root.id)) {
-            parentChildRoots.push(root)
-            inParentChildTree.add(root.id)
-            collectChildren(root, sessionById, inParentChildTree)
-          }
-          inParentChildTree.add(s.id)
-          continue
-        }
-      }
-      standalone.push(s)
-    }
-  }
-
-  return { dagOwned, parentChildRoots, standalone }
-}
-
-function collectChildren(
-  session: ApiSession,
-  sessionById: Map<string, ApiSession>,
-  collected: Set<string>,
-): void {
-  for (const childId of session.childIds) {
-    if (collected.has(childId)) continue
-    collected.add(childId)
-    const child = sessionById.get(childId)
-    if (child) {
-      collectChildren(child, sessionById, collected)
-    }
-  }
 }
 
 function layoutDagGroup(dag: ApiDagGraph, isDark: boolean): LayoutGroup {
@@ -319,12 +246,7 @@ export function layoutUniverse(
     return { nodes: [], edges: [] }
   }
 
-  const sessionById = new Map<string, ApiSession>()
-  for (const s of sessions) {
-    sessionById.set(s.id, s)
-  }
-
-  const { parentChildRoots, standalone } = classifySessions(sessions, dags)
+  const { parentChildRoots, standalone, sessionById } = classifySessions(sessions, dags)
 
   const groups: LayoutGroup[] = []
 

--- a/src/state/hierarchy.ts
+++ b/src/state/hierarchy.ts
@@ -89,3 +89,101 @@ function sortByUpdatedAt(list: ApiSession[]): ApiSession[] {
     return a.updatedAt < b.updatedAt ? 1 : -1
   })
 }
+
+export function buildSessionIndex(sessions: ApiSession[]): Map<string, ApiSession> {
+  const index = new Map<string, ApiSession>()
+  for (const s of sessions) index.set(s.id, s)
+  return index
+}
+
+export function collectChildren(
+  session: ApiSession,
+  sessionById: Map<string, ApiSession>,
+  collected: Set<string>,
+): void {
+  for (const childId of session.childIds) {
+    if (collected.has(childId)) continue
+    collected.add(childId)
+    const child = sessionById.get(childId)
+    if (child) collectChildren(child, sessionById, collected)
+  }
+}
+
+export function collectDescendants(
+  session: ApiSession,
+  sessionById: Map<string, ApiSession>,
+): Set<string> {
+  const collected = new Set<string>()
+  collectChildren(session, sessionById, collected)
+  return collected
+}
+
+export function findTreeRoot(
+  session: ApiSession,
+  sessionById: Map<string, ApiSession>,
+  excluded: Set<string> = new Set(),
+): ApiSession {
+  let root = session
+  while (root.parentId && sessionById.has(root.parentId) && !excluded.has(root.parentId)) {
+    root = sessionById.get(root.parentId)!
+  }
+  return root
+}
+
+export interface SessionClassification {
+  dagOwned: Set<string>
+  parentChildRoots: ApiSession[]
+  parentChildMembers: Set<string>
+  standalone: ApiSession[]
+  sessionById: Map<string, ApiSession>
+}
+
+export function classifySessions(
+  sessions: ApiSession[],
+  dags: ApiDagGraph[],
+): SessionClassification {
+  const dagOwned = new Set<string>()
+  for (const dag of dags) {
+    for (const node of Object.values(dag.nodes)) {
+      if (node.session) dagOwned.add(node.session.id)
+    }
+  }
+
+  const sessionById = buildSessionIndex(sessions)
+
+  const parentChildMembers = new Set<string>()
+  const parentChildRoots: ApiSession[] = []
+
+  for (const s of sessions) {
+    if (dagOwned.has(s.id)) continue
+    if (parentChildMembers.has(s.id)) continue
+
+    if (s.childIds.length > 0 && !s.parentId) {
+      parentChildRoots.push(s)
+      parentChildMembers.add(s.id)
+      collectChildren(s, sessionById, parentChildMembers)
+    }
+  }
+
+  const standalone: ApiSession[] = []
+  for (const s of sessions) {
+    if (dagOwned.has(s.id) || parentChildMembers.has(s.id)) continue
+
+    if (s.parentId && sessionById.has(s.parentId)) {
+      const parent = sessionById.get(s.parentId)!
+      if (parent.childIds.includes(s.id) && !dagOwned.has(parent.id)) {
+        const root = findTreeRoot(parent, sessionById, dagOwned)
+        if (!parentChildMembers.has(root.id)) {
+          parentChildRoots.push(root)
+          parentChildMembers.add(root.id)
+          collectChildren(root, sessionById, parentChildMembers)
+        }
+        parentChildMembers.add(s.id)
+        continue
+      }
+    }
+    standalone.push(s)
+  }
+
+  return { dagOwned, parentChildRoots, parentChildMembers, standalone, sessionById }
+}

--- a/test/state/hierarchy.test.ts
+++ b/test/state/hierarchy.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { buildSessionGroups } from '../../src/state/hierarchy'
 import type { ApiDagGraph, ApiSession } from '../../src/api/types'
+import {
+  buildSessionGroups,
+  buildSessionIndex,
+  classifySessions,
+  collectChildren,
+  collectDescendants,
+  findTreeRoot,
+} from '../../src/state/hierarchy'
 
 function mkSession(over: Partial<ApiSession> = {}): ApiSession {
   return {
@@ -17,6 +24,27 @@ function mkSession(over: Partial<ApiSession> = {}): ApiSession {
     mode: 'task',
     conversation: [],
     ...over,
+  }
+}
+
+function makeSession(overrides: Partial<ApiSession> & { id: string; slug: string }): ApiSession {
+  return mkSession({
+    status: 'running',
+    command: '/task test',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  })
+}
+
+function makeDag(overrides: Partial<ApiDagGraph> & { id: string }): ApiDagGraph {
+  return {
+    rootTaskId: 'node-1',
+    nodes: {},
+    status: 'running',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
   }
 }
 
@@ -102,5 +130,240 @@ describe('buildSessionGroups', () => {
       }
     }
     expect(seen.size).toBe(2)
+  })
+})
+
+describe('hierarchy', () => {
+  describe('buildSessionIndex', () => {
+    it('indexes sessions by id', () => {
+      const sessions = [
+        makeSession({ id: 'a', slug: 'alpha' }),
+        makeSession({ id: 'b', slug: 'beta' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      expect(index.size).toBe(2)
+      expect(index.get('a')?.slug).toBe('alpha')
+      expect(index.get('b')?.slug).toBe('beta')
+    })
+
+    it('handles empty input', () => {
+      expect(buildSessionIndex([]).size).toBe(0)
+    })
+
+    it('overwrites earlier entries with later ones when ids collide', () => {
+      const sessions = [
+        makeSession({ id: 'a', slug: 'first' }),
+        makeSession({ id: 'a', slug: 'second' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      expect(index.size).toBe(1)
+      expect(index.get('a')?.slug).toBe('second')
+    })
+  })
+
+  describe('collectChildren', () => {
+    it('collects direct children ids', () => {
+      const sessions = [
+        makeSession({ id: 'root', slug: 'root', childIds: ['c1', 'c2'] }),
+        makeSession({ id: 'c1', slug: 'c1', parentId: 'root' }),
+        makeSession({ id: 'c2', slug: 'c2', parentId: 'root' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      const collected = new Set<string>()
+      collectChildren(sessions[0], index, collected)
+      expect([...collected].sort()).toEqual(['c1', 'c2'])
+    })
+
+    it('recurses through deep trees', () => {
+      const sessions = [
+        makeSession({ id: 'root', slug: 'root', childIds: ['mid'] }),
+        makeSession({ id: 'mid', slug: 'mid', parentId: 'root', childIds: ['leaf'] }),
+        makeSession({ id: 'leaf', slug: 'leaf', parentId: 'mid' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      const collected = new Set<string>()
+      collectChildren(sessions[0], index, collected)
+      expect([...collected].sort()).toEqual(['leaf', 'mid'])
+    })
+
+    it('skips already-collected ids to avoid cycles', () => {
+      const a = makeSession({ id: 'a', slug: 'a', childIds: ['b'] })
+      const b = makeSession({ id: 'b', slug: 'b', parentId: 'a', childIds: ['a'] })
+      const index = buildSessionIndex([a, b])
+      const collected = new Set<string>()
+      collectChildren(a, index, collected)
+      expect([...collected].sort()).toEqual(['a', 'b'].filter((id) => collected.has(id)))
+      expect(collected.has('b')).toBe(true)
+    })
+
+    it('tolerates missing child entries', () => {
+      const root = makeSession({ id: 'root', slug: 'root', childIds: ['missing'] })
+      const index = buildSessionIndex([root])
+      const collected = new Set<string>()
+      collectChildren(root, index, collected)
+      expect(collected.has('missing')).toBe(true)
+    })
+  })
+
+  describe('collectDescendants', () => {
+    it('returns a new set of all descendants', () => {
+      const sessions = [
+        makeSession({ id: 'root', slug: 'root', childIds: ['mid'] }),
+        makeSession({ id: 'mid', slug: 'mid', parentId: 'root', childIds: ['leaf'] }),
+        makeSession({ id: 'leaf', slug: 'leaf', parentId: 'mid' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      const descendants = collectDescendants(sessions[0], index)
+      expect([...descendants].sort()).toEqual(['leaf', 'mid'])
+    })
+
+    it('returns empty set for leaf sessions', () => {
+      const leaf = makeSession({ id: 'leaf', slug: 'leaf' })
+      const index = buildSessionIndex([leaf])
+      expect(collectDescendants(leaf, index).size).toBe(0)
+    })
+  })
+
+  describe('findTreeRoot', () => {
+    it('walks up to the topmost ancestor', () => {
+      const sessions = [
+        makeSession({ id: 'root', slug: 'root', childIds: ['mid'] }),
+        makeSession({ id: 'mid', slug: 'mid', parentId: 'root', childIds: ['leaf'] }),
+        makeSession({ id: 'leaf', slug: 'leaf', parentId: 'mid' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      expect(findTreeRoot(sessions[2], index).id).toBe('root')
+    })
+
+    it('returns the session itself when it has no parent', () => {
+      const orphan = makeSession({ id: 'orphan', slug: 'orphan' })
+      const index = buildSessionIndex([orphan])
+      expect(findTreeRoot(orphan, index).id).toBe('orphan')
+    })
+
+    it('stops walking when parent is excluded', () => {
+      const sessions = [
+        makeSession({ id: 'grand', slug: 'grand', childIds: ['parent'] }),
+        makeSession({ id: 'parent', slug: 'parent', parentId: 'grand', childIds: ['child'] }),
+        makeSession({ id: 'child', slug: 'child', parentId: 'parent' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      const excluded = new Set<string>(['grand'])
+      expect(findTreeRoot(sessions[2], index, excluded).id).toBe('parent')
+    })
+
+    it('stops walking when parent is missing from the index', () => {
+      const orphan = makeSession({ id: 'orphan', slug: 'orphan', parentId: 'missing' })
+      const index = buildSessionIndex([orphan])
+      expect(findTreeRoot(orphan, index).id).toBe('orphan')
+    })
+  })
+
+  describe('classifySessions', () => {
+    it('returns empty buckets for empty input', () => {
+      const result = classifySessions([], [])
+      expect(result.dagOwned.size).toBe(0)
+      expect(result.parentChildRoots).toEqual([])
+      expect(result.parentChildMembers.size).toBe(0)
+      expect(result.standalone).toEqual([])
+      expect(result.sessionById.size).toBe(0)
+    })
+
+    it('puts solo sessions in the standalone bucket', () => {
+      const sessions = [
+        makeSession({ id: 's1', slug: 'one' }),
+        makeSession({ id: 's2', slug: 'two' }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.standalone).toHaveLength(2)
+      expect(result.parentChildRoots).toHaveLength(0)
+    })
+
+    it('identifies parent sessions with children as parent-child roots', () => {
+      const sessions = [
+        makeSession({ id: 'p', slug: 'parent', childIds: ['c1', 'c2'] }),
+        makeSession({ id: 'c1', slug: 'c1', parentId: 'p' }),
+        makeSession({ id: 'c2', slug: 'c2', parentId: 'p' }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.parentChildRoots.map((s) => s.id)).toEqual(['p'])
+      expect(result.parentChildMembers.has('p')).toBe(true)
+      expect(result.parentChildMembers.has('c1')).toBe(true)
+      expect(result.parentChildMembers.has('c2')).toBe(true)
+      expect(result.standalone).toHaveLength(0)
+    })
+
+    it('auto-discovers a root from an orphaned child that arrives before its parent', () => {
+      const sessions = [
+        makeSession({ id: 'orphan-child', slug: 'child', parentId: 'parent' }),
+        makeSession({ id: 'parent', slug: 'parent', childIds: ['orphan-child'] }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.parentChildRoots.map((s) => s.id)).toEqual(['parent'])
+      expect(result.parentChildMembers.has('orphan-child')).toBe(true)
+      expect(result.standalone).toHaveLength(0)
+    })
+
+    it('marks DAG-owned sessions and excludes them from other buckets', () => {
+      const dagSession = makeSession({ id: 'dag-session', slug: 'dag-owned' })
+      const standalone = makeSession({ id: 'solo', slug: 'solo' })
+      const dag = makeDag({
+        id: 'dag-1',
+        nodes: {
+          n1: {
+            id: 'n1',
+            slug: 'node',
+            status: 'running',
+            dependencies: [],
+            dependents: [],
+            session: dagSession,
+          },
+        },
+      })
+
+      const result = classifySessions([dagSession, standalone], [dag])
+      expect(result.dagOwned.has('dag-session')).toBe(true)
+      expect(result.parentChildRoots).toHaveLength(0)
+      expect(result.standalone.map((s) => s.id)).toEqual(['solo'])
+    })
+
+    it('does not promote a DAG-owned parent into a parent-child root', () => {
+      const dagParent = makeSession({ id: 'dp', slug: 'dag-parent', childIds: ['child'] })
+      const child = makeSession({ id: 'child', slug: 'child', parentId: 'dp' })
+      const dag = makeDag({
+        id: 'dag-1',
+        nodes: {
+          n1: {
+            id: 'n1',
+            slug: 'node',
+            status: 'running',
+            dependencies: [],
+            dependents: [],
+            session: dagParent,
+          },
+        },
+      })
+      const result = classifySessions([dagParent, child], [dag])
+      expect(result.parentChildRoots).toHaveLength(0)
+      expect(result.standalone.map((s) => s.id)).toEqual(['child'])
+    })
+
+    it('handles deep trees by placing only the root in parentChildRoots', () => {
+      const sessions = [
+        makeSession({ id: 'root', slug: 'root', childIds: ['mid'] }),
+        makeSession({ id: 'mid', slug: 'mid', parentId: 'root', childIds: ['leaf'] }),
+        makeSession({ id: 'leaf', slug: 'leaf', parentId: 'mid' }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.parentChildRoots.map((s) => s.id)).toEqual(['root'])
+      expect(result.parentChildMembers.size).toBe(3)
+      expect(result.standalone).toHaveLength(0)
+    })
+
+    it('exposes a ready-built session index', () => {
+      const sessions = [makeSession({ id: 'a', slug: 'alpha' })]
+      const result = classifySessions(sessions, [])
+      expect(result.sessionById.get('a')?.slug).toBe('alpha')
+    })
   })
 })


### PR DESCRIPTION
## Summary

Extract `classifySessions` and related helper functions from `src/components/universe-layout.ts` into a new shared module `src/state/hierarchy.ts`. This enables both the canvas layout and the upcoming list-view component to use a single source of truth for DAG / parent-child / standalone grouping.

**Key changes:**
- New `src/state/hierarchy.ts` exports: `buildSessionIndex`, `collectChildren`, `collectDescendants`, `findTreeRoot`, `classifySessions`, and the `SessionClassification` interface
- `src/components/universe-layout.ts` now imports and uses the shared exports
- Full unit coverage in `test/state/hierarchy.test.ts` (247/247 tests pass)
- Existing `universe-layout.test.ts` still guards the layout contract

**Motivation:** Eliminates duplication and drift risk across components that need to reason about session hierarchies and DAG ownership.

**Testing:** Unit and component tests pass locally. No e2e run per minion policy.

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  extract-hierarchy["✅ Extract classifySessions to shared state module"]
  chat-header-context["✅ Add parent/children/DAG/branch context to chat header"]
  attention-triage-bar["✅ Add action bar for sessions needing attention"]
  enhance-node-popup["✅ Add hierarchy metadata to NodeDetailPopup"]
  group-session-list["✅ Group SessionList by DAG/Tree/Standalone with nesting"]
  mount-canvas-tab["✅ Mount UniverseCanvas as second tab with view toggle"]
  fix-rendering-edges["✅ Fix edge-case rendering (status, animation, orphans)"]
  ship-mode-grouping["✅ Add fourth classification bucket for ship mode"]
  ship-pipeline-kanban["✅ Create Kanban view for ship pipelines"]
  enhance-context-menu["✅ Add navigation actions to ContextMenu"]
  polish-ui-details["✅ Polish: badges, chips, keyboard nav, DAG summaries"]
  extract-hierarchy --> group-session-list
  extract-hierarchy --> mount-canvas-tab
  extract-hierarchy --> fix-rendering-edges
  extract-hierarchy --> ship-mode-grouping
  mount-canvas-tab --> ship-pipeline-kanban
  mount-canvas-tab --> enhance-context-menu
  group-session-list --> polish-ui-details
  mount-canvas-tab --> polish-ui-details
  class extract-hierarchy done
  class extract-hierarchy current
  class chat-header-context done
  class attention-triage-bar done
  class enhance-node-popup done
  class group-session-list done
  class mount-canvas-tab done
  class fix-rendering-edges done
  class ship-mode-grouping done
  class ship-pipeline-kanban done
  class enhance-context-menu done
  class polish-ui-details done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | **Extract classifySessions to shared state module** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/11) |
| 2 | Add parent/children/DAG/branch context to chat header | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/12) |
| 3 | Add action bar for sessions needing attention | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/13) |
| 4 | Add hierarchy metadata to NodeDetailPopup | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/19) |
| 5 | Group SessionList by DAG/Tree/Standalone with nesting | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/14) |
| 6 | Mount UniverseCanvas as second tab with view toggle | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/20) |
| 7 | Fix edge-case rendering (status, animation, orphans) | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/17) |
| 8 | Add fourth classification bucket for ship mode | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/18) |
| 9 | Create Kanban view for ship pipelines | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/21) |
| 10 | Add navigation actions to ContextMenu | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/22) |
| 11 | Polish: badges, chips, keyboard nav, DAG summaries | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/24) |

**Progress:** 11/11 complete

<!-- dag-status-end -->










