### PR TITLE
[minions] feat(chat): add hierarchy context to chat header

### DIFF
--- a/e2e/tests/bad-token.spec.ts
+++ b/e2e/tests/bad-token.spec.ts
@@ -41,7 +41,7 @@ test.describe('bad token', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Bad Token Minion')
 
-      await expect(page.getByTestId('universe-node-correct-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-correct-session')).toBeVisible({ timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/connect.spec.ts
+++ b/e2e/tests/connect.spec.ts
@@ -62,7 +62,7 @@ test.describe('connection flow', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion A')
 
-      await expect(page.getByTestId('universe-node-s1')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-s1')).toBeVisible({ timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/multi-connection.spec.ts
+++ b/e2e/tests/multi-connection.spec.ts
@@ -46,7 +46,7 @@ test.describe('multi-connection', () => {
     try {
       await connectToMinion(page, mockA, 'Minion Alpha')
 
-      await expect(page.getByTestId('universe-node-a-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-a-session')).toBeVisible({ timeout: 8_000 })
 
       await page.getByTestId('connection-picker-trigger').click()
       await expect(page.getByTestId('connection-picker-dropdown')).toBeVisible()
@@ -66,8 +66,8 @@ test.describe('multi-connection', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion Beta')
 
-      await expect(page.getByTestId('universe-node-b-session')).toBeVisible({ timeout: 8_000 })
-      await expect(page.getByTestId('universe-node-a-session')).not.toBeVisible()
+      await expect(page.getByTestId('session-item-b-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-a-session')).not.toBeVisible()
 
       await page.getByTestId('connection-picker-trigger').click()
       const dropdown = page.getByTestId('connection-picker-dropdown')
@@ -79,8 +79,8 @@ test.describe('multi-connection', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion Alpha')
 
-      await expect(page.getByTestId('universe-node-a-session')).toBeVisible({ timeout: 8_000 })
-      await expect(page.getByTestId('universe-node-b-session')).not.toBeVisible()
+      await expect(page.getByTestId('session-item-a-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-b-session')).not.toBeVisible()
     } finally {
       await mockA.close()
       await mockB.close()

--- a/e2e/tests/reconnect.spec.ts
+++ b/e2e/tests/reconnect.spec.ts
@@ -34,7 +34,7 @@ test.describe('SSE reconnect', () => {
 
       await expect(page.getByText('live')).toBeVisible({ timeout: 20_000 })
 
-      await expect(page.getByTestId('universe-node-s-reconnect')).toBeVisible({ timeout: 10_000 })
+      await expect(page.getByTestId('session-item-s-reconnect')).toBeVisible({ timeout: 10_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/task-lifecycle.spec.ts
+++ b/e2e/tests/task-lifecycle.spec.ts
@@ -26,13 +26,9 @@ test.describe('task lifecycle', () => {
     try {
       await connectToMinion(page, mock, 'My Minion')
 
-      await expect(page.getByTestId('universe-node-seed-1')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-seed-1')).toBeVisible({ timeout: 8_000 })
 
-      await page.getByTestId('universe-node-seed-1').dispatchEvent('click')
-
-      await expect(page.locator('[role="dialog"]')).toBeVisible()
-
-      await page.getByRole('button', { name: 'Open Chat' }).click()
+      await page.getByTestId('session-item-seed-1').click()
 
       await expect(page.getByTestId('message-textarea')).toBeVisible()
 
@@ -45,15 +41,9 @@ test.describe('task lifecycle', () => {
 
       mock.emit({ type: 'session_created', session: makeSession('new-1', 'hello-task', 'running') })
 
-      await expect(page.getByTestId('universe-node-new-1')).toBeAttached({ timeout: 5_000 })
+      await expect(page.getByTestId('session-item-new-1')).toBeVisible({ timeout: 5_000 })
 
-      await page.getByTestId('chat-close-btn').click()
-
-      await page.getByTestId('universe-node-new-1').dispatchEvent('click')
-
-      await expect(page.locator('[aria-labelledby="node-detail-title"]')).toBeVisible()
-
-      await page.getByRole('button', { name: 'Open Chat' }).click()
+      await page.getByTestId('session-item-new-1').click()
 
       await expect(page.getByTestId('message-textarea')).toBeVisible()
 
@@ -68,11 +58,7 @@ test.describe('task lifecycle', () => {
       mock.setSessions([makeSession('seed-1', 'seed-task', 'running'), completedSession])
       mock.emit({ type: 'session_updated', session: completedSession })
 
-      await page.getByTestId('universe-node-new-1').dispatchEvent('click')
-
-      await expect(
-        page.locator('[aria-labelledby="node-detail-title"]').getByText('Done')
-      ).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-new-1')).toContainText('completed', { timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,16 +5,12 @@ import { connections, activeId, getActiveStore } from './connections/store'
 import { ConnectionSettings } from './connections/ConnectionSettings'
 import { ConnectionPicker } from './connections/ConnectionPicker'
 import { ConnectionsDrawer } from './connections/ConnectionsDrawer'
-import { ConversationView } from './chat/ConversationView'
-import { MessageInput } from './chat/MessageInput'
-import { QuickActionsBar } from './chat/QuickActionsBar'
-import { SlashCommandMenu, type SlashCommand } from './chat/SlashCommandMenu'
-import { confirm } from './hooks/useConfirm'
+import { ChatPane } from './chat/ChatPane'
 import { ConfirmRoot } from './hooks/useConfirm'
 import { InstallPrompt } from './pwa/InstallPrompt'
 import { useOnlineStatus } from './pwa/useOnlineStatus'
 import { useMediaQuery } from './hooks/useMediaQuery'
-import type { ApiSession, MinionCommand, QuickAction, RepoEntry } from './api/types'
+import type { ApiSession, MinionCommand, RepoEntry } from './api/types'
 
 const showSettings = signal(false)
 const showDrawer = signal(false)
@@ -207,121 +203,6 @@ function SessionList({
   )
 }
 
-function ChatPane({
-  session,
-  onSend,
-  onCommand,
-}: {
-  session: ApiSession
-  onSend: (text: string, sessionId: string) => Promise<void>
-  onCommand: (cmd: MinionCommand) => Promise<void>
-}) {
-  const [text, setText] = useState('')
-  const [pending, setPending] = useState<'stop' | 'close' | null>(null)
-  const handleSend = (t: string) => onSend(t, session.id)
-  const handleQuickAction = (action: QuickAction) => onSend(action.message, session.id)
-
-  const handleSlashCommand = async (fullText: string, cmd: SlashCommand) => {
-    if (cmd.destructive) {
-      const ok = await confirm({
-        title: `Run ${cmd.cmd}?`,
-        message: cmd.hint,
-        destructive: true,
-        confirmLabel: cmd.cmd,
-      })
-      if (!ok) return
-    }
-    await onSend(fullText, session.id)
-    setText('')
-  }
-
-  const handleStop = async () => {
-    const ok = await confirm({
-      title: `Stop ${session.slug}?`,
-      message: 'Interrupts the running session. You can continue it later.',
-      destructive: true,
-      confirmLabel: 'Stop',
-    })
-    if (!ok) return
-    setPending('stop')
-    try {
-      await onCommand({ action: 'stop', sessionId: session.id })
-    } finally {
-      setPending(null)
-    }
-  }
-
-  const handleClose = async () => {
-    const ok = await confirm({
-      title: `Close ${session.slug}?`,
-      message: 'Closes this session permanently. Conversation history stays, but you cannot resume it.',
-      destructive: true,
-      confirmLabel: 'Close',
-    })
-    if (!ok) return
-    setPending('close')
-    try {
-      await onCommand({ action: 'close', sessionId: session.id })
-    } finally {
-      setPending(null)
-    }
-  }
-
-  const stoppable = session.status === 'running' || session.status === 'pending'
-  const closable = session.status !== 'completed' && session.status !== 'failed'
-
-  return (
-    <div class="flex flex-col flex-1 min-h-0 bg-white dark:bg-slate-800">
-      <header class="flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-700 shrink-0">
-        <span class={`inline-block h-2 w-2 rounded-full ${statusDot(session.status)}`} />
-        <span class="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">{session.slug}</span>
-        <span class="text-xs text-slate-500 dark:text-slate-400">{session.status}</span>
-        <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500 ml-2">
-          {session.mode}
-        </span>
-        {session.prUrl && (
-          <a
-            href={session.prUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-xs underline text-indigo-600 dark:text-indigo-400 ml-2"
-          >
-            PR
-          </a>
-        )}
-        <div class="ml-auto flex items-center gap-1.5">
-          <button
-            type="button"
-            onClick={() => void handleStop()}
-            disabled={!stoppable || pending !== null}
-            title={stoppable ? 'Stop this session' : 'Session is not running'}
-            class="rounded-md border border-amber-300 dark:border-amber-800 text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-950/40 px-2 py-1 text-xs font-medium hover:bg-amber-100 dark:hover:bg-amber-900/50 disabled:opacity-40 disabled:cursor-not-allowed"
-            data-testid="chat-stop-btn"
-          >
-            {pending === 'stop' ? 'Stopping…' : 'Stop'}
-          </button>
-          <button
-            type="button"
-            onClick={() => void handleClose()}
-            disabled={!closable || pending !== null}
-            title={closable ? 'Close this session permanently' : 'Session is already terminal'}
-            class="rounded-md border border-red-300 dark:border-red-800 text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 px-2 py-1 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-900/50 disabled:opacity-40 disabled:cursor-not-allowed"
-            data-testid="chat-close-btn"
-          >
-            {pending === 'close' ? 'Closing…' : 'Close'}
-          </button>
-        </div>
-      </header>
-      <ConversationView messages={session.conversation} />
-      <div class="shrink-0 border-t border-slate-200 dark:border-slate-700">
-        <QuickActionsBar actions={session.quickActions} onAction={handleQuickAction} />
-        <SlashCommandMenu session={session} context={text} onCommand={handleSlashCommand} />
-        <MessageInput session={session} value={text} onValueChange={setText} onSend={handleSend} />
-      </div>
-    </div>
-  )
-}
-
 function EmptyPane() {
   return (
     <div class="flex-1 flex items-center justify-center p-8 bg-slate-50 dark:bg-slate-900">
@@ -402,7 +283,14 @@ function ActiveView() {
             />
           </aside>
           {selected ? (
-            <ChatPane session={selected} onSend={handleSendMessage} onCommand={handleCommand} />
+            <ChatPane
+              session={selected}
+              sessions={sessions}
+              dags={store.dags.value}
+              onNavigate={setSessionId}
+              onSend={handleSendMessage}
+              onCommand={handleCommand}
+            />
           ) : (
             <EmptyPane />
           )}
@@ -416,7 +304,14 @@ function ActiveView() {
             orientation="horizontal"
           />
           {selected ? (
-            <ChatPane session={selected} onSend={handleSendMessage} onCommand={handleCommand} />
+            <ChatPane
+              session={selected}
+              sessions={sessions}
+              dags={store.dags.value}
+              onNavigate={setSessionId}
+              onSend={handleSendMessage}
+              onCommand={handleCommand}
+            />
           ) : (
             <EmptyPane />
           )}

--- a/src/chat/ChatPane.tsx
+++ b/src/chat/ChatPane.tsx
@@ -1,0 +1,433 @@
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import type { ApiSession, ApiDagGraph, MinionCommand, QuickAction } from '../api/types'
+import { confirm } from '../hooks/useConfirm'
+import { ConversationView } from './ConversationView'
+import { MessageInput } from './MessageInput'
+import { QuickActionsBar } from './QuickActionsBar'
+import { SlashCommandMenu, type SlashCommand } from './SlashCommandMenu'
+
+function statusDot(status: ApiSession['status']): string {
+  if (status === 'running') return 'bg-blue-500 animate-pulse'
+  if (status === 'completed') return 'bg-green-500'
+  if (status === 'failed') return 'bg-red-500'
+  return 'bg-slate-400'
+}
+
+interface DagContext {
+  dag: ApiDagGraph
+  rootSlug: string | null
+  position: number
+  total: number
+  dependencies: { id: string; slug: string; status: string }[]
+  dependents: { id: string; slug: string; status: string }[]
+}
+
+function findDagContext(
+  sessionId: string,
+  dags: ApiDagGraph[],
+  sessionById: Map<string, ApiSession>,
+): DagContext | null {
+  for (const dag of dags) {
+    const node = dag.nodes[sessionId]
+    if (!node) continue
+    const allNodes = Object.values(dag.nodes)
+    const total = allNodes.length
+    const landedOrDone = allNodes.filter(
+      (n) => n.status === 'landed' || n.status === 'completed',
+    ).length
+    const position = node.status === 'landed' || node.status === 'completed'
+      ? landedOrDone
+      : landedOrDone + 1
+    const rootNode = dag.nodes[dag.rootTaskId]
+    const rootSlug = rootNode?.slug ?? sessionById.get(dag.rootTaskId)?.slug ?? null
+    const dependencies = node.dependencies
+      .map((depId) => {
+        const depNode = dag.nodes[depId]
+        if (!depNode) return null
+        return { id: depId, slug: depNode.slug, status: depNode.status }
+      })
+      .filter((x): x is { id: string; slug: string; status: string } => x !== null)
+    const dependents = node.dependents
+      .map((depId) => {
+        const depNode = dag.nodes[depId]
+        if (!depNode) return null
+        return { id: depId, slug: depNode.slug, status: depNode.status }
+      })
+      .filter((x): x is { id: string; slug: string; status: string } => x !== null)
+    return { dag, rootSlug, position, total, dependencies, dependents }
+  }
+  return null
+}
+
+function dagNodeDot(status: string): string {
+  if (status === 'running') return 'bg-blue-500 animate-pulse'
+  if (status === 'completed' || status === 'landed') return 'bg-green-500'
+  if (status === 'failed' || status === 'ci-failed') return 'bg-red-500'
+  if (status === 'ci-pending') return 'bg-yellow-500'
+  if (status === 'skipped') return 'bg-stone-400'
+  return 'bg-slate-400'
+}
+
+function ParentChip({ parent, onNavigate }: { parent: ApiSession; onNavigate: (id: string) => void }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onNavigate(parent.id)}
+      title={`Parent session: ${parent.slug}`}
+      class="inline-flex items-center gap-1 rounded-full border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 px-2 py-0.5 text-[11px] font-mono text-slate-700 dark:text-slate-200 max-w-[160px]"
+      data-testid="chat-parent-chip"
+    >
+      <span aria-hidden="true" class="text-slate-400 dark:text-slate-500">↰</span>
+      <span class={`inline-block h-1.5 w-1.5 rounded-full shrink-0 ${statusDot(parent.status)}`} />
+      <span class="truncate">{parent.slug}</span>
+    </button>
+  )
+}
+
+function ChildrenChip({
+  children,
+  onNavigate,
+}: {
+  children: ApiSession[]
+  onNavigate: (id: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (!containerRef.current) return
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  return (
+    <div class="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="true"
+        title={`${children.length} child session${children.length === 1 ? '' : 's'}`}
+        class="inline-flex items-center gap-1 rounded-full border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 px-2 py-0.5 text-[11px] text-slate-700 dark:text-slate-200"
+        data-testid="chat-children-chip"
+      >
+        <span aria-hidden="true" class="text-slate-400 dark:text-slate-500">↳</span>
+        <span>
+          {children.length} child{children.length === 1 ? '' : 'ren'}
+        </span>
+        <span aria-hidden="true" class="text-slate-400 dark:text-slate-500">▾</span>
+      </button>
+      {open && (
+        <div
+          class="absolute left-0 top-full mt-1 z-20 min-w-[200px] max-w-[280px] rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-lg py-1"
+          role="menu"
+          data-testid="chat-children-menu"
+        >
+          {children.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false)
+                onNavigate(c.id)
+              }}
+              class="w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+              data-testid={`chat-children-item-${c.id}`}
+            >
+              <span class={`inline-block h-1.5 w-1.5 rounded-full shrink-0 ${statusDot(c.status)}`} />
+              <span class="font-mono truncate flex-1">{c.slug}</span>
+              <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500 shrink-0">
+                {c.status}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DagBreadcrumb({
+  context,
+  onNavigate,
+}: {
+  context: DagContext
+  onNavigate: (id: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (!containerRef.current) return
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  const hasDeps = context.dependencies.length > 0 || context.dependents.length > 0
+  const rootLabel = context.rootSlug ?? context.dag.rootTaskId.slice(0, 8)
+
+  return (
+    <div class="relative inline-flex items-center" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => hasDeps && setOpen((v) => !v)}
+        disabled={!hasDeps}
+        aria-expanded={hasDeps ? open : undefined}
+        aria-haspopup={hasDeps ? 'true' : undefined}
+        title={hasDeps ? 'Show DAG dependencies' : `DAG rooted at ${rootLabel}`}
+        class="inline-flex items-center gap-1.5 rounded-full border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-950/40 hover:bg-indigo-100 dark:hover:bg-indigo-900/40 disabled:hover:bg-indigo-50 dark:disabled:hover:bg-indigo-950/40 disabled:cursor-default px-2 py-0.5 text-[11px] text-indigo-700 dark:text-indigo-300 max-w-[240px]"
+        data-testid="chat-dag-breadcrumb"
+      >
+        <span class="font-medium uppercase tracking-wide text-[9px]">DAG</span>
+        <span class="font-mono truncate">{rootLabel}</span>
+        <span class="text-indigo-400 dark:text-indigo-500" aria-hidden="true">·</span>
+        <span class="tabular-nums font-medium">
+          {context.position}/{context.total}
+        </span>
+        {hasDeps && <span aria-hidden="true" class="text-indigo-400 dark:text-indigo-500">▾</span>}
+      </button>
+      {open && hasDeps && (
+        <div
+          class="absolute left-0 top-full mt-1 z-20 min-w-[220px] max-w-[300px] rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-lg py-1"
+          role="menu"
+          data-testid="chat-dag-menu"
+        >
+          {context.dependencies.length > 0 && (
+            <div class="px-3 pt-1.5 pb-0.5 text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500">
+              Depends on
+            </div>
+          )}
+          {context.dependencies.map((d) => (
+            <button
+              key={`dep-${d.id}`}
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false)
+                onNavigate(d.id)
+              }}
+              class="w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+              data-testid={`chat-dag-dep-${d.id}`}
+            >
+              <span class={`inline-block h-1.5 w-1.5 rounded-full shrink-0 ${dagNodeDot(d.status)}`} />
+              <span class="font-mono truncate flex-1">{d.slug}</span>
+            </button>
+          ))}
+          {context.dependents.length > 0 && (
+            <div class="px-3 pt-1.5 pb-0.5 text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500">
+              Unblocks
+            </div>
+          )}
+          {context.dependents.map((d) => (
+            <button
+              key={`dependent-${d.id}`}
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false)
+                onNavigate(d.id)
+              }}
+              class="w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+              data-testid={`chat-dag-dependent-${d.id}`}
+            >
+              <span class={`inline-block h-1.5 w-1.5 rounded-full shrink-0 ${dagNodeDot(d.status)}`} />
+              <span class="font-mono truncate flex-1">{d.slug}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function BranchChip({ branch }: { branch: string }) {
+  return (
+    <span
+      title={`Branch: ${branch}`}
+      class="inline-flex items-center gap-1 rounded-md bg-slate-100 dark:bg-slate-700 px-1.5 py-0.5 text-[11px] font-mono text-slate-700 dark:text-slate-200 max-w-[180px]"
+      data-testid="chat-branch-chip"
+    >
+      <svg viewBox="0 0 16 16" width="10" height="10" fill="currentColor" aria-hidden="true">
+        <path d="M11.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm-2.25.75a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.492 2.492 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm.75 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z" />
+      </svg>
+      <span class="truncate">{branch}</span>
+    </span>
+  )
+}
+
+export interface ChatPaneProps {
+  session: ApiSession
+  sessions: ApiSession[]
+  dags: ApiDagGraph[]
+  onNavigate: (sessionId: string) => void
+  onSend: (text: string, sessionId: string) => Promise<void>
+  onCommand: (cmd: MinionCommand) => Promise<void>
+}
+
+export function ChatPane({
+  session,
+  sessions,
+  dags,
+  onNavigate,
+  onSend,
+  onCommand,
+}: ChatPaneProps) {
+  const [text, setText] = useState('')
+  const [pending, setPending] = useState<'stop' | 'close' | null>(null)
+
+  const sessionById = useMemo(() => {
+    const map = new Map<string, ApiSession>()
+    for (const s of sessions) map.set(s.id, s)
+    return map
+  }, [sessions])
+
+  const parent = session.parentId ? sessionById.get(session.parentId) ?? null : null
+  const children = useMemo(
+    () => session.childIds.map((id) => sessionById.get(id)).filter((s): s is ApiSession => Boolean(s)),
+    [session.childIds, sessionById],
+  )
+  const dagContext = useMemo(
+    () => findDagContext(session.id, dags, sessionById),
+    [session.id, dags, sessionById],
+  )
+
+  const hasHierarchy = Boolean(parent) || children.length > 0 || Boolean(dagContext)
+
+  const handleSend = (t: string) => onSend(t, session.id)
+  const handleQuickAction = (action: QuickAction) => onSend(action.message, session.id)
+
+  const handleSlashCommand = async (fullText: string, cmd: SlashCommand) => {
+    if (cmd.destructive) {
+      const ok = await confirm({
+        title: `Run ${cmd.cmd}?`,
+        message: cmd.hint,
+        destructive: true,
+        confirmLabel: cmd.cmd,
+      })
+      if (!ok) return
+    }
+    await onSend(fullText, session.id)
+    setText('')
+  }
+
+  const handleStop = async () => {
+    const ok = await confirm({
+      title: `Stop ${session.slug}?`,
+      message: 'Interrupts the running session. You can continue it later.',
+      destructive: true,
+      confirmLabel: 'Stop',
+    })
+    if (!ok) return
+    setPending('stop')
+    try {
+      await onCommand({ action: 'stop', sessionId: session.id })
+    } finally {
+      setPending(null)
+    }
+  }
+
+  const handleClose = async () => {
+    const ok = await confirm({
+      title: `Close ${session.slug}?`,
+      message: 'Closes this session permanently. Conversation history stays, but you cannot resume it.',
+      destructive: true,
+      confirmLabel: 'Close',
+    })
+    if (!ok) return
+    setPending('close')
+    try {
+      await onCommand({ action: 'close', sessionId: session.id })
+    } finally {
+      setPending(null)
+    }
+  }
+
+  const stoppable = session.status === 'running' || session.status === 'pending'
+  const closable = session.status !== 'completed' && session.status !== 'failed'
+
+  return (
+    <div class="flex flex-col flex-1 min-h-0 bg-white dark:bg-slate-800">
+      <header class="flex flex-col gap-1 px-4 py-2 border-b border-slate-200 dark:border-slate-700 shrink-0">
+        <div class="flex items-center gap-2">
+          <span class={`inline-block h-2 w-2 rounded-full ${statusDot(session.status)}`} />
+          <span class="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">
+            {session.slug}
+          </span>
+          <span class="text-xs text-slate-500 dark:text-slate-400">{session.status}</span>
+          <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500 ml-2">
+            {session.mode}
+          </span>
+          {session.prUrl && (
+            <a
+              href={session.prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs underline text-indigo-600 dark:text-indigo-400 ml-2"
+            >
+              PR
+            </a>
+          )}
+          {session.branch && <BranchChip branch={session.branch} />}
+          <div class="ml-auto flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => void handleStop()}
+              disabled={!stoppable || pending !== null}
+              title={stoppable ? 'Stop this session' : 'Session is not running'}
+              class="rounded-md border border-amber-300 dark:border-amber-800 text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-950/40 px-2 py-1 text-xs font-medium hover:bg-amber-100 dark:hover:bg-amber-900/50 disabled:opacity-40 disabled:cursor-not-allowed"
+              data-testid="chat-stop-btn"
+            >
+              {pending === 'stop' ? 'Stopping…' : 'Stop'}
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleClose()}
+              disabled={!closable || pending !== null}
+              title={closable ? 'Close this session permanently' : 'Session is already terminal'}
+              class="rounded-md border border-red-300 dark:border-red-800 text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 px-2 py-1 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-900/50 disabled:opacity-40 disabled:cursor-not-allowed"
+              data-testid="chat-close-btn"
+            >
+              {pending === 'close' ? 'Closing…' : 'Close'}
+            </button>
+          </div>
+        </div>
+        {hasHierarchy && (
+          <div class="flex items-center gap-1.5 flex-wrap" data-testid="chat-hierarchy-row">
+            {parent && <ParentChip parent={parent} onNavigate={onNavigate} />}
+            {children.length > 0 && <ChildrenChip children={children} onNavigate={onNavigate} />}
+            {dagContext && <DagBreadcrumb context={dagContext} onNavigate={onNavigate} />}
+          </div>
+        )}
+      </header>
+      <ConversationView messages={session.conversation} />
+      <div class="shrink-0 border-t border-slate-200 dark:border-slate-700">
+        <QuickActionsBar actions={session.quickActions} onAction={handleQuickAction} />
+        <SlashCommandMenu session={session} context={text} onCommand={handleSlashCommand} />
+        <MessageInput session={session} value={text} onValueChange={setText} onSend={handleSend} />
+      </div>
+    </div>
+  )
+}

--- a/src/chat/ChatPane.tsx
+++ b/src/chat/ChatPane.tsx
@@ -46,14 +46,14 @@ function findDagContext(
         if (!depNode) return null
         return { id: depId, slug: depNode.slug, status: depNode.status }
       })
-      .filter((x): x is { id: string; slug: string; status: string } => x !== null)
+      .filter((x) => x !== null)
     const dependents = node.dependents
       .map((depId) => {
         const depNode = dag.nodes[depId]
         if (!depNode) return null
         return { id: depId, slug: depNode.slug, status: depNode.status }
       })
-      .filter((x): x is { id: string; slug: string; status: string } => x !== null)
+      .filter((x) => x !== null)
     return { dag, rootSlug, position, total, dependencies, dependents }
   }
   return null

--- a/test/chat/ChatPane.test.tsx
+++ b/test/chat/ChatPane.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen, fireEvent, within } from '@testing-library/preact'
+import { describe, it, expect, vi } from 'vitest'
+import { ChatPane } from '../../src/chat/ChatPane'
+import type { ApiSession, ApiDagGraph, ApiDagNode } from '../../src/api/types'
+
+function makeSession(over: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 's1',
+    slug: 'brave-fox',
+    status: 'running',
+    command: '/task foo',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...over,
+  }
+}
+
+function makeDagNode(over: Partial<ApiDagNode> & Pick<ApiDagNode, 'id' | 'slug'>): ApiDagNode {
+  return {
+    status: 'pending',
+    dependencies: [],
+    dependents: [],
+    ...over,
+  }
+}
+
+function renderPane(
+  session: ApiSession,
+  sessions: ApiSession[] = [session],
+  dags: ApiDagGraph[] = [],
+  overrides: Partial<Parameters<typeof ChatPane>[0]> = {},
+) {
+  const onNavigate = vi.fn()
+  const onSend = vi.fn().mockResolvedValue(undefined)
+  const onCommand = vi.fn().mockResolvedValue(undefined)
+  const result = render(
+    <ChatPane
+      session={session}
+      sessions={sessions}
+      dags={dags}
+      onNavigate={onNavigate}
+      onSend={onSend}
+      onCommand={onCommand}
+      {...overrides}
+    />,
+  )
+  return { ...result, onNavigate, onSend, onCommand }
+}
+
+describe('ChatPane header', () => {
+  describe('branch chip', () => {
+    it('renders branch name when session.branch is set', () => {
+      renderPane(makeSession({ branch: 'feat/improve-dag' }))
+      const chip = screen.getByTestId('chat-branch-chip')
+      expect(chip.textContent).toContain('feat/improve-dag')
+    })
+
+    it('does not render branch chip when session.branch is missing', () => {
+      renderPane(makeSession({ branch: undefined }))
+      expect(screen.queryByTestId('chat-branch-chip')).toBeNull()
+    })
+  })
+
+  describe('parent chip', () => {
+    it('renders and navigates to parent when clicked', () => {
+      const parent = makeSession({ id: 'p1', slug: 'wise-owl', status: 'completed' })
+      const child = makeSession({ id: 's1', slug: 'brave-fox', parentId: 'p1' })
+      const { onNavigate } = renderPane(child, [parent, child])
+      const chip = screen.getByTestId('chat-parent-chip')
+      expect(chip.textContent).toContain('wise-owl')
+      fireEvent.click(chip)
+      expect(onNavigate).toHaveBeenCalledWith('p1')
+    })
+
+    it('does not render when session has no parentId', () => {
+      renderPane(makeSession({ parentId: undefined }))
+      expect(screen.queryByTestId('chat-parent-chip')).toBeNull()
+    })
+
+    it('does not render when parentId references a missing session', () => {
+      const child = makeSession({ parentId: 'ghost' })
+      renderPane(child, [child])
+      expect(screen.queryByTestId('chat-parent-chip')).toBeNull()
+    })
+  })
+
+  describe('children chip', () => {
+    it('shows singular "1 child" for one child', () => {
+      const parent = makeSession({ id: 's1', childIds: ['c1'] })
+      const c1 = makeSession({ id: 'c1', slug: 'sly-cat' })
+      renderPane(parent, [parent, c1])
+      expect(screen.getByTestId('chat-children-chip').textContent).toContain('1 child')
+    })
+
+    it('pluralizes "N children" for more than one child', () => {
+      const parent = makeSession({ id: 's1', childIds: ['c1', 'c2'] })
+      const c1 = makeSession({ id: 'c1', slug: 'sly-cat' })
+      const c2 = makeSession({ id: 'c2', slug: 'swift-dog' })
+      renderPane(parent, [parent, c1, c2])
+      expect(screen.getByTestId('chat-children-chip').textContent).toContain('2 children')
+    })
+
+    it('opens a menu of children and navigates when a child is clicked', () => {
+      const parent = makeSession({ id: 's1', childIds: ['c1', 'c2'] })
+      const c1 = makeSession({ id: 'c1', slug: 'sly-cat', status: 'completed' })
+      const c2 = makeSession({ id: 'c2', slug: 'swift-dog', status: 'failed' })
+      const { onNavigate } = renderPane(parent, [parent, c1, c2])
+
+      expect(screen.queryByTestId('chat-children-menu')).toBeNull()
+      fireEvent.click(screen.getByTestId('chat-children-chip'))
+
+      const menu = screen.getByTestId('chat-children-menu')
+      expect(within(menu).getByText('sly-cat')).toBeTruthy()
+      expect(within(menu).getByText('swift-dog')).toBeTruthy()
+
+      fireEvent.click(screen.getByTestId('chat-children-item-c2'))
+      expect(onNavigate).toHaveBeenCalledWith('c2')
+      expect(screen.queryByTestId('chat-children-menu')).toBeNull()
+    })
+
+    it('skips child ids that reference missing sessions', () => {
+      const parent = makeSession({ id: 's1', childIds: ['missing'] })
+      renderPane(parent, [parent])
+      expect(screen.queryByTestId('chat-children-chip')).toBeNull()
+    })
+  })
+
+  describe('DAG breadcrumb', () => {
+    const dag: ApiDagGraph = {
+      id: 'dag-1',
+      rootTaskId: 'root',
+      status: 'running',
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+      nodes: {
+        root: makeDagNode({ id: 'root', slug: 'ship-feature', status: 'completed', dependents: ['s1'] }),
+        s1: makeDagNode({ id: 's1', slug: 'brave-fox', status: 'running', dependencies: ['root'], dependents: ['n2'] }),
+        n2: makeDagNode({ id: 'n2', slug: 'next-step', status: 'pending', dependencies: ['s1'] }),
+      },
+    }
+
+    it('shows the DAG breadcrumb with root slug and position counter', () => {
+      renderPane(makeSession(), [makeSession()], [dag])
+      const bc = screen.getByTestId('chat-dag-breadcrumb')
+      expect(bc.textContent).toContain('ship-feature')
+      expect(bc.textContent).toContain('2/3')
+    })
+
+    it('opens a menu of dependencies and navigates when clicked', () => {
+      const { onNavigate } = renderPane(makeSession(), [makeSession()], [dag])
+      fireEvent.click(screen.getByTestId('chat-dag-breadcrumb'))
+      const menu = screen.getByTestId('chat-dag-menu')
+      expect(within(menu).getByText('ship-feature')).toBeTruthy()
+      expect(within(menu).getByText('next-step')).toBeTruthy()
+
+      fireEvent.click(screen.getByTestId('chat-dag-dep-root'))
+      expect(onNavigate).toHaveBeenCalledWith('root')
+    })
+
+    it('is disabled (no menu) when the node has no dependencies or dependents', () => {
+      const isolated: ApiDagGraph = {
+        ...dag,
+        nodes: {
+          s1: makeDagNode({ id: 's1', slug: 'brave-fox', status: 'running' }),
+        },
+        rootTaskId: 's1',
+      }
+      renderPane(makeSession(), [makeSession()], [isolated])
+      const bc = screen.getByTestId('chat-dag-breadcrumb')
+      expect((bc as HTMLButtonElement).disabled).toBe(true)
+      fireEvent.click(bc)
+      expect(screen.queryByTestId('chat-dag-menu')).toBeNull()
+    })
+
+    it('does not render when session is not part of any DAG', () => {
+      renderPane(makeSession({ id: 'solo' }), [makeSession({ id: 'solo' })], [dag])
+      expect(screen.queryByTestId('chat-dag-breadcrumb')).toBeNull()
+    })
+  })
+
+  describe('hierarchy row', () => {
+    it('is not rendered when session has no parent, children, or DAG', () => {
+      renderPane(makeSession())
+      expect(screen.queryByTestId('chat-hierarchy-row')).toBeNull()
+    })
+
+    it('is rendered when any hierarchy signal is present', () => {
+      const parent = makeSession({ id: 'p', slug: 'root' })
+      const child = makeSession({ id: 's1', parentId: 'p' })
+      renderPane(child, [parent, child])
+      expect(screen.getByTestId('chat-hierarchy-row')).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Richer chat header that surfaces the relationships a session lives in, so it's obvious at a glance whether the active minion is part of a DAG, a parent/child tree, or running on its own branch.

- **Parent chip** — clickable, jumps to the parent session.
- **Children dropdown** — count chip that opens a list of child slugs with status dots; clicking a child navigates to it.
- **DAG breadcrumb** — root slug + \`position/total\` progress counter; clicking opens a menu of dependencies (\"depends on\") and dependents (\"unblocks\") that route to the upstream/downstream nodes.
- **Branch chip** — compact pill next to the existing PR link.

The second hierarchy row only renders when a session has at least one of: parent, children, DAG membership. Standalone sessions keep today's single-row header.

## Why

Ships, stacks, and parent/child minion trees were only visible on the canvas. When driving work from the chat view it was easy to lose track of whether a session was a ship root, a CI-fix child, or a DAG leaf — and there was no way to pivot across the graph without leaving the chat. These chips put that context one click away.

## Implementation notes

- \`ChatPane\` was previously defined inline inside \`src/App.tsx\`. It's now its own module at \`src/chat/ChatPane.tsx\` so it can own the extra context without bloating \`App.tsx\`.
- New props: \`sessions\`, \`dags\`, \`onNavigate\`. \`App.tsx\` wires these from the active \`ConnectionStore\` and reuses the existing session selector.
- Progress counter treats \`completed\`/\`landed\` nodes as done; the current node occupies the \"next\" slot unless it is itself terminal.
- Missing parent or child ids (e.g. a \`session_deleted\` SSE event that arrives before the sibling update) render nothing rather than a broken chip.
- No changes to \`SessionList\`, \`NodeDetailPopup\`, \`ContextMenu\`, or \`shared.tsx\` — kept scope isolated to minimize merge friction with the sibling UI minions.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test\` — 241 passing (15 new cases in \`test/chat/ChatPane.test.tsx\`)
- [ ] Not run: \`npm run test:e2e\` (skipped per task guidance)

## Assumptions

- \`ApiDagGraph.rootTaskId\` points at a node that is always present in \`dag.nodes\`; if it's missing we fall back to the first 8 chars of the id.
- \`session.childIds\` is the source of truth for parent → child navigation (mirrors what \`universe-layout.classifySessions\` already assumes).

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  extract-hierarchy["✅ Extract classifySessions to shared state module"]
  chat-header-context["✅ Add parent/children/DAG/branch context to chat header"]
  attention-triage-bar["✅ Add action bar for sessions needing attention"]
  enhance-node-popup["✅ Add hierarchy metadata to NodeDetailPopup"]
  group-session-list["✅ Group SessionList by DAG/Tree/Standalone with nesting"]
  mount-canvas-tab["✅ Mount UniverseCanvas as second tab with view toggle"]
  fix-rendering-edges["✅ Fix edge-case rendering (status, animation, orphans)"]
  ship-mode-grouping["✅ Add fourth classification bucket for ship mode"]
  ship-pipeline-kanban["✅ Create Kanban view for ship pipelines"]
  enhance-context-menu["✅ Add navigation actions to ContextMenu"]
  polish-ui-details["✅ Polish: badges, chips, keyboard nav, DAG summaries"]
  extract-hierarchy --> group-session-list
  extract-hierarchy --> mount-canvas-tab
  extract-hierarchy --> fix-rendering-edges
  extract-hierarchy --> ship-mode-grouping
  mount-canvas-tab --> ship-pipeline-kanban
  mount-canvas-tab --> enhance-context-menu
  group-session-list --> polish-ui-details
  mount-canvas-tab --> polish-ui-details
  class extract-hierarchy done
  class chat-header-context done
  class chat-header-context current
  class attention-triage-bar done
  class enhance-node-popup done
  class group-session-list done
  class mount-canvas-tab done
  class fix-rendering-edges done
  class ship-mode-grouping done
  class ship-pipeline-kanban done
  class enhance-context-menu done
  class polish-ui-details done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | Extract classifySessions to shared state module | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/11) |
| 2 | **Add parent/children/DAG/branch context to chat header** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/12) |
| 3 | Add action bar for sessions needing attention | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/13) |
| 4 | Add hierarchy metadata to NodeDetailPopup | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/19) |
| 5 | Group SessionList by DAG/Tree/Standalone with nesting | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/14) |
| 6 | Mount UniverseCanvas as second tab with view toggle | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/20) |
| 7 | Fix edge-case rendering (status, animation, orphans) | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/17) |
| 8 | Add fourth classification bucket for ship mode | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/18) |
| 9 | Create Kanban view for ship pipelines | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/21) |
| 10 | Add navigation actions to ContextMenu | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/22) |
| 11 | Polish: badges, chips, keyboard nav, DAG summaries | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/24) |

**Progress:** 11/11 complete

<!-- dag-status-end -->










