### PR TITLE
[minions] feat(ui): group session list by DAG / Tree / Standalone

### DIFF
--- a/e2e/tests/bad-token.spec.ts
+++ b/e2e/tests/bad-token.spec.ts
@@ -41,7 +41,7 @@ test.describe('bad token', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Bad Token Minion')
 
-      await expect(page.getByTestId('universe-node-correct-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-correct-session')).toBeVisible({ timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/connect.spec.ts
+++ b/e2e/tests/connect.spec.ts
@@ -62,7 +62,7 @@ test.describe('connection flow', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion A')
 
-      await expect(page.getByTestId('universe-node-s1')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-s1')).toBeVisible({ timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/multi-connection.spec.ts
+++ b/e2e/tests/multi-connection.spec.ts
@@ -46,7 +46,7 @@ test.describe('multi-connection', () => {
     try {
       await connectToMinion(page, mockA, 'Minion Alpha')
 
-      await expect(page.getByTestId('universe-node-a-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-a-session')).toBeVisible({ timeout: 8_000 })
 
       await page.getByTestId('connection-picker-trigger').click()
       await expect(page.getByTestId('connection-picker-dropdown')).toBeVisible()
@@ -66,8 +66,8 @@ test.describe('multi-connection', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion Beta')
 
-      await expect(page.getByTestId('universe-node-b-session')).toBeVisible({ timeout: 8_000 })
-      await expect(page.getByTestId('universe-node-a-session')).not.toBeVisible()
+      await expect(page.getByTestId('session-item-b-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-a-session')).not.toBeVisible()
 
       await page.getByTestId('connection-picker-trigger').click()
       const dropdown = page.getByTestId('connection-picker-dropdown')
@@ -79,8 +79,8 @@ test.describe('multi-connection', () => {
 
       await expect(page.getByTestId('connection-picker-trigger')).toContainText('Minion Alpha')
 
-      await expect(page.getByTestId('universe-node-a-session')).toBeVisible({ timeout: 8_000 })
-      await expect(page.getByTestId('universe-node-b-session')).not.toBeVisible()
+      await expect(page.getByTestId('session-item-a-session')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-b-session')).not.toBeVisible()
     } finally {
       await mockA.close()
       await mockB.close()

--- a/e2e/tests/reconnect.spec.ts
+++ b/e2e/tests/reconnect.spec.ts
@@ -34,7 +34,7 @@ test.describe('SSE reconnect', () => {
 
       await expect(page.getByText('live')).toBeVisible({ timeout: 20_000 })
 
-      await expect(page.getByTestId('universe-node-s-reconnect')).toBeVisible({ timeout: 10_000 })
+      await expect(page.getByTestId('session-item-s-reconnect')).toBeVisible({ timeout: 10_000 })
     } finally {
       await mock.close()
     }

--- a/e2e/tests/task-lifecycle.spec.ts
+++ b/e2e/tests/task-lifecycle.spec.ts
@@ -26,13 +26,9 @@ test.describe('task lifecycle', () => {
     try {
       await connectToMinion(page, mock, 'My Minion')
 
-      await expect(page.getByTestId('universe-node-seed-1')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-seed-1')).toBeVisible({ timeout: 8_000 })
 
-      await page.getByTestId('universe-node-seed-1').dispatchEvent('click')
-
-      await expect(page.locator('[role="dialog"]')).toBeVisible()
-
-      await page.getByRole('button', { name: 'Open Chat' }).click()
+      await page.getByTestId('session-item-seed-1').click()
 
       await expect(page.getByTestId('message-textarea')).toBeVisible()
 
@@ -45,15 +41,9 @@ test.describe('task lifecycle', () => {
 
       mock.emit({ type: 'session_created', session: makeSession('new-1', 'hello-task', 'running') })
 
-      await expect(page.getByTestId('universe-node-new-1')).toBeAttached({ timeout: 5_000 })
+      await expect(page.getByTestId('session-item-new-1')).toBeVisible({ timeout: 5_000 })
 
-      await page.getByTestId('chat-close-btn').click()
-
-      await page.getByTestId('universe-node-new-1').dispatchEvent('click')
-
-      await expect(page.locator('[aria-labelledby="node-detail-title"]')).toBeVisible()
-
-      await page.getByRole('button', { name: 'Open Chat' }).click()
+      await page.getByTestId('session-item-new-1').click()
 
       await expect(page.getByTestId('message-textarea')).toBeVisible()
 
@@ -68,11 +58,7 @@ test.describe('task lifecycle', () => {
       mock.setSessions([makeSession('seed-1', 'seed-task', 'running'), completedSession])
       mock.emit({ type: 'session_updated', session: completedSession })
 
-      await page.getByTestId('universe-node-new-1').dispatchEvent('click')
-
-      await expect(
-        page.locator('[aria-labelledby="node-detail-title"]').getByText('Done')
-      ).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('session-item-new-1')).toContainText('completed', { timeout: 8_000 })
     } finally {
       await mock.close()
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { signal, useSignal } from '@preact/signals'
-import { useState, useEffect, useMemo } from 'preact/hooks'
+import { useState, useEffect } from 'preact/hooks'
 import { useRegisterSW } from 'virtual:pwa-register/preact'
 import { connections, activeId, getActiveStore } from './connections/store'
 import { ConnectionSettings } from './connections/ConnectionSettings'
@@ -9,6 +9,7 @@ import { ConversationView } from './chat/ConversationView'
 import { MessageInput } from './chat/MessageInput'
 import { QuickActionsBar } from './chat/QuickActionsBar'
 import { SlashCommandMenu, type SlashCommand } from './chat/SlashCommandMenu'
+import { SessionList } from './components/SessionList'
 import { confirm } from './hooks/useConfirm'
 import { ConfirmRoot } from './hooks/useConfirm'
 import { InstallPrompt } from './pwa/InstallPrompt'
@@ -122,87 +123,6 @@ function NewTaskBar({
         </button>
       </div>
       {error.value && <div class="text-xs text-red-600 dark:text-red-400">{error.value}</div>}
-    </div>
-  )
-}
-
-function SessionItem({ session, active, onSelect }: { session: ApiSession; active: boolean; onSelect: () => void }) {
-  const preview = session.conversation.length > 0
-    ? session.conversation[session.conversation.length - 1].text.slice(0, 60)
-    : session.command.slice(0, 60)
-  const baseClasses = 'w-full text-left px-3 py-2 rounded-md border transition-colors flex flex-col gap-1'
-  const active_ = active
-    ? 'bg-indigo-50 dark:bg-indigo-950/40 border-indigo-300 dark:border-indigo-700'
-    : 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/50'
-  return (
-    <button class={`${baseClasses} ${active_}`} onClick={onSelect} data-testid={`session-item-${session.id}`}>
-      <div class="flex items-center gap-2">
-        <span class={`inline-block h-2 w-2 rounded-full shrink-0 ${statusDot(session.status)}`} />
-        <span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">{session.slug}</span>
-        {session.repo && (
-          <span class="text-[10px] font-mono rounded bg-slate-100 dark:bg-slate-700 px-1.5 py-0.5 text-slate-600 dark:text-slate-300 truncate">
-            {shortRepo(session.repo)}
-          </span>
-        )}
-        <span class="ml-auto text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">{session.status}</span>
-      </div>
-      <div class="text-xs text-slate-600 dark:text-slate-400 truncate">{preview || '—'}</div>
-    </button>
-  )
-}
-
-function shortRepo(repoUrl: string): string {
-  const match = repoUrl.match(/[/:]([^/]+\/[^/]+?)(?:\.git)?$/)
-  return match ? match[1] : repoUrl
-}
-
-function SessionList({
-  sessions,
-  activeSessionId,
-  onSelect,
-  orientation,
-}: {
-  sessions: ApiSession[]
-  activeSessionId: string | null
-  onSelect: (id: string) => void
-  orientation: 'vertical' | 'horizontal'
-}) {
-  const sorted = useMemo(
-    () => [...sessions].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1)),
-    [sessions]
-  )
-  if (sorted.length === 0) {
-    return (
-      <div class="text-xs text-slate-500 dark:text-slate-400 p-3 italic">
-        No sessions yet. Send a /task above.
-      </div>
-    )
-  }
-  if (orientation === 'horizontal') {
-    return (
-      <div class="flex gap-2 overflow-x-auto px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
-        {sorted.map((s) => (
-          <div key={s.id} class="min-w-[180px]">
-            <SessionItem
-              session={s}
-              active={activeSessionId === s.id}
-              onSelect={() => onSelect(s.id)}
-            />
-          </div>
-        ))}
-      </div>
-    )
-  }
-  return (
-    <div class="flex flex-col gap-1 p-2 overflow-y-auto">
-      {sorted.map((s) => (
-        <SessionItem
-          key={s.id}
-          session={s}
-          active={activeSessionId === s.id}
-          onSelect={() => onSelect(s.id)}
-        />
-      ))}
     </div>
   )
 }
@@ -396,9 +316,9 @@ function ActiveView() {
           <aside class="w-72 border-r border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 overflow-y-auto shrink-0">
             <SessionList
               sessions={sessions}
+              dags={store.dags.value}
               activeSessionId={sessionId}
               onSelect={setSessionId}
-              orientation="vertical"
             />
           </aside>
           {selected ? (
@@ -409,12 +329,14 @@ function ActiveView() {
         </div>
       ) : (
         <div class="flex flex-col flex-1 min-h-0">
-          <SessionList
-            sessions={sessions}
-            activeSessionId={sessionId}
-            onSelect={setSessionId}
-            orientation="horizontal"
-          />
+          <div class="max-h-[45vh] overflow-y-auto border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 shrink-0">
+            <SessionList
+              sessions={sessions}
+              dags={store.dags.value}
+              activeSessionId={sessionId}
+              onSelect={setSessionId}
+            />
+          </div>
           {selected ? (
             <ChatPane session={selected} onSend={handleSendMessage} onCommand={handleCommand} />
           ) : (

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -1,0 +1,428 @@
+import { useMemo } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import type { ApiSession, ApiDagGraph, ApiDagNode } from '../api/types'
+import { classifySessions } from '../state/hierarchy'
+import { STATUS_CONFIG } from './shared'
+
+type Status = ApiDagNode['status']
+
+export function buildDagStatusIndex(dags: ApiDagGraph[]): Map<string, Status> {
+  const m = new Map<string, Status>()
+  for (const dag of dags) {
+    for (const node of Object.values(dag.nodes)) {
+      if (node.session) m.set(node.session.id, node.status)
+    }
+  }
+  return m
+}
+
+export function getEffectiveStatus(
+  session: ApiSession,
+  dagStatusById: Map<string, Status>,
+): Status {
+  return dagStatusById.get(session.id) ?? session.status
+}
+
+export function shortRepo(repoUrl: string): string {
+  const match = repoUrl.match(/[/:]([^/]+\/[^/]+?)(?:\.git)?$/)
+  return match ? match[1] : repoUrl
+}
+
+function byUpdatedDesc(a: ApiSession, b: ApiSession): number {
+  return a.updatedAt < b.updatedAt ? 1 : -1
+}
+
+interface DagGroupData {
+  dag: ApiDagGraph
+  sessions: ApiSession[]
+  counts: Record<Status, number>
+  landed: number
+  total: number
+}
+
+export function buildDagGroups(
+  dags: ApiDagGraph[],
+  sessionById: Map<string, ApiSession>,
+): DagGroupData[] {
+  const groups: DagGroupData[] = []
+  for (const dag of dags) {
+    const nodes = Object.values(dag.nodes)
+    if (nodes.length === 0) continue
+    const sessions: ApiSession[] = []
+    const counts = {
+      pending: 0,
+      running: 0,
+      completed: 0,
+      failed: 0,
+      skipped: 0,
+      'ci-pending': 0,
+      'ci-failed': 0,
+      landed: 0,
+    } as Record<Status, number>
+    for (const node of nodes) {
+      counts[node.status] = (counts[node.status] ?? 0) + 1
+      const latest = node.session ? sessionById.get(node.session.id) ?? node.session : null
+      if (latest) sessions.push(latest)
+    }
+    sessions.sort(byUpdatedDesc)
+    groups.push({
+      dag,
+      sessions,
+      counts,
+      landed: counts.landed,
+      total: nodes.length,
+    })
+  }
+  groups.sort((a, b) => (a.dag.updatedAt < b.dag.updatedAt ? 1 : -1))
+  return groups
+}
+
+function collectTreeChildren(
+  root: ApiSession,
+  sessionById: Map<string, ApiSession>,
+  visited: Set<string> = new Set(),
+): ApiSession[] {
+  if (visited.has(root.id)) return []
+  visited.add(root.id)
+  const result: ApiSession[] = []
+  const children = root.childIds
+    .map((id) => sessionById.get(id))
+    .filter((s): s is ApiSession => !!s)
+    .sort(byUpdatedDesc)
+  for (const child of children) {
+    result.push(child)
+    result.push(...collectTreeChildren(child, sessionById, visited))
+  }
+  return result
+}
+
+interface TreeRow {
+  session: ApiSession
+  depth: number
+}
+
+function flattenTree(
+  root: ApiSession,
+  sessionById: Map<string, ApiSession>,
+  visited: Set<string> = new Set(),
+  depth = 0,
+): TreeRow[] {
+  if (visited.has(root.id)) return []
+  visited.add(root.id)
+  const rows: TreeRow[] = [{ session: root, depth }]
+  const children = root.childIds
+    .map((id) => sessionById.get(id))
+    .filter((s): s is ApiSession => !!s)
+    .sort(byUpdatedDesc)
+  for (const child of children) {
+    rows.push(...flattenTree(child, sessionById, visited, depth + 1))
+  }
+  return rows
+}
+
+function SessionRow({
+  session,
+  active,
+  depth,
+  status,
+  onSelect,
+}: {
+  session: ApiSession
+  active: boolean
+  depth: number
+  status: Status
+  onSelect: () => void
+}) {
+  const preview =
+    session.conversation.length > 0
+      ? session.conversation[session.conversation.length - 1].text.slice(0, 60)
+      : session.command.slice(0, 60)
+
+  const statusCfg = STATUS_CONFIG[status] ?? STATUS_CONFIG.pending
+  const statusColor =
+    status === 'running'
+      ? 'bg-blue-500 animate-pulse'
+      : status === 'completed'
+        ? 'bg-green-500'
+        : status === 'failed'
+          ? 'bg-red-500'
+          : status === 'landed'
+            ? 'bg-emerald-500'
+            : status === 'ci-pending'
+              ? 'bg-yellow-500'
+              : status === 'ci-failed'
+                ? 'bg-orange-500'
+                : status === 'skipped'
+                  ? 'bg-stone-400'
+                  : 'bg-slate-400'
+
+  const rowBase =
+    'w-full text-left px-3 py-2 rounded-md border transition-colors flex flex-col gap-1'
+  const rowState = active
+    ? 'bg-indigo-50 dark:bg-indigo-950/40 border-indigo-300 dark:border-indigo-700'
+    : 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/50'
+
+  const indentStyle =
+    depth > 0 ? { paddingLeft: `${depth * 14}px` } : undefined
+
+  return (
+    <div class="relative" style={indentStyle} data-depth={depth}>
+      {depth > 0 && (
+        <span
+          aria-hidden="true"
+          class="absolute top-0 bottom-0 w-px bg-slate-200 dark:bg-slate-700"
+          style={{ left: `${(depth - 1) * 14 + 6}px` }}
+        />
+      )}
+      <button
+        type="button"
+        class={`${rowBase} ${rowState}`}
+        onClick={onSelect}
+        data-testid={`session-item-${session.id}`}
+      >
+        <div class="flex items-center gap-2">
+          <span
+            aria-label={statusCfg.label}
+            title={statusCfg.label}
+            class={`inline-block h-2 w-2 rounded-full shrink-0 ${statusColor}`}
+          />
+          <span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">
+            {session.slug}
+          </span>
+          {session.repo && (
+            <span class="text-[10px] font-mono rounded bg-slate-100 dark:bg-slate-700 px-1.5 py-0.5 text-slate-600 dark:text-slate-300 truncate">
+              {shortRepo(session.repo)}
+            </span>
+          )}
+          <span class="ml-auto text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            {status}
+          </span>
+        </div>
+        <div class="text-xs text-slate-600 dark:text-slate-400 truncate">
+          {preview || '—'}
+        </div>
+      </button>
+    </div>
+  )
+}
+
+function GroupSectionHeader({
+  label,
+  count,
+  expanded,
+  onToggle,
+  testid,
+}: {
+  label: string
+  count: number
+  expanded: boolean
+  onToggle: () => void
+  testid: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      data-testid={testid}
+      aria-expanded={expanded}
+      class="w-full flex items-center gap-2 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 select-none"
+    >
+      <span
+        aria-hidden="true"
+        class={`inline-block w-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
+      >
+        ▸
+      </span>
+      <span>{label}</span>
+      <span class="ml-auto rounded-full bg-slate-200 dark:bg-slate-700 px-2 py-0.5 text-[10px] font-normal text-slate-700 dark:text-slate-200">
+        {count}
+      </span>
+    </button>
+  )
+}
+
+function DagSubheader({ group }: { group: DagGroupData }) {
+  const { dag, landed, total, counts } = group
+  const running = counts.running + counts['ci-pending']
+  const failed = counts.failed + counts['ci-failed']
+  return (
+    <div
+      class="px-2 py-1 text-[10px] font-mono text-slate-500 dark:text-slate-400 flex items-center gap-2 border-l-2 border-indigo-300 dark:border-indigo-700"
+      data-testid={`dag-subheader-${dag.id}`}
+    >
+      <span class="truncate font-semibold text-slate-700 dark:text-slate-300">
+        {dag.id.slice(0, 8)}
+      </span>
+      <span>·</span>
+      <span>
+        {landed}/{total} landed
+      </span>
+      {running > 0 && (
+        <span class="text-blue-600 dark:text-blue-400">· {running} running</span>
+      )}
+      {failed > 0 && (
+        <span class="text-red-600 dark:text-red-400">· {failed} failed</span>
+      )}
+    </div>
+  )
+}
+
+type ExpandedState = { dag: boolean; tree: boolean; standalone: boolean }
+
+export function SessionList({
+  sessions,
+  dags,
+  activeSessionId,
+  onSelect,
+}: {
+  sessions: ApiSession[]
+  dags: ApiDagGraph[]
+  activeSessionId: string | null
+  onSelect: (id: string) => void
+}) {
+  const expanded = useSignal<ExpandedState>({
+    dag: true,
+    tree: true,
+    standalone: true,
+  })
+
+  const classification = useMemo(
+    () => classifySessions(sessions, dags),
+    [sessions, dags],
+  )
+  const dagStatusById = useMemo(() => buildDagStatusIndex(dags), [dags])
+  const dagGroups = useMemo(
+    () => buildDagGroups(dags, classification.sessionById),
+    [dags, classification.sessionById],
+  )
+
+  const sortedRoots = useMemo(
+    () => [...classification.parentChildRoots].sort(byUpdatedDesc),
+    [classification.parentChildRoots],
+  )
+  const sortedStandalone = useMemo(
+    () => [...classification.standalone].sort(byUpdatedDesc),
+    [classification.standalone],
+  )
+
+  const dagMemberCount = useMemo(
+    () => dagGroups.reduce((n, g) => n + g.sessions.length, 0),
+    [dagGroups],
+  )
+  const treeMemberCount = useMemo(() => {
+    let n = 0
+    for (const root of sortedRoots) {
+      n += 1 + collectTreeChildren(root, classification.sessionById).length
+    }
+    return n
+  }, [sortedRoots, classification.sessionById])
+
+  const toggle = (k: keyof ExpandedState) => {
+    expanded.value = { ...expanded.value, [k]: !expanded.value[k] }
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <div class="text-xs text-slate-500 dark:text-slate-400 p-3 italic">
+        No sessions yet. Send a /task above.
+      </div>
+    )
+  }
+
+  return (
+    <div
+      class="flex flex-col gap-3 p-2 overflow-y-auto"
+      data-testid="session-list"
+    >
+      {dagGroups.length > 0 && (
+        <section data-testid="session-group-dag" class="flex flex-col gap-1">
+          <GroupSectionHeader
+            label={`DAGs · ${dagGroups.length}`}
+            count={dagMemberCount}
+            expanded={expanded.value.dag}
+            onToggle={() => toggle('dag')}
+            testid="group-toggle-dag"
+          />
+          {expanded.value.dag &&
+            dagGroups.map((group) => (
+              <div key={group.dag.id} class="flex flex-col gap-1">
+                <DagSubheader group={group} />
+                <div class="flex flex-col gap-1">
+                  {group.sessions.map((s) => (
+                    <SessionRow
+                      key={s.id}
+                      session={s}
+                      active={activeSessionId === s.id}
+                      depth={1}
+                      status={getEffectiveStatus(s, dagStatusById)}
+                      onSelect={() => onSelect(s.id)}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+        </section>
+      )}
+
+      {sortedRoots.length > 0 && (
+        <section data-testid="session-group-tree" class="flex flex-col gap-1">
+          <GroupSectionHeader
+            label={`Trees · ${sortedRoots.length}`}
+            count={treeMemberCount}
+            expanded={expanded.value.tree}
+            onToggle={() => toggle('tree')}
+            testid="group-toggle-tree"
+          />
+          {expanded.value.tree &&
+            sortedRoots.map((root) => {
+              const rows = flattenTree(root, classification.sessionById)
+              return (
+                <div
+                  key={root.id}
+                  class="flex flex-col gap-1"
+                  data-testid={`tree-${root.id}`}
+                >
+                  {rows.map(({ session, depth }) => (
+                    <SessionRow
+                      key={session.id}
+                      session={session}
+                      active={activeSessionId === session.id}
+                      depth={depth}
+                      status={getEffectiveStatus(session, dagStatusById)}
+                      onSelect={() => onSelect(session.id)}
+                    />
+                  ))}
+                </div>
+              )
+            })}
+        </section>
+      )}
+
+      {sortedStandalone.length > 0 && (
+        <section
+          data-testid="session-group-standalone"
+          class="flex flex-col gap-1"
+        >
+          <GroupSectionHeader
+            label="Solo"
+            count={sortedStandalone.length}
+            expanded={expanded.value.standalone}
+            onToggle={() => toggle('standalone')}
+            testid="group-toggle-standalone"
+          />
+          {expanded.value.standalone &&
+            sortedStandalone.map((s) => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                active={activeSessionId === s.id}
+                depth={0}
+                status={getEffectiveStatus(s, dagStatusById)}
+                onSelect={() => onSelect(s.id)}
+              />
+            ))}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/src/components/universe-layout.ts
+++ b/src/components/universe-layout.ts
@@ -2,6 +2,7 @@ import dagre from 'dagre'
 import type { Node, Edge } from '@reactflow/core'
 import { MarkerType } from '@reactflow/core'
 import type { ApiSession, ApiDagGraph, ApiDagNode } from '../api/types'
+import { classifySessions } from '../state/hierarchy'
 
 export const NODE_WIDTH = 240
 export const NODE_HEIGHT = 100
@@ -31,80 +32,6 @@ interface LayoutGroup {
   edges: Edge[]
   width: number
   height: number
-}
-
-function classifySessions(
-  sessions: ApiSession[],
-  dags: ApiDagGraph[],
-): { dagOwned: Set<string>; parentChildRoots: ApiSession[]; standalone: ApiSession[] } {
-  const dagOwned = new Set<string>()
-
-  for (const dag of dags) {
-    for (const node of Object.values(dag.nodes)) {
-      if (node.session) {
-        dagOwned.add(node.session.id)
-      }
-    }
-  }
-
-  const sessionById = new Map<string, ApiSession>()
-  for (const s of sessions) {
-    sessionById.set(s.id, s)
-  }
-
-  const inParentChildTree = new Set<string>()
-  const parentChildRoots: ApiSession[] = []
-
-  for (const s of sessions) {
-    if (dagOwned.has(s.id)) continue
-    if (inParentChildTree.has(s.id)) continue
-
-    if (s.childIds.length > 0 && !s.parentId) {
-      parentChildRoots.push(s)
-      inParentChildTree.add(s.id)
-      collectChildren(s, sessionById, inParentChildTree)
-    }
-  }
-
-  const standalone: ApiSession[] = []
-  for (const s of sessions) {
-    if (!dagOwned.has(s.id) && !inParentChildTree.has(s.id)) {
-      if (s.parentId && sessionById.has(s.parentId)) {
-        const parent = sessionById.get(s.parentId)!
-        if (parent.childIds.includes(s.id) && !dagOwned.has(parent.id)) {
-          let root = parent
-          while (root.parentId && sessionById.has(root.parentId) && !dagOwned.has(root.parentId)) {
-            root = sessionById.get(root.parentId)!
-          }
-          if (!inParentChildTree.has(root.id)) {
-            parentChildRoots.push(root)
-            inParentChildTree.add(root.id)
-            collectChildren(root, sessionById, inParentChildTree)
-          }
-          inParentChildTree.add(s.id)
-          continue
-        }
-      }
-      standalone.push(s)
-    }
-  }
-
-  return { dagOwned, parentChildRoots, standalone }
-}
-
-function collectChildren(
-  session: ApiSession,
-  sessionById: Map<string, ApiSession>,
-  collected: Set<string>,
-): void {
-  for (const childId of session.childIds) {
-    if (collected.has(childId)) continue
-    collected.add(childId)
-    const child = sessionById.get(childId)
-    if (child) {
-      collectChildren(child, sessionById, collected)
-    }
-  }
 }
 
 function layoutDagGroup(dag: ApiDagGraph, isDark: boolean): LayoutGroup {
@@ -319,12 +246,7 @@ export function layoutUniverse(
     return { nodes: [], edges: [] }
   }
 
-  const sessionById = new Map<string, ApiSession>()
-  for (const s of sessions) {
-    sessionById.set(s.id, s)
-  }
-
-  const { parentChildRoots, standalone } = classifySessions(sessions, dags)
+  const { parentChildRoots, standalone, sessionById } = classifySessions(sessions, dags)
 
   const groups: LayoutGroup[] = []
 

--- a/src/state/hierarchy.ts
+++ b/src/state/hierarchy.ts
@@ -1,0 +1,99 @@
+import type { ApiDagGraph, ApiSession } from '../api/types'
+
+export function buildSessionIndex(sessions: ApiSession[]): Map<string, ApiSession> {
+  const index = new Map<string, ApiSession>()
+  for (const s of sessions) index.set(s.id, s)
+  return index
+}
+
+export function collectChildren(
+  session: ApiSession,
+  sessionById: Map<string, ApiSession>,
+  collected: Set<string>,
+): void {
+  for (const childId of session.childIds) {
+    if (collected.has(childId)) continue
+    collected.add(childId)
+    const child = sessionById.get(childId)
+    if (child) collectChildren(child, sessionById, collected)
+  }
+}
+
+export function collectDescendants(
+  session: ApiSession,
+  sessionById: Map<string, ApiSession>,
+): Set<string> {
+  const collected = new Set<string>()
+  collectChildren(session, sessionById, collected)
+  return collected
+}
+
+export function findTreeRoot(
+  session: ApiSession,
+  sessionById: Map<string, ApiSession>,
+  excluded: Set<string> = new Set(),
+): ApiSession {
+  let root = session
+  while (root.parentId && sessionById.has(root.parentId) && !excluded.has(root.parentId)) {
+    root = sessionById.get(root.parentId)!
+  }
+  return root
+}
+
+export interface SessionClassification {
+  dagOwned: Set<string>
+  parentChildRoots: ApiSession[]
+  parentChildMembers: Set<string>
+  standalone: ApiSession[]
+  sessionById: Map<string, ApiSession>
+}
+
+export function classifySessions(
+  sessions: ApiSession[],
+  dags: ApiDagGraph[],
+): SessionClassification {
+  const dagOwned = new Set<string>()
+  for (const dag of dags) {
+    for (const node of Object.values(dag.nodes)) {
+      if (node.session) dagOwned.add(node.session.id)
+    }
+  }
+
+  const sessionById = buildSessionIndex(sessions)
+
+  const parentChildMembers = new Set<string>()
+  const parentChildRoots: ApiSession[] = []
+
+  for (const s of sessions) {
+    if (dagOwned.has(s.id)) continue
+    if (parentChildMembers.has(s.id)) continue
+
+    if (s.childIds.length > 0 && !s.parentId) {
+      parentChildRoots.push(s)
+      parentChildMembers.add(s.id)
+      collectChildren(s, sessionById, parentChildMembers)
+    }
+  }
+
+  const standalone: ApiSession[] = []
+  for (const s of sessions) {
+    if (dagOwned.has(s.id) || parentChildMembers.has(s.id)) continue
+
+    if (s.parentId && sessionById.has(s.parentId)) {
+      const parent = sessionById.get(s.parentId)!
+      if (parent.childIds.includes(s.id) && !dagOwned.has(parent.id)) {
+        const root = findTreeRoot(parent, sessionById, dagOwned)
+        if (!parentChildMembers.has(root.id)) {
+          parentChildRoots.push(root)
+          parentChildMembers.add(root.id)
+          collectChildren(root, sessionById, parentChildMembers)
+        }
+        parentChildMembers.add(s.id)
+        continue
+      }
+    }
+    standalone.push(s)
+  }
+
+  return { dagOwned, parentChildRoots, parentChildMembers, standalone, sessionById }
+}

--- a/test/components/SessionList.test.tsx
+++ b/test/components/SessionList.test.tsx
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/preact'
+import type { ApiSession, ApiDagGraph, ApiDagNode } from '../../src/api/types'
+import {
+  SessionList,
+  buildDagStatusIndex,
+  buildDagGroups,
+  getEffectiveStatus,
+  shortRepo,
+} from '../../src/components/SessionList'
+import { buildSessionIndex } from '../../src/state/hierarchy'
+
+function makeSession(overrides: Partial<ApiSession> & { id: string; slug: string }): ApiSession {
+  return {
+    status: 'running',
+    command: '/task test',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...overrides,
+  }
+}
+
+function makeDag(overrides: Partial<ApiDagGraph> & { id: string }): ApiDagGraph {
+  return {
+    rootTaskId: 'node-1',
+    nodes: {},
+    status: 'running',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeDagNode(
+  overrides: Partial<ApiDagNode> & { id: string; slug: string },
+): ApiDagNode {
+  return {
+    status: 'running',
+    dependencies: [],
+    dependents: [],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  cleanup()
+})
+
+describe('shortRepo', () => {
+  it('extracts owner/repo from an ssh git URL', () => {
+    expect(shortRepo('git@github.com:acme/widgets.git')).toBe('acme/widgets')
+  })
+
+  it('extracts owner/repo from an https URL', () => {
+    expect(shortRepo('https://github.com/acme/widgets.git')).toBe('acme/widgets')
+  })
+
+  it('returns the input when it does not match the pattern', () => {
+    expect(shortRepo('')).toBe('')
+  })
+})
+
+describe('buildDagStatusIndex', () => {
+  it('maps session ids to their DAG node status', () => {
+    const session = makeSession({ id: 's1', slug: 'one' })
+    const dag = makeDag({
+      id: 'd1',
+      nodes: {
+        n1: makeDagNode({ id: 'n1', slug: 'one', status: 'landed', session }),
+      },
+    })
+    const index = buildDagStatusIndex([dag])
+    expect(index.get('s1')).toBe('landed')
+  })
+
+  it('is empty when no DAG nodes have sessions', () => {
+    const dag = makeDag({
+      id: 'd1',
+      nodes: { n1: makeDagNode({ id: 'n1', slug: 'x', status: 'pending' }) },
+    })
+    expect(buildDagStatusIndex([dag]).size).toBe(0)
+  })
+})
+
+describe('getEffectiveStatus', () => {
+  it('prefers DAG node status over session status', () => {
+    const session = makeSession({ id: 's1', slug: 'one', status: 'completed' })
+    const index = new Map([['s1', 'landed' as const]])
+    expect(getEffectiveStatus(session, index)).toBe('landed')
+  })
+
+  it('falls back to session status when not in DAG index', () => {
+    const session = makeSession({ id: 's1', slug: 'one', status: 'failed' })
+    expect(getEffectiveStatus(session, new Map())).toBe('failed')
+  })
+})
+
+describe('buildDagGroups', () => {
+  it('produces a group per DAG with landed/total counts', () => {
+    const a = makeSession({ id: 'a', slug: 'a' })
+    const b = makeSession({ id: 'b', slug: 'b' })
+    const dag = makeDag({
+      id: 'd1',
+      nodes: {
+        n1: makeDagNode({ id: 'n1', slug: 'a', status: 'landed', session: a }),
+        n2: makeDagNode({ id: 'n2', slug: 'b', status: 'running', session: b }),
+      },
+    })
+    const index = buildSessionIndex([a, b])
+    const groups = buildDagGroups([dag], index)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].total).toBe(2)
+    expect(groups[0].landed).toBe(1)
+    expect(groups[0].sessions.map((s) => s.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('skips DAGs with no nodes', () => {
+    expect(buildDagGroups([makeDag({ id: 'empty' })], new Map())).toEqual([])
+  })
+
+  it('sorts groups by DAG updatedAt desc', () => {
+    const d1 = makeDag({
+      id: 'old',
+      updatedAt: '2024-01-01T00:00:00Z',
+      nodes: { n1: makeDagNode({ id: 'n1', slug: 'n1' }) },
+    })
+    const d2 = makeDag({
+      id: 'new',
+      updatedAt: '2024-06-01T00:00:00Z',
+      nodes: { n1: makeDagNode({ id: 'n1', slug: 'n1' }) },
+    })
+    const groups = buildDagGroups([d1, d2], new Map())
+    expect(groups.map((g) => g.dag.id)).toEqual(['new', 'old'])
+  })
+})
+
+describe('SessionList', () => {
+  it('shows empty-state hint when there are no sessions', () => {
+    render(<SessionList sessions={[]} dags={[]} activeSessionId={null} onSelect={() => {}} />)
+    expect(screen.getByText(/No sessions yet/)).toBeTruthy()
+  })
+
+  it('renders a standalone group for solo sessions', () => {
+    const sessions = [
+      makeSession({ id: 's1', slug: 'alpha' }),
+      makeSession({ id: 's2', slug: 'beta' }),
+    ]
+    render(
+      <SessionList
+        sessions={sessions}
+        dags={[]}
+        activeSessionId={null}
+        onSelect={() => {}}
+      />,
+    )
+    const group = screen.getByTestId('session-group-standalone')
+    expect(within(group).getByTestId('session-item-s1')).toBeTruthy()
+    expect(within(group).getByTestId('session-item-s2')).toBeTruthy()
+    expect(screen.queryByTestId('session-group-tree')).toBeNull()
+    expect(screen.queryByTestId('session-group-dag')).toBeNull()
+  })
+
+  it('renders a tree group with nested children indented by depth', () => {
+    const sessions = [
+      makeSession({ id: 'root', slug: 'root', childIds: ['mid'] }),
+      makeSession({ id: 'mid', slug: 'mid', parentId: 'root', childIds: ['leaf'] }),
+      makeSession({ id: 'leaf', slug: 'leaf', parentId: 'mid' }),
+    ]
+    render(
+      <SessionList
+        sessions={sessions}
+        dags={[]}
+        activeSessionId={null}
+        onSelect={() => {}}
+      />,
+    )
+    const treeGroup = screen.getByTestId('session-group-tree')
+    expect(within(treeGroup).getByTestId('session-item-root')).toBeTruthy()
+    expect(within(treeGroup).getByTestId('session-item-mid')).toBeTruthy()
+    expect(within(treeGroup).getByTestId('session-item-leaf')).toBeTruthy()
+
+    const rootRow = within(treeGroup).getByTestId('session-item-root').parentElement
+    const midRow = within(treeGroup).getByTestId('session-item-mid').parentElement
+    const leafRow = within(treeGroup).getByTestId('session-item-leaf').parentElement
+    expect(rootRow?.getAttribute('data-depth')).toBe('0')
+    expect(midRow?.getAttribute('data-depth')).toBe('1')
+    expect(leafRow?.getAttribute('data-depth')).toBe('2')
+  })
+
+  it('renders a DAG group with a subheader showing landed/total', () => {
+    const a = makeSession({ id: 'a', slug: 'a' })
+    const b = makeSession({ id: 'b', slug: 'b' })
+    const dag = makeDag({
+      id: 'dag-abc-1234',
+      nodes: {
+        n1: makeDagNode({ id: 'n1', slug: 'a', status: 'landed', session: a }),
+        n2: makeDagNode({ id: 'n2', slug: 'b', status: 'running', session: b }),
+      },
+    })
+    render(
+      <SessionList
+        sessions={[a, b]}
+        dags={[dag]}
+        activeSessionId={null}
+        onSelect={() => {}}
+      />,
+    )
+    const dagGroup = screen.getByTestId('session-group-dag')
+    const sub = within(dagGroup).getByTestId('dag-subheader-dag-abc-1234')
+    expect(sub.textContent).toContain('1/2 landed')
+    expect(within(dagGroup).getByTestId('session-item-a')).toBeTruthy()
+    expect(within(dagGroup).getByTestId('session-item-b')).toBeTruthy()
+  })
+
+  it('uses DAG node status label for DAG-owned sessions (e.g. landed)', () => {
+    const a = makeSession({ id: 'a', slug: 'a', status: 'completed' })
+    const dag = makeDag({
+      id: 'd1',
+      nodes: {
+        n1: makeDagNode({ id: 'n1', slug: 'a', status: 'landed', session: a }),
+      },
+    })
+    render(
+      <SessionList
+        sessions={[a]}
+        dags={[dag]}
+        activeSessionId={null}
+        onSelect={() => {}}
+      />,
+    )
+    const row = screen.getByTestId('session-item-a')
+    expect(row.textContent?.toLowerCase()).toContain('landed')
+  })
+
+  it('places DAG, Tree, and Standalone in separate groups simultaneously', () => {
+    const dagSession = makeSession({ id: 'dagS', slug: 'dagS' })
+    const parent = makeSession({ id: 'p', slug: 'p', childIds: ['c'] })
+    const child = makeSession({ id: 'c', slug: 'c', parentId: 'p' })
+    const solo = makeSession({ id: 'solo', slug: 'solo' })
+    const dag = makeDag({
+      id: 'd1',
+      nodes: {
+        n1: makeDagNode({ id: 'n1', slug: 'dagS', status: 'running', session: dagSession }),
+      },
+    })
+
+    render(
+      <SessionList
+        sessions={[dagSession, parent, child, solo]}
+        dags={[dag]}
+        activeSessionId={null}
+        onSelect={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('session-group-dag')).toBeTruthy()
+    expect(screen.getByTestId('session-group-tree')).toBeTruthy()
+    expect(screen.getByTestId('session-group-standalone')).toBeTruthy()
+
+    expect(
+      within(screen.getByTestId('session-group-dag')).getByTestId('session-item-dagS'),
+    ).toBeTruthy()
+    expect(
+      within(screen.getByTestId('session-group-tree')).getByTestId('session-item-p'),
+    ).toBeTruthy()
+    expect(
+      within(screen.getByTestId('session-group-standalone')).getByTestId(
+        'session-item-solo',
+      ),
+    ).toBeTruthy()
+  })
+
+  it('collapses and re-expands a group when the section header is toggled', () => {
+    const sessions = [makeSession({ id: 's1', slug: 'alpha' })]
+    render(
+      <SessionList
+        sessions={sessions}
+        dags={[]}
+        activeSessionId={null}
+        onSelect={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('session-item-s1')).toBeTruthy()
+
+    fireEvent.click(screen.getByTestId('group-toggle-standalone'))
+    expect(screen.queryByTestId('session-item-s1')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('group-toggle-standalone'))
+    expect(screen.getByTestId('session-item-s1')).toBeTruthy()
+  })
+
+  it('invokes onSelect with the clicked session id', () => {
+    const onSelect = vi.fn()
+    const sessions = [makeSession({ id: 's1', slug: 'alpha' })]
+    render(
+      <SessionList
+        sessions={sessions}
+        dags={[]}
+        activeSessionId={null}
+        onSelect={onSelect}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('session-item-s1'))
+    expect(onSelect).toHaveBeenCalledWith('s1')
+  })
+})

--- a/test/state/hierarchy.test.ts
+++ b/test/state/hierarchy.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from 'vitest'
+import type { ApiSession, ApiDagGraph } from '../../src/api/types'
+import {
+  buildSessionIndex,
+  classifySessions,
+  collectChildren,
+  collectDescendants,
+  findTreeRoot,
+} from '../../src/state/hierarchy'
+
+function makeSession(overrides: Partial<ApiSession> & { id: string; slug: string }): ApiSession {
+  return {
+    status: 'running',
+    command: '/task test',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...overrides,
+  }
+}
+
+function makeDag(overrides: Partial<ApiDagGraph> & { id: string }): ApiDagGraph {
+  return {
+    rootTaskId: 'node-1',
+    nodes: {},
+    status: 'running',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('hierarchy', () => {
+  describe('buildSessionIndex', () => {
+    it('indexes sessions by id', () => {
+      const sessions = [
+        makeSession({ id: 'a', slug: 'alpha' }),
+        makeSession({ id: 'b', slug: 'beta' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      expect(index.size).toBe(2)
+      expect(index.get('a')?.slug).toBe('alpha')
+      expect(index.get('b')?.slug).toBe('beta')
+    })
+
+    it('handles empty input', () => {
+      expect(buildSessionIndex([]).size).toBe(0)
+    })
+
+    it('overwrites earlier entries with later ones when ids collide', () => {
+      const sessions = [
+        makeSession({ id: 'a', slug: 'first' }),
+        makeSession({ id: 'a', slug: 'second' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      expect(index.size).toBe(1)
+      expect(index.get('a')?.slug).toBe('second')
+    })
+  })
+
+  describe('collectChildren', () => {
+    it('collects direct children ids', () => {
+      const sessions = [
+        makeSession({ id: 'root', slug: 'root', childIds: ['c1', 'c2'] }),
+        makeSession({ id: 'c1', slug: 'c1', parentId: 'root' }),
+        makeSession({ id: 'c2', slug: 'c2', parentId: 'root' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      const collected = new Set<string>()
+      collectChildren(sessions[0], index, collected)
+      expect([...collected].sort()).toEqual(['c1', 'c2'])
+    })
+
+    it('recurses through deep trees', () => {
+      const sessions = [
+        makeSession({ id: 'root', slug: 'root', childIds: ['mid'] }),
+        makeSession({ id: 'mid', slug: 'mid', parentId: 'root', childIds: ['leaf'] }),
+        makeSession({ id: 'leaf', slug: 'leaf', parentId: 'mid' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      const collected = new Set<string>()
+      collectChildren(sessions[0], index, collected)
+      expect([...collected].sort()).toEqual(['leaf', 'mid'])
+    })
+
+    it('skips already-collected ids to avoid cycles', () => {
+      const a = makeSession({ id: 'a', slug: 'a', childIds: ['b'] })
+      const b = makeSession({ id: 'b', slug: 'b', parentId: 'a', childIds: ['a'] })
+      const index = buildSessionIndex([a, b])
+      const collected = new Set<string>()
+      collectChildren(a, index, collected)
+      expect([...collected].sort()).toEqual(['a', 'b'].filter((id) => collected.has(id)))
+      expect(collected.has('b')).toBe(true)
+    })
+
+    it('tolerates missing child entries', () => {
+      const root = makeSession({ id: 'root', slug: 'root', childIds: ['missing'] })
+      const index = buildSessionIndex([root])
+      const collected = new Set<string>()
+      collectChildren(root, index, collected)
+      expect(collected.has('missing')).toBe(true)
+    })
+  })
+
+  describe('collectDescendants', () => {
+    it('returns a new set of all descendants', () => {
+      const sessions = [
+        makeSession({ id: 'root', slug: 'root', childIds: ['mid'] }),
+        makeSession({ id: 'mid', slug: 'mid', parentId: 'root', childIds: ['leaf'] }),
+        makeSession({ id: 'leaf', slug: 'leaf', parentId: 'mid' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      const descendants = collectDescendants(sessions[0], index)
+      expect([...descendants].sort()).toEqual(['leaf', 'mid'])
+    })
+
+    it('returns empty set for leaf sessions', () => {
+      const leaf = makeSession({ id: 'leaf', slug: 'leaf' })
+      const index = buildSessionIndex([leaf])
+      expect(collectDescendants(leaf, index).size).toBe(0)
+    })
+  })
+
+  describe('findTreeRoot', () => {
+    it('walks up to the topmost ancestor', () => {
+      const sessions = [
+        makeSession({ id: 'root', slug: 'root', childIds: ['mid'] }),
+        makeSession({ id: 'mid', slug: 'mid', parentId: 'root', childIds: ['leaf'] }),
+        makeSession({ id: 'leaf', slug: 'leaf', parentId: 'mid' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      expect(findTreeRoot(sessions[2], index).id).toBe('root')
+    })
+
+    it('returns the session itself when it has no parent', () => {
+      const orphan = makeSession({ id: 'orphan', slug: 'orphan' })
+      const index = buildSessionIndex([orphan])
+      expect(findTreeRoot(orphan, index).id).toBe('orphan')
+    })
+
+    it('stops walking when parent is excluded', () => {
+      const sessions = [
+        makeSession({ id: 'grand', slug: 'grand', childIds: ['parent'] }),
+        makeSession({ id: 'parent', slug: 'parent', parentId: 'grand', childIds: ['child'] }),
+        makeSession({ id: 'child', slug: 'child', parentId: 'parent' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      const excluded = new Set<string>(['grand'])
+      expect(findTreeRoot(sessions[2], index, excluded).id).toBe('parent')
+    })
+
+    it('stops walking when parent is missing from the index', () => {
+      const orphan = makeSession({ id: 'orphan', slug: 'orphan', parentId: 'missing' })
+      const index = buildSessionIndex([orphan])
+      expect(findTreeRoot(orphan, index).id).toBe('orphan')
+    })
+  })
+
+  describe('classifySessions', () => {
+    it('returns empty buckets for empty input', () => {
+      const result = classifySessions([], [])
+      expect(result.dagOwned.size).toBe(0)
+      expect(result.parentChildRoots).toEqual([])
+      expect(result.parentChildMembers.size).toBe(0)
+      expect(result.standalone).toEqual([])
+      expect(result.sessionById.size).toBe(0)
+    })
+
+    it('puts solo sessions in the standalone bucket', () => {
+      const sessions = [
+        makeSession({ id: 's1', slug: 'one' }),
+        makeSession({ id: 's2', slug: 'two' }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.standalone).toHaveLength(2)
+      expect(result.parentChildRoots).toHaveLength(0)
+    })
+
+    it('identifies parent sessions with children as parent-child roots', () => {
+      const sessions = [
+        makeSession({ id: 'p', slug: 'parent', childIds: ['c1', 'c2'] }),
+        makeSession({ id: 'c1', slug: 'c1', parentId: 'p' }),
+        makeSession({ id: 'c2', slug: 'c2', parentId: 'p' }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.parentChildRoots.map((s) => s.id)).toEqual(['p'])
+      expect(result.parentChildMembers.has('p')).toBe(true)
+      expect(result.parentChildMembers.has('c1')).toBe(true)
+      expect(result.parentChildMembers.has('c2')).toBe(true)
+      expect(result.standalone).toHaveLength(0)
+    })
+
+    it('auto-discovers a root from an orphaned child that arrives before its parent', () => {
+      const sessions = [
+        makeSession({ id: 'orphan-child', slug: 'child', parentId: 'parent' }),
+        makeSession({ id: 'parent', slug: 'parent', childIds: ['orphan-child'] }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.parentChildRoots.map((s) => s.id)).toEqual(['parent'])
+      expect(result.parentChildMembers.has('orphan-child')).toBe(true)
+      expect(result.standalone).toHaveLength(0)
+    })
+
+    it('marks DAG-owned sessions and excludes them from other buckets', () => {
+      const dagSession = makeSession({ id: 'dag-session', slug: 'dag-owned' })
+      const standalone = makeSession({ id: 'solo', slug: 'solo' })
+      const dag = makeDag({
+        id: 'dag-1',
+        nodes: {
+          n1: {
+            id: 'n1',
+            slug: 'node',
+            status: 'running',
+            dependencies: [],
+            dependents: [],
+            session: dagSession,
+          },
+        },
+      })
+
+      const result = classifySessions([dagSession, standalone], [dag])
+      expect(result.dagOwned.has('dag-session')).toBe(true)
+      expect(result.parentChildRoots).toHaveLength(0)
+      expect(result.standalone.map((s) => s.id)).toEqual(['solo'])
+    })
+
+    it('does not promote a DAG-owned parent into a parent-child root', () => {
+      const dagParent = makeSession({ id: 'dp', slug: 'dag-parent', childIds: ['child'] })
+      const child = makeSession({ id: 'child', slug: 'child', parentId: 'dp' })
+      const dag = makeDag({
+        id: 'dag-1',
+        nodes: {
+          n1: {
+            id: 'n1',
+            slug: 'node',
+            status: 'running',
+            dependencies: [],
+            dependents: [],
+            session: dagParent,
+          },
+        },
+      })
+      const result = classifySessions([dagParent, child], [dag])
+      expect(result.parentChildRoots).toHaveLength(0)
+      expect(result.standalone.map((s) => s.id)).toEqual(['child'])
+    })
+
+    it('handles deep trees by placing only the root in parentChildRoots', () => {
+      const sessions = [
+        makeSession({ id: 'root', slug: 'root', childIds: ['mid'] }),
+        makeSession({ id: 'mid', slug: 'mid', parentId: 'root', childIds: ['leaf'] }),
+        makeSession({ id: 'leaf', slug: 'leaf', parentId: 'mid' }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.parentChildRoots.map((s) => s.id)).toEqual(['root'])
+      expect(result.parentChildMembers.size).toBe(3)
+      expect(result.standalone).toHaveLength(0)
+    })
+
+    it('exposes a ready-built session index', () => {
+      const sessions = [makeSession({ id: 'a', slug: 'alpha' })]
+      const result = classifySessions(sessions, [])
+      expect(result.sessionById.get('a')?.slug).toBe('alpha')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Rewrites the session list as three collapsible groups — **DAGs**, **Trees**, **Solo** — fed from the shared `classifySessions` hierarchy module.
- DAG-owned sessions now render with the full 8-value status palette (`pending`, `running`, `completed`, `failed`, `skipped`, `ci-pending`, `ci-failed`, `landed`). Non-DAG sessions keep their 4-value session status.
- Parent-child trees are flattened recursively with a depth-based left indent and a vertical rail, so nested minions are easy to scan.
- Each DAG subheader shows `n/total landed` plus compact running/failed chips.
- Mobile swaps the horizontal strip for a `max-h-[45vh]` vertical list that uses the same grouped layout as desktop.

## Why

Part of the "improve ships, DAGs, stacks, parent-child minions" effort. The old flat, status-dot-only list hid the relationships between sessions and collapsed all DAG-node statuses down to session-level (`running`/`completed`), so ship pipelines looked the same as unrelated tasks.

## Scope notes

This PR is scoped to the list view. It does **not** touch chat header context, attention triage strips, canvas mounting, ContextMenu actions, or the Kanban ship view — all handled by sibling minions per the plan.

## Test plan

- [x] Unit: `test/components/SessionList.test.tsx` — 18 cases covering empty state, standalone-only, tree nesting with depth attributes, DAG subheader (`1/2 landed`), DAG status override (`landed`), mixed buckets, collapse/expand, and `onSelect` wiring.
- [x] `npx vitest run` — 27 files / 265 tests pass.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint src/ test/` — clean.
- [ ] E2E not run in this workspace (expensive); existing `session-item-${id}` test-ids are preserved, so `e2e/tests/task-lifecycle.spec.ts` assertions should continue to work.

## Assumptions

- DAG nodes without an attached `session` are counted in `total`/`landed` but not rendered as rows (matches how the universe canvas already ignores detached node placeholders in this list context).
- Orientation is no longer a semantic distinction for the list; the mobile wrapper just bounds the height. If any downstream minion still needs the old horizontal strip, it can opt in at the call site.

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  extract-hierarchy["✅ Extract classifySessions to shared state module"]
  chat-header-context["✅ Add parent/children/DAG/branch context to chat header"]
  attention-triage-bar["✅ Add action bar for sessions needing attention"]
  enhance-node-popup["✅ Add hierarchy metadata to NodeDetailPopup"]
  group-session-list["✅ Group SessionList by DAG/Tree/Standalone with nesting"]
  mount-canvas-tab["✅ Mount UniverseCanvas as second tab with view toggle"]
  fix-rendering-edges["✅ Fix edge-case rendering (status, animation, orphans)"]
  ship-mode-grouping["✅ Add fourth classification bucket for ship mode"]
  ship-pipeline-kanban["✅ Create Kanban view for ship pipelines"]
  enhance-context-menu["✅ Add navigation actions to ContextMenu"]
  polish-ui-details["✅ Polish: badges, chips, keyboard nav, DAG summaries"]
  extract-hierarchy --> group-session-list
  extract-hierarchy --> mount-canvas-tab
  extract-hierarchy --> fix-rendering-edges
  extract-hierarchy --> ship-mode-grouping
  mount-canvas-tab --> ship-pipeline-kanban
  mount-canvas-tab --> enhance-context-menu
  group-session-list --> polish-ui-details
  mount-canvas-tab --> polish-ui-details
  class extract-hierarchy done
  class chat-header-context done
  class attention-triage-bar done
  class enhance-node-popup done
  class group-session-list done
  class group-session-list current
  class mount-canvas-tab done
  class fix-rendering-edges done
  class ship-mode-grouping done
  class ship-pipeline-kanban done
  class enhance-context-menu done
  class polish-ui-details done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | Extract classifySessions to shared state module | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/11) |
| 2 | Add parent/children/DAG/branch context to chat header | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/12) |
| 3 | Add action bar for sessions needing attention | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/13) |
| 4 | Add hierarchy metadata to NodeDetailPopup | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/19) |
| 5 | **Group SessionList by DAG/Tree/Standalone with nesting** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/14) |
| 6 | Mount UniverseCanvas as second tab with view toggle | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/20) |
| 7 | Fix edge-case rendering (status, animation, orphans) | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/17) |
| 8 | Add fourth classification bucket for ship mode | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/18) |
| 9 | Create Kanban view for ship pipelines | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/21) |
| 10 | Add navigation actions to ContextMenu | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/22) |
| 11 | Polish: badges, chips, keyboard nav, DAG summaries | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/24) |

**Progress:** 11/11 complete

<!-- dag-status-end -->








