### PR TITLE
[minions] feat(ui): add hierarchy metadata to NodeDetailPopup

### DIFF
--- a/src/components/NodeDetailPopup.tsx
+++ b/src/components/NodeDetailPopup.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'preact/hooks'
-import type { ApiSession } from '../api/types'
+import { useEffect, useMemo, useRef } from 'preact/hooks'
+import type { ApiDagGraph, ApiDagNode, ApiSession } from '../api/types'
 import { useTheme } from '../hooks/useTheme'
 import { StatusBadge, AttentionBadge, formatRelativeTime } from './shared'
 import { PrLink } from './PrLink'
@@ -8,6 +8,9 @@ interface NodeDetailPopupProps {
   session: ApiSession
   onClose: () => void
   onOpenChat?: (sessionId: string) => void
+  sessions?: ApiSession[]
+  dags?: ApiDagGraph[]
+  onSelectSession?: (session: ApiSession) => void
 }
 
 function MetaRow({ label, children, isDark }: { label: string; children: preact.ComponentChildren; isDark: boolean }) {
@@ -23,7 +26,55 @@ function MetaRow({ label, children, isDark }: { label: string; children: preact.
   )
 }
 
-export function NodeDetailPopup({ session, onClose, onOpenChat }: NodeDetailPopupProps) {
+interface SessionLinkProps {
+  session: ApiSession
+  onClick?: (session: ApiSession) => void
+  isDark: boolean
+}
+
+function SessionLink({ session, onClick, isDark }: SessionLinkProps) {
+  const linkColor = isDark ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'
+  if (!onClick) {
+    return <span class="font-mono text-[11px] truncate">{session.slug}</span>
+  }
+  return (
+    <button
+      type="button"
+      onClick={(e: Event) => {
+        e.stopPropagation()
+        onClick(session)
+      }}
+      class={`font-mono text-[11px] truncate hover:underline cursor-pointer bg-transparent border-0 p-0 ${linkColor}`}
+      data-testid={`node-detail-session-link-${session.id}`}
+    >
+      {session.slug}
+    </button>
+  )
+}
+
+function findOwningDag(
+  sessionId: string,
+  dags: ApiDagGraph[] | undefined,
+): { dag: ApiDagGraph; node: ApiDagNode } | null {
+  if (!dags) return null
+  for (const dag of dags) {
+    for (const node of Object.values(dag.nodes)) {
+      if (node.session?.id === sessionId || node.id === sessionId) {
+        return { dag, node }
+      }
+    }
+  }
+  return null
+}
+
+export function NodeDetailPopup({
+  session,
+  onClose,
+  onOpenChat,
+  sessions,
+  dags,
+  onSelectSession,
+}: NodeDetailPopupProps) {
   const theme = useTheme()
   const isDark = theme.value === 'dark'
   const popupRef = useRef<HTMLDivElement>(null)
@@ -35,6 +86,28 @@ export function NodeDetailPopup({ session, onClose, onOpenChat }: NodeDetailPopu
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [onClose])
+
+  const sessionById = useMemo(() => {
+    const map = new Map<string, ApiSession>()
+    if (sessions) {
+      for (const s of sessions) map.set(s.id, s)
+    }
+    return map
+  }, [sessions])
+
+  const parentSession = session.parentId ? sessionById.get(session.parentId) : undefined
+  const childSessions = useMemo(() => {
+    const result: ApiSession[] = []
+    for (const id of session.childIds) {
+      const child = sessionById.get(id)
+      if (child) result.push(child)
+    }
+    return result
+  }, [session.childIds, sessionById])
+
+  const dagMatch = useMemo(() => findOwningDag(session.id, dags), [session.id, dags])
+  const dagNodeStatus = dagMatch?.node.status
+  const showDagStatus = dagNodeStatus && dagNodeStatus !== session.status
 
   const overlayBg = isDark ? 'bg-black/70' : 'bg-black/50'
   const dialogBg = isDark ? 'bg-gray-800' : 'bg-white'
@@ -48,6 +121,11 @@ export function NodeDetailPopup({ session, onClose, onOpenChat }: NodeDetailPopu
     : session.command
 
   const hasChatAction = Boolean(onOpenChat)
+
+  const hasHierarchyMeta =
+    parentSession !== undefined ||
+    childSessions.length > 0 ||
+    dagMatch !== null
 
   return (
     <div class="fixed inset-0 z-50 flex items-center justify-center">
@@ -89,6 +167,44 @@ export function NodeDetailPopup({ session, onClose, onOpenChat }: NodeDetailPopu
             >
               {truncatedPrompt}
             </div>
+          </div>
+        )}
+
+        {hasHierarchyMeta && (
+          <div class={`px-4 py-3 border-b ${borderColor} flex flex-col gap-2`} data-testid="node-detail-hierarchy">
+            {parentSession && (
+              <MetaRow label="Parent" isDark={isDark}>
+                <SessionLink session={parentSession} onClick={onSelectSession} isDark={isDark} />
+              </MetaRow>
+            )}
+            {childSessions.length > 0 && (
+              <MetaRow label={childSessions.length === 1 ? 'Child' : 'Children'} isDark={isDark}>
+                <span class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                  {childSessions.map((child, i) => (
+                    <span key={child.id} class="inline-flex items-center">
+                      <SessionLink session={child} onClick={onSelectSession} isDark={isDark} />
+                      {i < childSessions.length - 1 && (
+                        <span class="ml-2" style={{ color: isDark ? '#4b5563' : '#d1d5db' }}>·</span>
+                      )}
+                    </span>
+                  ))}
+                </span>
+              </MetaRow>
+            )}
+            {dagMatch && (
+              <MetaRow label="DAG" isDark={isDark}>
+                <span class="font-mono text-[11px] truncate block" data-testid="node-detail-dag-id">
+                  {dagMatch.dag.id}
+                </span>
+              </MetaRow>
+            )}
+            {dagMatch && showDagStatus && (
+              <MetaRow label="DAG node" isDark={isDark}>
+                <span data-testid="node-detail-dag-node-status">
+                  <StatusBadge status={dagNodeStatus!} />
+                </span>
+              </MetaRow>
+            )}
           </div>
         )}
 

--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -329,6 +329,9 @@ export function UniverseCanvas({
           session={detailSession}
           onClose={() => setDetailSession(null)}
           onOpenChat={onOpenChat}
+          sessions={sessions}
+          dags={dags}
+          onSelectSession={(s) => setDetailSession(s)}
         />
       )}
     </div>

--- a/test/components/NodeDetailPopup.test.tsx
+++ b/test/components/NodeDetailPopup.test.tsx
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/preact'
+import { NodeDetailPopup } from '../../src/components/NodeDetailPopup'
+import type { ApiDagGraph, ApiSession } from '../../src/api/types'
+
+function makeSession(overrides: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 'session-1',
+    slug: 'bold-meadow',
+    status: 'running',
+    command: '/task Add feature',
+    repo: 'https://github.com/org/repo',
+    branch: 'feature-branch',
+    threadId: 123,
+    chatId: -100,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...overrides,
+  }
+}
+
+function makeDag(overrides: Partial<ApiDagGraph> = {}): ApiDagGraph {
+  return {
+    id: 'dag-xyz',
+    rootTaskId: 'node-a',
+    nodes: {
+      'node-a': {
+        id: 'node-a',
+        slug: 'root-node',
+        status: 'running',
+        dependencies: [],
+        dependents: ['node-b'],
+        session: makeSession({ id: 'sess-a', slug: 'root-node', status: 'running' }),
+      },
+      'node-b': {
+        id: 'node-b',
+        slug: 'leaf-node',
+        status: 'ci-pending',
+        dependencies: ['node-a'],
+        dependents: [],
+        session: makeSession({ id: 'sess-b', slug: 'leaf-node', status: 'running' }),
+      },
+    },
+    status: 'running',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('NodeDetailPopup hierarchy metadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders without hierarchy section when session has no parent, children, or DAG', () => {
+    const session = makeSession({ id: 's1', slug: 'lone-session' })
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        sessions={[session]}
+        dags={[]}
+      />
+    )
+    expect(document.querySelector('[data-testid="node-detail-hierarchy"]')).toBeFalsy()
+  })
+
+  it('renders parent link when session has a parent in sessions list', () => {
+    const parent = makeSession({ id: 'p1', slug: 'parent-slug', childIds: ['c1'] })
+    const child = makeSession({ id: 'c1', slug: 'child-slug', parentId: 'p1' })
+    render(
+      <NodeDetailPopup
+        session={child}
+        onClose={vi.fn()}
+        sessions={[parent, child]}
+        dags={[]}
+      />
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')
+    expect(hierarchy).toBeTruthy()
+    expect(hierarchy!.innerHTML).toContain('Parent')
+    expect(hierarchy!.innerHTML).toContain('parent-slug')
+  })
+
+  it('clicking parent link invokes onSelectSession with the parent session', () => {
+    const parent = makeSession({ id: 'p1', slug: 'parent-slug', childIds: ['c1'] })
+    const child = makeSession({ id: 'c1', slug: 'child-slug', parentId: 'p1' })
+    const onSelectSession = vi.fn()
+    render(
+      <NodeDetailPopup
+        session={child}
+        onClose={vi.fn()}
+        sessions={[parent, child]}
+        dags={[]}
+        onSelectSession={onSelectSession}
+      />
+    )
+    const link = document.querySelector('[data-testid="node-detail-session-link-p1"]') as HTMLButtonElement
+    expect(link).toBeTruthy()
+    fireEvent.click(link)
+    expect(onSelectSession).toHaveBeenCalledWith(expect.objectContaining({ id: 'p1', slug: 'parent-slug' }))
+  })
+
+  it('renders child links and uses singular "Child" for one child', () => {
+    const parent = makeSession({ id: 'p1', slug: 'parent-slug', childIds: ['c1'] })
+    const child = makeSession({ id: 'c1', slug: 'child-slug', parentId: 'p1' })
+    render(
+      <NodeDetailPopup
+        session={parent}
+        onClose={vi.fn()}
+        sessions={[parent, child]}
+        dags={[]}
+      />
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')!
+    expect(hierarchy.innerHTML).toContain('Child')
+    expect(hierarchy.innerHTML).not.toContain('Children')
+    expect(hierarchy.innerHTML).toContain('child-slug')
+  })
+
+  it('renders multiple child links with pluralized label', () => {
+    const parent = makeSession({ id: 'p1', slug: 'parent-slug', childIds: ['c1', 'c2'] })
+    const c1 = makeSession({ id: 'c1', slug: 'child-one', parentId: 'p1' })
+    const c2 = makeSession({ id: 'c2', slug: 'child-two', parentId: 'p1' })
+    render(
+      <NodeDetailPopup
+        session={parent}
+        onClose={vi.fn()}
+        sessions={[parent, c1, c2]}
+        dags={[]}
+      />
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')!
+    expect(hierarchy.innerHTML).toContain('Children')
+    expect(hierarchy.innerHTML).toContain('child-one')
+    expect(hierarchy.innerHTML).toContain('child-two')
+  })
+
+  it('skips unresolved children that are not in sessions list', () => {
+    const parent = makeSession({ id: 'p1', slug: 'parent-slug', childIds: ['missing', 'c1'] })
+    const c1 = makeSession({ id: 'c1', slug: 'child-one', parentId: 'p1' })
+    render(
+      <NodeDetailPopup
+        session={parent}
+        onClose={vi.fn()}
+        sessions={[parent, c1]}
+        dags={[]}
+      />
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')!
+    expect(hierarchy.innerHTML).toContain('child-one')
+    expect(hierarchy.innerHTML).not.toContain('missing')
+  })
+
+  it('renders DAG id when session belongs to a DAG node (by session.id match)', () => {
+    const dag = makeDag()
+    const session = dag.nodes['node-a'].session!
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        sessions={[session]}
+        dags={[dag]}
+      />
+    )
+    const dagId = document.querySelector('[data-testid="node-detail-dag-id"]')
+    expect(dagId).toBeTruthy()
+    expect(dagId!.textContent).toContain('dag-xyz')
+  })
+
+  it('renders DAG node status badge when DAG status differs from session status', () => {
+    const dag = makeDag()
+    const session = dag.nodes['node-b'].session!
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        sessions={[session]}
+        dags={[dag]}
+      />
+    )
+    const dagStatus = document.querySelector('[data-testid="node-detail-dag-node-status"]')
+    expect(dagStatus).toBeTruthy()
+    expect(dagStatus!.innerHTML).toContain('CI Pending')
+  })
+
+  it('omits DAG node status row when DAG status matches session status', () => {
+    const dag = makeDag({
+      nodes: {
+        'node-a': {
+          id: 'node-a',
+          slug: 'same-status',
+          status: 'running',
+          dependencies: [],
+          dependents: [],
+          session: makeSession({ id: 'sess-a', slug: 'same-status', status: 'running' }),
+        },
+      },
+    })
+    const session = dag.nodes['node-a'].session!
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        sessions={[session]}
+        dags={[dag]}
+      />
+    )
+    expect(document.querySelector('[data-testid="node-detail-dag-node-status"]')).toBeFalsy()
+    expect(document.querySelector('[data-testid="node-detail-dag-id"]')).toBeTruthy()
+  })
+
+  it('resolves DAG by node.id when the DAG node has no attached session (id-match fallback)', () => {
+    const session = makeSession({ id: 'node-a', slug: 'bold-meadow' })
+    const dag = makeDag({
+      nodes: {
+        'node-a': {
+          id: 'node-a',
+          slug: 'bold-meadow',
+          status: 'pending',
+          dependencies: [],
+          dependents: [],
+        },
+      },
+    })
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        sessions={[session]}
+        dags={[dag]}
+      />
+    )
+    const dagId = document.querySelector('[data-testid="node-detail-dag-id"]')
+    expect(dagId).toBeTruthy()
+    expect(dagId!.textContent).toContain('dag-xyz')
+  })
+
+  it('clicking a child link invokes onSelectSession with the child session', () => {
+    const parent = makeSession({ id: 'p1', slug: 'parent-slug', childIds: ['c1'] })
+    const c1 = makeSession({ id: 'c1', slug: 'child-one', parentId: 'p1' })
+    const onSelectSession = vi.fn()
+    render(
+      <NodeDetailPopup
+        session={parent}
+        onClose={vi.fn()}
+        sessions={[parent, c1]}
+        dags={[]}
+        onSelectSession={onSelectSession}
+      />
+    )
+    const link = document.querySelector('[data-testid="node-detail-session-link-c1"]') as HTMLButtonElement
+    expect(link).toBeTruthy()
+    fireEvent.click(link)
+    expect(onSelectSession).toHaveBeenCalledWith(expect.objectContaining({ id: 'c1' }))
+  })
+
+  it('renders non-interactive slug when onSelectSession is not provided', () => {
+    const parent = makeSession({ id: 'p1', slug: 'parent-slug', childIds: ['c1'] })
+    const child = makeSession({ id: 'c1', slug: 'child-slug', parentId: 'p1' })
+    render(
+      <NodeDetailPopup
+        session={child}
+        onClose={vi.fn()}
+        sessions={[parent, child]}
+        dags={[]}
+      />
+    )
+    expect(document.querySelector('[data-testid="node-detail-session-link-p1"]')).toBeFalsy()
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')!
+    expect(hierarchy.innerHTML).toContain('parent-slug')
+  })
+
+  it('still renders existing meta rows (branch, repo, mode) alongside hierarchy', () => {
+    const parent = makeSession({ id: 'p1', slug: 'parent-slug', childIds: ['c1'] })
+    const child = makeSession({
+      id: 'c1',
+      slug: 'child-slug',
+      parentId: 'p1',
+      branch: 'feat/x',
+      repo: 'https://github.com/acme/w',
+      mode: 'task',
+    })
+    render(
+      <NodeDetailPopup
+        session={child}
+        onClose={vi.fn()}
+        sessions={[parent, child]}
+        dags={[]}
+      />
+    )
+    expect(document.body.innerHTML).toContain('feat/x')
+    expect(document.body.innerHTML).toContain('github.com/acme/w')
+    expect(document.body.innerHTML).toContain('task')
+  })
+
+  it('Escape key triggers onClose', () => {
+    const session = makeSession()
+    const onClose = vi.fn()
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={onClose}
+        sessions={[session]}
+        dags={[]}
+      />
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('works without sessions/dags props (backwards-safe optional)', () => {
+    const session = makeSession({ parentId: 'other', childIds: ['x'] })
+    render(<NodeDetailPopup session={session} onClose={vi.fn()} />)
+    expect(document.querySelector('[data-testid="node-detail-hierarchy"]')).toBeFalsy()
+  })
+})


### PR DESCRIPTION
## Summary

Enhance the per-node detail popup with clickable parent/child navigation, DAG membership, and inline node status. Users can now navigate minion relationships and understand DAG node status without leaving the universe canvas.

## Changes

- **NodeDetailPopup.tsx**: Added optional `sessions`, `dags`, `onSelectSession` props to render a hierarchy meta block featuring:
  - Parent minion slug (linkified, swaps detail popup target on click)
  - Children minions (pluralized, each linkified for navigation)
  - DAG id (resolved via session id match, falls back to raw id)
  - Node status within DAG (only displayed when different from session status)
  - Escape key closes meta block
- **UniverseCanvas.tsx**: Threads `sessions`, `dags`, and `onSelectSession` callback to detail popup for seamless parent/child navigation
- **test/components/NodeDetailPopup.test.tsx**: 15 new component tests covering all branches (parent present/absent, children pluralization, DAG id logic, divergent DAG node status, click-to-navigate, Escape close, optional-prop behavior)

## Test verification

- TypeScript: clean
- ESLint: clean
- vitest: 418 tests passing (43 files), including 15 new tests

🤖 Generated with Claude Code

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  extract-hierarchy["✅ Extract classifySessions to shared state module"]
  chat-header-context["✅ Add parent/children/DAG/branch context to chat header"]
  attention-triage-bar["✅ Add action bar for sessions needing attention"]
  enhance-node-popup["✅ Add hierarchy metadata to NodeDetailPopup"]
  group-session-list["✅ Group SessionList by DAG/Tree/Standalone with nesting"]
  mount-canvas-tab["✅ Mount UniverseCanvas as second tab with view toggle"]
  fix-rendering-edges["✅ Fix edge-case rendering (status, animation, orphans)"]
  ship-mode-grouping["✅ Add fourth classification bucket for ship mode"]
  ship-pipeline-kanban["✅ Create Kanban view for ship pipelines"]
  enhance-context-menu["✅ Add navigation actions to ContextMenu"]
  polish-ui-details["✅ Polish: badges, chips, keyboard nav, DAG summaries"]
  extract-hierarchy --> group-session-list
  extract-hierarchy --> mount-canvas-tab
  extract-hierarchy --> fix-rendering-edges
  extract-hierarchy --> ship-mode-grouping
  mount-canvas-tab --> ship-pipeline-kanban
  mount-canvas-tab --> enhance-context-menu
  group-session-list --> polish-ui-details
  mount-canvas-tab --> polish-ui-details
  class extract-hierarchy done
  class chat-header-context done
  class attention-triage-bar done
  class enhance-node-popup done
  class enhance-node-popup current
  class group-session-list done
  class mount-canvas-tab done
  class fix-rendering-edges done
  class ship-mode-grouping done
  class ship-pipeline-kanban done
  class enhance-context-menu done
  class polish-ui-details done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | Extract classifySessions to shared state module | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/11) |
| 2 | Add parent/children/DAG/branch context to chat header | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/12) |
| 3 | Add action bar for sessions needing attention | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/13) |
| 4 | **Add hierarchy metadata to NodeDetailPopup** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/19) |
| 5 | Group SessionList by DAG/Tree/Standalone with nesting | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/14) |
| 6 | Mount UniverseCanvas as second tab with view toggle | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/20) |
| 7 | Fix edge-case rendering (status, animation, orphans) | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/17) |
| 8 | Add fourth classification bucket for ship mode | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/18) |
| 9 | Create Kanban view for ship pipelines | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/21) |
| 10 | Add navigation actions to ContextMenu | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/22) |
| 11 | Polish: badges, chips, keyboard nav, DAG summaries | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/24) |

**Progress:** 11/11 complete

<!-- dag-status-end -->



