### PR TITLE
[minions] feat(ui): parent/child/DAG context in node detail popup

### DIFF
--- a/src/components/NodeDetailPopup.tsx
+++ b/src/components/NodeDetailPopup.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useRef } from 'preact/hooks'
-import type { ApiSession } from '../api/types'
+import { useEffect, useMemo, useRef } from 'preact/hooks'
+import type { ApiDagGraph, ApiDagNode, ApiSession } from '../api/types'
 import { useTheme } from '../hooks/useTheme'
 import { StatusBadge, AttentionBadge, formatRelativeTime } from './shared'
 import { PrLink } from './PrLink'
 
 interface NodeDetailPopupProps {
   session: ApiSession
+  sessions?: ApiSession[]
+  dags?: ApiDagGraph[]
   onClose: () => void
   onOpenChat?: (sessionId: string) => void
+  onNavigate?: (sessionId: string) => void
 }
 
 function MetaRow({ label, children, isDark }: { label: string; children: preact.ComponentChildren; isDark: boolean }) {
@@ -23,7 +26,38 @@ function MetaRow({ label, children, isDark }: { label: string; children: preact.
   )
 }
 
-export function NodeDetailPopup({ session, onClose, onOpenChat }: NodeDetailPopupProps) {
+interface SessionLinkProps {
+  id: string
+  label: string
+  onNavigate?: (sessionId: string) => void
+  isDark: boolean
+}
+
+function SessionLink({ id, label, onNavigate, isDark }: SessionLinkProps) {
+  if (!onNavigate) {
+    return <span class="font-mono text-[11px] truncate">{label}</span>
+  }
+  const linkColor = isDark ? 'text-indigo-300 hover:text-indigo-200' : 'text-indigo-600 hover:text-indigo-700'
+  return (
+    <button
+      type="button"
+      onClick={() => onNavigate(id)}
+      class={`font-mono text-[11px] truncate underline ${linkColor}`}
+      data-testid={`node-detail-link-${id}`}
+    >
+      {label}
+    </button>
+  )
+}
+
+export function NodeDetailPopup({
+  session,
+  sessions,
+  dags,
+  onClose,
+  onOpenChat,
+  onNavigate,
+}: NodeDetailPopupProps) {
   const theme = useTheme()
   const isDark = theme.value === 'dark'
   const popupRef = useRef<HTMLDivElement>(null)
@@ -35,6 +69,29 @@ export function NodeDetailPopup({ session, onClose, onOpenChat }: NodeDetailPopu
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [onClose])
+
+  const sessionById = useMemo(() => {
+    const map = new Map<string, ApiSession>()
+    for (const s of sessions ?? []) map.set(s.id, s)
+    return map
+  }, [sessions])
+
+  const parent = session.parentId ? sessionById.get(session.parentId) ?? null : null
+  const children: Array<{ id: string; session: ApiSession | null }> = useMemo(
+    () => session.childIds.map((id) => ({ id, session: sessionById.get(id) ?? null })),
+    [session.childIds, sessionById],
+  )
+
+  const dagMembership = useMemo<{ dag: ApiDagGraph; node: ApiDagNode } | null>(() => {
+    for (const dag of dags ?? []) {
+      for (const node of Object.values(dag.nodes)) {
+        if (node.session?.id === session.id) {
+          return { dag, node }
+        }
+      }
+    }
+    return null
+  }, [dags, session.id])
 
   const overlayBg = isDark ? 'bg-black/70' : 'bg-black/50'
   const dialogBg = isDark ? 'bg-gray-800' : 'bg-white'
@@ -48,6 +105,7 @@ export function NodeDetailPopup({ session, onClose, onOpenChat }: NodeDetailPopu
     : session.command
 
   const hasChatAction = Boolean(onOpenChat)
+  const hasHierarchy = Boolean(session.parentId) || children.length > 0 || dagMembership !== null
 
   return (
     <div class="fixed inset-0 z-50 flex items-center justify-center">
@@ -122,6 +180,55 @@ export function NodeDetailPopup({ session, onClose, onOpenChat }: NodeDetailPopu
             {formatRelativeTime(session.updatedAt)}
           </MetaRow>
         </div>
+
+        {hasHierarchy && (
+          <div class={`px-4 py-3 border-b ${borderColor} flex flex-col gap-2`} data-testid="node-detail-hierarchy">
+            {parent && (
+              <MetaRow label="Parent" isDark={isDark}>
+                <SessionLink
+                  id={parent.id}
+                  label={parent.slug}
+                  onNavigate={onNavigate}
+                  isDark={isDark}
+                />
+              </MetaRow>
+            )}
+            {!parent && session.parentId && (
+              <MetaRow label="Parent" isDark={isDark}>
+                <span class="font-mono text-[11px] truncate" style={{ color: isDark ? '#9ca3af' : '#9ca3af' }}>
+                  {session.parentId}
+                </span>
+              </MetaRow>
+            )}
+            {children.length > 0 && (
+              <MetaRow label={children.length === 1 ? 'Child' : `Children (${children.length})`} isDark={isDark}>
+                <div class="flex flex-col gap-1">
+                  {children.map((child) => (
+                    <SessionLink
+                      key={child.id}
+                      id={child.id}
+                      label={child.session?.slug ?? child.id}
+                      onNavigate={child.session ? onNavigate : undefined}
+                      isDark={isDark}
+                    />
+                  ))}
+                </div>
+              </MetaRow>
+            )}
+            {dagMembership && (
+              <>
+                <MetaRow label="DAG" isDark={isDark}>
+                  <span class="font-mono text-[11px] truncate block">{dagMembership.dag.id}</span>
+                </MetaRow>
+                <MetaRow label="DAG node" isDark={isDark}>
+                  <div class="flex items-center gap-2 min-w-0">
+                    <StatusBadge status={dagMembership.node.status} />
+                  </div>
+                </MetaRow>
+              </>
+            )}
+          </div>
+        )}
 
         <div class="px-4 py-3 flex gap-2">
           {hasChatAction && (

--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -327,8 +327,14 @@ export function UniverseCanvas({
       {detailSession && (
         <NodeDetailPopup
           session={detailSession}
+          sessions={sessions}
+          dags={dags}
           onClose={() => setDetailSession(null)}
           onOpenChat={onOpenChat}
+          onNavigate={(sid) => {
+            const next = sessions.find((s) => s.id === sid)
+            if (next) setDetailSession(next)
+          }}
         />
       )}
     </div>

--- a/test/chat/NewTaskBar.test.tsx
+++ b/test/chat/NewTaskBar.test.tsx
@@ -3,7 +3,7 @@ import { signal } from '@preact/signals'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NewTaskBar } from '../../src/chat/NewTaskBar'
 import { getVariantGroup, resetVariantGroupsForTests } from '../../src/groups/store'
-import type { ConnectionStore } from '../../src/state/types'
+import type { ConnectionStore, DiffStats } from '../../src/state/types'
 import type {
   ApiDagGraph,
   ApiSession,
@@ -78,6 +78,8 @@ function makeStore(opts: {
     error: signal<string | null>(null),
     version: signal<VersionInfo | null>(version),
     stale: signal(false),
+    diffStatsBySessionId: signal<Map<string, DiffStats>>(new Map()),
+    loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi.fn(async () => ({ success: true })),
     dispose: vi.fn(),

--- a/test/components/NodeDetailPopup.test.tsx
+++ b/test/components/NodeDetailPopup.test.tsx
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/preact'
+import { NodeDetailPopup } from '../../src/components/NodeDetailPopup'
+import type { ApiDagGraph, ApiSession } from '../../src/api/types'
+
+function createSession(overrides: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 'session-1',
+    slug: 'bold-meadow',
+    status: 'running',
+    command: '/task Add feature',
+    repo: 'https://github.com/org/repo',
+    branch: 'feature-branch',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...overrides,
+  }
+}
+
+function createDag(overrides: Partial<ApiDagGraph> = {}): ApiDagGraph {
+  return {
+    id: 'dag-1',
+    rootTaskId: 'node-1',
+    nodes: {},
+    status: 'running',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('NodeDetailPopup hierarchy', () => {
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('renders without hierarchy section when session has no parent/children/dag', () => {
+    const session = createSession()
+    render(<NodeDetailPopup session={session} onClose={vi.fn()} />)
+    expect(document.querySelector('[data-testid="node-detail-hierarchy"]')).toBeNull()
+  })
+
+  it('renders parent as a linkified chip when parent session is present', () => {
+    const parent = createSession({ id: 'parent-1', slug: 'parent-task', childIds: ['child-1'] })
+    const child = createSession({ id: 'child-1', slug: 'child-task', parentId: 'parent-1' })
+    const onNavigate = vi.fn()
+    render(
+      <NodeDetailPopup
+        session={child}
+        sessions={[parent, child]}
+        onClose={vi.fn()}
+        onNavigate={onNavigate}
+      />,
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')
+    expect(hierarchy).toBeTruthy()
+    expect(hierarchy?.textContent).toContain('Parent')
+    const link = document.querySelector('[data-testid="node-detail-link-parent-1"]') as HTMLButtonElement
+    expect(link).toBeTruthy()
+    expect(link.textContent).toBe('parent-task')
+    fireEvent.click(link)
+    expect(onNavigate).toHaveBeenCalledWith('parent-1')
+  })
+
+  it('shows parent id as plain text when parent session is missing from sessions list', () => {
+    const child = createSession({ id: 'child-1', slug: 'child-task', parentId: 'missing-parent' })
+    render(
+      <NodeDetailPopup
+        session={child}
+        sessions={[child]}
+        onClose={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    )
+    expect(document.body.innerHTML).toContain('missing-parent')
+    expect(document.querySelector('[data-testid="node-detail-link-missing-parent"]')).toBeNull()
+  })
+
+  it('renders children as linkified chips and pluralizes label', () => {
+    const parent = createSession({
+      id: 'parent-1',
+      slug: 'parent-task',
+      childIds: ['child-1', 'child-2'],
+    })
+    const child1 = createSession({ id: 'child-1', slug: 'child-one', parentId: 'parent-1' })
+    const child2 = createSession({ id: 'child-2', slug: 'child-two', parentId: 'parent-1' })
+    const onNavigate = vi.fn()
+    render(
+      <NodeDetailPopup
+        session={parent}
+        sessions={[parent, child1, child2]}
+        onClose={vi.fn()}
+        onNavigate={onNavigate}
+      />,
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')
+    expect(hierarchy?.textContent).toContain('Children (2)')
+    const link1 = document.querySelector('[data-testid="node-detail-link-child-1"]') as HTMLButtonElement
+    const link2 = document.querySelector('[data-testid="node-detail-link-child-2"]') as HTMLButtonElement
+    expect(link1.textContent).toBe('child-one')
+    expect(link2.textContent).toBe('child-two')
+    fireEvent.click(link2)
+    expect(onNavigate).toHaveBeenCalledWith('child-2')
+  })
+
+  it('renders singular Child label when only one child exists', () => {
+    const parent = createSession({ id: 'parent-1', slug: 'parent-task', childIds: ['child-1'] })
+    const child = createSession({ id: 'child-1', slug: 'child-task', parentId: 'parent-1' })
+    render(
+      <NodeDetailPopup
+        session={parent}
+        sessions={[parent, child]}
+        onClose={vi.fn()}
+      />,
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')
+    expect(hierarchy?.textContent).toContain('Child')
+    expect(hierarchy?.textContent).not.toContain('Children (')
+  })
+
+  it('renders missing child id as non-linkified text', () => {
+    const parent = createSession({
+      id: 'parent-1',
+      slug: 'parent-task',
+      childIds: ['missing-child'],
+    })
+    render(
+      <NodeDetailPopup
+        session={parent}
+        sessions={[parent]}
+        onClose={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    )
+    expect(document.body.innerHTML).toContain('missing-child')
+    expect(document.querySelector('[data-testid="node-detail-link-missing-child"]')).toBeNull()
+  })
+
+  it('renders DAG id and node status when session belongs to a DAG', () => {
+    const session = createSession({ id: 'dag-session-1', slug: 'dag-root' })
+    const dag = createDag({
+      id: 'my-dag-id',
+      nodes: {
+        'node-1': {
+          id: 'node-1',
+          slug: 'dag-root',
+          status: 'completed',
+          dependencies: [],
+          dependents: [],
+          session,
+        },
+      },
+    })
+    render(
+      <NodeDetailPopup
+        session={session}
+        sessions={[session]}
+        dags={[dag]}
+        onClose={vi.fn()}
+      />,
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')
+    expect(hierarchy?.textContent).toContain('my-dag-id')
+    expect(hierarchy?.textContent).toContain('DAG node')
+    expect(hierarchy?.textContent).toContain('Done')
+  })
+
+  it('does not render DAG section when session is not part of any DAG', () => {
+    const session = createSession()
+    const otherSession = createSession({ id: 'other' })
+    const dag = createDag({
+      id: 'unrelated-dag',
+      nodes: {
+        'node-1': {
+          id: 'node-1',
+          slug: 'unrelated',
+          status: 'running',
+          dependencies: [],
+          dependents: [],
+          session: otherSession,
+        },
+      },
+    })
+    render(
+      <NodeDetailPopup
+        session={session}
+        sessions={[session, otherSession]}
+        dags={[dag]}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(document.querySelector('[data-testid="node-detail-hierarchy"]')).toBeNull()
+    expect(document.body.innerHTML).not.toContain('unrelated-dag')
+  })
+
+  it('renders DAG-specific status distinct from session status (landed)', () => {
+    const session = createSession({ id: 'dag-session-1', slug: 'dag-tail', status: 'completed' })
+    const dag = createDag({
+      id: 'ship-dag',
+      nodes: {
+        'node-1': {
+          id: 'node-1',
+          slug: 'dag-tail',
+          status: 'landed',
+          dependencies: [],
+          dependents: [],
+          session,
+        },
+      },
+    })
+    render(
+      <NodeDetailPopup
+        session={session}
+        sessions={[session]}
+        dags={[dag]}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(document.body.innerHTML).toContain('Landed')
+  })
+
+  it('renders children without navigation links when onNavigate is omitted', () => {
+    const parent = createSession({ id: 'parent-1', slug: 'parent-task', childIds: ['child-1'] })
+    const child = createSession({ id: 'child-1', slug: 'child-task', parentId: 'parent-1' })
+    render(
+      <NodeDetailPopup
+        session={parent}
+        sessions={[parent, child]}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(document.body.innerHTML).toContain('child-task')
+    expect(document.querySelector('[data-testid="node-detail-link-child-1"]')).toBeNull()
+  })
+
+  it('closes on Escape key', () => {
+    const onClose = vi.fn()
+    const session = createSession()
+    render(<NodeDetailPopup session={session} onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/test/components/WorktreeHeader.test.tsx
+++ b/test/components/WorktreeHeader.test.tsx
@@ -37,6 +37,7 @@ function makeStore(opts: {
   })
   const diffStatsBySessionId = signal<Map<string, DiffStats>>(opts.initialStats ?? new Map())
   return {
+    connectionId: 'test-conn',
     client: {} as ConnectionStore['client'],
     sessions: signal([]),
     dags: signal([]),

--- a/test/groups/VariantGroupView.test.tsx
+++ b/test/groups/VariantGroupView.test.tsx
@@ -8,7 +8,7 @@ import {
   resetVariantGroupsForTests,
 } from '../../src/groups/store'
 import { ConfirmRoot } from '../../src/hooks/useConfirm'
-import type { ConnectionStore } from '../../src/state/types'
+import type { ConnectionStore, DiffStats } from '../../src/state/types'
 import type {
   ApiDagGraph,
   ApiSession,
@@ -55,6 +55,8 @@ function makeStore(opts: {
     error: signal<string | null>(null),
     version: signal<VersionInfo | null>(version),
     stale: signal(false),
+    diffStatsBySessionId: signal<Map<string, DiffStats>>(new Map()),
+    loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi
       .fn<(cmd: MinionCommand) => Promise<CommandResult>>()


### PR DESCRIPTION
## Summary
- Extends `NodeDetailPopup` with a hierarchy section that shows the session's parent, children (pluralized), DAG id, and DAG-specific node status.
- Parent/child entries are linkified — clicking swaps the popup to the related session, so users can walk up/down a tree or DAG without closing the dialog.
- `UniverseCanvas` now threads `sessions` and `dags` into the popup and wires the navigation handler.

## Why
Ships, DAGs, stacks, and parent/child minions are first-class concepts in the universe view, but the detail popup previously hid all of that context — users had to trust the canvas layout alone to reason about relationships. Surfacing it in the popup makes the hierarchy inspectable from any entry point (canvas click, future list clicks, etc.) and gives a navigable way to hop between relatives.

## Test plan
- [x] `npx vitest run test/components/NodeDetailPopup.test.tsx` — 11 new tests covering parent/child linkification, plural/singular labels, missing-session fallbacks, DAG membership rendering, and `landed` status carry-through.
- [x] `npx vitest run` — full unit suite (393 tests) passes.
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint` on touched files clean.
- [ ] Not run here: e2e, manual browser verification (noted per task instructions).