### PR TITLE
[minions] feat(hierarchy): classify ship-mode sessions as a linear stack bucket

### DIFF
--- a/src/components/universe-layout.ts
+++ b/src/components/universe-layout.ts
@@ -11,7 +11,7 @@ const GRID_COLUMNS = 3
 const GRID_NODE_GAP_X = NODE_WIDTH + 40
 const GRID_NODE_GAP_Y = NODE_HEIGHT + 40
 
-export type EdgeRelationship = 'dag-dependency' | 'parent-child' | 'ci-fix'
+export type EdgeRelationship = 'dag-dependency' | 'parent-child' | 'ci-fix' | 'ship'
 
 export type UniverseNode = Node<{
   session?: ApiSession
@@ -19,7 +19,7 @@ export type UniverseNode = Node<{
   label: string
   status: string
   groupId: string
-  nodeType: 'dag' | 'parent-child' | 'standalone'
+  nodeType: 'dag' | 'parent-child' | 'standalone' | 'ship'
 }>
 
 export type UniverseEdge = Edge<{
@@ -174,6 +174,74 @@ function layoutParentChildGroup(
   return { id: `pc-${root.id}`, nodes, edges, width, height }
 }
 
+function layoutShipGroup(
+  root: ApiSession,
+  sessionById: Map<string, ApiSession>,
+  shipMembers: Set<string>,
+  isDark: boolean,
+): LayoutGroup {
+  const g = new dagre.graphlib.Graph()
+  g.setDefaultEdgeLabel(() => ({}))
+  g.setGraph({ rankdir: 'LR', nodesep: 60, ranksep: 100 })
+
+  const visited = new Set<string>()
+  const groupSessions: ApiSession[] = []
+  const edges: Edge[] = []
+  const stroke = isDark ? '#a78bfa' : '#7c3aed'
+
+  function walk(session: ApiSession): void {
+    if (visited.has(session.id)) return
+    visited.add(session.id)
+    groupSessions.push(session)
+    g.setNode(session.id, { width: NODE_WIDTH, height: NODE_HEIGHT })
+
+    for (const childId of session.childIds) {
+      if (!shipMembers.has(childId)) continue
+      const child = sessionById.get(childId)
+      if (!child) continue
+
+      edges.push({
+        id: `ship-${session.id}-${childId}`,
+        source: session.id,
+        target: childId,
+        type: 'smoothstep',
+        animated: child.status === 'running',
+        style: { stroke, strokeDasharray: '6 3' },
+        markerEnd: { type: MarkerType.ArrowClosed, color: stroke },
+        data: { relationship: 'ship' as EdgeRelationship },
+      })
+
+      g.setEdge(session.id, childId)
+      walk(child)
+    }
+  }
+
+  walk(root)
+  dagre.layout(g)
+
+  const nodes: Node[] = groupSessions.map((s) => {
+    const pos = g.node(s.id)
+    return {
+      id: s.id,
+      type: 'universeNode',
+      position: { x: pos.x - NODE_WIDTH / 2, y: pos.y - NODE_HEIGHT / 2 },
+      data: {
+        session: s,
+        label: s.slug,
+        status: s.status,
+        groupId: `ship-${root.id}`,
+        nodeType: 'ship' as const,
+      },
+    }
+  })
+
+  const graphInfo = g.graph()
+  const width = (graphInfo?.width ?? NODE_WIDTH) as number
+  const height = (graphInfo?.height ?? NODE_HEIGHT) as number
+
+  return { id: `ship-${root.id}`, nodes, edges, width, height }
+}
+
 function layoutStandaloneGroup(sessions: ApiSession[]): LayoutGroup {
   if (sessions.length === 0) {
     return { id: 'standalone', nodes: [], edges: [], width: 0, height: 0 }
@@ -300,7 +368,10 @@ export function layoutUniverse(
     return { nodes: [], edges: [] }
   }
 
-  const { parentChildRoots, standalone, sessionById } = classifySessions(sessions, dags)
+  const { parentChildRoots, shipRoots, shipMembers, standalone, sessionById } = classifySessions(
+    sessions,
+    dags,
+  )
 
   const groups: LayoutGroup[] = []
 
@@ -308,6 +379,10 @@ export function layoutUniverse(
     if (Object.keys(dag.nodes).length > 0) {
       groups.push(layoutDagGroup(dag, isDark))
     }
+  }
+
+  for (const root of shipRoots) {
+    groups.push(layoutShipGroup(root, sessionById, shipMembers, isDark))
   }
 
   for (const root of parentChildRoots) {

--- a/src/state/hierarchy.ts
+++ b/src/state/hierarchy.ts
@@ -1,5 +1,12 @@
 import type { ApiDagGraph, ApiSession } from '../api/types'
 
+const SHIP_MODE_PREFIX = 'ship-'
+const SHIP_MODE_EXACT = 'ship'
+
+export function isShipMode(mode: string): boolean {
+  return mode === SHIP_MODE_EXACT || mode.startsWith(SHIP_MODE_PREFIX)
+}
+
 export type SessionGroup =
   | { kind: 'dag'; dag: ApiDagGraph; parent: ApiSession | null; children: ApiSession[] }
   | { kind: 'parent-child'; parent: ApiSession; children: ApiSession[] }
@@ -25,7 +32,6 @@ export function buildSessionGroups(sessions: ApiSession[], dags: ApiDagGraph[]):
   const consumed = new Set<string>()
   const groups: SessionGroup[] = []
 
-  // 1. DAGs first. rootTaskId is the parent's threadId as a string.
   for (const dag of dags) {
     const parent = byThreadId.get(dag.rootTaskId) ?? null
     const childIds = Object.values(dag.nodes)
@@ -39,7 +45,6 @@ export function buildSessionGroups(sessions: ApiSession[], dags: ApiDagGraph[]):
     groups.push({ kind: 'dag', dag, parent, children: sortByUpdatedAt(children) })
   }
 
-  // 2. Non-DAG parent/child trees.
   for (const s of sessions) {
     if (consumed.has(s.id)) continue
     if (s.childIds.length === 0 || s.parentId) continue
@@ -55,7 +60,6 @@ export function buildSessionGroups(sessions: ApiSession[], dags: ApiDagGraph[]):
     groups.push({ kind: 'parent-child', parent: s, children: sortByUpdatedAt(children) })
   }
 
-  // 3. Variant groups.
   const variantBuckets = new Map<string, ApiSession[]>()
   for (const s of sessions) {
     if (consumed.has(s.id)) continue
@@ -70,7 +74,6 @@ export function buildSessionGroups(sessions: ApiSession[], dags: ApiDagGraph[]):
     groups.push({ kind: 'variant', groupId, sessions: sortByUpdatedAt(members) })
   }
 
-  // 4. Standalone.
   const standalone: ApiSession[] = []
   for (const s of sessions) {
     if (consumed.has(s.id)) continue
@@ -100,12 +103,14 @@ export function collectChildren(
   session: ApiSession,
   sessionById: Map<string, ApiSession>,
   collected: Set<string>,
+  excluded?: Set<string>,
 ): void {
   for (const childId of session.childIds) {
     if (collected.has(childId)) continue
+    if (excluded?.has(childId)) continue
     collected.add(childId)
     const child = sessionById.get(childId)
-    if (child) collectChildren(child, sessionById, collected)
+    if (child) collectChildren(child, sessionById, collected, excluded)
   }
 }
 
@@ -130,8 +135,45 @@ export function findTreeRoot(
   return root
 }
 
+export function findShipRoot(
+  session: ApiSession,
+  sessionById: Map<string, ApiSession>,
+  excluded: Set<string> = new Set(),
+): ApiSession {
+  let root = session
+  while (root.parentId && sessionById.has(root.parentId) && !excluded.has(root.parentId)) {
+    const parent = sessionById.get(root.parentId)!
+    if (!isShipMode(parent.mode)) break
+    root = parent
+  }
+  return root
+}
+
+export function collectShipDescendants(
+  session: ApiSession,
+  sessionById: Map<string, ApiSession>,
+  excluded: Set<string> = new Set(),
+): Set<string> {
+  const result = new Set<string>()
+  function walk(s: ApiSession): void {
+    for (const childId of s.childIds) {
+      if (result.has(childId)) continue
+      if (excluded.has(childId)) continue
+      const child = sessionById.get(childId)
+      if (!child) continue
+      if (!isShipMode(child.mode)) continue
+      result.add(childId)
+      walk(child)
+    }
+  }
+  walk(session)
+  return result
+}
+
 export interface SessionClassification {
   dagOwned: Set<string>
+  shipRoots: ApiSession[]
+  shipMembers: Set<string>
   parentChildRoots: ApiSession[]
   parentChildMembers: Set<string>
   standalone: ApiSession[]
@@ -151,39 +193,67 @@ export function classifySessions(
 
   const sessionById = buildSessionIndex(sessions)
 
+  const shipMembers = new Set<string>()
+  const shipRoots: ApiSession[] = []
+
+  for (const s of sessions) {
+    if (dagOwned.has(s.id)) continue
+    if (shipMembers.has(s.id)) continue
+    if (!isShipMode(s.mode)) continue
+
+    const root = findShipRoot(s, sessionById, dagOwned)
+    if (dagOwned.has(root.id)) continue
+    if (shipMembers.has(root.id)) continue
+
+    shipRoots.push(root)
+    shipMembers.add(root.id)
+    for (const id of collectShipDescendants(root, sessionById, dagOwned)) {
+      shipMembers.add(id)
+    }
+  }
+
+  const excluded = new Set<string>([...dagOwned, ...shipMembers])
+
   const parentChildMembers = new Set<string>()
   const parentChildRoots: ApiSession[] = []
 
   for (const s of sessions) {
-    if (dagOwned.has(s.id)) continue
+    if (excluded.has(s.id)) continue
     if (parentChildMembers.has(s.id)) continue
 
     if (s.childIds.length > 0 && !s.parentId) {
       parentChildRoots.push(s)
       parentChildMembers.add(s.id)
-      collectChildren(s, sessionById, parentChildMembers)
+      collectChildren(s, sessionById, parentChildMembers, excluded)
     }
   }
 
   const standalone: ApiSession[] = []
   for (const s of sessions) {
-    if (dagOwned.has(s.id) || parentChildMembers.has(s.id)) continue
+    if (excluded.has(s.id) || parentChildMembers.has(s.id)) continue
 
     if (s.parentId && sessionById.has(s.parentId)) {
       const parent = sessionById.get(s.parentId)!
-      if (parent.childIds.includes(s.id) && !dagOwned.has(parent.id)) {
-        const root = findTreeRoot(parent, sessionById, dagOwned)
-        if (!parentChildMembers.has(root.id)) {
+      if (parent.childIds.includes(s.id) && !excluded.has(parent.id)) {
+        const root = findTreeRoot(parent, sessionById, excluded)
+        if (!parentChildMembers.has(root.id) && !excluded.has(root.id)) {
           parentChildRoots.push(root)
           parentChildMembers.add(root.id)
-          collectChildren(root, sessionById, parentChildMembers)
+          collectChildren(root, sessionById, parentChildMembers, excluded)
         }
-        parentChildMembers.add(s.id)
-        continue
+        if (parentChildMembers.has(s.id)) continue
       }
     }
     standalone.push(s)
   }
 
-  return { dagOwned, parentChildRoots, parentChildMembers, standalone, sessionById }
+  return {
+    dagOwned,
+    shipRoots,
+    shipMembers,
+    parentChildRoots,
+    parentChildMembers,
+    standalone,
+    sessionById,
+  }
 }

--- a/test/components/universe-layout.test.ts
+++ b/test/components/universe-layout.test.ts
@@ -404,6 +404,83 @@ describe('universe-layout', () => {
     expect(NODE_HEIGHT).toBe(100)
   })
 
+  it('renders ship-mode sessions as a dedicated ship group with LR-rank edges', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const sessions = [
+      makeSession({
+        id: 'topic',
+        slug: 'feature',
+        mode: 'ship-plan',
+        childIds: ['verify'],
+      }),
+      makeSession({
+        id: 'verify',
+        slug: 'verify-pr',
+        mode: 'ship-verify',
+        parentId: 'topic',
+      }),
+    ]
+
+    const result = layoutUniverse(sessions, [], false)
+
+    const shipNodes = result.nodes.filter((n) => n.data.nodeType === 'ship')
+    expect(shipNodes).toHaveLength(2)
+    expect(shipNodes.map((n) => n.data.label).sort()).toEqual(['feature', 'verify-pr'])
+    expect(shipNodes.every((n) => n.data.groupId === 'ship-topic')).toBe(true)
+
+    const shipEdges = result.edges.filter((e) => e.data?.relationship === 'ship')
+    expect(shipEdges).toHaveLength(1)
+    expect(shipEdges[0].source).toBe('topic')
+    expect(shipEdges[0].target).toBe('verify')
+    expect(shipEdges[0].animated).toBe(true)
+  })
+
+  it('keeps a lone ship-think session in the ship bucket, not standalone', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const sessions = [makeSession({ id: 's1', slug: 'feat', mode: 'ship-think' })]
+
+    const result = layoutUniverse(sessions, [], false)
+
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0].data.nodeType).toBe('ship')
+    expect(result.nodes[0].data.groupId).toBe('ship-s1')
+  })
+
+  it('uses purple ship-edge stroke that flips with dark mode', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const sessions = [
+      makeSession({ id: 'p', slug: 'p', mode: 'ship-plan', childIds: ['c'] }),
+      makeSession({ id: 'c', slug: 'c', mode: 'ship-verify', parentId: 'p' }),
+    ]
+
+    const lightResult = layoutUniverse(sessions, [], false)
+    const darkResult = layoutUniverse(sessions, [], true)
+
+    expect(lightResult.edges[0].style?.stroke).toBe('#7c3aed')
+    expect(darkResult.edges[0].style?.stroke).toBe('#a78bfa')
+  })
+
+  it('does not pull non-ship descendants into the ship group', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const sessions = [
+      makeSession({
+        id: 'topic',
+        slug: 'topic',
+        mode: 'ship-plan',
+        childIds: ['ship-c', 'task-c'],
+      }),
+      makeSession({ id: 'ship-c', slug: 'ship-c', mode: 'ship-verify', parentId: 'topic' }),
+      makeSession({ id: 'task-c', slug: 'task-c', mode: 'task', parentId: 'topic' }),
+    ]
+
+    const result = layoutUniverse(sessions, [], false)
+
+    const shipNodes = result.nodes.filter((n) => n.data.nodeType === 'ship')
+    const standaloneNodes = result.nodes.filter((n) => n.data.nodeType === 'standalone')
+    expect(shipNodes.map((n) => n.data.label).sort()).toEqual(['ship-c', 'topic'])
+    expect(standaloneNodes.map((n) => n.data.label)).toEqual(['task-c'])
+  })
+
   it('handles child session whose parent is a standalone (auto-discovers tree)', async () => {
     const { layoutUniverse } = await import('../../src/components/universe-layout')
     const sessions = [

--- a/test/state/hierarchy.test.ts
+++ b/test/state/hierarchy.test.ts
@@ -6,7 +6,10 @@ import {
   classifySessions,
   collectChildren,
   collectDescendants,
+  collectShipDescendants,
+  findShipRoot,
   findTreeRoot,
+  isShipMode,
 } from '../../src/state/hierarchy'
 
 function mkSession(over: Partial<ApiSession> = {}): ApiSession {
@@ -364,6 +367,284 @@ describe('hierarchy', () => {
       const sessions = [makeSession({ id: 'a', slug: 'alpha' })]
       const result = classifySessions(sessions, [])
       expect(result.sessionById.get('a')?.slug).toBe('alpha')
+    })
+
+    it('returns empty ship buckets when no ship sessions exist', () => {
+      const sessions = [
+        makeSession({ id: 's1', slug: 'task1' }),
+        makeSession({ id: 's2', slug: 'task2' }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.shipRoots).toEqual([])
+      expect(result.shipMembers.size).toBe(0)
+    })
+
+    it('classifies a lone ship-think session as a ship root', () => {
+      const sessions = [makeSession({ id: 's1', slug: 'feature', mode: 'ship-think' })]
+      const result = classifySessions(sessions, [])
+      expect(result.shipRoots.map((s) => s.id)).toEqual(['s1'])
+      expect(result.shipMembers.has('s1')).toBe(true)
+      expect(result.standalone).toEqual([])
+      expect(result.parentChildRoots).toEqual([])
+    })
+
+    it('groups a ship-think → ship-plan → ship-verify pipeline into one root', () => {
+      const sessions = [
+        makeSession({
+          id: 'topic',
+          slug: 'feature',
+          mode: 'ship-plan',
+          childIds: ['verify'],
+        }),
+        makeSession({
+          id: 'verify',
+          slug: 'verify-pr',
+          mode: 'ship-verify',
+          parentId: 'topic',
+        }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.shipRoots.map((s) => s.id)).toEqual(['topic'])
+      expect(result.shipMembers.has('topic')).toBe(true)
+      expect(result.shipMembers.has('verify')).toBe(true)
+      expect(result.parentChildRoots).toEqual([])
+      expect(result.standalone).toEqual([])
+    })
+
+    it('walks up to find the topmost ship-mode ancestor when starting from a ship child', () => {
+      const sessions = [
+        makeSession({
+          id: 'verify',
+          slug: 'verify',
+          mode: 'ship-verify',
+          parentId: 'topic',
+        }),
+        makeSession({
+          id: 'topic',
+          slug: 'topic',
+          mode: 'ship-plan',
+          childIds: ['verify'],
+        }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.shipRoots.map((s) => s.id)).toEqual(['topic'])
+      expect(result.shipMembers.size).toBe(2)
+    })
+
+    it('does not promote a non-ship parent into the ship bucket', () => {
+      const sessions = [
+        makeSession({
+          id: 'task-parent',
+          slug: 'parent',
+          mode: 'task',
+          childIds: ['ship-child'],
+        }),
+        makeSession({
+          id: 'ship-child',
+          slug: 'ship-child',
+          mode: 'ship-think',
+          parentId: 'task-parent',
+        }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.shipRoots.map((s) => s.id)).toEqual(['ship-child'])
+      expect(result.shipMembers.has('task-parent')).toBe(false)
+      expect(result.parentChildRoots.map((s) => s.id)).toEqual(['task-parent'])
+      expect(result.parentChildMembers.has('ship-child')).toBe(false)
+    })
+
+    it('does not pull non-ship descendants into the ship bucket', () => {
+      const sessions = [
+        makeSession({
+          id: 'topic',
+          slug: 'topic',
+          mode: 'ship-plan',
+          childIds: ['ship-child', 'task-child'],
+        }),
+        makeSession({
+          id: 'ship-child',
+          slug: 'ship-child',
+          mode: 'ship-verify',
+          parentId: 'topic',
+        }),
+        makeSession({
+          id: 'task-child',
+          slug: 'task-child',
+          mode: 'task',
+          parentId: 'topic',
+        }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.shipMembers.has('topic')).toBe(true)
+      expect(result.shipMembers.has('ship-child')).toBe(true)
+      expect(result.shipMembers.has('task-child')).toBe(false)
+      expect(result.standalone.map((s) => s.id)).toEqual(['task-child'])
+    })
+
+    it('excludes DAG-owned ship sessions from the ship bucket', () => {
+      const dagSession = makeSession({
+        id: 'dag-ship',
+        slug: 'dag-ship',
+        mode: 'ship-verify',
+      })
+      const standalone = makeSession({
+        id: 'topic',
+        slug: 'topic',
+        mode: 'ship-plan',
+      })
+      const dag = makeDag({
+        id: 'dag-1',
+        nodes: {
+          n1: {
+            id: 'n1',
+            slug: 'node',
+            status: 'running',
+            dependencies: [],
+            dependents: [],
+            session: dagSession,
+          },
+        },
+      })
+      const result = classifySessions([dagSession, standalone], [dag])
+      expect(result.shipRoots.map((s) => s.id)).toEqual(['topic'])
+      expect(result.shipMembers.has('dag-ship')).toBe(false)
+      expect(result.shipMembers.has('topic')).toBe(true)
+      expect(result.dagOwned.has('dag-ship')).toBe(true)
+    })
+
+    it('treats multiple sibling ship sessions as separate roots', () => {
+      const sessions = [
+        makeSession({ id: 'ship1', slug: 'one', mode: 'ship-think' }),
+        makeSession({ id: 'ship2', slug: 'two', mode: 'ship-plan' }),
+      ]
+      const result = classifySessions(sessions, [])
+      expect(result.shipRoots.map((s) => s.id).sort()).toEqual(['ship1', 'ship2'])
+      expect(result.shipMembers.size).toBe(2)
+    })
+
+    it('recognizes the bare "ship" mode as a ship session', () => {
+      const sessions = [makeSession({ id: 's1', slug: 'feat', mode: 'ship' })]
+      const result = classifySessions(sessions, [])
+      expect(result.shipRoots.map((s) => s.id)).toEqual(['s1'])
+    })
+  })
+
+  describe('isShipMode', () => {
+    it('returns true for known ship modes', () => {
+      expect(isShipMode('ship')).toBe(true)
+      expect(isShipMode('ship-think')).toBe(true)
+      expect(isShipMode('ship-plan')).toBe(true)
+      expect(isShipMode('ship-verify')).toBe(true)
+    })
+
+    it('returns true for any future ship-prefixed mode', () => {
+      expect(isShipMode('ship-future')).toBe(true)
+    })
+
+    it('returns false for non-ship modes', () => {
+      expect(isShipMode('task')).toBe(false)
+      expect(isShipMode('plan')).toBe(false)
+      expect(isShipMode('think')).toBe(false)
+      expect(isShipMode('ci-fix')).toBe(false)
+      expect(isShipMode('shipper')).toBe(false)
+      expect(isShipMode('')).toBe(false)
+    })
+  })
+
+  describe('findShipRoot', () => {
+    it('walks up through ship-mode ancestors', () => {
+      const sessions = [
+        makeSession({ id: 'a', slug: 'a', mode: 'ship-think', childIds: ['b'] }),
+        makeSession({ id: 'b', slug: 'b', mode: 'ship-plan', parentId: 'a', childIds: ['c'] }),
+        makeSession({ id: 'c', slug: 'c', mode: 'ship-verify', parentId: 'b' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      expect(findShipRoot(sessions[2], index).id).toBe('a')
+    })
+
+    it('stops at the first non-ship ancestor', () => {
+      const sessions = [
+        makeSession({ id: 'task', slug: 'task', mode: 'task', childIds: ['ship'] }),
+        makeSession({ id: 'ship', slug: 'ship', mode: 'ship-think', parentId: 'task' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      expect(findShipRoot(sessions[1], index).id).toBe('ship')
+    })
+
+    it('respects the excluded set', () => {
+      const sessions = [
+        makeSession({ id: 'top', slug: 'top', mode: 'ship-plan', childIds: ['mid'] }),
+        makeSession({
+          id: 'mid',
+          slug: 'mid',
+          mode: 'ship-verify',
+          parentId: 'top',
+          childIds: ['bot'],
+        }),
+        makeSession({ id: 'bot', slug: 'bot', mode: 'ship-verify', parentId: 'mid' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      expect(findShipRoot(sessions[2], index, new Set(['top'])).id).toBe('mid')
+    })
+  })
+
+  describe('collectShipDescendants', () => {
+    it('collects only ship-mode descendants', () => {
+      const sessions = [
+        makeSession({
+          id: 'root',
+          slug: 'root',
+          mode: 'ship-plan',
+          childIds: ['ship-child', 'task-child'],
+        }),
+        makeSession({
+          id: 'ship-child',
+          slug: 'ship-child',
+          mode: 'ship-verify',
+          parentId: 'root',
+        }),
+        makeSession({ id: 'task-child', slug: 'task-child', mode: 'task', parentId: 'root' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      const result = collectShipDescendants(sessions[0], index)
+      expect([...result].sort()).toEqual(['ship-child'])
+    })
+
+    it('honors the excluded set', () => {
+      const sessions = [
+        makeSession({
+          id: 'root',
+          slug: 'root',
+          mode: 'ship-plan',
+          childIds: ['skip', 'keep'],
+        }),
+        makeSession({ id: 'skip', slug: 'skip', mode: 'ship-verify', parentId: 'root' }),
+        makeSession({ id: 'keep', slug: 'keep', mode: 'ship-verify', parentId: 'root' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      const result = collectShipDescendants(sessions[0], index, new Set(['skip']))
+      expect([...result].sort()).toEqual(['keep'])
+    })
+
+    it('returns empty set for a leaf', () => {
+      const leaf = makeSession({ id: 'leaf', slug: 'leaf', mode: 'ship-think' })
+      const index = buildSessionIndex([leaf])
+      expect(collectShipDescendants(leaf, index).size).toBe(0)
+    })
+  })
+
+  describe('collectChildren with excluded set', () => {
+    it('skips children present in the excluded set', () => {
+      const sessions = [
+        makeSession({ id: 'root', slug: 'root', childIds: ['a', 'b'] }),
+        makeSession({ id: 'a', slug: 'a', parentId: 'root', childIds: ['c'] }),
+        makeSession({ id: 'b', slug: 'b', parentId: 'root' }),
+        makeSession({ id: 'c', slug: 'c', parentId: 'a' }),
+      ]
+      const index = buildSessionIndex(sessions)
+      const collected = new Set<string>()
+      collectChildren(sessions[0], index, collected, new Set(['a']))
+      expect([...collected].sort()).toEqual(['b'])
     })
   })
 })


### PR DESCRIPTION
## Summary

- Added ship-mode session classification to the hierarchy module: `isShipMode`, `findShipRoot`, and `collectShipDescendants` helpers
- Extended `classifySessions` to expose `shipRoots` and `shipMembers` buckets, computed before parent-child classification so ship sessions don't leak into other buckets
- Rendered ship bucket as a left-to-right (`rankdir: 'LR'`) dagre group on the canvas with purple edge strokes and `'ship'` edge relationship type
- Added unit test coverage for ship classification and layout rendering

## Why

Ship-think drift was flagged during planning. Keeping ship pipelines visually distinct from generic parent-child DAG trees prevents confusion and improves session organization on the canvas.

## Notes

- Builds on the upstream `refactor: extract session classification into shared hierarchy module` commit (commit `0fff860`)
- E2E tests intentionally not run per task instructions
- All type checks and lint clean; 270/270 unit tests passing

🤖 Generated with Claude Code

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  extract-hierarchy["✅ Extract classifySessions to shared state module"]
  chat-header-context["✅ Add parent/children/DAG/branch context to chat header"]
  attention-triage-bar["✅ Add action bar for sessions needing attention"]
  enhance-node-popup["✅ Add hierarchy metadata to NodeDetailPopup"]
  group-session-list["✅ Group SessionList by DAG/Tree/Standalone with nesting"]
  mount-canvas-tab["✅ Mount UniverseCanvas as second tab with view toggle"]
  fix-rendering-edges["✅ Fix edge-case rendering (status, animation, orphans)"]
  ship-mode-grouping["✅ Add fourth classification bucket for ship mode"]
  ship-pipeline-kanban["✅ Create Kanban view for ship pipelines"]
  enhance-context-menu["✅ Add navigation actions to ContextMenu"]
  polish-ui-details["✅ Polish: badges, chips, keyboard nav, DAG summaries"]
  extract-hierarchy --> group-session-list
  extract-hierarchy --> mount-canvas-tab
  extract-hierarchy --> fix-rendering-edges
  extract-hierarchy --> ship-mode-grouping
  mount-canvas-tab --> ship-pipeline-kanban
  mount-canvas-tab --> enhance-context-menu
  group-session-list --> polish-ui-details
  mount-canvas-tab --> polish-ui-details
  class extract-hierarchy done
  class chat-header-context done
  class attention-triage-bar done
  class enhance-node-popup done
  class group-session-list done
  class mount-canvas-tab done
  class fix-rendering-edges done
  class ship-mode-grouping done
  class ship-mode-grouping current
  class ship-pipeline-kanban done
  class enhance-context-menu done
  class polish-ui-details done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | Extract classifySessions to shared state module | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/11) |
| 2 | Add parent/children/DAG/branch context to chat header | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/12) |
| 3 | Add action bar for sessions needing attention | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/13) |
| 4 | Add hierarchy metadata to NodeDetailPopup | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/19) |
| 5 | Group SessionList by DAG/Tree/Standalone with nesting | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/14) |
| 6 | Mount UniverseCanvas as second tab with view toggle | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/20) |
| 7 | Fix edge-case rendering (status, animation, orphans) | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/17) |
| 8 | **Add fourth classification bucket for ship mode** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/18) |
| 9 | Create Kanban view for ship pipelines | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/21) |
| 10 | Add navigation actions to ContextMenu | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/22) |
| 11 | Polish: badges, chips, keyboard nav, DAG summaries | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/24) |

**Progress:** 11/11 complete

<!-- dag-status-end -->





