### PR TITLE
[minions] feat(ui): mount UniverseCanvas as second tab with view toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { signal } from '@preact/signals'
-import { useState, useEffect, useMemo, useRef } from 'preact/hooks'
+import { useState, useEffect, useMemo, useRef, useCallback } from 'preact/hooks'
 import { useRegisterSW } from 'virtual:pwa-register/preact'
 import { connections, activeId, getActiveStore } from './connections/store'
 import { ConnectionSettings } from './connections/ConnectionSettings'
@@ -15,6 +15,7 @@ import { DiffTab } from './chat/DiffTab'
 import { ScreenshotsTab } from './chat/ScreenshotsTab'
 import { PrPreviewCard } from './components/PrPreviewCard'
 import { AttentionBar, filterSessionsByReason } from './components/AttentionBar'
+import { UniverseCanvas } from './components/UniverseCanvas'
 import { hasFeature } from './api/features'
 import type { ConnectionStore } from './state/types'
 import { confirm } from './hooks/useConfirm'
@@ -33,8 +34,48 @@ import { currentRoute } from './routing/current'
 import { VariantGroupView } from './groups/VariantGroupView'
 import type { ApiSession, AttentionReason, MinionCommand, QuickAction } from './api/types'
 
+export type ViewMode = 'list' | 'canvas'
+
 const showSettings = signal(false)
 const showDrawer = signal(false)
+export const viewMode = signal<ViewMode>('list')
+
+function ViewToggle({ mode, onChange }: { mode: ViewMode; onChange: (m: ViewMode) => void }) {
+  const tabClass = (active: boolean) =>
+    `px-2.5 py-1 text-xs font-medium transition-colors ${
+      active
+        ? 'bg-indigo-600 text-white'
+        : 'bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700'
+    }`
+  return (
+    <div
+      class="inline-flex rounded-md border border-slate-300 dark:border-slate-600 overflow-hidden"
+      role="tablist"
+      data-testid="view-toggle"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === 'list'}
+        onClick={() => onChange('list')}
+        class={tabClass(mode === 'list')}
+        data-testid="view-toggle-list"
+      >
+        List
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === 'canvas'}
+        onClick={() => onChange('canvas')}
+        class={`${tabClass(mode === 'canvas')} border-l border-slate-300 dark:border-slate-600`}
+        data-testid="view-toggle-canvas"
+      >
+        Canvas
+      </button>
+    </div>
+  )
+}
 
 function ConnectionStatusBadge({ status }: { status: string }) {
   const color =
@@ -721,9 +762,11 @@ function ActiveView() {
   const conn = connections.value.find((c) => c.id === id)
   const [sessionId, setSessionId] = useState<string | null>(null)
   const [attentionFilter, setAttentionFilter] = useState<AttentionReason | null>(null)
+  const [isActionLoading, setIsActionLoading] = useState(false)
   const isOnline = useOnlineStatus()
   const isDesktop = useMediaQuery('(min-width: 768px)')
   const route = currentRoute.value
+  const mode = viewMode.value
 
   useEffect(() => {
     const color = conn?.color ?? '#3b82f6'
@@ -741,10 +784,71 @@ function ActiveView() {
   }, [id])
 
   const sessions = store?.sessions.value ?? []
+  const dags = store?.dags.value ?? []
   const visibleSessions = useMemo(
     () => filterSessionsByReason(sessions, attentionFilter),
     [sessions, attentionFilter],
   )
+
+  const handleSendMessage = useCallback(
+    async (text: string, sid: string) => {
+      if (!store) return
+      await store.client.sendMessage(text, sid)
+    },
+    [store]
+  )
+
+  const handleCommand = useCallback(
+    async (cmd: MinionCommand) => {
+      if (!store) return
+      await store.sendCommand(cmd)
+    },
+    [store]
+  )
+
+  const handleCanvasSendReply = useCallback(
+    async (sid: string, message: string) => {
+      if (!store) return
+      setIsActionLoading(true)
+      try {
+        await store.client.sendMessage(message, sid)
+      } finally {
+        setIsActionLoading(false)
+      }
+    },
+    [store]
+  )
+
+  const handleCanvasStop = useCallback(
+    async (sid: string) => {
+      if (!store) return
+      setIsActionLoading(true)
+      try {
+        await store.sendCommand({ action: 'stop', sessionId: sid })
+      } finally {
+        setIsActionLoading(false)
+      }
+    },
+    [store]
+  )
+
+  const handleCanvasClose = useCallback(
+    async (sid: string) => {
+      if (!store) return
+      setIsActionLoading(true)
+      try {
+        await store.sendCommand({ action: 'close', sessionId: sid })
+      } finally {
+        setIsActionLoading(false)
+      }
+    },
+    [store]
+  )
+
+  const handleOpenChat = useCallback((sid: string) => {
+    setSessionId(sid)
+    viewMode.value = 'list'
+  }, [])
 
   if (!store || !conn) return null
 
@@ -759,15 +863,20 @@ function ActiveView() {
     if (firstMatchId !== null) setSessionId(firstMatchId)
   }
 
-  const handleSendMessage = async (text: string, sid: string) => {
-    await store.client.sendMessage(text, sid)
-  }
-
-  const handleCommand = async (cmd: MinionCommand) => {
-    await store.sendCommand(cmd)
-  }
 
   const showOfflineBanner = !isOnline.value && store.stale.value
+
+  const canvasProps = {
+    sessions,
+    dags,
+    onSendReply: handleCanvasSendReply,
+    onStopMinion: handleCanvasStop,
+    onCloseSession: handleCanvasClose,
+    onOpenThread: () => {},
+    onOpenChat: handleOpenChat,
+    isActionLoading,
+    accentColor: conn.color,
+  }
 
   return (
     <div class="flex flex-col h-[100dvh] bg-slate-50 dark:bg-slate-900">
@@ -780,6 +889,7 @@ function ActiveView() {
         <ConnectionPicker onManage={() => { showDrawer.value = true }} />
         <ConnectionStatusBadge status={store.status.value} />
         <div class="ml-auto flex items-center gap-1.5">
+          <ViewToggle mode={mode} onChange={(m) => { viewMode.value = m }} />
           <ThemeToggle />
           <button
             type="button"
@@ -802,19 +912,25 @@ function ActiveView() {
       {isGroupRoute ? (
         <VariantGroupView store={store} groupId={route.groupId} />
       ) : isDesktop.value ? (
-        <DesktopBody
-          sessions={sessions}
-          visibleSessions={visibleSessions}
-          dags={store.dags.value}
-          sessionId={sessionId}
-          setSessionId={setSessionId}
-          selected={selected}
-          store={store}
-          onSend={handleSendMessage}
-          onCommand={handleCommand}
-          attentionFilter={attentionFilter}
-          onAttentionSelect={handleAttentionSelect}
-        />
+        mode === 'canvas' ? (
+          <div class="flex flex-1 min-h-0" data-testid="canvas-pane">
+            <UniverseCanvas {...canvasProps} />
+          </div>
+        ) : (
+          <DesktopBody
+            sessions={sessions}
+            visibleSessions={visibleSessions}
+            dags={store.dags.value}
+            sessionId={sessionId}
+            setSessionId={setSessionId}
+            selected={selected}
+            store={store}
+            onSend={handleSendMessage}
+            onCommand={handleCommand}
+            attentionFilter={attentionFilter}
+            onAttentionSelect={handleAttentionSelect}
+          />
+        )
       ) : (
         <div class="flex flex-col flex-1 min-h-0">
           <AttentionBar
@@ -840,6 +956,28 @@ function ActiveView() {
           ) : (
             <EmptyPane />
           )}
+        </div>
+      )}
+      {!isDesktop.value && mode === 'canvas' && (
+        <div
+          class="fixed inset-0 z-40 bg-slate-50 dark:bg-slate-900 flex flex-col"
+          data-testid="canvas-mobile-modal"
+        >
+          <div class="flex items-center gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0">
+            <span class="text-sm font-medium text-slate-900 dark:text-slate-100">Canvas</span>
+            <button
+              type="button"
+              onClick={() => { viewMode.value = 'list' }}
+              class="ml-auto rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+              data-testid="canvas-mobile-close"
+              aria-label="Close canvas"
+            >
+              Close
+            </button>
+          </div>
+          <div class="flex-1 min-h-0">
+            <UniverseCanvas {...canvasProps} />
+          </div>
         </div>
       )}
       {showDrawer.value && (

--- a/test/App.viewToggle.test.tsx
+++ b/test/App.viewToggle.test.tsx
@@ -1,0 +1,278 @@
+import { render, screen, fireEvent, within } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { installMockEventSource } from './sse-mock'
+import type { VersionInfo, ApiSession, ApiDagGraph } from '../src/api/types'
+
+vi.mock('virtual:pwa-register/preact', () => ({
+  useRegisterSW: vi.fn().mockReturnValue({}),
+}))
+
+vi.mock('idb-keyval', () => ({
+  get: vi.fn().mockResolvedValue(undefined),
+  set: vi.fn().mockResolvedValue(undefined),
+  del: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@reactflow/core', () => ({
+  ReactFlow: vi.fn(({ nodes, nodeTypes, children }) => (
+    <div data-testid="react-flow" data-node-count={nodes?.length || 0}>
+      {nodes?.map((n: { id: string; type: string; data: Record<string, unknown> }) => {
+        const Comp = nodeTypes?.[n.type]
+        return Comp ? (
+          <div key={n.id} data-testid={`flow-node-${n.id}`}>
+            <Comp data={n.data} />
+          </div>
+        ) : (
+          <div key={n.id} data-testid={`flow-node-${n.id}`}>
+            {String(n.data?.label ?? n.id)}
+          </div>
+        )
+      })}
+      {children}
+    </div>
+  )),
+  useNodesState: vi.fn((initial: unknown[]) => [initial, vi.fn(), vi.fn()]),
+  useEdgesState: vi.fn((initial: unknown[]) => [initial, vi.fn(), vi.fn()]),
+  MarkerType: { ArrowClosed: 'arrowClosed' },
+  Handle: vi.fn(() => null),
+  Position: { Top: 'top', Bottom: 'bottom' },
+}))
+
+vi.mock('@reactflow/background', () => ({
+  Background: vi.fn(() => <div data-testid="background" />),
+}))
+
+vi.mock('@reactflow/controls', () => ({
+  Controls: vi.fn(() => <div data-testid="controls" />),
+}))
+
+vi.mock('@reactflow/minimap', () => ({
+  MiniMap: vi.fn(() => <div data-testid="minimap" />),
+}))
+
+vi.mock('dagre', () => {
+  function MockGraph(this: {
+    setDefaultEdgeLabel: ReturnType<typeof vi.fn>
+    setGraph: ReturnType<typeof vi.fn>
+    setNode: ReturnType<typeof vi.fn>
+    setEdge: ReturnType<typeof vi.fn>
+    node: ReturnType<typeof vi.fn>
+    graph: ReturnType<typeof vi.fn>
+  }) {
+    this.setDefaultEdgeLabel = vi.fn()
+    this.setGraph = vi.fn()
+    this.setNode = vi.fn()
+    this.setEdge = vi.fn()
+    this.node = vi.fn(() => ({ x: 100, y: 100 }))
+    this.graph = vi.fn(() => ({ width: 400, height: 300 }))
+  }
+  return {
+    default: {
+      graphlib: { Graph: MockGraph },
+      layout: vi.fn(),
+    },
+  }
+})
+
+const VERSION: VersionInfo = { apiVersion: '1', libraryVersion: '0.1.0', features: [] }
+
+function stubFetch(sessions: ApiSession[] = [], dags: ApiDagGraph[] = []) {
+  const sendMessage = vi.fn().mockResolvedValue({ ok: true, sessionId: 's1' })
+  const sendCommand = vi.fn().mockResolvedValue({ success: true })
+  const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+    if (url.includes('/api/version')) {
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: VERSION }) })
+    }
+    if (url.includes('/api/sessions')) {
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: sessions }) })
+    }
+    if (url.includes('/api/dags')) {
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: dags }) })
+    }
+    if (url.includes('/api/messages')) {
+      const body = init?.body ? JSON.parse(init.body as string) : {}
+      sendMessage(body)
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: { ok: true, sessionId: body.sessionId ?? 's1' } }) })
+    }
+    if (url.includes('/api/commands')) {
+      const body = init?.body ? JSON.parse(init.body as string) : {}
+      sendCommand(body)
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: { success: true } }) })
+    }
+    return Promise.resolve({ ok: false, status: 404, statusText: 'NF', json: () => Promise.resolve({ data: null }) })
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return { fetchMock, sendMessage, sendCommand }
+}
+
+function setDesktop(isDesktop: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn(() => ({
+      matches: isDesktop,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  })
+}
+
+function session(over: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 's1',
+    slug: 'brave-fox',
+    status: 'running',
+    command: '/task foo',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...over,
+  }
+}
+
+function seedConnection() {
+  localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
+    version: 1,
+    connections: [
+      { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+    ],
+    activeId: 'c1',
+  }))
+}
+
+async function resetViewMode() {
+  const mod = await import('../src/App')
+  mod.viewMode.value = 'list'
+}
+
+describe('App view toggle', () => {
+  let mock: ReturnType<typeof installMockEventSource>
+
+  beforeEach(() => {
+    localStorage.clear()
+    mock = installMockEventSource()
+    vi.resetModules()
+    setDesktop(true)
+  })
+
+  afterEach(() => {
+    mock.restore()
+    vi.unstubAllGlobals()
+    localStorage.clear()
+  })
+
+  it('renders ViewToggle with List selected by default', async () => {
+    seedConnection()
+    stubFetch([session()])
+    await resetViewMode()
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    const toggle = await screen.findByTestId('view-toggle')
+    const listBtn = within(toggle).getByTestId('view-toggle-list')
+    const canvasBtn = within(toggle).getByTestId('view-toggle-canvas')
+    expect(listBtn.getAttribute('aria-selected')).toBe('true')
+    expect(canvasBtn.getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('switches to canvas view when Canvas tab clicked on desktop', async () => {
+    seedConnection()
+    stubFetch([session()])
+    await resetViewMode()
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    await screen.findByText('brave-fox')
+    fireEvent.click(screen.getByTestId('view-toggle-canvas'))
+
+    const canvasPane = await screen.findByTestId('canvas-pane')
+    expect(canvasPane).toBeTruthy()
+    expect(within(canvasPane).getByTestId('universe-canvas')).toBeTruthy()
+  })
+
+  it('switching back to List hides the canvas pane', async () => {
+    seedConnection()
+    stubFetch([session()])
+    await resetViewMode()
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    fireEvent.click(await screen.findByTestId('view-toggle-canvas'))
+    await screen.findByTestId('canvas-pane')
+
+    fireEvent.click(screen.getByTestId('view-toggle-list'))
+    expect(screen.queryByTestId('canvas-pane')).toBeNull()
+    await screen.findByTestId('session-item-s1')
+  })
+
+  it('clicking a node in canvas opens detail popup with Open Chat button', async () => {
+    seedConnection()
+    stubFetch([session({ id: 's1', slug: 'brave-fox' })])
+    await resetViewMode()
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    fireEvent.click(await screen.findByTestId('view-toggle-canvas'))
+    const node = await screen.findByTestId('universe-node-s1')
+    fireEvent.click(node)
+    expect(await screen.findByText('Open Chat')).toBeTruthy()
+  })
+
+  it('Open Chat from canvas popup switches to list and selects session', async () => {
+    seedConnection()
+    stubFetch([session({ id: 's1', slug: 'brave-fox', conversation: [{ role: 'user', text: 'hello-from-canvas' }] })])
+    await resetViewMode()
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    fireEvent.click(await screen.findByTestId('view-toggle-canvas'))
+    const node = await screen.findByTestId('universe-node-s1')
+    fireEvent.click(node)
+    fireEvent.click(await screen.findByText('Open Chat'))
+
+    const conv = await screen.findByTestId('conversation-view')
+    expect(within(conv).getByText('hello-from-canvas')).toBeTruthy()
+    expect(screen.queryByTestId('canvas-pane')).toBeNull()
+  })
+
+  it('renders mobile full-screen canvas modal with close button on mobile', async () => {
+    setDesktop(false)
+    seedConnection()
+    stubFetch([session()])
+    await resetViewMode()
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    fireEvent.click(await screen.findByTestId('view-toggle-canvas'))
+
+    const modal = await screen.findByTestId('canvas-mobile-modal')
+    expect(modal).toBeTruthy()
+    expect(within(modal).getByTestId('universe-canvas')).toBeTruthy()
+
+    fireEvent.click(within(modal).getByTestId('canvas-mobile-close'))
+    expect(screen.queryByTestId('canvas-mobile-modal')).toBeNull()
+  })
+
+  it('canvas sendReply callback calls /api/messages', async () => {
+    seedConnection()
+    const { sendMessage } = stubFetch([session({ id: 's1', slug: 'brave-fox', quickActions: [{ type: 'retry', label: 'Retry', message: 'retry please' }] })])
+    await resetViewMode()
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    fireEvent.click(await screen.findByTestId('view-toggle-canvas'))
+    const node = await screen.findByTestId('universe-node-s1')
+    fireEvent.contextMenu(node.parentElement!, { clientX: 10, clientY: 10 })
+
+    const retryBtn = await screen.findByText('Retry')
+    fireEvent.click(retryBtn)
+
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 's1', text: 'retry please' }))
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `viewMode` signal (`'list' | 'canvas'`) and a segmented **View toggle** next to Refresh in the connection header.
- Mounts `UniverseCanvas` as the second view: replaces the sidebar+chat layout on desktop when canvas mode is active; renders as a full-screen modal with a Close button on mobile.
- Wires canvas callbacks (`onSendReply`, `onStopMinion`, `onCloseSession`) through the active connection store. Clicking **Open Chat** on a node switches back to the list view with that session selected.

## Why
Part of the UI improvements thread for ships / DAGs / stacks / parent-child minions — surfacing the graph view alongside the list so users can navigate hierarchies visually without losing the chat flow.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 27 files, 254 tests pass, including 7 new cases in `test/App.viewToggle.test.tsx` covering toggle state, desktop/mobile rendering, canvas → chat navigation, and reply dispatch.
- [ ] E2E not run (out of scope per task deliverable).

## Notes / assumptions
- Kept the shared header, `NewTaskBar`, and offline banner visible in both modes so the toggle, connection status, and task entry stay reachable.
- `onOpenThread` on `UniverseCanvas` is Telegram-only and wired as a no-op here.
- Canvas view mounts the existing component unchanged — edge-case rendering, ship-pipeline classification, hierarchy metadata, etc. are handled by sibling minions.

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  extract-hierarchy["✅ Extract classifySessions to shared state module"]
  chat-header-context["✅ Add parent/children/DAG/branch context to chat header"]
  attention-triage-bar["✅ Add action bar for sessions needing attention"]
  enhance-node-popup["✅ Add hierarchy metadata to NodeDetailPopup"]
  group-session-list["✅ Group SessionList by DAG/Tree/Standalone with nesting"]
  mount-canvas-tab["✅ Mount UniverseCanvas as second tab with view toggle"]
  fix-rendering-edges["✅ Fix edge-case rendering (status, animation, orphans)"]
  ship-mode-grouping["✅ Add fourth classification bucket for ship mode"]
  ship-pipeline-kanban["✅ Create Kanban view for ship pipelines"]
  enhance-context-menu["✅ Add navigation actions to ContextMenu"]
  polish-ui-details["✅ Polish: badges, chips, keyboard nav, DAG summaries"]
  extract-hierarchy --> group-session-list
  extract-hierarchy --> mount-canvas-tab
  extract-hierarchy --> fix-rendering-edges
  extract-hierarchy --> ship-mode-grouping
  mount-canvas-tab --> ship-pipeline-kanban
  mount-canvas-tab --> enhance-context-menu
  group-session-list --> polish-ui-details
  mount-canvas-tab --> polish-ui-details
  class extract-hierarchy done
  class chat-header-context done
  class attention-triage-bar done
  class enhance-node-popup done
  class group-session-list done
  class mount-canvas-tab done
  class mount-canvas-tab current
  class fix-rendering-edges done
  class ship-mode-grouping done
  class ship-pipeline-kanban done
  class enhance-context-menu done
  class polish-ui-details done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | Extract classifySessions to shared state module | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/11) |
| 2 | Add parent/children/DAG/branch context to chat header | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/12) |
| 3 | Add action bar for sessions needing attention | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/13) |
| 4 | Add hierarchy metadata to NodeDetailPopup | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/19) |
| 5 | Group SessionList by DAG/Tree/Standalone with nesting | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/14) |
| 6 | **Mount UniverseCanvas as second tab with view toggle** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/20) |
| 7 | Fix edge-case rendering (status, animation, orphans) | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/17) |
| 8 | Add fourth classification bucket for ship mode | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/18) |
| 9 | Create Kanban view for ship pipelines | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/21) |
| 10 | Add navigation actions to ContextMenu | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/22) |
| 11 | Polish: badges, chips, keyboard nav, DAG summaries | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/24) |

**Progress:** 11/11 complete

<!-- dag-status-end -->


