### PR TITLE
[minions] feat(ui): add attention triage bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { SessionTabs, type SessionTabId } from './chat/SessionTabs'
 import { DiffTab } from './chat/DiffTab'
 import { ScreenshotsTab } from './chat/ScreenshotsTab'
 import { PrPreviewCard } from './components/PrPreviewCard'
+import { AttentionBar, filterSessionsByReason } from './components/AttentionBar'
 import { hasFeature } from './api/features'
 import type { ConnectionStore } from './state/types'
 import { confirm } from './hooks/useConfirm'
@@ -30,7 +31,7 @@ import { buildSessionGroups, type SessionGroup } from './state/hierarchy'
 import type { ApiDagGraph } from './api/types'
 import { currentRoute } from './routing/current'
 import { VariantGroupView } from './groups/VariantGroupView'
-import type { ApiSession, MinionCommand, QuickAction } from './api/types'
+import type { ApiSession, AttentionReason, MinionCommand, QuickAction } from './api/types'
 
 const showSettings = signal(false)
 const showDrawer = signal(false)
@@ -548,6 +549,7 @@ function EmptyPane() {
 
 function DesktopBody({
   sessions,
+  visibleSessions,
   dags,
   sessionId,
   setSessionId,
@@ -555,8 +557,11 @@ function DesktopBody({
   store,
   onSend,
   onCommand,
+  attentionFilter,
+  onAttentionSelect,
 }: {
   sessions: ApiSession[]
+  visibleSessions: ApiSession[]
   dags: ApiDagGraph[]
   sessionId: string | null
   setSessionId: (id: string) => void
@@ -564,6 +569,8 @@ function DesktopBody({
   store: ConnectionStore
   onSend: (text: string, sid: string) => Promise<void>
   onCommand: (cmd: MinionCommand) => Promise<void>
+  attentionFilter: AttentionReason | null
+  onAttentionSelect: (reason: AttentionReason | null, firstMatchId: string | null) => void
 }) {
   const { width, onHandleDown, reset } = useResizable({
     storageKey: 'minions-ui:sidebar-width',
@@ -594,8 +601,13 @@ function DesktopBody({
         style={{ width: `${width}px` }}
         data-testid="desktop-sidebar"
       >
-        <SessionList
+        <AttentionBar
           sessions={sessions}
+          filter={attentionFilter}
+          onSelect={onAttentionSelect}
+        />
+        <SessionList
+          sessions={visibleSessions}
           dags={dags}
           activeSessionId={sessionId}
           onSelect={setSessionId}
@@ -708,6 +720,7 @@ function ActiveView() {
   const store = id ? getActiveStore() : null
   const conn = connections.value.find((c) => c.id === id)
   const [sessionId, setSessionId] = useState<string | null>(null)
+  const [attentionFilter, setAttentionFilter] = useState<AttentionReason | null>(null)
   const isOnline = useOnlineStatus()
   const isDesktop = useMediaQuery('(min-width: 768px)')
   const route = currentRoute.value
@@ -723,11 +736,28 @@ function ActiveView() {
     if (match && match.id !== sessionId) setSessionId(match.id)
   }, [route, store, sessionId])
 
+  useEffect(() => {
+    setAttentionFilter(null)
+  }, [id])
+
+  const sessions = store?.sessions.value ?? []
+  const visibleSessions = useMemo(
+    () => filterSessionsByReason(sessions, attentionFilter),
+    [sessions, attentionFilter],
+  )
+
   if (!store || !conn) return null
 
-  const sessions = store.sessions.value
   const selected = sessionId ? sessions.find((s) => s.id === sessionId) ?? null : null
   const isGroupRoute = route.name === 'group'
+
+  const handleAttentionSelect = (
+    reason: AttentionReason | null,
+    firstMatchId: string | null,
+  ) => {
+    setAttentionFilter(reason)
+    if (firstMatchId !== null) setSessionId(firstMatchId)
+  }
 
   const handleSendMessage = async (text: string, sid: string) => {
     await store.client.sendMessage(text, sid)
@@ -774,6 +804,7 @@ function ActiveView() {
       ) : isDesktop.value ? (
         <DesktopBody
           sessions={sessions}
+          visibleSessions={visibleSessions}
           dags={store.dags.value}
           sessionId={sessionId}
           setSessionId={setSessionId}
@@ -781,11 +812,18 @@ function ActiveView() {
           store={store}
           onSend={handleSendMessage}
           onCommand={handleCommand}
+          attentionFilter={attentionFilter}
+          onAttentionSelect={handleAttentionSelect}
         />
       ) : (
         <div class="flex flex-col flex-1 min-h-0">
-          <MobileSessionStrip
+          <AttentionBar
             sessions={sessions}
+            filter={attentionFilter}
+            onSelect={handleAttentionSelect}
+          />
+          <MobileSessionStrip
+            sessions={visibleSessions}
             dags={store.dags.value}
             activeSessionId={sessionId}
             onSelect={setSessionId}

--- a/src/components/AttentionBar.tsx
+++ b/src/components/AttentionBar.tsx
@@ -1,0 +1,119 @@
+import type { ApiSession, AttentionReason } from '../api/types'
+import { useTheme } from '../hooks/useTheme'
+import { ATTENTION_CONFIG } from './shared'
+
+const REASON_ORDER: AttentionReason[] = [
+  'failed',
+  'waiting_for_feedback',
+  'interrupted',
+  'ci_fix',
+  'idle_long',
+]
+
+export type AttentionCounts = Record<AttentionReason, number>
+
+export function countByAttentionReason(sessions: ApiSession[]): AttentionCounts {
+  const counts: AttentionCounts = {
+    failed: 0,
+    waiting_for_feedback: 0,
+    interrupted: 0,
+    ci_fix: 0,
+    idle_long: 0,
+  }
+  for (const s of sessions) {
+    if (!s.needsAttention) continue
+    for (const r of s.attentionReasons) {
+      if (r in counts) counts[r] += 1
+    }
+  }
+  return counts
+}
+
+export function firstSessionWithReason(
+  sessions: ApiSession[],
+  reason: AttentionReason,
+): ApiSession | null {
+  const sorted = [...sessions].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
+  return (
+    sorted.find((s) => s.needsAttention && s.attentionReasons.includes(reason)) ?? null
+  )
+}
+
+export function filterSessionsByReason(
+  sessions: ApiSession[],
+  reason: AttentionReason | null,
+): ApiSession[] {
+  if (reason === null) return sessions
+  return sessions.filter((s) => s.needsAttention && s.attentionReasons.includes(reason))
+}
+
+interface AttentionBarProps {
+  sessions: ApiSession[]
+  filter: AttentionReason | null
+  onSelect: (reason: AttentionReason | null, firstMatchId: string | null) => void
+}
+
+export function AttentionBar({ sessions, filter, onSelect }: AttentionBarProps) {
+  const theme = useTheme()
+  const dark = theme.value === 'dark'
+  const counts = countByAttentionReason(sessions)
+  const total = REASON_ORDER.reduce((t, r) => t + counts[r], 0)
+
+  if (total === 0) return null
+
+  return (
+    <div
+      class="flex items-center gap-1.5 overflow-x-auto px-3 py-1.5 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
+      data-testid="attention-bar"
+      role="toolbar"
+      aria-label="Sessions needing attention"
+    >
+      <span class="shrink-0 text-[11px] uppercase tracking-wide font-medium text-slate-500 dark:text-slate-400 mr-1">
+        Needs attention
+      </span>
+      {REASON_ORDER.map((reason) => {
+        const count = counts[reason]
+        if (count === 0) return null
+        const config = ATTENTION_CONFIG[reason]
+        const tone = dark ? config.darkClassName : config.className
+        const isActive = filter === reason
+        const ring = isActive
+          ? 'ring-2 ring-indigo-500 dark:ring-indigo-400 shadow-sm'
+          : 'ring-0 opacity-80 hover:opacity-100'
+        const handleClick = () => {
+          if (isActive) {
+            onSelect(null, null)
+            return
+          }
+          const first = firstSessionWithReason(sessions, reason)
+          onSelect(reason, first?.id ?? null)
+        }
+        return (
+          <button
+            key={reason}
+            type="button"
+            onClick={handleClick}
+            aria-pressed={isActive}
+            title={`${count} ${count === 1 ? 'session' : 'sessions'} — ${config.label}`}
+            data-testid={`attention-pill-${reason}`}
+            class={`shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-all ${tone} ${ring}`}
+          >
+            <span aria-hidden>{config.emoji}</span>
+            <span>{config.label}</span>
+            <span class="ml-0.5 tabular-nums font-semibold">{count}</span>
+          </button>
+        )
+      })}
+      {filter !== null && (
+        <button
+          type="button"
+          onClick={() => onSelect(null, null)}
+          class="shrink-0 ml-auto text-xs font-medium text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 underline"
+          data-testid="attention-clear"
+        >
+          Clear filter
+        </button>
+      )}
+    </div>
+  )
+}

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -160,6 +160,48 @@ describe('App', () => {
     }
   })
 
+  it('renders attention pills and filters the session list when a pill is clicked', async () => {
+    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
+      version: 1,
+      connections: [
+        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+      ],
+      activeId: 'c1',
+    }))
+    stubFetch([
+      session({
+        id: 's1',
+        slug: 'brave-fox',
+        status: 'failed',
+        needsAttention: true,
+        attentionReasons: ['failed'],
+      }),
+      session({
+        id: 's2',
+        slug: 'swift-cat',
+        needsAttention: true,
+        attentionReasons: ['waiting_for_feedback'],
+      }),
+      session({ id: 's3', slug: 'calm-owl' }),
+    ])
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    await screen.findByTestId('attention-bar')
+    expect(screen.getByTestId('attention-pill-failed').textContent).toContain('1')
+    expect(screen.getByTestId('attention-pill-waiting_for_feedback').textContent).toContain('1')
+
+    expect(await screen.findByTestId('session-item-s3')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('attention-pill-failed'))
+
+    expect(screen.getByTestId('session-item-s1')).toBeTruthy()
+    expect(screen.queryByTestId('session-item-s2')).toBeNull()
+    expect(screen.queryByTestId('session-item-s3')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('attention-clear'))
+    expect(screen.getByTestId('session-item-s3')).toBeTruthy()
+  })
+
   it('switching sessions swaps the conversation pane', async () => {
     localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
       version: 1,

--- a/test/components/AttentionBar.test.tsx
+++ b/test/components/AttentionBar.test.tsx
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/preact'
+import {
+  AttentionBar,
+  countByAttentionReason,
+  filterSessionsByReason,
+  firstSessionWithReason,
+} from '../../src/components/AttentionBar'
+import type { ApiSession, AttentionReason } from '../../src/api/types'
+
+function makeSession(overrides: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 'session-1',
+    slug: 'bold-meadow',
+    status: 'running',
+    command: '/task Add feature',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...overrides,
+  }
+}
+
+describe('countByAttentionReason', () => {
+  it('returns zero counts for all reasons when nothing needs attention', () => {
+    const sessions = [makeSession(), makeSession({ id: 's2', slug: 'calm-lake' })]
+    const counts = countByAttentionReason(sessions)
+    expect(counts).toEqual({
+      failed: 0,
+      waiting_for_feedback: 0,
+      interrupted: 0,
+      ci_fix: 0,
+      idle_long: 0,
+    })
+  })
+
+  it('ignores sessions where needsAttention is false even if they have reasons', () => {
+    const sessions = [
+      makeSession({ needsAttention: false, attentionReasons: ['failed'] }),
+    ]
+    expect(countByAttentionReason(sessions).failed).toBe(0)
+  })
+
+  it('counts each reason independently, not per session', () => {
+    const sessions = [
+      makeSession({
+        id: 's1',
+        needsAttention: true,
+        attentionReasons: ['failed', 'waiting_for_feedback'],
+      }),
+      makeSession({
+        id: 's2',
+        slug: 's2',
+        needsAttention: true,
+        attentionReasons: ['failed'],
+      }),
+      makeSession({
+        id: 's3',
+        slug: 's3',
+        needsAttention: true,
+        attentionReasons: ['interrupted'],
+      }),
+    ]
+    const counts = countByAttentionReason(sessions)
+    expect(counts.failed).toBe(2)
+    expect(counts.waiting_for_feedback).toBe(1)
+    expect(counts.interrupted).toBe(1)
+    expect(counts.ci_fix).toBe(0)
+    expect(counts.idle_long).toBe(0)
+  })
+})
+
+describe('filterSessionsByReason', () => {
+  const sessions: ApiSession[] = [
+    makeSession({ id: 's1', needsAttention: true, attentionReasons: ['failed'] }),
+    makeSession({
+      id: 's2',
+      slug: 's2',
+      needsAttention: true,
+      attentionReasons: ['waiting_for_feedback'],
+    }),
+    makeSession({ id: 's3', slug: 's3' }),
+  ]
+
+  it('returns all sessions when filter is null', () => {
+    expect(filterSessionsByReason(sessions, null)).toHaveLength(3)
+  })
+
+  it('returns only sessions with the filter reason', () => {
+    const filtered = filterSessionsByReason(sessions, 'failed')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0].id).toBe('s1')
+  })
+
+  it('returns empty array when no session matches', () => {
+    expect(filterSessionsByReason(sessions, 'idle_long')).toHaveLength(0)
+  })
+})
+
+describe('firstSessionWithReason', () => {
+  it('returns null when no matching session exists', () => {
+    const sessions = [makeSession()]
+    expect(firstSessionWithReason(sessions, 'failed')).toBeNull()
+  })
+
+  it('returns the most recently updated matching session', () => {
+    const sessions = [
+      makeSession({
+        id: 'old',
+        slug: 'old',
+        updatedAt: '2024-01-01T00:00:00Z',
+        needsAttention: true,
+        attentionReasons: ['failed'],
+      }),
+      makeSession({
+        id: 'new',
+        slug: 'new',
+        updatedAt: '2024-02-01T00:00:00Z',
+        needsAttention: true,
+        attentionReasons: ['failed'],
+      }),
+      makeSession({
+        id: 'other',
+        slug: 'other',
+        updatedAt: '2024-03-01T00:00:00Z',
+        needsAttention: true,
+        attentionReasons: ['waiting_for_feedback'],
+      }),
+    ]
+    expect(firstSessionWithReason(sessions, 'failed')?.id).toBe('new')
+  })
+})
+
+describe('AttentionBar', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  it('renders nothing when no sessions need attention', () => {
+    const { container } = render(
+      <AttentionBar sessions={[makeSession()]} filter={null} onSelect={() => {}} />,
+    )
+    expect(container.querySelector('[data-testid="attention-bar"]')).toBeNull()
+  })
+
+  it('renders a pill per non-empty attention reason with counts', () => {
+    const sessions = [
+      makeSession({ id: 's1', needsAttention: true, attentionReasons: ['failed'] }),
+      makeSession({
+        id: 's2',
+        slug: 's2',
+        needsAttention: true,
+        attentionReasons: ['failed', 'waiting_for_feedback'],
+      }),
+      makeSession({
+        id: 's3',
+        slug: 's3',
+        needsAttention: true,
+        attentionReasons: ['interrupted'],
+      }),
+    ]
+    render(<AttentionBar sessions={sessions} filter={null} onSelect={() => {}} />)
+
+    expect(screen.getByTestId('attention-bar')).toBeTruthy()
+    expect(screen.getByTestId('attention-pill-failed').textContent).toContain('2')
+    expect(screen.getByTestId('attention-pill-waiting_for_feedback').textContent).toContain('1')
+    expect(screen.getByTestId('attention-pill-interrupted').textContent).toContain('1')
+    expect(screen.queryByTestId('attention-pill-ci_fix')).toBeNull()
+    expect(screen.queryByTestId('attention-pill-idle_long')).toBeNull()
+  })
+
+  it('invokes onSelect with reason and first matching session id when pill is clicked', () => {
+    const onSelect = vi.fn()
+    const sessions = [
+      makeSession({
+        id: 'old',
+        updatedAt: '2024-01-01T00:00:00Z',
+        needsAttention: true,
+        attentionReasons: ['failed'],
+      }),
+      makeSession({
+        id: 'new',
+        slug: 'new',
+        updatedAt: '2024-06-01T00:00:00Z',
+        needsAttention: true,
+        attentionReasons: ['failed'],
+      }),
+    ]
+    render(<AttentionBar sessions={sessions} filter={null} onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByTestId('attention-pill-failed'))
+    expect(onSelect).toHaveBeenCalledWith('failed', 'new')
+  })
+
+  it('clicking the active pill toggles the filter off with null id', () => {
+    const onSelect = vi.fn()
+    const sessions = [
+      makeSession({ id: 's1', needsAttention: true, attentionReasons: ['failed'] }),
+    ]
+    render(<AttentionBar sessions={sessions} filter="failed" onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByTestId('attention-pill-failed'))
+    expect(onSelect).toHaveBeenCalledWith(null, null)
+  })
+
+  it('marks the active pill with aria-pressed=true and others false', () => {
+    const sessions = [
+      makeSession({
+        id: 's1',
+        needsAttention: true,
+        attentionReasons: ['failed', 'waiting_for_feedback'],
+      }),
+    ]
+    render(<AttentionBar sessions={sessions} filter="failed" onSelect={() => {}} />)
+
+    expect(
+      screen.getByTestId('attention-pill-failed').getAttribute('aria-pressed'),
+    ).toBe('true')
+    expect(
+      screen.getByTestId('attention-pill-waiting_for_feedback').getAttribute('aria-pressed'),
+    ).toBe('false')
+  })
+
+  it('shows a Clear filter button only when a filter is active', () => {
+    const sessions = [
+      makeSession({ id: 's1', needsAttention: true, attentionReasons: ['failed'] }),
+    ]
+    const { rerender } = render(
+      <AttentionBar sessions={sessions} filter={null} onSelect={() => {}} />,
+    )
+    expect(screen.queryByTestId('attention-clear')).toBeNull()
+
+    rerender(<AttentionBar sessions={sessions} filter="failed" onSelect={() => {}} />)
+    expect(screen.getByTestId('attention-clear')).toBeTruthy()
+  })
+
+  it('Clear filter button calls onSelect(null, null)', () => {
+    const onSelect = vi.fn()
+    const sessions = [
+      makeSession({ id: 's1', needsAttention: true, attentionReasons: ['failed'] }),
+    ]
+    render(<AttentionBar sessions={sessions} filter="failed" onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByTestId('attention-clear'))
+    expect(onSelect).toHaveBeenCalledWith(null, null)
+  })
+
+  it('pill click with no matching session passes null id (edge case)', () => {
+    const onSelect = vi.fn()
+    const sessions = [
+      makeSession({
+        id: 's1',
+        needsAttention: true,
+        attentionReasons: ['failed'] as AttentionReason[],
+      }),
+    ]
+    render(<AttentionBar sessions={sessions} filter={null} onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByTestId('attention-pill-failed'))
+    expect(onSelect).toHaveBeenCalledWith('failed', 's1')
+  })
+})


### PR DESCRIPTION
## Summary
- New `AttentionBar` component shows one pill per non-empty attention reason (failed / waiting-for-reply / interrupted / ci_fix / idle_long) with live counts, above the session list on both desktop and mobile.
- Clicking a pill filters the session list to matching sessions and auto-selects the most-recently-updated match (satisfies "jumps to first match"). Clicking the active pill, or the **Clear filter** button, restores the full list.
- The bar hides itself entirely when nothing needs attention, so it adds no noise to a clean inbox.
- Filter state is scoped to `ActiveView` and resets when the active connection changes.

## Why
Currently, triaging minion state requires scanning every row in the session list for status dots. With DAGs, stacks, and long-running ship pipelines there can be dozens of sessions at once. The triage bar turns "who needs me right now?" into a single glance + one click.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 243 / 243 passing, including:
  - 11 new `AttentionBar` tests (helpers + component: render, counts, click-to-filter, toggle, Clear, aria-pressed)
  - 1 new integration test in `App.test.tsx` that clicks a pill and asserts the session list is filtered end-to-end
- [ ] e2e intentionally skipped per task instructions

## Notes / assumptions
- `AttentionReason` has five values in `src/api/types.ts`; the bar supports all five but only renders a pill when its count is > 0. The parenthetical in the task ("failed, waiting-for-reply, interrupted") listed the three common ones — the other two (`ci_fix`, `idle_long`) are strictly additive.
- Pill order is by severity (failed → waiting → interrupted → ci_fix → idle_long), mirroring the ring-color priority in `getAttentionBorder`.
- The filter only affects the visible session list; the ChatPane for the currently-open session continues to render even if that session is no longer in the filtered set.

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  extract-hierarchy["✅ Extract classifySessions to shared state module"]
  chat-header-context["✅ Add parent/children/DAG/branch context to chat header"]
  attention-triage-bar["✅ Add action bar for sessions needing attention"]
  enhance-node-popup["✅ Add hierarchy metadata to NodeDetailPopup"]
  group-session-list["✅ Group SessionList by DAG/Tree/Standalone with nesting"]
  mount-canvas-tab["✅ Mount UniverseCanvas as second tab with view toggle"]
  fix-rendering-edges["✅ Fix edge-case rendering (status, animation, orphans)"]
  ship-mode-grouping["✅ Add fourth classification bucket for ship mode"]
  ship-pipeline-kanban["✅ Create Kanban view for ship pipelines"]
  enhance-context-menu["✅ Add navigation actions to ContextMenu"]
  polish-ui-details["✅ Polish: badges, chips, keyboard nav, DAG summaries"]
  extract-hierarchy --> group-session-list
  extract-hierarchy --> mount-canvas-tab
  extract-hierarchy --> fix-rendering-edges
  extract-hierarchy --> ship-mode-grouping
  mount-canvas-tab --> ship-pipeline-kanban
  mount-canvas-tab --> enhance-context-menu
  group-session-list --> polish-ui-details
  mount-canvas-tab --> polish-ui-details
  class extract-hierarchy done
  class chat-header-context done
  class attention-triage-bar done
  class attention-triage-bar current
  class enhance-node-popup done
  class group-session-list done
  class mount-canvas-tab done
  class fix-rendering-edges done
  class ship-mode-grouping done
  class ship-pipeline-kanban done
  class enhance-context-menu done
  class polish-ui-details done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | Extract classifySessions to shared state module | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/11) |
| 2 | Add parent/children/DAG/branch context to chat header | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/12) |
| 3 | **Add action bar for sessions needing attention** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/13) |
| 4 | Add hierarchy metadata to NodeDetailPopup | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/19) |
| 5 | Group SessionList by DAG/Tree/Standalone with nesting | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/14) |
| 6 | Mount UniverseCanvas as second tab with view toggle | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/20) |
| 7 | Fix edge-case rendering (status, animation, orphans) | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/17) |
| 8 | Add fourth classification bucket for ship mode | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/18) |
| 9 | Create Kanban view for ship pipelines | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/21) |
| 10 | Add navigation actions to ContextMenu | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/22) |
| 11 | Polish: badges, chips, keyboard nav, DAG summaries | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/24) |

**Progress:** 11/11 complete

<!-- dag-status-end -->








