### PR TITLE
[minions] feat(universe): icon-stack attention, edge animation, cross-group edges

### DIFF
--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -15,7 +15,7 @@ import '@reactflow/core/dist/base.css'
 import '@reactflow/controls/dist/style.css'
 import '@reactflow/minimap/dist/style.css'
 import type { ApiSession, ApiDagGraph } from '../api/types'
-import { StatusBadge, AttentionBadge, getStatusColors, getAttentionBorder, formatRelativeTime } from './shared'
+import { StatusBadge, AttentionIconStack, getStatusColors, getAttentionBorder, formatRelativeTime } from './shared'
 import { PrLink } from './PrLink'
 import { ContextMenu, useLongPress, useContextMenu } from './ContextMenu'
 import type { ContextMenuActions } from './ContextMenu'
@@ -116,7 +116,7 @@ function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
         <div class="flex items-center gap-2 mt-1">
           <StatusBadge status={status} />
           {session?.needsAttention && session.attentionReasons.length > 0 && (
-            <AttentionBadge reason={session.attentionReasons[0]} darkMode={isDark} />
+            <AttentionIconStack reasons={session.attentionReasons} darkMode={isDark} />
           )}
         </div>
 

--- a/src/components/shared.tsx
+++ b/src/components/shared.tsx
@@ -121,6 +121,34 @@ export function AttentionBadge({ reason, darkMode }: AttentionBadgeProps) {
   )
 }
 
+interface AttentionIconStackProps {
+  reasons: AttentionReason[]
+  darkMode: boolean
+}
+
+export function AttentionIconStack({ reasons, darkMode }: AttentionIconStackProps) {
+  if (reasons.length === 0) return null
+  return (
+    <div class="inline-flex items-center gap-0.5" data-testid="attention-icon-stack">
+      {reasons.map((reason) => {
+        const config = ATTENTION_CONFIG[reason] ?? ATTENTION_CONFIG.idle_long
+        const className = darkMode ? config.darkClassName : config.className
+        return (
+          <span
+            key={reason}
+            title={config.label}
+            aria-label={config.label}
+            data-attention-reason={reason}
+            class={`inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full text-xs ${className}`}
+          >
+            {config.emoji}
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
 type DagNodeStatus = ApiDagNode['status']
 
 export function getStatusColors(isDark: boolean): Record<DagNodeStatus, { bg: string; border: string; text: string }> {

--- a/src/components/universe-layout.ts
+++ b/src/components/universe-layout.ts
@@ -49,12 +49,14 @@ function layoutDagGroup(dag: ApiDagGraph, isDark: boolean): LayoutGroup {
   for (const node of dagNodes) {
     for (const depId of node.dependencies) {
       g.setEdge(depId, node.id)
+      const depNode = dag.nodes[depId]
+      const animated = node.status === 'running' || depNode?.status === 'running'
       edges.push({
         id: `dag-${dag.id}-${depId}-${node.id}`,
         source: depId,
         target: node.id,
         type: 'smoothstep',
-        animated: node.status === 'running',
+        animated,
         markerEnd: {
           type: MarkerType.ArrowClosed,
           color: isDark ? '#9ca3af' : '#6b7280',
@@ -119,13 +121,14 @@ function layoutParentChildGroup(
 
       const isCiFix = child.mode === 'ci-fix'
       const relationship: EdgeRelationship = isCiFix ? 'ci-fix' : 'parent-child'
+      const animated = child.status === 'running' || session.status === 'running'
 
       edges.push({
         id: `pc-${session.id}-${childId}`,
         source: session.id,
         target: childId,
         type: 'smoothstep',
-        animated: child.status === 'running',
+        animated,
         style: {
           stroke: isCiFix ? '#f97316' : (isDark ? '#60a5fa' : '#3b82f6'),
           strokeDasharray: isCiFix ? '4 4' : '6 3',
@@ -237,6 +240,57 @@ function positionGroups(groups: LayoutGroup[]): { nodes: Node[]; edges: Edge[] }
   return { nodes: allNodes, edges: allEdges }
 }
 
+function buildDagNodeIndexBySessionId(dags: ApiDagGraph[]): Map<string, ApiDagNode> {
+  const map = new Map<string, ApiDagNode>()
+  for (const dag of dags) {
+    for (const node of Object.values(dag.nodes)) {
+      if (node.session) map.set(node.session.id, node)
+    }
+  }
+  return map
+}
+
+function buildCrossGroupEdges(
+  standalone: ApiSession[],
+  dagNodeBySessionId: Map<string, ApiDagNode>,
+  isDark: boolean,
+): Edge[] {
+  const edges: Edge[] = []
+  for (const child of standalone) {
+    if (!child.parentId) continue
+    const parentDagNode = dagNodeBySessionId.get(child.parentId)
+    if (!parentDagNode) continue
+
+    const isCiFix = child.mode === 'ci-fix'
+    const relationship: EdgeRelationship = isCiFix ? 'ci-fix' : 'parent-child'
+    const parentRunning = parentDagNode.status === 'running'
+    const parentCiPending = parentDagNode.status === 'ci-pending'
+    const childRunning = child.status === 'running'
+    const animated = childRunning || parentRunning || (isCiFix && parentCiPending)
+
+    const color = isCiFix ? '#f97316' : (isDark ? '#a78bfa' : '#7c3aed')
+
+    edges.push({
+      id: `cross-${parentDagNode.id}-${child.id}`,
+      source: parentDagNode.id,
+      target: child.id,
+      type: 'smoothstep',
+      animated,
+      style: {
+        stroke: color,
+        strokeDasharray: isCiFix ? '4 4' : '2 3',
+        opacity: 0.7,
+      },
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color,
+      },
+      data: { relationship },
+    })
+  }
+  return edges
+}
+
 export function layoutUniverse(
   sessions: ApiSession[],
   dags: ApiDagGraph[],
@@ -265,5 +319,10 @@ export function layoutUniverse(
     groups.push(standaloneGroup)
   }
 
-  return positionGroups(groups)
+  const positioned = positionGroups(groups)
+
+  const dagNodeBySessionId = buildDagNodeIndexBySessionId(dags)
+  const crossGroupEdges = buildCrossGroupEdges(standalone, dagNodeBySessionId, isDark)
+
+  return { nodes: positioned.nodes, edges: [...positioned.edges, ...crossGroupEdges] }
 }

--- a/test/components/UniverseCanvas.test.tsx
+++ b/test/components/UniverseCanvas.test.tsx
@@ -214,6 +214,25 @@ describe('UniverseCanvas', () => {
     expect(document.body.innerHTML).toContain('Waiting for reply')
   })
 
+  it('renders all attention reasons as an icon stack', () => {
+    const sessions = [
+      createSession({
+        id: 's1',
+        slug: 'stacked',
+        needsAttention: true,
+        attentionReasons: ['failed', 'waiting_for_feedback', 'idle_long'],
+      }),
+    ]
+    render(<UniverseCanvas {...defaultProps} sessions={sessions} />)
+    const stack = document.querySelector('[data-testid="attention-icon-stack"]')
+    expect(stack).toBeTruthy()
+    const icons = stack!.querySelectorAll('[data-attention-reason]')
+    expect(icons).toHaveLength(3)
+    expect(icons[0].getAttribute('data-attention-reason')).toBe('failed')
+    expect(icons[1].getAttribute('data-attention-reason')).toBe('waiting_for_feedback')
+    expect(icons[2].getAttribute('data-attention-reason')).toBe('idle_long')
+  })
+
   it('renders PR links on nodes with PRs', () => {
     const sessions = [
       createSession({

--- a/test/components/shared.test.tsx
+++ b/test/components/shared.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, cleanup } from '@testing-library/preact'
 import {
   StatusBadge,
   AttentionBadge,
+  AttentionIconStack,
   getStatusColors,
   getAttentionBorder,
   formatRelativeTime,
@@ -105,6 +106,53 @@ describe('AttentionBadge', () => {
       render(<AttentionBadge reason={reason as keyof typeof ATTENTION_CONFIG} darkMode={false} />)
       expect(screen.getByText(config.emoji)).toBeTruthy()
     }
+  })
+})
+
+describe('AttentionIconStack', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  it('renders nothing when reasons is empty', () => {
+    const { container } = render(<AttentionIconStack reasons={[]} darkMode={false} />)
+    expect(container.querySelector('[data-testid="attention-icon-stack"]')).toBeNull()
+  })
+
+  it('renders a single icon for a single reason', () => {
+    render(<AttentionIconStack reasons={['failed']} darkMode={false} />)
+    const stack = document.querySelector('[data-testid="attention-icon-stack"]')
+    expect(stack).toBeTruthy()
+    const icons = stack!.querySelectorAll('[data-attention-reason]')
+    expect(icons).toHaveLength(1)
+    expect(icons[0].getAttribute('data-attention-reason')).toBe('failed')
+  })
+
+  it('renders all reasons as separate icons in order', () => {
+    render(
+      <AttentionIconStack
+        reasons={['failed', 'waiting_for_feedback', 'ci_fix']}
+        darkMode={false}
+      />
+    )
+    const icons = document.querySelectorAll('[data-attention-reason]')
+    expect(icons).toHaveLength(3)
+    expect(icons[0].getAttribute('data-attention-reason')).toBe('failed')
+    expect(icons[1].getAttribute('data-attention-reason')).toBe('waiting_for_feedback')
+    expect(icons[2].getAttribute('data-attention-reason')).toBe('ci_fix')
+  })
+
+  it('sets title attribute to the full reason label for accessibility', () => {
+    render(<AttentionIconStack reasons={['waiting_for_feedback']} darkMode={false} />)
+    const icon = document.querySelector('[data-attention-reason="waiting_for_feedback"]')
+    expect(icon?.getAttribute('title')).toBe('Waiting for reply')
+    expect(icon?.getAttribute('aria-label')).toBe('Waiting for reply')
+  })
+
+  it('uses dark-mode classes when darkMode is true', () => {
+    render(<AttentionIconStack reasons={['failed']} darkMode={true} />)
+    const icon = document.querySelector('[data-attention-reason="failed"]')!
+    expect(icon.className).toContain('bg-red-900/50')
   })
 })
 

--- a/test/components/universe-layout.test.ts
+++ b/test/components/universe-layout.test.ts
@@ -417,4 +417,229 @@ describe('universe-layout', () => {
     expect(pcNodes).toHaveLength(2)
     expect(result.edges).toHaveLength(1)
   })
+
+  it('animates DAG edges when the source (dependency) is running', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const dag = makeDag({
+      id: 'dag-1',
+      nodes: {
+        n1: {
+          id: 'n1',
+          slug: 'first',
+          status: 'running',
+          dependencies: [],
+          dependents: ['n2'],
+        },
+        n2: {
+          id: 'n2',
+          slug: 'second',
+          status: 'pending',
+          dependencies: ['n1'],
+          dependents: [],
+        },
+      },
+    })
+
+    const result = layoutUniverse([], [dag], false)
+    const edge = result.edges.find((e) => e.source === 'n1' && e.target === 'n2')
+    expect(edge?.animated).toBe(true)
+  })
+
+  it('does not animate DAG edges when neither end is running', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const dag = makeDag({
+      id: 'dag-1',
+      nodes: {
+        n1: {
+          id: 'n1',
+          slug: 'first',
+          status: 'completed',
+          dependencies: [],
+          dependents: ['n2'],
+        },
+        n2: {
+          id: 'n2',
+          slug: 'second',
+          status: 'pending',
+          dependencies: ['n1'],
+          dependents: [],
+        },
+      },
+    })
+
+    const result = layoutUniverse([], [dag], false)
+    const edge = result.edges.find((e) => e.source === 'n1' && e.target === 'n2')
+    expect(edge?.animated).toBe(false)
+  })
+
+  it('animates parent-child edges when the parent is running', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const sessions = [
+      makeSession({ id: 'p', slug: 'parent', childIds: ['c'], status: 'running' }),
+      makeSession({ id: 'c', slug: 'child', parentId: 'p', status: 'completed' }),
+    ]
+
+    const result = layoutUniverse(sessions, [], false)
+    expect(result.edges[0].animated).toBe(true)
+  })
+
+  it('does not animate parent-child edges when both ends are idle', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const sessions = [
+      makeSession({ id: 'p', slug: 'parent', childIds: ['c'], status: 'completed' }),
+      makeSession({ id: 'c', slug: 'child', parentId: 'p', status: 'completed' }),
+    ]
+
+    const result = layoutUniverse(sessions, [], false)
+    expect(result.edges[0].animated).toBe(false)
+  })
+
+  it('draws a cross-group edge from a DAG-owned parent to a standalone child', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const dagSession = makeSession({ id: 'dag-sess', slug: 'dag-parent', childIds: ['orphan'] })
+    const orphan = makeSession({
+      id: 'orphan',
+      slug: 'orphan-child',
+      parentId: 'dag-sess',
+      status: 'running',
+    })
+    const dag = makeDag({
+      id: 'dag-1',
+      nodes: {
+        dn1: {
+          id: 'dn1',
+          slug: 'dag-node',
+          status: 'ci-pending',
+          dependencies: [],
+          dependents: [],
+          session: dagSession,
+        },
+      },
+    })
+
+    const result = layoutUniverse([dagSession, orphan], [dag], false)
+
+    const cross = result.edges.find((e) => e.target === 'orphan')
+    expect(cross).toBeDefined()
+    expect(cross?.source).toBe('dn1')
+    expect(cross?.data?.relationship).toBe('parent-child')
+    expect(cross?.animated).toBe(true)
+    expect(cross?.style?.opacity).toBe(0.7)
+  })
+
+  it('marks cross-group ci-fix edges with ci-fix styling and animates while parent is ci-pending', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const dagSession = makeSession({
+      id: 'dag-sess',
+      slug: 'dag-parent',
+      childIds: ['ci'],
+      status: 'running',
+    })
+    const ciFix = makeSession({
+      id: 'ci',
+      slug: 'ci-fix',
+      parentId: 'dag-sess',
+      mode: 'ci-fix',
+      status: 'pending',
+    })
+    const dag = makeDag({
+      id: 'dag-1',
+      nodes: {
+        dn1: {
+          id: 'dn1',
+          slug: 'dag-node',
+          status: 'ci-pending',
+          dependencies: [],
+          dependents: [],
+          session: dagSession,
+        },
+      },
+    })
+
+    const result = layoutUniverse([dagSession, ciFix], [dag], false)
+
+    const cross = result.edges.find((e) => e.target === 'ci')
+    expect(cross).toBeDefined()
+    expect(cross?.source).toBe('dn1')
+    expect(cross?.data?.relationship).toBe('ci-fix')
+    expect(cross?.style?.stroke).toBe('#f97316')
+    expect(cross?.style?.strokeDasharray).toBe('4 4')
+    expect(cross?.animated).toBe(true)
+  })
+
+  it('does not animate cross-group edges when parent is completed and child is idle', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const dagSession = makeSession({
+      id: 'dag-sess',
+      slug: 'dag-parent',
+      childIds: ['orphan'],
+      status: 'completed',
+    })
+    const orphan = makeSession({
+      id: 'orphan',
+      slug: 'orphan-child',
+      parentId: 'dag-sess',
+      status: 'completed',
+    })
+    const dag = makeDag({
+      id: 'dag-1',
+      nodes: {
+        dn1: {
+          id: 'dn1',
+          slug: 'dag-node',
+          status: 'completed',
+          dependencies: [],
+          dependents: [],
+          session: dagSession,
+        },
+      },
+    })
+
+    const result = layoutUniverse([dagSession, orphan], [dag], false)
+    const cross = result.edges.find((e) => e.target === 'orphan')
+    expect(cross?.animated).toBe(false)
+  })
+
+  it('does not draw cross-group edges for standalone sessions without DAG-owned parents', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const sessions = [
+      makeSession({ id: 'a', slug: 'alpha' }),
+      makeSession({ id: 'b', slug: 'beta' }),
+    ]
+    const result = layoutUniverse(sessions, [], false)
+    expect(result.edges).toHaveLength(0)
+  })
+
+  it('does not animate cross-group non-ci-fix edges when parent is ci-pending', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const dagSession = makeSession({
+      id: 'dag-sess',
+      slug: 'dag-parent',
+      childIds: ['orphan'],
+    })
+    const orphan = makeSession({
+      id: 'orphan',
+      slug: 'orphan-child',
+      parentId: 'dag-sess',
+      status: 'pending',
+    })
+    const dag = makeDag({
+      id: 'dag-1',
+      nodes: {
+        dn1: {
+          id: 'dn1',
+          slug: 'dag-node',
+          status: 'ci-pending',
+          dependencies: [],
+          dependents: [],
+          session: dagSession,
+        },
+      },
+    })
+
+    const result = layoutUniverse([dagSession, orphan], [dag], false)
+    const cross = result.edges.find((e) => e.target === 'orphan')
+    expect(cross?.data?.relationship).toBe('parent-child')
+    expect(cross?.animated).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

This change addresses edge-case rendering on the Universe canvas by introducing three key improvements:

1. **Icon-stack attention**: Multiple attention reasons now render as icons on canvas nodes, improving layout and readability
2. **Edge animation**: DAG (ship) and parent-child edges animate when either endpoint is running, providing visual feedback
3. **Cross-group edges**: New cross-group edges link standalone sessions to their DAG-owned parents, with ci-fix variant animating while parent is ci-pending

## Test plan

- All 262 unit+component tests pass
- TypeScript (\`npx tsc --noEmit\`) clean
- ESLint (\`npx eslint src/ test/\`) clean
- Visual verification of canvas rendering and animations in browser

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  extract-hierarchy["✅ Extract classifySessions to shared state module"]
  chat-header-context["✅ Add parent/children/DAG/branch context to chat header"]
  attention-triage-bar["✅ Add action bar for sessions needing attention"]
  enhance-node-popup["✅ Add hierarchy metadata to NodeDetailPopup"]
  group-session-list["✅ Group SessionList by DAG/Tree/Standalone with nesting"]
  mount-canvas-tab["✅ Mount UniverseCanvas as second tab with view toggle"]
  fix-rendering-edges["✅ Fix edge-case rendering (status, animation, orphans)"]
  ship-mode-grouping["✅ Add fourth classification bucket for ship mode"]
  ship-pipeline-kanban["✅ Create Kanban view for ship pipelines"]
  enhance-context-menu["✅ Add navigation actions to ContextMenu"]
  polish-ui-details["✅ Polish: badges, chips, keyboard nav, DAG summaries"]
  extract-hierarchy --> group-session-list
  extract-hierarchy --> mount-canvas-tab
  extract-hierarchy --> fix-rendering-edges
  extract-hierarchy --> ship-mode-grouping
  mount-canvas-tab --> ship-pipeline-kanban
  mount-canvas-tab --> enhance-context-menu
  group-session-list --> polish-ui-details
  mount-canvas-tab --> polish-ui-details
  class extract-hierarchy done
  class chat-header-context done
  class attention-triage-bar done
  class enhance-node-popup done
  class group-session-list done
  class mount-canvas-tab done
  class fix-rendering-edges done
  class fix-rendering-edges current
  class ship-mode-grouping done
  class ship-pipeline-kanban done
  class enhance-context-menu done
  class polish-ui-details done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | Extract classifySessions to shared state module | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/11) |
| 2 | Add parent/children/DAG/branch context to chat header | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/12) |
| 3 | Add action bar for sessions needing attention | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/13) |
| 4 | Add hierarchy metadata to NodeDetailPopup | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/19) |
| 5 | Group SessionList by DAG/Tree/Standalone with nesting | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/14) |
| 6 | Mount UniverseCanvas as second tab with view toggle | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/20) |
| 7 | **Fix edge-case rendering (status, animation, orphans)** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/17) |
| 8 | Add fourth classification bucket for ship mode | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/18) |
| 9 | Create Kanban view for ship pipelines | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/21) |
| 10 | Add navigation actions to ContextMenu | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/22) |
| 11 | Polish: badges, chips, keyboard nav, DAG summaries | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/24) |

**Progress:** 11/11 complete

<!-- dag-status-end -->





