### PR TITLE
[minions] feat(ui): add Ship pipeline Kanban view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { ScreenshotsTab } from './chat/ScreenshotsTab'
 import { PrPreviewCard } from './components/PrPreviewCard'
 import { AttentionBar, filterSessionsByReason } from './components/AttentionBar'
 import { UniverseCanvas } from './components/UniverseCanvas'
+import { ShipPipelineView } from './components/ShipPipeline'
 import { hasFeature } from './api/features'
 import type { ConnectionStore } from './state/types'
 import { confirm } from './hooks/useConfirm'
@@ -34,7 +35,7 @@ import { currentRoute } from './routing/current'
 import { VariantGroupView } from './groups/VariantGroupView'
 import type { ApiSession, AttentionReason, MinionCommand, QuickAction } from './api/types'
 
-export type ViewMode = 'list' | 'canvas'
+export type ViewMode = 'list' | 'canvas' | 'ship'
 
 const showSettings = signal(false)
 const showDrawer = signal(false)
@@ -72,6 +73,16 @@ function ViewToggle({ mode, onChange }: { mode: ViewMode; onChange: (m: ViewMode
         data-testid="view-toggle-canvas"
       >
         Canvas
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === 'ship'}
+        onClick={() => onChange('ship')}
+        class={`${tabClass(mode === 'ship')} border-l border-slate-300 dark:border-slate-600`}
+        data-testid="view-toggle-ship"
+      >
+        Ship
       </button>
     </div>
   )
@@ -916,6 +927,10 @@ function ActiveView() {
           <div class="flex flex-1 min-h-0" data-testid="canvas-pane">
             <UniverseCanvas {...canvasProps} />
           </div>
+        ) : mode === 'ship' ? (
+          <div class="flex flex-1 min-h-0" data-testid="ship-pane">
+            <ShipPipelineView dags={dags} onOpenChat={handleOpenChat} />
+          </div>
         ) : (
           <DesktopBody
             sessions={sessions}
@@ -977,6 +992,28 @@ function ActiveView() {
           </div>
           <div class="flex-1 min-h-0">
             <UniverseCanvas {...canvasProps} />
+          </div>
+        </div>
+      )}
+      {!isDesktop.value && mode === 'ship' && (
+        <div
+          class="fixed inset-0 z-40 bg-slate-50 dark:bg-slate-900 flex flex-col"
+          data-testid="ship-mobile-modal"
+        >
+          <div class="flex items-center gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0">
+            <span class="text-sm font-medium text-slate-900 dark:text-slate-100">Ship</span>
+            <button
+              type="button"
+              onClick={() => { viewMode.value = 'list' }}
+              class="ml-auto rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+              data-testid="ship-mobile-close"
+              aria-label="Close ship view"
+            >
+              Close
+            </button>
+          </div>
+          <div class="flex-1 min-h-0 flex flex-col">
+            <ShipPipelineView dags={dags} onOpenChat={handleOpenChat} />
           </div>
         </div>
       )}

--- a/src/components/ShipPipeline.tsx
+++ b/src/components/ShipPipeline.tsx
@@ -1,0 +1,212 @@
+import { useMemo } from 'preact/hooks'
+import type { ApiDagNode } from '../api/types'
+import { useTheme } from '../hooks/useTheme'
+import { StatusBadge, formatRelativeTime } from './shared'
+import { PrLink } from './PrLink'
+import {
+  SHIP_COLUMN_LABELS,
+  SHIP_COLUMN_ORDER,
+  selectShipPipelines,
+  type ShipColumn,
+  type ShipPipelineSummary,
+} from './ship-pipeline'
+import type { ApiDagGraph } from '../api/types'
+
+export interface ShipPipelineViewProps {
+  dags: ApiDagGraph[]
+  onOpenChat?: (sessionId: string) => void
+}
+
+const COLUMN_ACCENTS: Record<ShipColumn, { light: string; dark: string; label: string }> = {
+  running: { light: 'border-blue-300 bg-blue-50', dark: 'border-blue-700 bg-blue-950/30', label: 'text-blue-700 dark:text-blue-300' },
+  review: { light: 'border-indigo-300 bg-indigo-50', dark: 'border-indigo-700 bg-indigo-950/30', label: 'text-indigo-700 dark:text-indigo-300' },
+  ci: { light: 'border-amber-300 bg-amber-50', dark: 'border-amber-700 bg-amber-950/30', label: 'text-amber-700 dark:text-amber-300' },
+  landed: { light: 'border-emerald-300 bg-emerald-50', dark: 'border-emerald-700 bg-emerald-950/30', label: 'text-emerald-700 dark:text-emerald-300' },
+}
+
+function NodeCard({
+  node,
+  onOpenChat,
+}: {
+  node: ApiDagNode
+  onOpenChat?: (sessionId: string) => void
+}) {
+  const session = node.session
+  const clickable = Boolean(session && onOpenChat)
+
+  const handleClick = () => {
+    if (session && onOpenChat) onOpenChat(session.id)
+  }
+
+  return (
+    <div
+      role={clickable ? 'button' : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onClick={clickable ? handleClick : undefined}
+      onKeyDown={
+        clickable
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                handleClick()
+              }
+            }
+          : undefined
+      }
+      class={`flex flex-col gap-2 rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-2.5 text-left shadow-sm transition-colors ${
+        clickable ? 'cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-700/60' : 'cursor-default'
+      }`}
+      data-testid={`ship-pipeline-card-${node.id}`}
+    >
+      <div class="flex items-center justify-between gap-2">
+        <span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">
+          {node.slug}
+        </span>
+        <StatusBadge status={node.status} />
+      </div>
+      <div class="flex items-center justify-between gap-2">
+        {session?.prUrl ? (
+          <div onClick={(e: Event) => e.stopPropagation()}>
+            <PrLink prUrl={session.prUrl} compact />
+          </div>
+        ) : session?.branch ? (
+          <span class="text-[11px] font-mono truncate text-slate-500 dark:text-slate-400 max-w-[180px]">
+            {session.branch}
+          </span>
+        ) : (
+          <span class="text-[11px] text-slate-400 dark:text-slate-500 italic">—</span>
+        )}
+        {session?.updatedAt && (
+          <span class="text-[10px] text-slate-400 dark:text-slate-500 shrink-0">
+            {formatRelativeTime(session.updatedAt)}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Column({
+  column,
+  nodes,
+  isDark,
+  onOpenChat,
+}: {
+  column: ShipColumn
+  nodes: ApiDagNode[]
+  isDark: boolean
+  onOpenChat?: (sessionId: string) => void
+}) {
+  const accent = COLUMN_ACCENTS[column]
+  const bg = isDark ? accent.dark : accent.light
+  return (
+    <div
+      class={`flex flex-col gap-2 rounded-lg border ${bg} p-2 min-w-[220px] flex-1`}
+      data-testid={`ship-pipeline-column-${column}`}
+    >
+      <div class="flex items-center justify-between px-1">
+        <span class={`text-xs font-semibold uppercase tracking-wide ${accent.label}`}>
+          {SHIP_COLUMN_LABELS[column]}
+        </span>
+        <span class="text-[10px] font-medium text-slate-500 dark:text-slate-400">
+          {nodes.length}
+        </span>
+      </div>
+      <div class="flex flex-col gap-1.5">
+        {nodes.length === 0 ? (
+          <div class="text-[11px] italic text-slate-400 dark:text-slate-500 px-1 py-2">
+            Empty
+          </div>
+        ) : (
+          nodes.map((node) => (
+            <NodeCard key={node.id} node={node} onOpenChat={onOpenChat} />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+function PipelineBoard({
+  summary,
+  isDark,
+  onOpenChat,
+}: {
+  summary: ShipPipelineSummary
+  isDark: boolean
+  onOpenChat?: (sessionId: string) => void
+}) {
+  const { dag, columns, total, landedCount } = summary
+  const progressLabel = `${landedCount} of ${total} landed`
+
+  return (
+    <section
+      class="flex flex-col gap-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-white/40 dark:bg-slate-900/40 p-3"
+      data-testid={`ship-pipeline-board-${dag.id}`}
+    >
+      <header class="flex items-center gap-2 flex-wrap">
+        <span class="text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Ship pipeline
+        </span>
+        <span class="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">
+          {dag.id}
+        </span>
+        <span class="text-xs text-slate-500 dark:text-slate-400 ml-auto">
+          {progressLabel}
+        </span>
+      </header>
+      <div class="flex gap-2 overflow-x-auto pb-1">
+        {SHIP_COLUMN_ORDER.map((column) => (
+          <Column
+            key={column}
+            column={column}
+            nodes={columns[column]}
+            isDark={isDark}
+            onOpenChat={onOpenChat}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export function ShipPipelineView({ dags, onOpenChat }: ShipPipelineViewProps) {
+  const theme = useTheme()
+  const isDark = theme.value === 'dark'
+  const pipelines = useMemo(() => selectShipPipelines(dags), [dags])
+
+  if (pipelines.length === 0) {
+    return (
+      <div
+        class="flex items-center justify-center flex-1 p-8 text-center text-sm text-slate-500 dark:text-slate-400"
+        data-testid="ship-pipeline-empty"
+      >
+        <div class="max-w-sm">
+          <div class="text-lg font-medium text-slate-700 dark:text-slate-200 mb-1">
+            No ship pipelines yet
+          </div>
+          <div>
+            Ship pipelines appear here when a DAG enters CI or lands.
+            Start one with <span class="font-mono">/ship</span>.
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      class="flex flex-col gap-4 p-4 overflow-y-auto flex-1 bg-slate-50 dark:bg-slate-900"
+      data-testid="ship-pipeline-view"
+    >
+      {pipelines.map((p) => (
+        <PipelineBoard
+          key={p.dag.id}
+          summary={p}
+          isDark={isDark}
+          onOpenChat={onOpenChat}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/ship-pipeline.ts
+++ b/src/components/ship-pipeline.ts
@@ -1,0 +1,79 @@
+import type { ApiDagGraph, ApiDagNode } from '../api/types'
+
+export type ShipColumn = 'running' | 'review' | 'ci' | 'landed'
+
+export const SHIP_COLUMN_ORDER: ShipColumn[] = ['running', 'review', 'ci', 'landed']
+
+export const SHIP_COLUMN_LABELS: Record<ShipColumn, string> = {
+  running: 'Running',
+  review: 'Review',
+  ci: 'CI',
+  landed: 'Landed',
+}
+
+export function classifyNodeForShip(status: ApiDagNode['status']): ShipColumn {
+  switch (status) {
+    case 'pending':
+    case 'running':
+    case 'failed':
+      return 'running'
+    case 'completed':
+      return 'review'
+    case 'ci-pending':
+    case 'ci-failed':
+      return 'ci'
+    case 'landed':
+    case 'skipped':
+      return 'landed'
+  }
+}
+
+export function isShipPipeline(dag: ApiDagGraph): boolean {
+  const nodes = Object.values(dag.nodes)
+  if (nodes.length === 0) return false
+  for (const node of nodes) {
+    if (node.status === 'ci-pending' || node.status === 'ci-failed' || node.status === 'landed') {
+      return true
+    }
+    if (node.session?.mode === 'ship-think') {
+      return true
+    }
+  }
+  return false
+}
+
+export interface ShipPipelineSummary {
+  dag: ApiDagGraph
+  columns: Record<ShipColumn, ApiDagNode[]>
+  total: number
+  landedCount: number
+}
+
+export function buildShipPipelineSummary(dag: ApiDagGraph): ShipPipelineSummary {
+  const columns: Record<ShipColumn, ApiDagNode[]> = {
+    running: [],
+    review: [],
+    ci: [],
+    landed: [],
+  }
+  const nodes = Object.values(dag.nodes)
+  for (const node of nodes) {
+    columns[classifyNodeForShip(node.status)].push(node)
+  }
+  return {
+    dag,
+    columns,
+    total: nodes.length,
+    landedCount: columns.landed.length,
+  }
+}
+
+export function selectShipPipelines(dags: ApiDagGraph[]): ShipPipelineSummary[] {
+  const summaries: ShipPipelineSummary[] = []
+  for (const dag of dags) {
+    if (!isShipPipeline(dag)) continue
+    summaries.push(buildShipPipelineSummary(dag))
+  }
+  summaries.sort((a, b) => (a.dag.updatedAt < b.dag.updatedAt ? 1 : -1))
+  return summaries
+}

--- a/test/App.viewToggle.test.tsx
+++ b/test/App.viewToggle.test.tsx
@@ -263,6 +263,77 @@ describe('App view toggle', () => {
     expect(screen.queryByTestId('canvas-mobile-modal')).toBeNull()
   })
 
+  it('renders the Ship tab in the view toggle', async () => {
+    seedConnection()
+    stubFetch([session()])
+    await resetViewMode()
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    const toggle = await screen.findByTestId('view-toggle')
+    expect(within(toggle).getByTestId('view-toggle-ship')).toBeTruthy()
+  })
+
+  it('switches to ship view when Ship tab clicked on desktop', async () => {
+    seedConnection()
+    const shipDag: ApiDagGraph = {
+      id: 'ship-1',
+      rootTaskId: 'n1',
+      nodes: {
+        n1: { id: 'n1', slug: 'ship-node', status: 'landed', dependencies: [], dependents: [] },
+      },
+      status: 'running',
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+    }
+    stubFetch([session()], [shipDag])
+    await resetViewMode()
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    fireEvent.click(await screen.findByTestId('view-toggle-ship'))
+    const shipPane = await screen.findByTestId('ship-pane')
+    expect(shipPane).toBeTruthy()
+    expect(within(shipPane).getByTestId('ship-pipeline-board-ship-1')).toBeTruthy()
+  })
+
+  it('shows the empty ship state when no DAG qualifies as a ship pipeline', async () => {
+    seedConnection()
+    stubFetch([session()])
+    await resetViewMode()
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    fireEvent.click(await screen.findByTestId('view-toggle-ship'))
+    expect(await screen.findByTestId('ship-pipeline-empty')).toBeTruthy()
+  })
+
+  it('renders mobile full-screen ship modal with close button on mobile', async () => {
+    setDesktop(false)
+    seedConnection()
+    const shipDag: ApiDagGraph = {
+      id: 'ship-m',
+      rootTaskId: 'n1',
+      nodes: {
+        n1: { id: 'n1', slug: 'ship-node', status: 'landed', dependencies: [], dependents: [] },
+      },
+      status: 'running',
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+    }
+    stubFetch([session()], [shipDag])
+    await resetViewMode()
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    fireEvent.click(await screen.findByTestId('view-toggle-ship'))
+    const modal = await screen.findByTestId('ship-mobile-modal')
+    expect(modal).toBeTruthy()
+
+    fireEvent.click(within(modal).getByTestId('ship-mobile-close'))
+    expect(screen.queryByTestId('ship-mobile-modal')).toBeNull()
+  })
+
   it('canvas sendReply callback calls /api/messages', async () => {
     seedConnection()
     const { sendMessage } = stubFetch([session({ id: 's1', slug: 'brave-fox', quickActions: [{ type: 'retry', label: 'Retry', message: 'retry please' }] })])

--- a/test/components/ShipPipeline.test.tsx
+++ b/test/components/ShipPipeline.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup, screen } from '@testing-library/preact'
+import { ShipPipelineView } from '../../src/components/ShipPipeline'
+import type { ApiDagGraph, ApiDagNode, ApiSession } from '../../src/api/types'
+
+function makeSession(overrides: Partial<ApiSession> & { id: string; slug: string }): ApiSession {
+  return {
+    status: 'running',
+    command: '/task test',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...overrides,
+  }
+}
+
+function makeNode(overrides: Partial<ApiDagNode> & { id: string }): ApiDagNode {
+  return {
+    slug: overrides.id,
+    status: 'pending',
+    dependencies: [],
+    dependents: [],
+    ...overrides,
+  }
+}
+
+function makeDag(overrides: Partial<ApiDagGraph> & { id: string }): ApiDagGraph {
+  return {
+    rootTaskId: 'n1',
+    nodes: {},
+    status: 'running',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ShipPipelineView', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the empty state when no ship pipelines exist', () => {
+    render(<ShipPipelineView dags={[]} />)
+    expect(screen.getByTestId('ship-pipeline-empty')).toBeTruthy()
+    expect(document.body.innerHTML).toContain('No ship pipelines yet')
+  })
+
+  it('ignores DAGs that have no ship markers', () => {
+    const dag = makeDag({
+      id: 'plain',
+      nodes: {
+        a: makeNode({ id: 'a', status: 'running' }),
+      },
+    })
+    render(<ShipPipelineView dags={[dag]} />)
+    expect(screen.getByTestId('ship-pipeline-empty')).toBeTruthy()
+  })
+
+  it('renders a board with all four columns when a DAG qualifies', () => {
+    const dag = makeDag({
+      id: 'ship-1',
+      nodes: {
+        a: makeNode({ id: 'a', status: 'running' }),
+        b: makeNode({ id: 'b', status: 'completed' }),
+        c: makeNode({ id: 'c', status: 'ci-pending' }),
+        d: makeNode({ id: 'd', status: 'landed' }),
+      },
+    })
+    render(<ShipPipelineView dags={[dag]} />)
+    expect(screen.getByTestId('ship-pipeline-board-ship-1')).toBeTruthy()
+    expect(screen.getByTestId('ship-pipeline-column-running')).toBeTruthy()
+    expect(screen.getByTestId('ship-pipeline-column-review')).toBeTruthy()
+    expect(screen.getByTestId('ship-pipeline-column-ci')).toBeTruthy()
+    expect(screen.getByTestId('ship-pipeline-column-landed')).toBeTruthy()
+  })
+
+  it('places each node in its mapped column', () => {
+    const dag = makeDag({
+      id: 'ship-1',
+      nodes: {
+        a: makeNode({ id: 'a', slug: 'run-task', status: 'running' }),
+        b: makeNode({ id: 'b', slug: 'review-task', status: 'completed' }),
+        c: makeNode({ id: 'c', slug: 'ci-task', status: 'ci-pending' }),
+        d: makeNode({ id: 'd', slug: 'landed-task', status: 'landed' }),
+      },
+    })
+    render(<ShipPipelineView dags={[dag]} />)
+    expect(
+      screen.getByTestId('ship-pipeline-column-running').innerHTML,
+    ).toContain('run-task')
+    expect(
+      screen.getByTestId('ship-pipeline-column-review').innerHTML,
+    ).toContain('review-task')
+    expect(
+      screen.getByTestId('ship-pipeline-column-ci').innerHTML,
+    ).toContain('ci-task')
+    expect(
+      screen.getByTestId('ship-pipeline-column-landed').innerHTML,
+    ).toContain('landed-task')
+  })
+
+  it('shows "Empty" placeholder text for empty columns', () => {
+    const dag = makeDag({
+      id: 'ship-1',
+      nodes: {
+        a: makeNode({ id: 'a', status: 'landed' }),
+      },
+    })
+    render(<ShipPipelineView dags={[dag]} />)
+    const runningCol = screen.getByTestId('ship-pipeline-column-running')
+    expect(runningCol.innerHTML).toContain('Empty')
+  })
+
+  it('shows landed progress in the header', () => {
+    const dag = makeDag({
+      id: 'ship-1',
+      nodes: {
+        a: makeNode({ id: 'a', status: 'running' }),
+        b: makeNode({ id: 'b', status: 'landed' }),
+        c: makeNode({ id: 'c', status: 'landed' }),
+      },
+    })
+    render(<ShipPipelineView dags={[dag]} />)
+    expect(
+      screen.getByTestId('ship-pipeline-board-ship-1').innerHTML,
+    ).toContain('2 of 3 landed')
+  })
+
+  it('includes ship-think-moded DAGs even without ci/landed nodes', () => {
+    const dag = makeDag({
+      id: 'planning',
+      nodes: {
+        a: makeNode({
+          id: 'a',
+          status: 'running',
+          session: makeSession({ id: 's1', slug: 'planner', mode: 'ship-think' }),
+        }),
+      },
+    })
+    render(<ShipPipelineView dags={[dag]} />)
+    expect(screen.getByTestId('ship-pipeline-board-planning')).toBeTruthy()
+  })
+
+  it('renders a PrLink when a node session has a PR url', () => {
+    const session = makeSession({
+      id: 's1',
+      slug: 'pr-task',
+      prUrl: 'https://github.com/org/repo/pull/42',
+    })
+    const dag = makeDag({
+      id: 'ship-1',
+      nodes: {
+        a: makeNode({ id: 'a', slug: 'pr-task', status: 'ci-pending', session }),
+      },
+    })
+    render(<ShipPipelineView dags={[dag]} />)
+    expect(document.body.innerHTML).toContain('#42')
+  })
+
+  it('calls onOpenChat when a card with a session is clicked', () => {
+    const onOpenChat = vi.fn()
+    const session = makeSession({ id: 's1', slug: 'clickable' })
+    const dag = makeDag({
+      id: 'ship-1',
+      nodes: {
+        a: makeNode({ id: 'a', slug: 'clickable', status: 'landed', session }),
+      },
+    })
+    render(<ShipPipelineView dags={[dag]} onOpenChat={onOpenChat} />)
+
+    fireEvent.click(screen.getByTestId('ship-pipeline-card-a'))
+    expect(onOpenChat).toHaveBeenCalledWith('s1')
+  })
+
+  it('cards without a session are not clickable', () => {
+    const onOpenChat = vi.fn()
+    const dag = makeDag({
+      id: 'ship-1',
+      nodes: {
+        a: makeNode({ id: 'a', slug: 'no-session', status: 'landed' }),
+      },
+    })
+    render(<ShipPipelineView dags={[dag]} onOpenChat={onOpenChat} />)
+
+    fireEvent.click(screen.getByTestId('ship-pipeline-card-a'))
+    expect(onOpenChat).not.toHaveBeenCalled()
+  })
+
+  it('renders multiple ship pipelines, newest first', () => {
+    const older = makeDag({
+      id: 'older',
+      updatedAt: '2024-01-01T00:00:00Z',
+      nodes: { n: makeNode({ id: 'n', status: 'landed' }) },
+    })
+    const newer = makeDag({
+      id: 'newer',
+      updatedAt: '2024-03-01T00:00:00Z',
+      nodes: { n: makeNode({ id: 'n', status: 'landed' }) },
+    })
+    render(<ShipPipelineView dags={[older, newer]} />)
+    const view = screen.getByTestId('ship-pipeline-view')
+    const newerIdx = view.innerHTML.indexOf('ship-pipeline-board-newer')
+    const olderIdx = view.innerHTML.indexOf('ship-pipeline-board-older')
+    expect(newerIdx).toBeGreaterThanOrEqual(0)
+    expect(olderIdx).toBeGreaterThan(newerIdx)
+  })
+})

--- a/test/components/ship-pipeline.test.ts
+++ b/test/components/ship-pipeline.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest'
+import type { ApiDagGraph, ApiDagNode, ApiSession } from '../../src/api/types'
+import {
+  SHIP_COLUMN_ORDER,
+  buildShipPipelineSummary,
+  classifyNodeForShip,
+  isShipPipeline,
+  selectShipPipelines,
+} from '../../src/components/ship-pipeline'
+
+function makeSession(overrides: Partial<ApiSession> & { id: string; slug: string }): ApiSession {
+  return {
+    status: 'running',
+    command: '/task test',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...overrides,
+  }
+}
+
+function makeNode(overrides: Partial<ApiDagNode> & { id: string }): ApiDagNode {
+  return {
+    slug: overrides.id,
+    status: 'pending',
+    dependencies: [],
+    dependents: [],
+    ...overrides,
+  }
+}
+
+function makeDag(overrides: Partial<ApiDagGraph> & { id: string }): ApiDagGraph {
+  return {
+    rootTaskId: 'n1',
+    nodes: {},
+    status: 'running',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ship-pipeline', () => {
+  describe('classifyNodeForShip', () => {
+    it('maps pending/running/failed to the Running column', () => {
+      expect(classifyNodeForShip('pending')).toBe('running')
+      expect(classifyNodeForShip('running')).toBe('running')
+      expect(classifyNodeForShip('failed')).toBe('running')
+    })
+
+    it('maps completed to the Review column', () => {
+      expect(classifyNodeForShip('completed')).toBe('review')
+    })
+
+    it('maps ci-pending/ci-failed to the CI column', () => {
+      expect(classifyNodeForShip('ci-pending')).toBe('ci')
+      expect(classifyNodeForShip('ci-failed')).toBe('ci')
+    })
+
+    it('maps landed/skipped to the Landed column', () => {
+      expect(classifyNodeForShip('landed')).toBe('landed')
+      expect(classifyNodeForShip('skipped')).toBe('landed')
+    })
+  })
+
+  describe('isShipPipeline', () => {
+    it('returns false for an empty DAG', () => {
+      expect(isShipPipeline(makeDag({ id: 'd1' }))).toBe(false)
+    })
+
+    it('returns false for a plain running/pending DAG with no ship markers', () => {
+      const dag = makeDag({
+        id: 'd1',
+        nodes: {
+          n1: makeNode({ id: 'n1', status: 'running' }),
+          n2: makeNode({ id: 'n2', status: 'pending' }),
+        },
+      })
+      expect(isShipPipeline(dag)).toBe(false)
+    })
+
+    it('returns true when any node has a landed status', () => {
+      const dag = makeDag({
+        id: 'd1',
+        nodes: {
+          n1: makeNode({ id: 'n1', status: 'completed' }),
+          n2: makeNode({ id: 'n2', status: 'landed' }),
+        },
+      })
+      expect(isShipPipeline(dag)).toBe(true)
+    })
+
+    it('returns true when any node is in CI', () => {
+      expect(
+        isShipPipeline(
+          makeDag({
+            id: 'd1',
+            nodes: { n1: makeNode({ id: 'n1', status: 'ci-pending' }) },
+          }),
+        ),
+      ).toBe(true)
+      expect(
+        isShipPipeline(
+          makeDag({
+            id: 'd2',
+            nodes: { n1: makeNode({ id: 'n1', status: 'ci-failed' }) },
+          }),
+        ),
+      ).toBe(true)
+    })
+
+    it('returns true when any node session has mode=ship-think', () => {
+      const session = makeSession({ id: 's1', slug: 'ship-plan', mode: 'ship-think' })
+      const dag = makeDag({
+        id: 'd1',
+        nodes: {
+          n1: makeNode({ id: 'n1', status: 'running', session }),
+        },
+      })
+      expect(isShipPipeline(dag)).toBe(true)
+    })
+  })
+
+  describe('buildShipPipelineSummary', () => {
+    it('groups nodes into the four columns and counts totals', () => {
+      const dag = makeDag({
+        id: 'd1',
+        nodes: {
+          a: makeNode({ id: 'a', status: 'running' }),
+          b: makeNode({ id: 'b', status: 'completed' }),
+          c: makeNode({ id: 'c', status: 'ci-pending' }),
+          d: makeNode({ id: 'd', status: 'ci-failed' }),
+          e: makeNode({ id: 'e', status: 'landed' }),
+          f: makeNode({ id: 'f', status: 'skipped' }),
+          g: makeNode({ id: 'g', status: 'failed' }),
+          h: makeNode({ id: 'h', status: 'pending' }),
+        },
+      })
+
+      const summary = buildShipPipelineSummary(dag)
+      expect(summary.total).toBe(8)
+      expect(summary.landedCount).toBe(2)
+      expect(summary.columns.running.map((n) => n.id).sort()).toEqual(['a', 'g', 'h'])
+      expect(summary.columns.review.map((n) => n.id)).toEqual(['b'])
+      expect(summary.columns.ci.map((n) => n.id).sort()).toEqual(['c', 'd'])
+      expect(summary.columns.landed.map((n) => n.id).sort()).toEqual(['e', 'f'])
+    })
+
+    it('exposes the four columns in the canonical order', () => {
+      expect(SHIP_COLUMN_ORDER).toEqual(['running', 'review', 'ci', 'landed'])
+    })
+  })
+
+  describe('selectShipPipelines', () => {
+    it('filters out non-ship DAGs', () => {
+      const plain = makeDag({
+        id: 'plain',
+        nodes: { n: makeNode({ id: 'n', status: 'running' }) },
+      })
+      const ship = makeDag({
+        id: 'ship',
+        nodes: { n: makeNode({ id: 'n', status: 'landed' }) },
+      })
+      const summaries = selectShipPipelines([plain, ship])
+      expect(summaries.map((s) => s.dag.id)).toEqual(['ship'])
+    })
+
+    it('sorts pipelines by updatedAt descending', () => {
+      const older = makeDag({
+        id: 'older',
+        updatedAt: '2024-01-01T00:00:00Z',
+        nodes: { n: makeNode({ id: 'n', status: 'landed' }) },
+      })
+      const newer = makeDag({
+        id: 'newer',
+        updatedAt: '2024-03-01T00:00:00Z',
+        nodes: { n: makeNode({ id: 'n', status: 'landed' }) },
+      })
+      const summaries = selectShipPipelines([older, newer])
+      expect(summaries.map((s) => s.dag.id)).toEqual(['newer', 'older'])
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a third view-mode tab (**Ship**) that renders a horizontal Kanban — Running / Review / CI / Landed — for each qualifying DAG.
- A DAG qualifies when any node has status \`ci-pending\`, \`ci-failed\`, or \`landed\`, or when any node session runs in \`ship-think\` mode.
- Reuses \`StatusBadge\`, \`PrLink\`, and \`formatRelativeTime\`; cards link back into the chat via \`onOpenChat\`.

## Why
Ship pipelines are the highest-signal flow (they're landing code), so they deserve a view that maps state to column at a glance instead of being buried among regular DAG nodes on the canvas.

## Column mapping
- **Running**: \`pending\`, \`running\`, \`failed\`
- **Review**: \`completed\`
- **CI**: \`ci-pending\`, \`ci-failed\`
- **Landed**: \`landed\`, \`skipped\`

## Files
- \`src/components/ship-pipeline.ts\` — pure classifier (\`classifyNodeForShip\`, \`isShipPipeline\`, \`buildShipPipelineSummary\`, \`selectShipPipelines\`).
- \`src/components/ShipPipeline.tsx\` — \`<ShipPipelineView />\` renders one \`<PipelineBoard />\` per qualifying DAG with four columns.
- \`src/App.tsx\` — extends \`ViewMode\` with \`'ship'\`, adds the third toggle tab, desktop pane, and mobile full-screen modal (mirroring the canvas pattern).

## Test plan
- [x] \`npx tsc --noEmit\`
- [x] \`npx eslint src/ test/\`
- [x] \`npx vitest run\` — 282 / 282 passing
- [x] 13 new unit/component tests covering classifier edge cases, column routing, clickability, sort order, and the empty state
- [x] 4 new App integration tests covering the toggle, ship pane, empty state, and mobile modal

## Scope / assumptions
- Kept the Ship tab always visible (empty state handles the no-pipelines case) so the toggle layout stays stable.
- \`skipped\` is bucketed with \`landed\` because it is a terminal, non-interactive state for ship flows.
- Does not overlap with the sibling tasks that are reshaping \`classifySessions\` or the SessionList — only adds a new view and reads \`dags\` directly.

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  extract-hierarchy["✅ Extract classifySessions to shared state module"]
  chat-header-context["✅ Add parent/children/DAG/branch context to chat header"]
  attention-triage-bar["✅ Add action bar for sessions needing attention"]
  enhance-node-popup["✅ Add hierarchy metadata to NodeDetailPopup"]
  group-session-list["✅ Group SessionList by DAG/Tree/Standalone with nesting"]
  mount-canvas-tab["✅ Mount UniverseCanvas as second tab with view toggle"]
  fix-rendering-edges["✅ Fix edge-case rendering (status, animation, orphans)"]
  ship-mode-grouping["✅ Add fourth classification bucket for ship mode"]
  ship-pipeline-kanban["✅ Create Kanban view for ship pipelines"]
  enhance-context-menu["✅ Add navigation actions to ContextMenu"]
  polish-ui-details["✅ Polish: badges, chips, keyboard nav, DAG summaries"]
  extract-hierarchy --> group-session-list
  extract-hierarchy --> mount-canvas-tab
  extract-hierarchy --> fix-rendering-edges
  extract-hierarchy --> ship-mode-grouping
  mount-canvas-tab --> ship-pipeline-kanban
  mount-canvas-tab --> enhance-context-menu
  group-session-list --> polish-ui-details
  mount-canvas-tab --> polish-ui-details
  class extract-hierarchy done
  class chat-header-context done
  class attention-triage-bar done
  class enhance-node-popup done
  class group-session-list done
  class mount-canvas-tab done
  class fix-rendering-edges done
  class ship-mode-grouping done
  class ship-pipeline-kanban done
  class ship-pipeline-kanban current
  class enhance-context-menu done
  class polish-ui-details done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | Extract classifySessions to shared state module | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/11) |
| 2 | Add parent/children/DAG/branch context to chat header | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/12) |
| 3 | Add action bar for sessions needing attention | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/13) |
| 4 | Add hierarchy metadata to NodeDetailPopup | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/19) |
| 5 | Group SessionList by DAG/Tree/Standalone with nesting | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/14) |
| 6 | Mount UniverseCanvas as second tab with view toggle | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/20) |
| 7 | Fix edge-case rendering (status, animation, orphans) | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/17) |
| 8 | Add fourth classification bucket for ship mode | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/18) |
| 9 | **Create Kanban view for ship pipelines** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/21) |
| 10 | Add navigation actions to ContextMenu | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/22) |
| 11 | Polish: badges, chips, keyboard nav, DAG summaries | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/24) |

**Progress:** 11/11 complete

<!-- dag-status-end -->

