### PR TITLE
[minions] feat(context-menu): add Open parent, View in DAG, Retry node actions

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -13,7 +13,14 @@ export interface ContextMenuActions {
   onStopMinion: (sessionId: string) => Promise<void>
   onCloseSession: (sessionId: string) => Promise<void>
   onOpenThread: (session: ApiSession) => void
+  onOpenParent?: (parentId: string) => void
+  onViewInDag?: (dagId: string, sessionId: string) => void
   isActionLoading: boolean
+}
+
+export interface DagContext {
+  dagId: string
+  nodeStatus: string
 }
 
 interface ContextMenuProps {
@@ -21,6 +28,7 @@ interface ContextMenuProps {
   position: ContextMenuPosition
   actions: ContextMenuActions
   onClose: () => void
+  dagContext?: DagContext | null
 }
 
 interface MenuItemConfig {
@@ -49,7 +57,7 @@ function clampPosition(
   }
 }
 
-export function ContextMenu({ session, position, actions, onClose }: ContextMenuProps) {
+export function ContextMenu({ session, position, actions, onClose, dagContext }: ContextMenuProps) {
   const theme = useTheme()
   const isDark = theme.value === 'dark'
   const [showReplyDialog, setShowReplyDialog] = useState(false)
@@ -100,6 +108,25 @@ export function ContextMenu({ session, position, actions, onClose }: ContextMenu
     [session.id, actions, onClose]
   )
 
+  const handleOpenParent = useCallback(() => {
+    if (session.parentId && actions.onOpenParent) {
+      actions.onOpenParent(session.parentId)
+    }
+    onClose()
+  }, [session.parentId, actions, onClose])
+
+  const handleViewInDag = useCallback(() => {
+    if (dagContext && actions.onViewInDag) {
+      actions.onViewInDag(dagContext.dagId, session.id)
+    }
+    onClose()
+  }, [dagContext, actions, session.id, onClose])
+
+  const handleRetry = useCallback(() => {
+    onClose()
+    actions.onSendReply(session.id, '/retry')
+  }, [session.id, actions, onClose])
+
   const handleConfirmStop = useCallback(async () => {
     await actions.onStopMinion(session.id)
     setShowStopConfirm(false)
@@ -120,7 +147,42 @@ export function ContextMenu({ session, position, actions, onClose }: ContextMenu
 
   const items: (MenuItemConfig | 'divider')[] = []
 
+  const hasParentNav = Boolean(session.parentId && actions.onOpenParent)
+  const hasDagNav = Boolean(dagContext && actions.onViewInDag)
+  const dagNodeFailed = dagContext?.nodeStatus === 'ci-failed' || dagContext?.nodeStatus === 'failed'
+  const sessionFailed = session.status === 'failed'
+  const canRetry = dagNodeFailed || sessionFailed
+
+  if (hasParentNav) {
+    items.push({
+      label: 'Open parent',
+      emoji: '↖',
+      variant: 'default',
+      onClick: handleOpenParent,
+    })
+  }
+
+  if (hasDagNav) {
+    items.push({
+      label: 'View in DAG',
+      emoji: '◇',
+      variant: 'default',
+      onClick: handleViewInDag,
+    })
+  }
+
+  if (canRetry) {
+    items.push({
+      label: 'Retry node',
+      emoji: '🔄',
+      variant: 'default',
+      onClick: handleRetry,
+      disabled: actions.isActionLoading,
+    })
+  }
+
   if (isActive) {
+    if (items.length > 0) items.push('divider')
     items.push({
       label: 'Send Reply',
       emoji: '✉️',

--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useCallback, useRef, useEffect, useState } from 'preact/hooks'
 import {
   ReactFlow,
+  ReactFlowProvider,
   useNodesState,
   useEdgesState,
+  useReactFlow,
   Handle,
   Position,
 } from '@reactflow/core'
@@ -18,9 +20,14 @@ import type { ApiSession, ApiDagGraph } from '../api/types'
 import { StatusBadge, AttentionIconStack, getStatusColors, getAttentionBorder, formatRelativeTime } from './shared'
 import { PrLink } from './PrLink'
 import { ContextMenu, useLongPress, useContextMenu } from './ContextMenu'
-import type { ContextMenuActions } from './ContextMenu'
-import { layoutUniverse } from './universe-layout'
+import type { ContextMenuActions, DagContext } from './ContextMenu'
+import { layoutUniverse, NODE_WIDTH, NODE_HEIGHT } from './universe-layout'
 import type { UniverseEdge } from './universe-layout'
+
+const NODE_FULL_WIDTH = NODE_WIDTH
+const NODE_FULL_HEIGHT = NODE_HEIGHT
+const NODE_WIDTH_HALF = NODE_WIDTH / 2
+const NODE_HEIGHT_HALF = NODE_HEIGHT / 2
 import { NodeDetailPopup } from './NodeDetailPopup'
 import { useTheme } from '../hooks/useTheme'
 
@@ -160,7 +167,15 @@ export interface UniverseCanvasProps {
   accentColor?: string
 }
 
-export function UniverseCanvas({
+export function UniverseCanvas(props: UniverseCanvasProps) {
+  return (
+    <ReactFlowProvider>
+      <UniverseCanvasInner {...props} />
+    </ReactFlowProvider>
+  )
+}
+
+function UniverseCanvasInner({
   sessions,
   dags,
   isLoading = false,
@@ -177,6 +192,21 @@ export function UniverseCanvas({
   const contextMenu = useContextMenu()
   const [detailSession, setDetailSession] = useState<ApiSession | null>(null)
   const prevLayoutRef = useRef<{ nodes: Node[]; edges: UniverseEdge[] } | null>(null)
+  const reactFlow = useReactFlow()
+
+  const dagBySessionId = useMemo(() => {
+    const map = new Map<string, { dagId: string; nodeStatus: string }>()
+    for (const dag of dags) {
+      for (const node of Object.values(dag.nodes)) {
+        if (node.session) {
+          map.set(node.session.id, { dagId: dag.id, nodeStatus: node.status })
+        } else {
+          map.set(node.id, { dagId: dag.id, nodeStatus: node.status })
+        }
+      }
+    }
+    return map
+  }, [dags])
 
   useEffect(() => {
     if (detailSession) {
@@ -242,16 +272,63 @@ export function UniverseCanvas({
     }
   }, [layoutKey, nodesWithHandlers, layoutEdges, setNodes, setEdges])
 
+  const handleOpenParent = useCallback(
+    (parentId: string) => {
+      const parent = sessions.find((s) => s.id === parentId)
+      if (parent) {
+        setDetailSession(parent)
+        onNodeSelect?.(parent)
+      }
+      const layoutNode = layoutNodes.find((n) => n.id === parentId)
+      if (layoutNode) {
+        const cx = layoutNode.position.x + NODE_WIDTH_HALF
+        const cy = layoutNode.position.y + NODE_HEIGHT_HALF
+        reactFlow.setCenter(cx, cy, { zoom: 1, duration: 400 })
+      }
+    },
+    [sessions, onNodeSelect, layoutNodes, reactFlow]
+  )
+
+  const handleViewInDag = useCallback(
+    (dagId: string, _sessionId: string) => {
+      const dagNodes = layoutNodes.filter((n) => {
+        const data = n.data as { groupId?: string } | undefined
+        return data?.groupId === `dag-${dagId}`
+      })
+      if (dagNodes.length === 0) return
+      let minX = Infinity
+      let minY = Infinity
+      let maxX = -Infinity
+      let maxY = -Infinity
+      for (const node of dagNodes) {
+        const nodeMaxX = node.position.x + NODE_FULL_WIDTH
+        const nodeMaxY = node.position.y + NODE_FULL_HEIGHT
+        if (node.position.x < minX) minX = node.position.x
+        if (node.position.y < minY) minY = node.position.y
+        if (nodeMaxX > maxX) maxX = nodeMaxX
+        if (nodeMaxY > maxY) maxY = nodeMaxY
+      }
+      reactFlow.fitBounds({ x: minX, y: minY, width: maxX - minX, height: maxY - minY }, { padding: 0.2, duration: 400 })
+    },
+    [layoutNodes, reactFlow]
+  )
+
   const contextMenuActions: ContextMenuActions = useMemo(
     () => ({
       onSendReply,
       onStopMinion,
       onCloseSession,
       onOpenThread,
+      onOpenParent: handleOpenParent,
+      onViewInDag: handleViewInDag,
       isActionLoading,
     }),
-    [onSendReply, onStopMinion, onCloseSession, onOpenThread, isActionLoading]
+    [onSendReply, onStopMinion, onCloseSession, onOpenThread, handleOpenParent, handleViewInDag, isActionLoading]
   )
+
+  const activeDagContext: DagContext | null = contextMenu.state.session
+    ? dagBySessionId.get(contextMenu.state.session.id) ?? null
+    : null
 
   const statusColors = getStatusColors(isDark)
 
@@ -321,6 +398,7 @@ export function UniverseCanvas({
           position={contextMenu.state.position}
           actions={contextMenuActions}
           onClose={contextMenu.close}
+          dagContext={activeDagContext}
         />
       )}
 

--- a/test/App.viewToggle.test.tsx
+++ b/test/App.viewToggle.test.tsx
@@ -31,6 +31,12 @@ vi.mock('@reactflow/core', () => ({
       {children}
     </div>
   )),
+  ReactFlowProvider: vi.fn(({ children }) => <>{children}</>),
+  useReactFlow: vi.fn(() => ({
+    setCenter: vi.fn(),
+    fitBounds: vi.fn(),
+    fitView: vi.fn(),
+  })),
   useNodesState: vi.fn((initial: unknown[]) => [initial, vi.fn(), vi.fn()]),
   useEdgesState: vi.fn((initial: unknown[]) => [initial, vi.fn(), vi.fn()]),
   MarkerType: { ArrowClosed: 'arrowClosed' },

--- a/test/components/ContextMenu.test.tsx
+++ b/test/components/ContextMenu.test.tsx
@@ -59,12 +59,28 @@ const mockPendingSession: ApiSession = {
   status: 'pending',
 }
 
+const mockChildSession: ApiSession = {
+  ...mockRunningSession,
+  id: 'child-1',
+  slug: 'busy-fox',
+  parentId: 'parent-1',
+}
+
+const mockFailedSession: ApiSession = {
+  ...mockRunningSession,
+  id: 'session-failed',
+  slug: 'broken-wheel',
+  status: 'failed',
+}
+
 function createMockActions(overrides: Partial<ContextMenuActions> = {}): ContextMenuActions {
   return {
     onSendReply: vi.fn().mockResolvedValue(undefined) as unknown as ContextMenuActions['onSendReply'],
     onStopMinion: vi.fn().mockResolvedValue(undefined) as unknown as ContextMenuActions['onStopMinion'],
     onCloseSession: vi.fn().mockResolvedValue(undefined) as unknown as ContextMenuActions['onCloseSession'],
     onOpenThread: vi.fn() as unknown as ContextMenuActions['onOpenThread'],
+    onOpenParent: vi.fn() as unknown as ContextMenuActions['onOpenParent'],
+    onViewInDag: vi.fn() as unknown as ContextMenuActions['onViewInDag'],
     isActionLoading: false,
     ...overrides,
   }
@@ -292,6 +308,190 @@ describe('ContextMenu', () => {
 
     const makeprButton = screen.getByText('Make PR').closest('button')
     expect(makeprButton?.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('renders "Open parent" when session has parentId and onOpenParent is provided', () => {
+    render(
+      <ContextMenu
+        session={mockChildSession}
+        position={{ x: 100, y: 100 }}
+        actions={mockActions}
+        onClose={mockOnClose}
+      />
+    )
+
+    expect(screen.getByText('Open parent')).toBeTruthy()
+  })
+
+  it('does not render "Open parent" when session has no parentId', () => {
+    render(
+      <ContextMenu
+        session={mockRunningSession}
+        position={{ x: 100, y: 100 }}
+        actions={mockActions}
+        onClose={mockOnClose}
+      />
+    )
+
+    expect(screen.queryByText('Open parent')).toBeNull()
+  })
+
+  it('does not render "Open parent" when onOpenParent callback is absent', () => {
+    const actionsWithoutParent = createMockActions({ onOpenParent: undefined })
+    render(
+      <ContextMenu
+        session={mockChildSession}
+        position={{ x: 100, y: 100 }}
+        actions={actionsWithoutParent}
+        onClose={mockOnClose}
+      />
+    )
+
+    expect(screen.queryByText('Open parent')).toBeNull()
+  })
+
+  it('invokes onOpenParent with parentId and closes menu when clicked', () => {
+    render(
+      <ContextMenu
+        session={mockChildSession}
+        position={{ x: 100, y: 100 }}
+        actions={mockActions}
+        onClose={mockOnClose}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Open parent'))
+    expect(mockActions.onOpenParent).toHaveBeenCalledWith('parent-1')
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('renders "View in DAG" when dagContext is provided', () => {
+    render(
+      <ContextMenu
+        session={mockRunningSession}
+        position={{ x: 100, y: 100 }}
+        actions={mockActions}
+        onClose={mockOnClose}
+        dagContext={{ dagId: 'dag-7', nodeStatus: 'running' }}
+      />
+    )
+
+    expect(screen.getByText('View in DAG')).toBeTruthy()
+  })
+
+  it('does not render "View in DAG" when dagContext is null', () => {
+    render(
+      <ContextMenu
+        session={mockRunningSession}
+        position={{ x: 100, y: 100 }}
+        actions={mockActions}
+        onClose={mockOnClose}
+        dagContext={null}
+      />
+    )
+
+    expect(screen.queryByText('View in DAG')).toBeNull()
+  })
+
+  it('invokes onViewInDag with dagId and sessionId when clicked', () => {
+    render(
+      <ContextMenu
+        session={mockRunningSession}
+        position={{ x: 100, y: 100 }}
+        actions={mockActions}
+        onClose={mockOnClose}
+        dagContext={{ dagId: 'dag-7', nodeStatus: 'running' }}
+      />
+    )
+
+    fireEvent.click(screen.getByText('View in DAG'))
+    expect(mockActions.onViewInDag).toHaveBeenCalledWith('dag-7', 'session-1')
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('renders "Retry node" when DAG node status is ci-failed', () => {
+    render(
+      <ContextMenu
+        session={mockRunningSession}
+        position={{ x: 100, y: 100 }}
+        actions={mockActions}
+        onClose={mockOnClose}
+        dagContext={{ dagId: 'dag-7', nodeStatus: 'ci-failed' }}
+      />
+    )
+
+    expect(screen.getByText('Retry node')).toBeTruthy()
+  })
+
+  it('renders "Retry node" when DAG node status is failed', () => {
+    render(
+      <ContextMenu
+        session={mockRunningSession}
+        position={{ x: 100, y: 100 }}
+        actions={mockActions}
+        onClose={mockOnClose}
+        dagContext={{ dagId: 'dag-7', nodeStatus: 'failed' }}
+      />
+    )
+
+    expect(screen.getByText('Retry node')).toBeTruthy()
+  })
+
+  it('renders "Retry node" when session status is failed', () => {
+    render(
+      <ContextMenu
+        session={mockFailedSession}
+        position={{ x: 100, y: 100 }}
+        actions={mockActions}
+        onClose={mockOnClose}
+      />
+    )
+
+    expect(screen.getByText('Retry node')).toBeTruthy()
+  })
+
+  it('does not render "Retry node" for healthy running session without failing DAG', () => {
+    render(
+      <ContextMenu
+        session={mockRunningSession}
+        position={{ x: 100, y: 100 }}
+        actions={mockActions}
+        onClose={mockOnClose}
+        dagContext={{ dagId: 'dag-7', nodeStatus: 'running' }}
+      />
+    )
+
+    expect(screen.queryByText('Retry node')).toBeNull()
+  })
+
+  it('sends /retry via onSendReply when "Retry node" is clicked', () => {
+    render(
+      <ContextMenu
+        session={mockFailedSession}
+        position={{ x: 100, y: 100 }}
+        actions={mockActions}
+        onClose={mockOnClose}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Retry node'))
+    expect(mockActions.onSendReply).toHaveBeenCalledWith('session-failed', '/retry')
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('disables "Retry node" when isActionLoading is true', () => {
+    const loadingActions = createMockActions({ isActionLoading: true })
+    render(
+      <ContextMenu
+        session={mockFailedSession}
+        position={{ x: 100, y: 100 }}
+        actions={loadingActions}
+        onClose={mockOnClose}
+      />
+    )
+
+    const retryButton = screen.getByText('Retry node').closest('button')
+    expect(retryButton?.hasAttribute('disabled')).toBe(true)
   })
 
   it('renders dividers between menu sections', () => {

--- a/test/components/UniverseCanvas.test.tsx
+++ b/test/components/UniverseCanvas.test.tsx
@@ -24,6 +24,12 @@ vi.mock('@reactflow/core', async () => {
         </div>
       )
     }),
+    ReactFlowProvider: vi.fn(({ children }) => <>{children}</>),
+    useReactFlow: vi.fn(() => ({
+      setCenter: vi.fn(),
+      fitBounds: vi.fn(),
+      fitView: vi.fn(),
+    })),
     useNodesState: vi.fn((initial: unknown[]) => [initial, vi.fn(), vi.fn()]),
     useEdgesState: vi.fn((initial: unknown[]) => [initial, vi.fn(), vi.fn()]),
     MarkerType: { ArrowClosed: 'arrowClosed' },
@@ -321,6 +327,101 @@ describe('UniverseCanvas', () => {
     if (node) {
       fireEvent.click(node)
       expect(onNodeSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 's1' }))
+    }
+  })
+
+  it('context menu shows "Open parent" for a child session', () => {
+    const parent = createSession({ id: 'parent-1', slug: 'parent-task', childIds: ['child-1'] })
+    const child = createSession({ id: 'child-1', slug: 'child-task', parentId: 'parent-1' })
+    render(<UniverseCanvas {...defaultProps} sessions={[parent, child]} />)
+
+    const node = document.querySelector('[data-testid="universe-node-child-1"]')
+    if (node) {
+      fireEvent.contextMenu(node.parentElement!, { clientX: 50, clientY: 50 })
+      expect(document.body.innerHTML).toContain('Open parent')
+    } else {
+      throw new Error('child node not found')
+    }
+  })
+
+  it('context menu shows "View in DAG" for a DAG-member session', () => {
+    const dag = createDag()
+    render(<UniverseCanvas {...defaultProps} dags={[dag]} />)
+
+    const node = document.querySelector('[data-testid="universe-node-dag-session-1"]')
+    if (node) {
+      fireEvent.contextMenu(node.parentElement!, { clientX: 50, clientY: 50 })
+      expect(document.body.innerHTML).toContain('View in DAG')
+    } else {
+      throw new Error('dag node not found')
+    }
+  })
+
+  it('context menu shows "Retry node" when DAG node status is ci-failed', () => {
+    const dag = createDag({
+      nodes: {
+        'node-1': {
+          id: 'node-1',
+          slug: 'dag-root',
+          status: 'ci-failed',
+          dependencies: [],
+          dependents: [],
+          session: createSession({ id: 'dag-session-1', slug: 'dag-root', status: 'running' }),
+        },
+      },
+    })
+    render(<UniverseCanvas {...defaultProps} dags={[dag]} />)
+
+    const node = document.querySelector('[data-testid="universe-node-dag-session-1"]')
+    if (node) {
+      fireEvent.contextMenu(node.parentElement!, { clientX: 50, clientY: 50 })
+      expect(document.body.innerHTML).toContain('Retry node')
+    } else {
+      throw new Error('dag node not found')
+    }
+  })
+
+  it('does not show "Open parent" for a standalone session', () => {
+    const sessions = [createSession({ id: 's1', slug: 'alone' })]
+    render(<UniverseCanvas {...defaultProps} sessions={sessions} />)
+
+    const node = document.querySelector('[data-testid="universe-node-s1"]')
+    if (node) {
+      fireEvent.contextMenu(node.parentElement!, { clientX: 50, clientY: 50 })
+      expect(document.body.innerHTML).not.toContain('Open parent')
+      expect(document.body.innerHTML).not.toContain('View in DAG')
+    }
+  })
+
+  it('retry click sends /retry via onSendReply', () => {
+    const onSendReply = vi.fn().mockResolvedValue(undefined)
+    const dag = createDag({
+      nodes: {
+        'node-1': {
+          id: 'node-1',
+          slug: 'dag-root',
+          status: 'ci-failed',
+          dependencies: [],
+          dependents: [],
+          session: createSession({ id: 'dag-session-1', slug: 'dag-root', status: 'running' }),
+        },
+      },
+    })
+    render(<UniverseCanvas {...defaultProps} dags={[dag]} onSendReply={onSendReply} />)
+
+    const node = document.querySelector('[data-testid="universe-node-dag-session-1"]')
+    if (node) {
+      fireEvent.contextMenu(node.parentElement!, { clientX: 50, clientY: 50 })
+      const retryButton = Array.from(document.querySelectorAll('button')).find(
+        (b) => b.textContent?.includes('Retry node')
+      )
+      expect(retryButton).toBeTruthy()
+      if (retryButton) {
+        fireEvent.click(retryButton)
+        expect(onSendReply).toHaveBeenCalledWith('dag-session-1', '/retry')
+      }
+    } else {
+      throw new Error('dag node not found')
     }
   })
 })


### PR DESCRIPTION
## Summary
- Adds three conditional menu items to `ContextMenu`:
  - **Open parent** — visible when `session.parentId` is set; invokes a caller-supplied `onOpenParent(parentId)` handler.
  - **View in DAG** — visible when a `dagContext` is passed; invokes `onViewInDag(dagId, sessionId)`.
  - **Retry node** — visible when DAG node status is `ci-failed`/`failed` or the session status is `failed`; re-uses `onSendReply(sessionId, '/retry')`.
- `UniverseCanvas` now computes a DAG lookup for the right-clicked node, wraps its ReactFlow in `ReactFlowProvider`, and supplies handlers that recenter the canvas on the parent node or fit the viewport to the DAG group via `useReactFlow()`.

## Why
Gives the canvas menu first-class navigation for hierarchy and DAG relationships — part of the broader UI improvements for ships/DAGs/stacks/parent-child minions. Retry previously required poking a quick-action or editing the chat input; exposing it on failure states makes the recovery loop obvious.

## Assumptions
- `/retry` is the correct message to send for retrying a node — matches the existing `retry` quick-action type (`src/api/types.ts`) and its message payload used elsewhere in the app.
- Context menu is only opened from the canvas today, so navigation targets focus the canvas viewport and the node detail popup rather than switching view modes. If the menu is later wired into `SessionList`, the same action callbacks can be re-used by passing view-switching implementations.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 272 tests pass, including new coverage:
  - ContextMenu: visibility + disabled state of each new item, callback payloads, retry via `onSendReply`.
  - UniverseCanvas integration: right-click on child/DAG/ci-failed nodes surfaces the expected items; standalone nodes don't show parent/DAG items; retry dispatches `/retry` through `onSendReply`.
- [ ] E2E/browser tests not run (not required for this task).

<!-- dag-status-start -->

```mermaid
flowchart TD
  classDef done fill:#2da44e,stroke:#1a7f37,color:#fff
  classDef running fill:#bf8700,stroke:#9a6700,color:#fff
  classDef pending fill:#656d76,stroke:#424a53,color:#fff
  classDef ready fill:#0969da,stroke:#0550ae,color:#fff
  classDef failed fill:#cf222e,stroke:#a40e26,color:#fff
  classDef skipped fill:#656d76,stroke:#424a53,color:#fff,stroke-dasharray: 5 5
  classDef ci-pending fill:#0969da,stroke:#0550ae,color:#fff,stroke-dasharray: 3 3
  classDef ci-failed fill:#bf8700,stroke:#9a6700,color:#fff
  classDef landed fill:#1a7f37,stroke:#116329,color:#fff
  classDef current stroke:#bf8700,stroke-width:3px
  extract-hierarchy["✅ Extract classifySessions to shared state module"]
  chat-header-context["✅ Add parent/children/DAG/branch context to chat header"]
  attention-triage-bar["✅ Add action bar for sessions needing attention"]
  enhance-node-popup["✅ Add hierarchy metadata to NodeDetailPopup"]
  group-session-list["✅ Group SessionList by DAG/Tree/Standalone with nesting"]
  mount-canvas-tab["✅ Mount UniverseCanvas as second tab with view toggle"]
  fix-rendering-edges["✅ Fix edge-case rendering (status, animation, orphans)"]
  ship-mode-grouping["✅ Add fourth classification bucket for ship mode"]
  ship-pipeline-kanban["✅ Create Kanban view for ship pipelines"]
  enhance-context-menu["✅ Add navigation actions to ContextMenu"]
  polish-ui-details["✅ Polish: badges, chips, keyboard nav, DAG summaries"]
  extract-hierarchy --> group-session-list
  extract-hierarchy --> mount-canvas-tab
  extract-hierarchy --> fix-rendering-edges
  extract-hierarchy --> ship-mode-grouping
  mount-canvas-tab --> ship-pipeline-kanban
  mount-canvas-tab --> enhance-context-menu
  group-session-list --> polish-ui-details
  mount-canvas-tab --> polish-ui-details
  class extract-hierarchy done
  class chat-header-context done
  class attention-triage-bar done
  class enhance-node-popup done
  class group-session-list done
  class mount-canvas-tab done
  class fix-rendering-edges done
  class ship-mode-grouping done
  class ship-pipeline-kanban done
  class enhance-context-menu done
  class enhance-context-menu current
  class polish-ui-details done
```

| # | Task | Status | PR |
|---|------|--------|----|
| 1 | Extract classifySessions to shared state module | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/11) |
| 2 | Add parent/children/DAG/branch context to chat header | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/12) |
| 3 | Add action bar for sessions needing attention | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/13) |
| 4 | Add hierarchy metadata to NodeDetailPopup | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/19) |
| 5 | Group SessionList by DAG/Tree/Standalone with nesting | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/14) |
| 6 | Mount UniverseCanvas as second tab with view toggle | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/20) |
| 7 | Fix edge-case rendering (status, animation, orphans) | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/17) |
| 8 | Add fourth classification bucket for ship mode | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/18) |
| 9 | Create Kanban view for ship pipelines | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/21) |
| 10 | **Add navigation actions to ContextMenu** _(this PR)_ | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/22) |
| 11 | Polish: badges, chips, keyboard nav, DAG summaries | ✅ Done | [PR](https://github.com/tprei/minions-ui/pull/24) |

**Progress:** 11/11 complete

<!-- dag-status-end -->
