### PR TITLE
fix(ui): Conductor-shaped polish — DiffTab crash, live DAG panel, sidebar hierarchy

### DIFF
--- a/e2e/fixtures/mock-minion.ts
+++ b/e2e/fixtures/mock-minion.ts
@@ -9,7 +9,7 @@ import type {
   CreateSessionRequest,
   CreateSessionVariantsRequest,
   PrPreview,
-  WorkspaceDiff,
+  WireWorkspaceDiff,
   ScreenshotList,
   ScreenshotEntry,
   VapidPublicKey,
@@ -25,7 +25,7 @@ export type {
   CreateSessionRequest,
   CreateSessionVariantsRequest,
   PrPreview,
-  WorkspaceDiff,
+  WireWorkspaceDiff,
   ScreenshotList,
   ScreenshotEntry,
   VapidPublicKey,
@@ -40,7 +40,7 @@ export interface MockMinion {
   setDags(dags: ApiDagGraph[]): void
   setVersion(v: Partial<VersionInfo>): void
   setPr(sessionId: string, pr: PrPreview | null): void
-  setDiff(sessionId: string, diff: WorkspaceDiff | null): void
+  setDiff(sessionId: string, diff: WireWorkspaceDiff | null): void
   setScreenshots(sessionId: string, screenshots: ScreenshotEntry[]): void
   setScreenshotBlob(file: string, body: Buffer, contentType?: string): void
   setVapidKey(key: string): void
@@ -112,7 +112,7 @@ export async function createMockMinion(opts?: {
   }
 
   const prBySession = new Map<string, PrPreview>()
-  const diffBySession = new Map<string, WorkspaceDiff>()
+  const diffBySession = new Map<string, WireWorkspaceDiff>()
   const screenshotsBySession = new Map<string, ScreenshotEntry[]>()
   const screenshotBlobs = new Map<string, { body: Buffer; contentType: string }>()
   let vapidKey = 'BMOCK_VAPID_PUBLIC_KEY_00000000000000000000000000000000000000000000000000000000000000000000000000000000'
@@ -357,7 +357,7 @@ export async function createMockMinion(opts?: {
       else prBySession.delete(sessionId)
     },
 
-    setDiff(sessionId: string, diff: WorkspaceDiff | null) {
+    setDiff(sessionId: string, diff: WireWorkspaceDiff | null) {
       if (diff) diffBySession.set(sessionId, diff)
       else diffBySession.delete(sessionId)
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dompurify": "^3.4.0",
         "idb-keyval": "^6.2.1",
         "marked": "^18.0.2",
+        "mermaid": "^11.14.0",
         "preact": "^10.26.4"
       },
       "devDependencies": {
@@ -60,6 +61,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1659,6 +1673,49 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -2421,6 +2478,23 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.0"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
@@ -2870,6 +2944,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -4451,6 +4534,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
@@ -4578,7 +4671,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -5023,6 +5115,34 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
+      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^12.0.0"
+      }
+    },
     "node_modules/classcat": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
@@ -5091,6 +5211,12 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5110,6 +5236,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -5194,11 +5329,173 @@
         "node": ">=18"
       }
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
+      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -5225,11 +5522,101 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -5246,11 +5633,152 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -5307,6 +5835,16 @@
       "dependencies": {
         "graphlib": "^2.1.8",
         "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
       }
     },
     "node_modules/data-urls": {
@@ -5376,6 +5914,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5486,6 +6030,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/detect-libc": {
@@ -6483,6 +7036,12 @@
         "lodash": "^4.17.15"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -6648,7 +7207,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6703,6 +7261,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arguments": {
@@ -7333,6 +7900,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7343,11 +7935,40 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
     "node_modules/kolorist": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/langium": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "license": "MIT"
     },
     "node_modules/leven": {
@@ -7657,6 +8278,12 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -7723,6 +8350,47 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mermaid": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -7747,6 +8415,18 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
       }
     },
     "node_modules/ms": {
@@ -7967,6 +8647,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -7979,6 +8665,12 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -8038,7 +8730,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -8059,6 +8750,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/playwright": {
@@ -8106,6 +8808,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8429,6 +9147,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -8474,12 +9198,30 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -8561,7 +9303,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -9054,6 +9795,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9167,7 +9914,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
       "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9257,6 +10003,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {
@@ -9408,6 +10163,12 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -9569,6 +10330,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "6.4.2",
@@ -9783,6 +10557,55 @@
           "optional": false
         }
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dompurify": "^3.4.0",
     "idb-keyval": "^6.2.1",
     "marked": "^18.0.2",
+    "mermaid": "^11.14.0",
     "preact": "^10.26.4"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { signal } from '@preact/signals'
-import { useState, useEffect, useMemo } from 'preact/hooks'
+import { useState, useEffect, useMemo, useRef } from 'preact/hooks'
 import { useRegisterSW } from 'virtual:pwa-register/preact'
 import { connections, activeId, getActiveStore } from './connections/store'
 import { ConnectionSettings } from './connections/ConnectionSettings'
@@ -22,6 +22,9 @@ import { InstallPrompt } from './pwa/InstallPrompt'
 import { useOnlineStatus } from './pwa/useOnlineStatus'
 import { useMediaQuery } from './hooks/useMediaQuery'
 import { WorktreeHeader } from './components/WorktreeHeader'
+import { DagStatusPanel } from './chat/DagStatusPanel'
+import { buildSessionGroups, type SessionGroup } from './state/hierarchy'
+import type { ApiDagGraph } from './api/types'
 import { currentRoute } from './routing/current'
 import { VariantGroupView } from './groups/VariantGroupView'
 import type { ApiSession, MinionCommand, QuickAction } from './api/types'
@@ -53,7 +56,48 @@ function statusDot(status: ApiSession['status']): string {
   return 'bg-slate-400'
 }
 
-function SessionItem({ session, active, onSelect }: { session: ApiSession; active: boolean; onSelect: () => void }) {
+function useFlashOnChange(session: ApiSession): 'success' | 'fail' | 'update' | null {
+  const [flash, setFlash] = useState<'success' | 'fail' | 'update' | null>(null)
+  const prev = useRef({ status: session.status, updatedAt: session.updatedAt, mounted: false })
+
+  useEffect(() => {
+    const p = prev.current
+    if (!p.mounted) {
+      p.mounted = true
+      p.status = session.status
+      p.updatedAt = session.updatedAt
+      return
+    }
+    let next: 'success' | 'fail' | 'update' | null = null
+    if (p.status !== session.status) {
+      if (session.status === 'completed') next = 'success'
+      else if (session.status === 'failed') next = 'fail'
+      else next = 'update'
+    } else if (p.updatedAt !== session.updatedAt) {
+      next = 'update'
+    }
+    p.status = session.status
+    p.updatedAt = session.updatedAt
+    if (!next) return
+    setFlash(next)
+    const timer = setTimeout(() => setFlash(null), 900)
+    return () => clearTimeout(timer)
+  }, [session.status, session.updatedAt])
+
+  return flash
+}
+
+function SessionItem({
+  session,
+  active,
+  onSelect,
+  indent = 0,
+}: {
+  session: ApiSession
+  active: boolean
+  onSelect: () => void
+  indent?: number
+}) {
   const preview = session.conversation.length > 0
     ? session.conversation[session.conversation.length - 1].text.slice(0, 60)
     : session.command.slice(0, 60)
@@ -61,21 +105,52 @@ function SessionItem({ session, active, onSelect }: { session: ApiSession; activ
   const active_ = active
     ? 'bg-indigo-50 dark:bg-indigo-950/40 border-indigo-300 dark:border-indigo-700'
     : 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/50'
+  const marginLeft = indent > 0 ? `${indent * 16}px` : undefined
+  const borderLeft = indent > 0 ? { borderLeft: '2px solid rgb(148 163 184 / 0.35)' } : undefined
+  const flash = useFlashOnChange(session)
   return (
-    <button class={`${baseClasses} ${active_}`} onClick={onSelect} data-testid={`session-item-${session.id}`}>
-      <div class="flex items-center gap-2">
-        <span class={`inline-block h-2 w-2 rounded-full shrink-0 ${statusDot(session.status)}`} />
-        <span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">{session.slug}</span>
-        {session.repo && (
-          <span class="text-[10px] font-mono rounded bg-slate-100 dark:bg-slate-700 px-1.5 py-0.5 text-slate-600 dark:text-slate-300 truncate">
-            {shortRepo(session.repo)}
-          </span>
-        )}
-        <span class="ml-auto text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">{session.status}</span>
-      </div>
-      <div class="text-xs text-slate-600 dark:text-slate-400 truncate">{preview || '—'}</div>
-    </button>
+    <div style={{ marginLeft, ...borderLeft }} data-flash={flash ?? undefined} data-testid={`session-row-${session.id}`}>
+      <button
+        class={`${baseClasses} ${active_}`}
+        onClick={onSelect}
+        data-testid={`session-item-${session.id}`}
+      >
+        <div class="flex items-center gap-2">
+          <span class={`inline-block h-2 w-2 rounded-full shrink-0 ${statusDot(session.status)}`} />
+          <span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">{session.slug}</span>
+          {session.repo && (
+            <span class="text-[10px] font-mono rounded bg-slate-100 dark:bg-slate-700 px-1.5 py-0.5 text-slate-600 dark:text-slate-300 truncate">
+              {shortRepo(session.repo)}
+            </span>
+          )}
+          <span class="ml-auto text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">{session.status}</span>
+        </div>
+        <div class="text-xs text-slate-600 dark:text-slate-400 truncate">{preview || '—'}</div>
+      </button>
+    </div>
   )
+}
+
+function GroupHeader({ label, count, tone = 'default' }: { label: string; count: number; tone?: 'default' | 'dag' | 'variant' }) {
+  const toneClass =
+    tone === 'dag'
+      ? 'text-indigo-700 dark:text-indigo-300'
+      : tone === 'variant'
+        ? 'text-fuchsia-700 dark:text-fuchsia-300'
+        : 'text-slate-500 dark:text-slate-400'
+  return (
+    <div class={`flex items-center gap-2 px-3 pt-3 pb-1 text-[10px] uppercase tracking-wider font-semibold ${toneClass}`}>
+      <span>{label}</span>
+      <span class="text-slate-400 dark:text-slate-500 font-normal">· {count}</span>
+    </div>
+  )
+}
+
+function dagStatusTone(status: ApiDagGraph['status']): string {
+  if (status === 'running') return 'text-blue-600 dark:text-blue-400'
+  if (status === 'completed') return 'text-green-600 dark:text-green-400'
+  if (status === 'failed') return 'text-red-600 dark:text-red-400'
+  return 'text-slate-500 dark:text-slate-400'
 }
 
 function shortRepo(repoUrl: string): string {
@@ -85,11 +160,13 @@ function shortRepo(repoUrl: string): string {
 
 function SessionList({
   sessions,
+  dags,
   activeSessionId,
   onSelect,
   orientation,
 }: {
   sessions: ApiSession[]
+  dags: ApiDagGraph[]
   activeSessionId: string | null
   onSelect: (id: string) => void
   orientation: 'vertical' | 'horizontal'
@@ -98,6 +175,8 @@ function SessionList({
     () => [...sessions].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1)),
     [sessions]
   )
+  const groups = useMemo(() => buildSessionGroups(sorted, dags), [sorted, dags])
+
   if (sorted.length === 0) {
     return (
       <div class="text-xs text-slate-500 dark:text-slate-400 p-3 italic">
@@ -121,15 +200,116 @@ function SessionList({
     )
   }
   return (
-    <div class="flex flex-col gap-1 p-2 overflow-y-auto">
-      {sorted.map((s) => (
-        <SessionItem
-          key={s.id}
-          session={s}
-          active={activeSessionId === s.id}
-          onSelect={() => onSelect(s.id)}
+    <div class="flex flex-col overflow-y-auto" data-testid="session-list">
+      {groups.map((g) => (
+        <GroupView
+          key={groupKey(g)}
+          group={g}
+          activeSessionId={activeSessionId}
+          onSelect={onSelect}
         />
       ))}
+    </div>
+  )
+}
+
+function groupKey(g: SessionGroup): string {
+  switch (g.kind) {
+    case 'dag': return `dag:${g.dag.id}`
+    case 'parent-child': return `pc:${g.parent.id}`
+    case 'variant': return `var:${g.groupId}`
+    case 'standalone': return `s:${g.session.id}`
+  }
+}
+
+function GroupView({
+  group,
+  activeSessionId,
+  onSelect,
+}: {
+  group: SessionGroup
+  activeSessionId: string | null
+  onSelect: (id: string) => void
+}) {
+  if (group.kind === 'dag') {
+    const dag = group.dag
+    const total = Object.keys(dag.nodes).length
+    return (
+      <>
+        <div class="flex items-center gap-2 px-3 pt-3 pb-1" data-testid={`group-dag-${dag.id}`}>
+          <span class="text-[10px] uppercase tracking-wider font-semibold text-indigo-700 dark:text-indigo-300">DAG</span>
+          <span class="font-mono text-[11px] text-slate-600 dark:text-slate-300 truncate">{dag.id.replace(/^dag-/, '')}</span>
+          <span class={`ml-auto text-[10px] font-medium ${dagStatusTone(dag.status)}`}>{dag.status} · {total}</span>
+        </div>
+        <div class="flex flex-col gap-1 p-2 pt-1">
+          {group.parent && (
+            <SessionItem
+              session={group.parent}
+              active={activeSessionId === group.parent.id}
+              onSelect={() => onSelect(group.parent!.id)}
+            />
+          )}
+          {group.children.map((s) => (
+            <SessionItem
+              key={s.id}
+              session={s}
+              active={activeSessionId === s.id}
+              onSelect={() => onSelect(s.id)}
+              indent={1}
+            />
+          ))}
+        </div>
+      </>
+    )
+  }
+  if (group.kind === 'parent-child') {
+    return (
+      <>
+        <GroupHeader label="Parent" count={1 + group.children.length} />
+        <div class="flex flex-col gap-1 p-2 pt-1">
+          <SessionItem
+            session={group.parent}
+            active={activeSessionId === group.parent.id}
+            onSelect={() => onSelect(group.parent.id)}
+          />
+          {group.children.map((s) => (
+            <SessionItem
+              key={s.id}
+              session={s}
+              active={activeSessionId === s.id}
+              onSelect={() => onSelect(s.id)}
+              indent={1}
+            />
+          ))}
+        </div>
+      </>
+    )
+  }
+  if (group.kind === 'variant') {
+    return (
+      <>
+        <GroupHeader label={`Variants`} count={group.sessions.length} tone="variant" />
+        <div class="flex flex-col gap-1 p-2 pt-1">
+          {group.sessions.map((s) => (
+            <SessionItem
+              key={s.id}
+              session={s}
+              active={activeSessionId === s.id}
+              onSelect={() => onSelect(s.id)}
+              indent={1}
+            />
+          ))}
+        </div>
+      </>
+    )
+  }
+  return (
+    <div class="px-2 py-0.5">
+      <SessionItem
+        session={group.session}
+        active={activeSessionId === group.session.id}
+        onSelect={() => onSelect(group.session.id)}
+      />
     </div>
   )
 }
@@ -243,6 +423,7 @@ function ChatPane({
         </div>
       </header>
       <WorktreeHeader session={session} store={store} />
+      <DagStatusPanel session={session} store={store} />
       <SessionTabs
         tabs={[
           { id: 'chat', label: 'Chat', available: true },
@@ -368,6 +549,7 @@ function ActiveView() {
           <aside class="w-72 border-r border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 overflow-y-auto shrink-0">
             <SessionList
               sessions={sessions}
+              dags={store.dags.value}
               activeSessionId={sessionId}
               onSelect={setSessionId}
               orientation="vertical"
@@ -383,6 +565,7 @@ function ActiveView() {
         <div class="flex flex-col flex-1 min-h-0">
           <SessionList
             sessions={sessions}
+            dags={store.dags.value}
             activeSessionId={sessionId}
             onSelect={setSessionId}
             orientation="horizontal"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ import { useMediaQuery } from './hooks/useMediaQuery'
 import { WorktreeHeader } from './components/WorktreeHeader'
 import { DagStatusPanel } from './chat/DagStatusPanel'
 import { ThemeToggle } from './chat/ThemeToggle'
+import { ResizeHandle } from './chat/ResizeHandle'
+import { useResizable } from './hooks/useResizable'
 import { buildSessionGroups, type SessionGroup } from './state/hierarchy'
 import type { ApiDagGraph } from './api/types'
 import { currentRoute } from './routing/current'
@@ -88,29 +90,39 @@ function useFlashOnChange(session: ApiSession): 'success' | 'fail' | 'update' | 
   return flash
 }
 
+type SessionItemKind = 'parent' | 'child' | 'variant' | undefined
+
 function SessionItem({
   session,
   active,
   onSelect,
   indent = 0,
+  kind,
 }: {
   session: ApiSession
   active: boolean
   onSelect: () => void
   indent?: number
+  kind?: SessionItemKind
 }) {
   const preview = session.conversation.length > 0
     ? session.conversation[session.conversation.length - 1].text.slice(0, 60)
     : session.command.slice(0, 60)
   const baseClasses = 'w-full text-left px-3 py-2 rounded-md border transition-colors flex flex-col gap-1'
   const active_ = active
-    ? 'bg-indigo-50 dark:bg-indigo-950/40 border-indigo-300 dark:border-indigo-700'
+    ? 'bg-indigo-50 dark:bg-indigo-950/40 border-indigo-300 dark:border-indigo-700 ring-2 ring-indigo-400/60 dark:ring-indigo-500/50'
     : 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/50'
   const marginLeft = indent > 0 ? `${indent * 16}px` : undefined
   const borderLeft = indent > 0 ? { borderLeft: '2px solid rgb(148 163 184 / 0.35)' } : undefined
   const flash = useFlashOnChange(session)
+  const combinedFlash = flash ?? (active ? 'focus' : undefined)
   return (
-    <div style={{ marginLeft, ...borderLeft }} data-flash={flash ?? undefined} data-testid={`session-row-${session.id}`}>
+    <div
+      style={{ marginLeft, ...borderLeft }}
+      data-flash={combinedFlash ?? undefined}
+      data-session-id={session.id}
+      data-testid={`session-row-${session.id}`}
+    >
       <button
         class={`${baseClasses} ${active_}`}
         onClick={onSelect}
@@ -118,6 +130,7 @@ function SessionItem({
       >
         <div class="flex items-center gap-2">
           <span class={`inline-block h-2 w-2 rounded-full shrink-0 ${statusDot(session.status)}`} />
+          {kind && <KindBadge kind={kind} />}
           <span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">{session.slug}</span>
           {session.repo && (
             <span class="text-[10px] font-mono rounded bg-slate-100 dark:bg-slate-700 px-1.5 py-0.5 text-slate-600 dark:text-slate-300 truncate">
@@ -129,6 +142,24 @@ function SessionItem({
         <div class="text-xs text-slate-600 dark:text-slate-400 truncate">{preview || '—'}</div>
       </button>
     </div>
+  )
+}
+
+function KindBadge({ kind }: { kind: NonNullable<SessionItemKind> }) {
+  const cfg = {
+    parent: { label: 'P', tone: 'bg-indigo-600 text-white dark:bg-indigo-500', title: 'DAG / split parent' },
+    child: { label: 'C', tone: 'bg-sky-500 text-white dark:bg-sky-400 dark:text-slate-900', title: 'Child of a DAG / split parent' },
+    variant: { label: 'V', tone: 'bg-fuchsia-500 text-white dark:bg-fuchsia-400 dark:text-slate-900', title: 'Variant session' },
+  }[kind]
+  return (
+    <span
+      class={`shrink-0 inline-flex items-center justify-center w-4 h-4 rounded text-[9px] font-bold ${cfg.tone}`}
+      title={cfg.title}
+      aria-label={cfg.title}
+      data-testid={`kind-badge-${kind}`}
+    >
+      {cfg.label}
+    </span>
   )
 }
 
@@ -248,6 +279,7 @@ function GroupView({
               session={group.parent}
               active={activeSessionId === group.parent.id}
               onSelect={() => onSelect(group.parent!.id)}
+              kind="parent"
             />
           )}
           {group.children.map((s) => (
@@ -257,6 +289,7 @@ function GroupView({
               active={activeSessionId === s.id}
               onSelect={() => onSelect(s.id)}
               indent={1}
+              kind="child"
             />
           ))}
         </div>
@@ -272,6 +305,7 @@ function GroupView({
             session={group.parent}
             active={activeSessionId === group.parent.id}
             onSelect={() => onSelect(group.parent.id)}
+            kind="parent"
           />
           {group.children.map((s) => (
             <SessionItem
@@ -280,6 +314,7 @@ function GroupView({
               active={activeSessionId === s.id}
               onSelect={() => onSelect(s.id)}
               indent={1}
+              kind="child"
             />
           ))}
         </div>
@@ -298,6 +333,7 @@ function GroupView({
               active={activeSessionId === s.id}
               onSelect={() => onSelect(s.id)}
               indent={1}
+              kind="variant"
             />
           ))}
         </div>
@@ -320,11 +356,13 @@ function ChatPane({
   store,
   onSend,
   onCommand,
+  onNavigate,
 }: {
   session: ApiSession
   store: ConnectionStore
   onSend: (text: string, sessionId: string) => Promise<void>
   onCommand: (cmd: MinionCommand) => Promise<void>
+  onNavigate?: (sessionId: string) => void
 }) {
   const [text, setText] = useState('')
   const [pending, setPending] = useState<'stop' | 'close' | null>(null)
@@ -424,7 +462,7 @@ function ChatPane({
         </div>
       </header>
       <WorktreeHeader session={session} store={store} />
-      <DagStatusPanel session={session} store={store} />
+      <DagStatusPanel session={session} store={store} onSelect={onNavigate} />
       <SessionTabs
         tabs={[
           { id: 'chat', label: 'Chat', available: true },
@@ -476,6 +514,151 @@ function EmptyPane() {
       <div class="text-center text-sm text-slate-500 dark:text-slate-400">
         Select a session on the left, or start a new one with the task bar above.
       </div>
+    </div>
+  )
+}
+
+function DesktopBody({
+  sessions,
+  dags,
+  sessionId,
+  setSessionId,
+  selected,
+  store,
+  onSend,
+  onCommand,
+}: {
+  sessions: ApiSession[]
+  dags: ApiDagGraph[]
+  sessionId: string | null
+  setSessionId: (id: string) => void
+  selected: ApiSession | null
+  store: ConnectionStore
+  onSend: (text: string, sid: string) => Promise<void>
+  onCommand: (cmd: MinionCommand) => Promise<void>
+}) {
+  const { width, onHandleDown, reset } = useResizable({
+    storageKey: 'minions-ui:sidebar-width',
+    defaultWidth: 288,
+    min: 200,
+    max: 520,
+  })
+  const asideRef = useRef<HTMLDivElement>(null)
+
+  // Scroll the active session row into view when it changes. Combined with the
+  // focus-pulse animation on the active item, this makes cross-navigation
+  // (e.g. clicking a child in DagStatusPanel) visually obvious.
+  useEffect(() => {
+    if (!sessionId) return
+    const aside = asideRef.current
+    if (!aside) return
+    const row = aside.querySelector<HTMLElement>(`[data-session-id="${sessionId}"]`)
+    row?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  }, [sessionId])
+
+  return (
+    <div class="flex flex-1 min-h-0">
+      <aside
+        ref={asideRef}
+        class="border-r border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 overflow-y-auto shrink-0"
+        style={{ width: `${width}px` }}
+        data-testid="desktop-sidebar"
+      >
+        <SessionList
+          sessions={sessions}
+          dags={dags}
+          activeSessionId={sessionId}
+          onSelect={setSessionId}
+          orientation="vertical"
+        />
+      </aside>
+      <ResizeHandle onMouseDown={onHandleDown} onDoubleClick={reset} />
+      {selected ? (
+        <ChatPane
+          key={selected.id}
+          session={selected}
+          store={store}
+          onSend={onSend}
+          onCommand={onCommand}
+          onNavigate={setSessionId}
+        />
+      ) : (
+        <EmptyPane />
+      )}
+    </div>
+  )
+}
+
+function MobileSessionStrip({
+  sessions,
+  dags,
+  activeSessionId,
+  onSelect,
+}: {
+  sessions: ApiSession[]
+  dags: ApiDagGraph[]
+  activeSessionId: string | null
+  onSelect: (id: string) => void
+}) {
+  const [collapsed, setCollapsed] = useState<boolean>(() =>
+    typeof localStorage !== 'undefined' && localStorage.getItem('minions-ui:mobile-strip-collapsed') === 'true',
+  )
+
+  function toggle() {
+    const next = !collapsed
+    setCollapsed(next)
+    try { localStorage.setItem('minions-ui:mobile-strip-collapsed', String(next)) } catch { /* ignore */ }
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <div class="text-xs text-slate-500 dark:text-slate-400 p-3 italic">
+        No sessions yet.
+      </div>
+    )
+  }
+
+  if (collapsed) {
+    const activeSlug = sessions.find((s) => s.id === activeSessionId)?.slug
+    return (
+      <button
+        type="button"
+        onClick={toggle}
+        class="w-full flex items-center gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-left"
+        data-testid="mobile-strip-expand"
+      >
+        <span class="text-[10px] uppercase tracking-wider font-semibold text-slate-500 dark:text-slate-400">Sessions</span>
+        <span class="text-xs font-mono text-slate-600 dark:text-slate-300">{sessions.length}</span>
+        {activeSlug && (
+          <>
+            <span class="text-slate-400 dark:text-slate-500">·</span>
+            <span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">{activeSlug}</span>
+          </>
+        )}
+        <span class="ml-auto text-[10px] text-slate-500 dark:text-slate-400">expand ▾</span>
+      </button>
+    )
+  }
+
+  return (
+    <div class="relative">
+      <SessionList
+        sessions={sessions}
+        dags={dags}
+        activeSessionId={activeSessionId}
+        onSelect={onSelect}
+        orientation="horizontal"
+      />
+      <button
+        type="button"
+        onClick={toggle}
+        class="absolute right-1.5 top-1.5 rounded-md border border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 bg-white dark:bg-slate-800 px-1.5 text-[10px] font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+        title="Collapse the session strip"
+        aria-label="Collapse session strip"
+        data-testid="mobile-strip-collapse"
+      >
+        ▴
+      </button>
     </div>
   )
 }
@@ -549,33 +732,32 @@ function ActiveView() {
       {isGroupRoute ? (
         <VariantGroupView store={store} groupId={route.groupId} />
       ) : isDesktop.value ? (
-        <div class="flex flex-1 min-h-0">
-          <aside class="w-72 border-r border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 overflow-y-auto shrink-0">
-            <SessionList
-              sessions={sessions}
-              dags={store.dags.value}
-              activeSessionId={sessionId}
-              onSelect={setSessionId}
-              orientation="vertical"
-            />
-          </aside>
-          {selected ? (
-            <ChatPane session={selected} store={store} onSend={handleSendMessage} onCommand={handleCommand} />
-          ) : (
-            <EmptyPane />
-          )}
-        </div>
+        <DesktopBody
+          sessions={sessions}
+          dags={store.dags.value}
+          sessionId={sessionId}
+          setSessionId={setSessionId}
+          selected={selected}
+          store={store}
+          onSend={handleSendMessage}
+          onCommand={handleCommand}
+        />
       ) : (
         <div class="flex flex-col flex-1 min-h-0">
-          <SessionList
+          <MobileSessionStrip
             sessions={sessions}
             dags={store.dags.value}
             activeSessionId={sessionId}
             onSelect={setSessionId}
-            orientation="horizontal"
           />
           {selected ? (
-            <ChatPane session={selected} store={store} onSend={handleSendMessage} onCommand={handleCommand} />
+            <ChatPane
+              key={selected.id}
+              session={selected}
+              store={store}
+              onSend={handleSendMessage}
+              onCommand={handleCommand}
+            />
           ) : (
             <EmptyPane />
           )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,8 +116,17 @@ function SessionItem({
   const borderLeft = indent > 0 ? { borderLeft: '2px solid rgb(148 163 184 / 0.35)' } : undefined
   const flash = useFlashOnChange(session)
   const combinedFlash = flash ?? (active ? 'focus' : undefined)
+  const rowRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!active) return
+    const node = rowRef.current
+    if (node && typeof node.scrollIntoView === 'function') {
+      node.scrollIntoView({ block: 'nearest', inline: 'center', behavior: 'smooth' })
+    }
+  }, [active, session.id])
   return (
     <div
+      ref={rowRef}
       style={{ marginLeft, ...borderLeft }}
       data-flash={combinedFlash ?? undefined}
       data-session-id={session.id}
@@ -208,6 +217,24 @@ function SessionList({
     [sessions]
   )
   const groups = useMemo(() => buildSessionGroups(sorted, dags), [sorted, dags])
+  // Map every session id to its kind (parent / child / variant) so the
+  // horizontal mobile strip can render the same P / C / V badges as the
+  // vertical desktop sidebar. Undefined for standalone sessions.
+  const kindById = useMemo(() => {
+    const m = new Map<string, NonNullable<SessionItemKind>>()
+    for (const g of groups) {
+      if (g.kind === 'dag') {
+        if (g.parent) m.set(g.parent.id, 'parent')
+        for (const c of g.children) m.set(c.id, 'child')
+      } else if (g.kind === 'parent-child') {
+        m.set(g.parent.id, 'parent')
+        for (const c of g.children) m.set(c.id, 'child')
+      } else if (g.kind === 'variant') {
+        for (const s of g.sessions) m.set(s.id, 'variant')
+      }
+    }
+    return m
+  }, [groups])
 
   if (sorted.length === 0) {
     return (
@@ -225,6 +252,7 @@ function SessionList({
               session={s}
               active={activeSessionId === s.id}
               onSelect={() => onSelect(s.id)}
+              kind={kindById.get(s.id)}
             />
           </div>
         ))}
@@ -553,7 +581,9 @@ function DesktopBody({
     const aside = asideRef.current
     if (!aside) return
     const row = aside.querySelector<HTMLElement>(`[data-session-id="${sessionId}"]`)
-    row?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    if (row && typeof row.scrollIntoView === 'function') {
+      row.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    }
   }, [sessionId])
 
   return (
@@ -609,6 +639,16 @@ function MobileSessionStrip({
     setCollapsed(next)
     try { localStorage.setItem('minions-ui:mobile-strip-collapsed', String(next)) } catch { /* ignore */ }
   }
+
+  // Auto-expand when the active session changes so the user can actually see
+  // the focus-pulse + horizontal scroll-into-view. The preference is not
+  // persisted on this code path — manual collapses still stick.
+  useEffect(() => {
+    if (!activeSessionId) return
+    if (collapsed) setCollapsed(false)
+    // Intentionally not persisting here; user's explicit collapse wins on next
+    // navigation if they toggle again.
+  }, [activeSessionId])
 
   if (sessions.length === 0) {
     return (
@@ -757,6 +797,7 @@ function ActiveView() {
               store={store}
               onSend={handleSendMessage}
               onCommand={handleCommand}
+              onNavigate={setSessionId}
             />
           ) : (
             <EmptyPane />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { useOnlineStatus } from './pwa/useOnlineStatus'
 import { useMediaQuery } from './hooks/useMediaQuery'
 import { WorktreeHeader } from './components/WorktreeHeader'
 import { DagStatusPanel } from './chat/DagStatusPanel'
+import { ThemeToggle } from './chat/ThemeToggle'
 import { buildSessionGroups, type SessionGroup } from './state/hierarchy'
 import type { ApiDagGraph } from './api/types'
 import { currentRoute } from './routing/current'
@@ -522,18 +523,21 @@ function ActiveView() {
           Offline — showing last snapshot
         </div>
       )}
-      <header class="flex items-center gap-3 px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0">
+      <header class="flex items-center gap-2 px-3 sm:px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0">
         <ConnectionPicker onManage={() => { showDrawer.value = true }} />
         <ConnectionStatusBadge status={store.status.value} />
-        <button
-          type="button"
-          onClick={() => void store.refresh()}
-          class="ml-auto rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
-          title="Refetch sessions and DAGs from the minion"
-          data-testid="header-refresh-btn"
-        >
-          Refresh
-        </button>
+        <div class="ml-auto flex items-center gap-1.5">
+          <ThemeToggle />
+          <button
+            type="button"
+            onClick={() => void store.refresh()}
+            class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+            title="Refetch sessions and DAGs from the minion"
+            data-testid="header-refresh-btn"
+          >
+            Refresh
+          </button>
+        </div>
       </header>
       {store.error.value && (
         <div class="flex items-center gap-3 px-4 py-2 bg-red-50 dark:bg-red-950 border-b border-red-200 dark:border-red-800 text-sm text-red-700 dark:text-red-300 shrink-0">

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -13,10 +13,12 @@ import type {
   ScreenshotList,
   VapidPublicKey,
   VersionInfo,
+  WireWorkspaceDiff,
   WorkspaceDiff,
 } from './types'
 import { openEventStream } from './sse'
 import type { SseHandlers, EventStreamHandle } from './sse'
+import { computeDiffStats } from './diff-stats'
 
 export class ApiError extends Error {
   constructor(
@@ -133,8 +135,15 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
       return get<PrPreview>(`/api/sessions/${encodeURIComponent(sessionId)}/pr`)
     },
 
-    getDiff(sessionId: string) {
-      return get<WorkspaceDiff>(`/api/sessions/${encodeURIComponent(sessionId)}/diff`)
+    async getDiff(sessionId: string): Promise<WorkspaceDiff> {
+      const raw = await get<WireWorkspaceDiff>(`/api/sessions/${encodeURIComponent(sessionId)}/diff`)
+      return {
+        branch: raw.head,
+        baseBranch: raw.base,
+        patch: raw.patch,
+        truncated: raw.truncated,
+        stats: computeDiffStats(raw.patch),
+      }
     },
 
     listScreenshots(sessionId: string) {

--- a/src/api/diff-stats.ts
+++ b/src/api/diff-stats.ts
@@ -1,0 +1,27 @@
+import type { WorkspaceDiffStats } from './types'
+
+// Parse a unified-diff patch and count files changed plus insertions/deletions.
+// Filters the per-file header lines (`+++ ` / `--- `) so they don't inflate the
+// insertion/deletion counts. Mirrors `git diff --shortstat` closely enough for
+// UI summaries; exact counts near binary-diff boundaries are best-effort.
+export function computeDiffStats(patch: string): WorkspaceDiffStats {
+  if (!patch) return { filesChanged: 0, insertions: 0, deletions: 0 }
+
+  let filesChanged = 0
+  let insertions = 0
+  let deletions = 0
+
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('diff --git ')) {
+      filesChanged++
+    } else if (line.startsWith('+++ ') || line.startsWith('--- ')) {
+      continue
+    } else if (line.startsWith('+')) {
+      insertions++
+    } else if (line.startsWith('-')) {
+      deletions++
+    }
+  }
+
+  return { filesChanged, insertions, deletions }
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -135,8 +135,16 @@ export interface WorkspaceDiffStats {
   deletions: number
 }
 
+// Wire-shape returned by `GET /api/sessions/:id/diff`. The UI-side
+// `WorkspaceDiff` layered on top of it decorates with derived stats.
+export interface WireWorkspaceDiff {
+  base: string
+  head: string
+  patch: string
+  truncated: boolean
+}
+
 export interface WorkspaceDiff {
-  sessionId: string
   branch: string
   baseBranch: string
   patch: string

--- a/src/chat/ConversationView.tsx
+++ b/src/chat/ConversationView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import type { ConversationMessage } from '../api/types'
-import { renderMarkdown } from '../components/markdown'
+import { MarkdownView } from '../components/MarkdownView'
 import { isOrchestratorStatus } from './orchestrator-filter'
 
 interface ConversationViewProps {
@@ -8,15 +8,14 @@ interface ConversationViewProps {
 }
 
 function AssistantMessage({ text }: { text: string }) {
-  const html = useMemo(() => renderMarkdown(text), [text])
   return (
     <div class="group flex gap-3 justify-start" data-testid="message-assistant">
       <div class="shrink-0 mt-1 w-6 h-6 rounded-full bg-indigo-100 dark:bg-indigo-900 flex items-center justify-center text-[10px] font-bold text-indigo-700 dark:text-indigo-300">
         M
       </div>
-      <div
+      <MarkdownView
+        source={text}
         class="flex-1 min-w-0 prose prose-sm dark:prose-invert max-w-none prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-pre:rounded-lg prose-pre:px-3 prose-pre:py-2 prose-pre:text-xs prose-code:before:content-none prose-code:after:content-none prose-code:bg-slate-100 dark:prose-code:bg-slate-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded text-slate-800 dark:text-slate-200"
-        dangerouslySetInnerHTML={{ __html: html }}
       />
     </div>
   )

--- a/src/chat/ConversationView.tsx
+++ b/src/chat/ConversationView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import type { ConversationMessage } from '../api/types'
 import { renderMarkdown } from '../components/markdown'
+import { isOrchestratorStatus } from './orchestrator-filter'
 
 interface ConversationViewProps {
   messages: ConversationMessage[]
@@ -35,8 +36,13 @@ const NEAR_BOTTOM_PX = 120
 
 export function ConversationView({ messages }: ConversationViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
-  const prevLengthRef = useRef(messages.length)
   const [following, setFollowing] = useState(true)
+
+  const visible = useMemo(
+    () => messages.filter((m) => !(m.role === 'assistant' && isOrchestratorStatus(m.text))),
+    [messages],
+  )
+  const prevLengthRef = useRef(visible.length)
 
   useEffect(() => {
     const el = scrollRef.current
@@ -48,10 +54,10 @@ export function ConversationView({ messages }: ConversationViewProps) {
     const el = scrollRef.current
     if (!el) return
     const prevLen = prevLengthRef.current
-    prevLengthRef.current = messages.length
-    if (messages.length <= prevLen) return
+    prevLengthRef.current = visible.length
+    if (visible.length <= prevLen) return
     if (following) el.scrollTop = el.scrollHeight
-  }, [messages.length, following])
+  }, [visible.length, following])
 
   function handleScroll() {
     const el = scrollRef.current
@@ -75,12 +81,12 @@ export function ConversationView({ messages }: ConversationViewProps) {
         class="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-4 bg-slate-50 dark:bg-slate-900"
         data-testid="conversation-view"
       >
-        {messages.length === 0 && (
+        {visible.length === 0 && (
           <div class="text-xs text-slate-500 dark:text-slate-400 italic text-center py-8">
             No messages yet.
           </div>
         )}
-        {messages.map((msg, idx) =>
+        {visible.map((msg, idx) =>
           msg.role === 'assistant' ? (
             <AssistantMessage key={idx} text={msg.text} />
           ) : (
@@ -88,7 +94,7 @@ export function ConversationView({ messages }: ConversationViewProps) {
           )
         )}
       </div>
-      {!following && messages.length > 0 && (
+      {!following && visible.length > 0 && (
         <button
           type="button"
           onClick={jumpToLatest}

--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -27,6 +27,13 @@ function findDagForSession(dags: ApiDagGraph[], session: ApiSession): ApiDagGrap
   return null
 }
 
+function findParentSession(sessions: ApiSession[], dag: ApiDagGraph): ApiSession | null {
+  for (const s of sessions) {
+    if (s.threadId !== undefined && String(s.threadId) === dag.rootTaskId) return s
+  }
+  return null
+}
+
 const DAG_NODE_COLORS: Record<ApiDagNode['status'], string> = {
   pending: 'bg-slate-300 dark:bg-slate-600',
   running: 'bg-blue-500 animate-pulse',
@@ -53,6 +60,10 @@ export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps
   const collapsed = useSignal(false)
 
   const dag = useComputed(() => findDagForSession(store.dags.value, session))
+  const parentSession = useComputed(() => {
+    const g = dag.value
+    return g ? findParentSession(store.sessions.value, g) : null
+  })
 
   useEffect(() => {
     collapsed.value = false
@@ -60,6 +71,9 @@ export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps
 
   const graph = dag.value
   if (!graph) return null
+
+  const parent = parentSession.value
+  const isViewingParent = !!parent && parent.id === session.id
 
   const nodes = Object.values(graph.nodes)
   const done = nodes.filter((n) => n.status === 'completed' || n.status === 'landed').length
@@ -74,42 +88,81 @@ export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps
         ? 'border-emerald-300 dark:border-emerald-800'
         : 'border-slate-200 dark:border-slate-700'
 
+  const parentClickable = !!parent && !!onSelect && !isViewingParent
+  const parentLabel = parent ? parent.slug || parent.id : `dag-${graph.id.replace(/^dag-/, '')}`
+
   return (
     <div
       class={`border-b ${graphTone} bg-white dark:bg-slate-800 shrink-0`}
       data-testid="dag-status-panel"
     >
-      <button
-        type="button"
-        onClick={() => { collapsed.value = !collapsed.value }}
-        class="w-full flex items-center gap-3 px-4 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700/50"
-        data-testid="dag-status-panel-toggle"
-        aria-expanded={!collapsed.value}
-      >
-        <span class="text-[10px] text-slate-500 dark:text-slate-400 w-3 inline-block shrink-0">
-          {collapsed.value ? '▸' : '▾'}
-        </span>
-        <span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">
-          DAG · {graph.id.replace(/^dag-/, '')}
-        </span>
-        <span class="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap ml-auto">
-          <span class="text-green-600 dark:text-green-400">{done}</span>
-          <span class="text-slate-400 dark:text-slate-500"> / </span>
-          <span>{total}</span>
-          {running > 0 && (
-            <>
-              <span class="text-slate-400 dark:text-slate-500"> · </span>
-              <span class="text-blue-600 dark:text-blue-400">{running} running</span>
-            </>
+      <div class="flex items-stretch">
+        <button
+          type="button"
+          onClick={() => { collapsed.value = !collapsed.value }}
+          class="flex items-center justify-center px-3 py-2 text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700/50"
+          data-testid="dag-status-panel-toggle"
+          aria-expanded={!collapsed.value}
+          aria-label={collapsed.value ? 'Expand DAG' : 'Collapse DAG'}
+        >
+          <span class="text-[10px] w-3 inline-block">
+            {collapsed.value ? '▸' : '▾'}
+          </span>
+        </button>
+        <button
+          type="button"
+          disabled={!parentClickable}
+          onClick={() => {
+            if (parentClickable && onSelect && parent) onSelect(parent.id)
+          }}
+          class={`flex-1 flex items-center gap-2 pr-4 py-2 text-left ${
+            parentClickable
+              ? 'hover:bg-slate-50 dark:hover:bg-slate-700/50 cursor-pointer'
+              : 'cursor-default'
+          }`}
+          data-testid="dag-status-parent-btn"
+          title={parentClickable ? 'Open parent session' : undefined}
+        >
+          <span
+            class={`inline-block h-2 w-2 rounded-full shrink-0 ${
+              graph.status === 'failed'
+                ? 'bg-red-500'
+                : graph.status === 'completed'
+                  ? 'bg-emerald-500'
+                  : 'bg-blue-500 animate-pulse'
+            }`}
+            aria-hidden="true"
+          />
+          <span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">
+            {parentLabel}
+          </span>
+          <span class="text-[10px] uppercase tracking-wide text-indigo-600 dark:text-indigo-400 shrink-0">
+            parent
+          </span>
+          {isViewingParent && (
+            <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500 shrink-0">
+              · current
+            </span>
           )}
-          {failed > 0 && (
-            <>
-              <span class="text-slate-400 dark:text-slate-500"> · </span>
-              <span class="text-red-600 dark:text-red-400">{failed} failed</span>
-            </>
-          )}
-        </span>
-      </button>
+          <span class="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap ml-auto">
+            <span class="text-green-600 dark:text-green-400">{done}</span>
+            <span class="text-slate-400 dark:text-slate-500"> / </span>
+            <span>{total}</span>
+            {running > 0 && (
+              <>
+                <span class="text-slate-400 dark:text-slate-500"> · </span>
+                <span class="text-blue-600 dark:text-blue-400">{running} running</span>
+              </>
+            )}
+            {failed > 0 && (
+              <>
+                <span class="text-slate-400 dark:text-slate-500"> · </span>
+                <span class="text-red-600 dark:text-red-400">{failed} failed</span>
+              </>
+            )}
+          </span>
+        </button>
+      </div>
       {!collapsed.value && (
         <ul class="px-4 pb-3 pt-1 flex flex-col gap-1.5" data-testid="dag-status-node-list">
           {nodes.map((node) => (

--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -6,11 +6,12 @@ import type { ConnectionStore } from '../state/types'
 interface DagStatusPanelProps {
   session: ApiSession
   store: ConnectionStore
+  onSelect?: (sessionId: string) => void
 }
 
-// Finds the DAG for an active session. Parent sessions own the DAG; the server
-// keys `ApiDagGraph.rootTaskId` by the parent session's threadId as a string,
-// and each child node embeds its own `ApiSession` via `node.session`.
+// Finds the DAG for an active session. Either the active session IS the DAG
+// parent (match via threadId → `ApiDagGraph.rootTaskId`) or one of the DAG's
+// child nodes wraps this session (match via `node.session.id`).
 function findDagForSession(dags: ApiDagGraph[], session: ApiSession): ApiDagGraph | null {
   if (session.threadId !== undefined) {
     const tidStr = String(session.threadId)
@@ -48,7 +49,7 @@ const DAG_NODE_LABELS: Record<ApiDagNode['status'], string> = {
   skipped: 'skipped',
 }
 
-export function DagStatusPanel({ session, store }: DagStatusPanelProps) {
+export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps) {
   const collapsed = useSignal(false)
 
   const dag = useComputed(() => findDagForSession(store.dags.value, session))
@@ -112,7 +113,12 @@ export function DagStatusPanel({ session, store }: DagStatusPanelProps) {
       {!collapsed.value && (
         <ul class="px-4 pb-3 pt-1 flex flex-col gap-1.5" data-testid="dag-status-node-list">
           {nodes.map((node) => (
-            <DagNodeRow key={node.id} node={node} />
+            <DagNodeRow
+              key={node.id}
+              node={node}
+              isActive={!!node.session && node.session.id === session.id}
+              onSelect={onSelect}
+            />
           ))}
         </ul>
       )}
@@ -120,7 +126,15 @@ export function DagStatusPanel({ session, store }: DagStatusPanelProps) {
   )
 }
 
-function DagNodeRow({ node }: { node: ApiDagNode }) {
+function DagNodeRow({
+  node,
+  isActive,
+  onSelect,
+}: {
+  node: ApiDagNode
+  isActive: boolean
+  onSelect?: (sessionId: string) => void
+}) {
   const dot = DAG_NODE_COLORS[node.status]
   const label = DAG_NODE_LABELS[node.status]
   const sess = node.session
@@ -135,11 +149,32 @@ function DagNodeRow({ node }: { node: ApiDagNode }) {
           ? 'bg-blue-50/40 dark:bg-blue-950/20'
           : 'bg-slate-50 dark:bg-slate-900/40'
 
+  const clickable = !!sess && !!onSelect
+  const handleClick = () => {
+    if (!clickable) return
+    onSelect!(sess!.id)
+  }
+
+  const activeRing = isActive ? 'ring-2 ring-indigo-400/60 dark:ring-indigo-500/50' : 'border border-slate-200 dark:border-slate-700'
+  const clickableClass = clickable
+    ? 'cursor-pointer hover:bg-white dark:hover:bg-slate-800/80 active:scale-[.99]'
+    : ''
+
   return (
     <li
-      class={`flex items-center gap-2.5 px-2.5 py-1.5 rounded-md border border-slate-200 dark:border-slate-700 text-xs transition-colors ${tone}`}
+      class={`flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-xs transition-all ${tone} ${activeRing} ${clickableClass}`}
       data-testid={`dag-status-node-${node.id}`}
       data-status={node.status}
+      data-active={isActive ? 'true' : undefined}
+      onClick={handleClick}
+      role={clickable ? 'button' : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onKeyDown={clickable ? (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleClick()
+        }
+      } : undefined}
     >
       <span class={`inline-block h-2 w-2 rounded-full shrink-0 ${dot}`} aria-hidden="true" />
       <span class="font-mono font-medium text-slate-900 dark:text-slate-100 truncate">

--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -1,0 +1,169 @@
+import { useComputed, useSignal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import type { ApiDagGraph, ApiDagNode, ApiSession } from '../api/types'
+import type { ConnectionStore } from '../state/types'
+
+interface DagStatusPanelProps {
+  session: ApiSession
+  store: ConnectionStore
+}
+
+// Finds the DAG for an active session. Parent sessions own the DAG; the server
+// keys `ApiDagGraph.rootTaskId` by the parent session's threadId as a string,
+// and each child node embeds its own `ApiSession` via `node.session`.
+function findDagForSession(dags: ApiDagGraph[], session: ApiSession): ApiDagGraph | null {
+  if (session.threadId !== undefined) {
+    const tidStr = String(session.threadId)
+    for (const g of dags) {
+      if (g.rootTaskId === tidStr) return g
+    }
+  }
+  for (const g of dags) {
+    for (const n of Object.values(g.nodes)) {
+      if (n.session?.id === session.id) return g
+    }
+  }
+  return null
+}
+
+const DAG_NODE_COLORS: Record<ApiDagNode['status'], string> = {
+  pending: 'bg-slate-300 dark:bg-slate-600',
+  running: 'bg-blue-500 animate-pulse',
+  'ci-pending': 'bg-amber-400 animate-pulse',
+  'ci-failed': 'bg-red-500',
+  completed: 'bg-green-500',
+  landed: 'bg-emerald-600',
+  failed: 'bg-red-500',
+  skipped: 'bg-slate-400',
+}
+
+const DAG_NODE_LABELS: Record<ApiDagNode['status'], string> = {
+  pending: 'pending',
+  running: 'running',
+  'ci-pending': 'CI',
+  'ci-failed': 'CI failed',
+  completed: 'done',
+  landed: 'landed',
+  failed: 'failed',
+  skipped: 'skipped',
+}
+
+export function DagStatusPanel({ session, store }: DagStatusPanelProps) {
+  const collapsed = useSignal(false)
+
+  const dag = useComputed(() => findDagForSession(store.dags.value, session))
+
+  useEffect(() => {
+    collapsed.value = false
+  }, [session.id, collapsed])
+
+  const graph = dag.value
+  if (!graph) return null
+
+  const nodes = Object.values(graph.nodes)
+  const done = nodes.filter((n) => n.status === 'completed' || n.status === 'landed').length
+  const running = nodes.filter((n) => n.status === 'running' || n.status === 'ci-pending').length
+  const failed = nodes.filter((n) => n.status === 'failed' || n.status === 'ci-failed').length
+  const total = nodes.length
+
+  const graphTone =
+    graph.status === 'failed'
+      ? 'border-red-300 dark:border-red-800'
+      : graph.status === 'completed'
+        ? 'border-emerald-300 dark:border-emerald-800'
+        : 'border-slate-200 dark:border-slate-700'
+
+  return (
+    <div
+      class={`border-b ${graphTone} bg-white dark:bg-slate-800 shrink-0`}
+      data-testid="dag-status-panel"
+    >
+      <button
+        type="button"
+        onClick={() => { collapsed.value = !collapsed.value }}
+        class="w-full flex items-center gap-3 px-4 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700/50"
+        data-testid="dag-status-panel-toggle"
+        aria-expanded={!collapsed.value}
+      >
+        <span class="text-[10px] text-slate-500 dark:text-slate-400 w-3 inline-block shrink-0">
+          {collapsed.value ? '▸' : '▾'}
+        </span>
+        <span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">
+          DAG · {graph.id.replace(/^dag-/, '')}
+        </span>
+        <span class="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap ml-auto">
+          <span class="text-green-600 dark:text-green-400">{done}</span>
+          <span class="text-slate-400 dark:text-slate-500"> / </span>
+          <span>{total}</span>
+          {running > 0 && (
+            <>
+              <span class="text-slate-400 dark:text-slate-500"> · </span>
+              <span class="text-blue-600 dark:text-blue-400">{running} running</span>
+            </>
+          )}
+          {failed > 0 && (
+            <>
+              <span class="text-slate-400 dark:text-slate-500"> · </span>
+              <span class="text-red-600 dark:text-red-400">{failed} failed</span>
+            </>
+          )}
+        </span>
+      </button>
+      {!collapsed.value && (
+        <ul class="px-4 pb-3 pt-1 flex flex-col gap-1.5" data-testid="dag-status-node-list">
+          {nodes.map((node) => (
+            <DagNodeRow key={node.id} node={node} />
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function DagNodeRow({ node }: { node: ApiDagNode }) {
+  const dot = DAG_NODE_COLORS[node.status]
+  const label = DAG_NODE_LABELS[node.status]
+  const sess = node.session
+  const prUrl = sess?.prUrl
+  const deps = node.dependencies
+  const tone =
+    node.status === 'failed' || node.status === 'ci-failed'
+      ? 'bg-red-50/60 dark:bg-red-950/30'
+      : node.status === 'completed' || node.status === 'landed'
+        ? 'bg-emerald-50/50 dark:bg-emerald-950/20'
+        : node.status === 'running' || node.status === 'ci-pending'
+          ? 'bg-blue-50/40 dark:bg-blue-950/20'
+          : 'bg-slate-50 dark:bg-slate-900/40'
+
+  return (
+    <li
+      class={`flex items-center gap-2.5 px-2.5 py-1.5 rounded-md border border-slate-200 dark:border-slate-700 text-xs transition-colors ${tone}`}
+      data-testid={`dag-status-node-${node.id}`}
+      data-status={node.status}
+    >
+      <span class={`inline-block h-2 w-2 rounded-full shrink-0 ${dot}`} aria-hidden="true" />
+      <span class="font-mono font-medium text-slate-900 dark:text-slate-100 truncate">
+        {node.slug || node.id}
+      </span>
+      <span class="text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400 whitespace-nowrap shrink-0">
+        {label}
+      </span>
+      {deps.length > 0 && (
+        <span class="hidden sm:inline text-[10px] text-slate-400 dark:text-slate-500 truncate">
+          ← {deps.join(', ')}
+        </span>
+      )}
+      {prUrl && (
+        <a
+          href={prUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="ml-auto text-[10px] font-medium text-indigo-600 dark:text-indigo-400 hover:underline shrink-0"
+          onClick={(e) => e.stopPropagation()}
+        >
+          PR ↗
+        </a>
+      )}
+    </li>
+  )
+}

--- a/src/chat/DiffTab.tsx
+++ b/src/chat/DiffTab.tsx
@@ -158,13 +158,13 @@ function DiffFileView({ file }: { file: DiffFile }) {
         </span>
       </button>
       {!collapsed && (
-        <div class="font-mono text-xs overflow-x-auto bg-white dark:bg-slate-900">
+        <div class="font-mono text-xs bg-white dark:bg-slate-900">
           {file.isBinary && (
             <div class="px-4 py-2 text-slate-500 dark:text-slate-400 italic">Binary file.</div>
           )}
           {file.hunks.map((hunk, hi) => (
             <div key={hi}>
-              <div class="px-4 py-1 bg-slate-50 dark:bg-slate-800/70 text-slate-500 dark:text-slate-400 border-y border-slate-200 dark:border-slate-700">
+              <div class="px-2 sm:px-4 py-1 bg-slate-50 dark:bg-slate-800/70 text-slate-500 dark:text-slate-400 border-y border-slate-200 dark:border-slate-700 whitespace-pre-wrap break-all">
                 {hunk.header}
               </div>
               {hunk.lines.map((line, li) => {
@@ -184,17 +184,19 @@ function DiffFileView({ file }: { file: DiffFile }) {
                 return (
                   <div
                     key={li}
-                    class={`flex gap-2 px-4 py-0.5 ${bg}`}
+                    class={`flex gap-2 px-2 sm:px-4 py-0.5 ${bg}`}
                     data-testid={`diff-line-${line.type}`}
                   >
-                    <span class="text-[10px] text-slate-400 dark:text-slate-500 w-8 text-right shrink-0 select-none">
+                    <span class="text-[10px] text-slate-400 dark:text-slate-500 w-6 sm:w-8 text-right shrink-0 select-none">
                       {line.oldLineNo ?? ''}
                     </span>
-                    <span class="text-[10px] text-slate-400 dark:text-slate-500 w-8 text-right shrink-0 select-none">
+                    <span class="hidden sm:inline text-[10px] text-slate-400 dark:text-slate-500 w-8 text-right shrink-0 select-none">
                       {line.newLineNo ?? ''}
                     </span>
                     <span class={`${signColor} w-3 shrink-0 select-none`}>{sign}</span>
-                    <span class="whitespace-pre text-slate-800 dark:text-slate-200">{line.text || ' '}</span>
+                    <span class="flex-1 min-w-0 whitespace-pre-wrap break-all text-slate-800 dark:text-slate-200">
+                      {line.text || ' '}
+                    </span>
                   </div>
                 )
               })}

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -159,12 +159,17 @@ export function NewTaskBar({ store, navigate = defaultNavigate }: NewTaskBarProp
         )}
 
         <div
-          class="flex items-center gap-1 ml-auto"
+          class="flex items-center gap-1.5 ml-auto"
           role="group"
           aria-label="Variant count"
           data-testid="variant-count"
         >
-          <span class="text-xs text-slate-500 dark:text-slate-400">×</span>
+          <span
+            class={`text-xs ${canVariants ? 'text-slate-600 dark:text-slate-300' : 'text-slate-400 dark:text-slate-500'}`}
+            title={canVariants ? 'How many parallel variants to spawn' : 'Parallel variants need library ≥ 1.111'}
+          >
+            Variants
+          </span>
           {VARIANT_COUNTS.map((n) => {
             const active = variantCount.value === n
             const gated = n > 1 && !canVariants
@@ -182,7 +187,7 @@ export function NewTaskBar({ store, navigate = defaultNavigate }: NewTaskBarProp
                 aria-pressed={active}
                 class={`h-7 min-w-7 rounded-full border px-2 text-xs font-medium transition-colors disabled:opacity-40 ${btnClass}`}
               >
-                {n}
+                ×{n}
               </button>
             )
           })}

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -5,6 +5,18 @@ import { hasFeature } from '../api/features'
 import { formatRoute } from '../routing/route'
 import { recordVariantGroup } from '../groups/store'
 
+const COLLAPSE_KEY = 'minions-ui:newtaskbar-collapsed'
+
+function readCollapsed(): boolean {
+  if (typeof localStorage === 'undefined') return false
+  return localStorage.getItem(COLLAPSE_KEY) === 'true'
+}
+
+function writeCollapsed(v: boolean): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(COLLAPSE_KEY, String(v))
+}
+
 export interface ModeOption {
   value: CreateSessionMode
   label: string
@@ -48,6 +60,16 @@ export function NewTaskBar({ store, navigate = defaultNavigate }: NewTaskBarProp
   const canCreate = hasFeature(store, 'sessions-create')
   const canVariants = hasFeature(store, 'sessions-variants')
   const wantVariants = useComputed(() => variantCount.value > 1)
+
+  // Collapsed state is user-controlled via the − button, persisted in
+  // localStorage. Defaults to expanded; tests rely on the expanded render.
+  const collapsed = useSignal(readCollapsed())
+
+  function toggleCollapsed() {
+    const next = !collapsed.value
+    collapsed.value = next
+    writeCollapsed(next)
+  }
 
   if (!canCreate) {
     return (
@@ -111,6 +133,27 @@ export function NewTaskBar({ store, navigate = defaultNavigate }: NewTaskBarProp
     : wantVariants.value
       ? `Launch ×${variantCount.value}`
       : 'Launch'
+
+  if (collapsed.value) {
+    return (
+      <div
+        class="flex items-center gap-2 px-3 py-1.5 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
+        data-testid="new-task-bar"
+        data-collapsed="true"
+      >
+        <button
+          type="button"
+          onClick={toggleCollapsed}
+          class="flex-1 flex items-center gap-2 rounded-md border border-indigo-300 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-950/40 px-3 py-1.5 text-xs font-medium text-indigo-700 dark:text-indigo-300 hover:bg-indigo-100 dark:hover:bg-indigo-900/40"
+          data-testid="new-task-expand"
+        >
+          <span aria-hidden="true">+</span>
+          <span>New task</span>
+          <span class="ml-auto text-[10px] text-indigo-400 dark:text-indigo-500">expand</span>
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div
@@ -218,6 +261,16 @@ export function NewTaskBar({ store, navigate = defaultNavigate }: NewTaskBarProp
           data-testid="new-task-send"
         >
           {launchLabel}
+        </button>
+        <button
+          type="button"
+          onClick={toggleCollapsed}
+          class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 bg-white dark:bg-slate-800 px-2 py-2 text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
+          title="Collapse the task bar"
+          aria-label="Collapse task bar"
+          data-testid="new-task-collapse"
+        >
+          −
         </button>
       </div>
 

--- a/src/chat/ResizeHandle.tsx
+++ b/src/chat/ResizeHandle.tsx
@@ -1,0 +1,27 @@
+// Vertical 6-px draggable grip shown between panels on desktop. Double-click
+// resets the caller-managed width to its default.
+export function ResizeHandle({
+  onMouseDown,
+  onDoubleClick,
+}: {
+  onMouseDown: (e: MouseEvent | TouchEvent) => void
+  onDoubleClick?: () => void
+}) {
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      title="Drag to resize · double-click to reset"
+      onMouseDown={onMouseDown}
+      onTouchStart={onMouseDown}
+      onDblClick={onDoubleClick}
+      class="group relative w-1.5 shrink-0 cursor-col-resize bg-slate-200 dark:bg-slate-700 hover:bg-indigo-400 dark:hover:bg-indigo-500 transition-colors"
+      data-testid="resize-handle"
+    >
+      <span
+        class="absolute inset-y-0 left-1/2 w-0 group-hover:w-1 -translate-x-1/2 bg-indigo-500 dark:bg-indigo-400 transition-all"
+        aria-hidden="true"
+      />
+    </div>
+  )
+}

--- a/src/chat/ThemeToggle.tsx
+++ b/src/chat/ThemeToggle.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'preact/hooks'
+import { useTheme, setTheme } from '../hooks/useTheme'
+
+// Cycle: system → light → dark → system. Persisted in localStorage via setTheme.
+type ThemePref = 'system' | 'light' | 'dark'
+
+const STORAGE_KEY = 'minions-ui:theme'
+
+function readPref(): ThemePref {
+  const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null
+  return raw === 'light' || raw === 'dark' ? raw : 'system'
+}
+
+export function ThemeToggle() {
+  const resolved = useTheme()
+  const [pref, setPref] = useState<ThemePref>(readPref)
+
+  function cycle() {
+    const next: ThemePref = pref === 'system' ? 'light' : pref === 'light' ? 'dark' : 'system'
+    setPref(next)
+    setTheme(next)
+  }
+
+  const icon = pref === 'system' ? '🖥' : resolved.value === 'dark' ? '🌙' : '☀'
+  const label =
+    pref === 'system'
+      ? `Theme: system (${resolved.value})`
+      : `Theme: ${pref}`
+
+  return (
+    <button
+      type="button"
+      onClick={cycle}
+      class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
+      title={label}
+      aria-label={label}
+      data-testid="theme-toggle"
+    >
+      <span aria-hidden="true">{icon}</span>
+    </button>
+  )
+}

--- a/src/chat/orchestrator-filter.ts
+++ b/src/chat/orchestrator-filter.ts
@@ -1,0 +1,44 @@
+// Server-authored orchestrator status messages arrive in TopicSession.conversation
+// via `ctx.postStatus` (see telegram-minions/src/engine/engine-context.ts). Telegram
+// users see them in their thread; the PWA hides them in favour of the live DAG /
+// status panels that read from `store.dags` and `store.sessions` directly.
+//
+// The filter matches plain-text prefixes the server emits. Lines authored by
+// humans (e.g. `/retry`, a user reply) don't match these patterns and pass
+// through untouched.
+
+const ORCHESTRATOR_PREFIXES = [
+  '🔗 DAG:',
+  '🔗 DAG ',
+  '📊 🔗 DAG Status',
+  '📊 DAG complete:',
+  '📚 Stack:',
+  '⚡ Starting:',
+  '⚡ DAG recovered after restart',
+  '🔄 ',
+  '📊 ',
+  '✅ Ship complete',
+  '🚢 Ship:',
+  '⚖️ Verdict',
+  '🗣 Advocate:',
+  '⏳ Pipeline is advancing',
+]
+
+const ORCHESTRATOR_REGEX_TESTS: RegExp[] = [
+  /^✅ [\w-]+ (?:\(https?:\/\/[^)]+\) )?completed:/,
+  /^❌ [\w-]+ (?:\(https?:\/\/[^)]+\) )?failed:/,
+  /^⚠️ [\w-]+ completed without a PR/,
+  /^⚠️ Pre-flight failed/,
+  /^🔍 Pre-flight check/,
+]
+
+export function isOrchestratorStatus(text: string): boolean {
+  const trimmed = text.trimStart()
+  for (const prefix of ORCHESTRATOR_PREFIXES) {
+    if (trimmed.startsWith(prefix)) return true
+  }
+  for (const regex of ORCHESTRATOR_REGEX_TESTS) {
+    if (regex.test(trimmed)) return true
+  }
+  return false
+}

--- a/src/components/MarkdownView.tsx
+++ b/src/components/MarkdownView.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useRef } from 'preact/hooks'
+import { renderMarkdown } from './markdown'
+
+type MermaidModule = typeof import('mermaid').default
+
+let mermaidPromise: Promise<MermaidModule> | null = null
+
+function loadMermaid(): Promise<MermaidModule> {
+  if (!mermaidPromise) {
+    mermaidPromise = import('mermaid').then(({ default: mermaid }) => {
+      const isDark =
+        typeof document !== 'undefined' &&
+        document.documentElement.getAttribute('data-theme') === 'dark'
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: isDark ? 'dark' : 'default',
+        securityLevel: 'strict',
+      })
+      return mermaid
+    })
+  }
+  return mermaidPromise
+}
+
+let mermaidIdCounter = 0
+
+interface MarkdownViewProps {
+  source: string
+  class?: string
+  'data-testid'?: string
+}
+
+export function MarkdownView({ source, class: className, 'data-testid': testId }: MarkdownViewProps) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const html = useMemo(() => renderMarkdown(source), [source])
+
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+    const blocks = Array.from(
+      root.querySelectorAll<HTMLElement>('pre > code.language-mermaid'),
+    )
+    if (blocks.length === 0) return
+
+    let cancelled = false
+    void (async () => {
+      let mermaid: MermaidModule
+      try {
+        mermaid = await loadMermaid()
+      } catch {
+        return
+      }
+      if (cancelled) return
+
+      for (const code of blocks) {
+        const pre = code.parentElement
+        if (!pre) continue
+        const src = code.textContent ?? ''
+        const id = `mmd-${Date.now().toString(36)}-${mermaidIdCounter++}`
+        try {
+          const { svg } = await mermaid.render(id, src)
+          if (cancelled) return
+          const wrap = document.createElement('div')
+          wrap.className = 'mermaid-diagram my-2 overflow-x-auto'
+          wrap.innerHTML = svg
+          pre.replaceWith(wrap)
+        } catch (err) {
+          if (cancelled) return
+          const note = document.createElement('div')
+          note.className = 'text-xs text-red-600 dark:text-red-400 mt-1'
+          note.textContent = `mermaid: ${err instanceof Error ? err.message : String(err)}`
+          pre.after(note)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [html])
+
+  return (
+    <div
+      ref={rootRef}
+      class={className}
+      data-testid={testId}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}

--- a/src/components/PrPreviewCard.tsx
+++ b/src/components/PrPreviewCard.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import type { ApiClient } from '../api/client'
 import type { PrCheck, PrCheckStatus, PrPreview, PrState } from '../api/types'
-import { renderMarkdown } from './markdown'
+import { MarkdownView } from './MarkdownView'
 
 export const PR_PREVIEW_POLL_MS = 30_000
 
@@ -204,11 +204,7 @@ export function PrPreviewCard({ sessionId, prUrl, client }: PrPreviewCardProps) 
     }
   }, [sessionId, client, reloadNonce])
 
-  const bodyHtml = useMemo(() => {
-    if (state.kind !== 'ready') return ''
-    const body = state.pr.body?.trim()
-    return body ? renderMarkdown(body) : ''
-  }, [state])
+  const bodySource = state.kind === 'ready' ? state.pr.body?.trim() ?? '' : ''
 
   if (state.kind === 'loading') return <LoadingCard />
   if (state.kind === 'error') {
@@ -283,7 +279,7 @@ export function PrPreviewCard({ sessionId, prUrl, client }: PrPreviewCardProps) 
           </span>
         )}
       </div>
-      {bodyHtml && (
+      {bodySource && (
         <div class="border-t border-slate-100 dark:border-slate-700">
           <button
             type="button"
@@ -294,9 +290,9 @@ export function PrPreviewCard({ sessionId, prUrl, client }: PrPreviewCardProps) 
             {expanded ? 'Hide description' : 'Show description'}
           </button>
           {expanded && (
-            <div
-              class="px-3 pb-3 prose prose-sm dark:prose-invert max-w-none prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-pre:rounded prose-pre:px-2 prose-pre:py-1 prose-pre:text-xs prose-code:before:content-none prose-code:after:content-none prose-code:bg-slate-100 dark:prose-code:bg-slate-800 prose-code:px-1 prose-code:rounded text-slate-700 dark:text-slate-200"
-              dangerouslySetInnerHTML={{ __html: bodyHtml }}
+            <MarkdownView
+              source={bodySource}
+              class="px-3 pb-3 max-h-64 sm:max-h-80 overflow-y-auto overscroll-contain prose prose-sm dark:prose-invert max-w-none prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-pre:rounded prose-pre:px-2 prose-pre:py-1 prose-pre:text-xs prose-code:before:content-none prose-code:after:content-none prose-code:bg-slate-100 dark:prose-code:bg-slate-800 prose-code:px-1 prose-code:rounded text-slate-700 dark:text-slate-200 break-words"
               data-testid="pr-body"
             />
           )}

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from 'preact/hooks'
+
+interface UseResizableOptions {
+  storageKey: string
+  defaultWidth: number
+  min: number
+  max: number
+}
+
+// Persisted draggable-width hook. Returns the current width + a mouse/touch
+// event handler the caller wires onto a <ResizeHandle>. Width is clamped to
+// [min, max] and written to localStorage under `storageKey`.
+export function useResizable({ storageKey, defaultWidth, min, max }: UseResizableOptions) {
+  const [width, setWidth] = useState<number>(() => {
+    if (typeof localStorage === 'undefined') return defaultWidth
+    const raw = localStorage.getItem(storageKey)
+    const n = raw ? Number(raw) : NaN
+    if (!Number.isFinite(n)) return defaultWidth
+    return Math.min(max, Math.max(min, n))
+  })
+  const dragging = useRef(false)
+  const startX = useRef(0)
+  const startW = useRef(0)
+
+  useEffect(() => {
+    function onMove(e: MouseEvent | TouchEvent) {
+      if (!dragging.current) return
+      const clientX = 'touches' in e ? e.touches[0]?.clientX ?? 0 : e.clientX
+      const delta = clientX - startX.current
+      const next = Math.min(max, Math.max(min, startW.current + delta))
+      setWidth(next)
+    }
+    function onEnd() {
+      if (!dragging.current) return
+      dragging.current = false
+      document.body.style.userSelect = ''
+      document.body.style.cursor = ''
+      try {
+        localStorage.setItem(storageKey, String(widthRef.current))
+      } catch {
+        // ignore quota errors
+      }
+    }
+    const widthRef = { current: width }
+    const syncRef = () => { widthRef.current = width }
+    syncRef()
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onEnd)
+    window.addEventListener('touchmove', onMove)
+    window.addEventListener('touchend', onEnd)
+    window.addEventListener('touchcancel', onEnd)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onEnd)
+      window.removeEventListener('touchmove', onMove)
+      window.removeEventListener('touchend', onEnd)
+      window.removeEventListener('touchcancel', onEnd)
+    }
+  }, [width, min, max, storageKey])
+
+  function onHandleDown(e: MouseEvent | TouchEvent) {
+    dragging.current = true
+    startX.current = 'touches' in e ? e.touches[0]?.clientX ?? 0 : (e as MouseEvent).clientX
+    startW.current = width
+    document.body.style.userSelect = 'none'
+    document.body.style.cursor = 'col-resize'
+    e.preventDefault()
+  }
+
+  function reset() {
+    setWidth(defaultWidth)
+    try {
+      localStorage.removeItem(storageKey)
+    } catch {
+      // ignore
+    }
+  }
+
+  return { width, onHandleDown, reset }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -18,3 +18,30 @@ body {
 #app {
   min-height: 100vh;
 }
+
+/* Flash animations used by SessionItem + DagStatusPanel rows when a session
+   transitions state. Pure CSS; driven by data-flash attribute. */
+@keyframes minions-flash-success {
+  0% { background-color: rgb(34 197 94 / 0.35); }
+  100% { background-color: transparent; }
+}
+
+@keyframes minions-flash-fail {
+  0% { background-color: rgb(239 68 68 / 0.35); }
+  100% { background-color: transparent; }
+}
+
+@keyframes minions-flash-update {
+  0% { background-color: rgb(99 102 241 / 0.22); }
+  100% { background-color: transparent; }
+}
+
+[data-flash="success"] {
+  animation: minions-flash-success 700ms ease-out;
+}
+[data-flash="fail"] {
+  animation: minions-flash-fail 900ms ease-out;
+}
+[data-flash="update"] {
+  animation: minions-flash-update 500ms ease-out;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -45,3 +45,13 @@ body {
 [data-flash="update"] {
   animation: minions-flash-update 500ms ease-out;
 }
+
+@keyframes minions-focus-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(99 102 241 / 0.55); }
+  70% { box-shadow: 0 0 0 8px rgb(99 102 241 / 0); }
+  100% { box-shadow: 0 0 0 0 rgb(99 102 241 / 0); }
+}
+[data-flash="focus"] {
+  animation: minions-focus-pulse 650ms ease-out;
+  border-radius: 0.375rem;
+}

--- a/src/state/hierarchy.ts
+++ b/src/state/hierarchy.ts
@@ -1,0 +1,91 @@
+import type { ApiDagGraph, ApiSession } from '../api/types'
+
+export type SessionGroup =
+  | { kind: 'dag'; dag: ApiDagGraph; parent: ApiSession | null; children: ApiSession[] }
+  | { kind: 'parent-child'; parent: ApiSession; children: ApiSession[] }
+  | { kind: 'variant'; groupId: string; sessions: ApiSession[] }
+  | { kind: 'standalone'; session: ApiSession }
+
+// Group sessions by their dominant relationship, in display order:
+//   1. DAGs (with their parent + child sessions, if the parent is in `sessions`)
+//   2. Non-DAG parent/child trees (plain `/split` without a DAG)
+//   3. Variant groups (`session.variantGroupId` set, no DAG)
+//   4. Standalone sessions
+//
+// A session only appears in one group — DAG membership wins over parent/child
+// which wins over variant group which wins over standalone.
+export function buildSessionGroups(sessions: ApiSession[], dags: ApiDagGraph[]): SessionGroup[] {
+  const byId = new Map<string, ApiSession>()
+  const byThreadId = new Map<string, ApiSession>()
+  for (const s of sessions) {
+    byId.set(s.id, s)
+    if (s.threadId !== undefined) byThreadId.set(String(s.threadId), s)
+  }
+
+  const consumed = new Set<string>()
+  const groups: SessionGroup[] = []
+
+  // 1. DAGs first. rootTaskId is the parent's threadId as a string.
+  for (const dag of dags) {
+    const parent = byThreadId.get(dag.rootTaskId) ?? null
+    const childIds = Object.values(dag.nodes)
+      .map((n) => n.session?.id)
+      .filter((id): id is string => typeof id === 'string')
+    const children = childIds
+      .map((id) => byId.get(id))
+      .filter((s): s is ApiSession => !!s)
+    if (parent) consumed.add(parent.id)
+    for (const c of children) consumed.add(c.id)
+    groups.push({ kind: 'dag', dag, parent, children: sortByUpdatedAt(children) })
+  }
+
+  // 2. Non-DAG parent/child trees.
+  for (const s of sessions) {
+    if (consumed.has(s.id)) continue
+    if (s.childIds.length === 0 || s.parentId) continue
+    const children: ApiSession[] = []
+    for (const cid of s.childIds) {
+      const child = byId.get(cid)
+      if (child && !consumed.has(child.id)) {
+        children.push(child)
+        consumed.add(child.id)
+      }
+    }
+    consumed.add(s.id)
+    groups.push({ kind: 'parent-child', parent: s, children: sortByUpdatedAt(children) })
+  }
+
+  // 3. Variant groups.
+  const variantBuckets = new Map<string, ApiSession[]>()
+  for (const s of sessions) {
+    if (consumed.has(s.id)) continue
+    if (!s.variantGroupId) continue
+    const list = variantBuckets.get(s.variantGroupId) ?? []
+    list.push(s)
+    variantBuckets.set(s.variantGroupId, list)
+  }
+  for (const [groupId, members] of variantBuckets) {
+    if (members.length === 0) continue
+    for (const m of members) consumed.add(m.id)
+    groups.push({ kind: 'variant', groupId, sessions: sortByUpdatedAt(members) })
+  }
+
+  // 4. Standalone.
+  const standalone: ApiSession[] = []
+  for (const s of sessions) {
+    if (consumed.has(s.id)) continue
+    standalone.push(s)
+  }
+  for (const s of sortByUpdatedAt(standalone)) {
+    groups.push({ kind: 'standalone', session: s })
+  }
+
+  return groups
+}
+
+function sortByUpdatedAt(list: ApiSession[]): ApiSession[] {
+  return [...list].sort((a, b) => {
+    if (a.updatedAt === b.updatedAt) return 0
+    return a.updatedAt < b.updatedAt ? 1 : -1
+  })
+}

--- a/test/api/client-extended.test.ts
+++ b/test/api/client-extended.test.ts
@@ -127,21 +127,31 @@ describe('ApiClient — getPr / getDiff / listScreenshots', () => {
     expect(url).toBe(`${BASE_URL}/api/sessions/${encodeURIComponent('weird id/with/slashes')}/pr`)
   })
 
-  it('getDiff returns workspace diff', async () => {
-    const diff: WorkspaceDiff = {
-      sessionId: 's-1',
-      branch: 'feature',
-      baseBranch: 'main',
-      patch: '--- a\n+++ b\n',
-      truncated: false,
-      stats: { filesChanged: 1, insertions: 3, deletions: 1 },
-    }
-    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: diff }))
+  it('getDiff maps the wire shape to the UI shape and derives stats from the patch', async () => {
+    const patch = [
+      'diff --git a/foo b/foo',
+      '--- a/foo',
+      '+++ b/foo',
+      '@@ -1,1 +1,3 @@',
+      '-x',
+      '+a',
+      '+b',
+      '+c',
+      '',
+    ].join('\n')
+    const wire = { base: 'main', head: 'feature', patch, truncated: false }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: wire }))
     vi.stubGlobal('fetch', fetchMock)
 
     const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
-    const out = await client.getDiff('s-1')
-    expect(out).toEqual(diff)
+    const out: WorkspaceDiff = await client.getDiff('s-1')
+    expect(out).toEqual({
+      branch: 'feature',
+      baseBranch: 'main',
+      patch,
+      truncated: false,
+      stats: { filesChanged: 1, insertions: 3, deletions: 1 },
+    })
   })
 
   it('listScreenshots returns list shape', async () => {

--- a/test/api/mock-minion-integration.test.ts
+++ b/test/api/mock-minion-integration.test.ts
@@ -71,17 +71,24 @@ describe('mock-minion integration', () => {
 
   it('getDiff returns the stored workspace diff when flag on', async () => {
     minion.setVersion({ features: ['diff-viewer'] })
-    const diff: WorkspaceDiff = {
-      sessionId: 's-1',
+    const patch = [
+      'diff --git a/x b/x',
+      '--- a/x',
+      '+++ b/x',
+      '@@ -1,1 +1,2 @@',
+      '+a',
+      '+b',
+      '',
+    ].join('\n')
+    minion.setDiff('s-1', { base: 'main', head: 'feat', patch, truncated: false })
+    const out: WorkspaceDiff = await client.getDiff('s-1')
+    expect(out).toEqual({
       branch: 'feat',
       baseBranch: 'main',
-      patch: 'diff --git a/x b/x',
+      patch,
       truncated: false,
       stats: { filesChanged: 1, insertions: 2, deletions: 0 },
-    }
-    minion.setDiff('s-1', diff)
-    const out = await client.getDiff('s-1')
-    expect(out).toEqual(diff)
+    })
   })
 
   it('listScreenshots + fetchScreenshotBlob round-trip', async () => {

--- a/test/chat/orchestrator-filter.test.ts
+++ b/test/chat/orchestrator-filter.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { isOrchestratorStatus } from '../../src/chat/orchestrator-filter'
+
+describe('isOrchestratorStatus', () => {
+  const blocked = [
+    '🔗 DAG: 7 tasks  ·  🏷 rich-shore',
+    '🔗 DAG · rich-shore · minions-ui',
+    '📊 🔗 DAG Status',
+    '📊 DAG complete: 7/7 succeeded',
+    '📊 5/7 complete',
+    '📊 5/7 complete, 1 running',
+    '⚡ Starting: API foundation (api-foundation)',
+    '⚡ DAG recovered after restart — some nodes were transitioned.',
+    '🔄 salt-cap waiting for CI: …',
+    '✅ salt-cap completed: API foundation',
+    '✅ salt-cap (https://t.me/c/3816475740/24754) completed: API foundation: types',
+    '❌ gold-tor failed: PR preview card',
+    '⚠️ full-rock completed without a PR — spawning recovery session…',
+    '🚢 Ship: dag complete · 🏷 rich-shore',
+    '⚖️ Verdict',
+    '🗣 Advocate: some-option — …',
+    '🔍 Pre-flight check',
+    '⚠️ Pre-flight failed at: unknown node',
+    '⏳ Pipeline is advancing to the next phase.',
+    '📚 Stack: 4 tasks',
+    '✅ Ship complete · 🏷 rich-shore',
+  ]
+
+  const passed = [
+    '/retry',
+    '/land',
+    'Here is my actual reply.',
+    'Working on something useful.',
+    '- [x] plan complete',
+    '⚙️ something custom the model typed',
+  ]
+
+  for (const t of blocked) {
+    it(`hides: ${JSON.stringify(t.slice(0, 40))}`, () => {
+      expect(isOrchestratorStatus(t)).toBe(true)
+    })
+  }
+
+  for (const t of passed) {
+    it(`shows: ${JSON.stringify(t.slice(0, 40))}`, () => {
+      expect(isOrchestratorStatus(t)).toBe(false)
+    })
+  }
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,13 @@
 import { cleanup } from '@testing-library/preact'
 import { afterEach, vi } from 'vitest'
+import { Blob as NodeBlob } from 'node:buffer'
+
+// jsdom's Blob implementation omits `arrayBuffer()`, `text()`, and `stream()`.
+// Swap in node's buffer-module Blob (full spec) so fetch round-trip tests can
+// read binary response bodies.
+if (typeof (globalThis.Blob as unknown as { prototype: { arrayBuffer?: unknown } }).prototype.arrayBuffer !== 'function') {
+  globalThis.Blob = NodeBlob as unknown as typeof globalThis.Blob
+}
 
 afterEach(() => {
   cleanup()

--- a/test/state/diff-stats.test.ts
+++ b/test/state/diff-stats.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createApiClient } from '../../src/api/client'
 import { installMockEventSource, MockEventSource } from '../sse-mock'
-import type { ApiSession, ApiDagGraph, VersionInfo, WorkspaceDiff } from '../../src/api/types'
+import type { ApiSession, ApiDagGraph, VersionInfo } from '../../src/api/types'
+
+// Wire-shape patch snippets. The client derives {filesChanged, insertions,
+// deletions} from the raw patch, so the fixtures must encode the intent
+// (2 files / 5 insertions / 1 deletion for V1; 3 / 10 / 2 for V2).
+interface WireDiff { base: string; head: string; patch: string; truncated: boolean }
 
 const BASE_URL = 'https://example.com'
 const TOKEN = 'tok'
@@ -25,18 +30,54 @@ const SESSION: ApiSession = {
 const VERSION: VersionInfo = { apiVersion: '1', libraryVersion: '0.1.0', features: ['diff-viewer'] }
 const DAGS: ApiDagGraph[] = []
 
-const DIFF_V1: WorkspaceDiff = {
-  sessionId: 's1',
-  branch: 'feature/x',
-  baseBranch: 'main',
-  patch: '',
-  truncated: false,
-  stats: { filesChanged: 2, insertions: 5, deletions: 1 },
-}
-const DIFF_V2: WorkspaceDiff = {
-  ...DIFF_V1,
-  stats: { filesChanged: 3, insertions: 10, deletions: 2 },
-}
+const PATCH_V1 = [
+  'diff --git a/x b/x',
+  '--- a/x',
+  '+++ b/x',
+  '@@ -1,1 +1,4 @@',
+  '-old',
+  '+a',
+  '+b',
+  '+c',
+  '+d',
+  'diff --git a/y b/y',
+  '--- a/y',
+  '+++ b/y',
+  '@@ -0,0 +1,1 @@',
+  '+e',
+  '',
+].join('\n')
+
+const PATCH_V2 = [
+  'diff --git a/x b/x',
+  '--- a/x',
+  '+++ b/x',
+  '@@ -1,2 +1,6 @@',
+  '-old1',
+  '-old2',
+  '+a',
+  '+b',
+  '+c',
+  '+d',
+  '+e',
+  '+f',
+  'diff --git a/y b/y',
+  '--- a/y',
+  '+++ b/y',
+  '@@ -0,0 +1,3 @@',
+  '+g',
+  '+h',
+  '+i',
+  'diff --git a/z b/z',
+  '--- a/z',
+  '+++ b/z',
+  '@@ -0,0 +1,1 @@',
+  '+j',
+  '',
+].join('\n')
+
+const DIFF_V1: WireDiff = { base: 'main', head: 'feature/x', patch: PATCH_V1, truncated: false }
+const DIFF_V2: WireDiff = { base: 'main', head: 'feature/x', patch: PATCH_V2, truncated: false }
 
 vi.mock('../../src/state/persist', () => ({
   loadSnapshot: vi.fn().mockResolvedValue(null),
@@ -44,7 +85,7 @@ vi.mock('../../src/state/persist', () => ({
   clearSnapshot: vi.fn().mockResolvedValue(undefined),
 }))
 
-function stubFetch(diffStack: WorkspaceDiff[]) {
+function stubFetch(diffStack: WireDiff[]) {
   return vi.fn().mockImplementation((url: string) => {
     if (url.includes('/api/version')) {
       return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: VERSION }) })

--- a/test/state/hierarchy.test.ts
+++ b/test/state/hierarchy.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { buildSessionGroups } from '../../src/state/hierarchy'
+import type { ApiDagGraph, ApiSession } from '../../src/api/types'
+
+function mkSession(over: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 's',
+    slug: 's',
+    status: 'pending',
+    command: '',
+    createdAt: '2026-04-19T00:00:00Z',
+    updatedAt: '2026-04-19T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...over,
+  }
+}
+
+describe('buildSessionGroups', () => {
+  it('puts DAG parent + its children into one group', () => {
+    const parent = mkSession({ id: 'p', slug: 'parent', threadId: 1, childIds: ['c1', 'c2'] })
+    const c1 = mkSession({ id: 'c1', slug: 'child-1', parentId: 'p', threadId: 10 })
+    const c2 = mkSession({ id: 'c2', slug: 'child-2', parentId: 'p', threadId: 11 })
+    const dag: ApiDagGraph = {
+      id: 'dag-parent',
+      rootTaskId: '1',
+      status: 'running',
+      createdAt: '',
+      updatedAt: '',
+      nodes: {
+        a: { id: 'a', slug: 'child-1', status: 'completed', dependencies: [], dependents: ['b'], session: c1 },
+        b: { id: 'b', slug: 'child-2', status: 'running', dependencies: ['a'], dependents: [], session: c2 },
+      },
+    }
+    const groups = buildSessionGroups([parent, c1, c2], [dag])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).toMatchObject({ kind: 'dag', parent })
+    if (groups[0].kind === 'dag') {
+      expect(groups[0].children.map((s) => s.id)).toEqual(['c1', 'c2'])
+    }
+  })
+
+  it('falls back to a parent-child group when there is no DAG', () => {
+    const parent = mkSession({ id: 'p', childIds: ['c'] })
+    const child = mkSession({ id: 'c', parentId: 'p' })
+    const groups = buildSessionGroups([parent, child], [])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].kind).toBe('parent-child')
+  })
+
+  it('groups variant sessions by variantGroupId when they are not in a DAG or tree', () => {
+    const v1 = mkSession({ id: 'v1', variantGroupId: 'group-x' })
+    const v2 = mkSession({ id: 'v2', variantGroupId: 'group-x' })
+    const standalone = mkSession({ id: 'alone' })
+    const groups = buildSessionGroups([v1, v2, standalone], [])
+    const variant = groups.find((g) => g.kind === 'variant')
+    expect(variant).toBeDefined()
+    if (variant?.kind === 'variant') {
+      expect(variant.groupId).toBe('group-x')
+      expect(variant.sessions.map((s) => s.id).sort()).toEqual(['v1', 'v2'])
+    }
+    expect(groups.find((g) => g.kind === 'standalone')).toBeDefined()
+  })
+
+  it('puts unclassified sessions into standalone, newest first', () => {
+    const older = mkSession({ id: 'older', updatedAt: '2026-04-18T00:00:00Z' })
+    const newer = mkSession({ id: 'newer', updatedAt: '2026-04-19T00:00:00Z' })
+    const groups = buildSessionGroups([older, newer], [])
+    expect(groups.map((g) => (g.kind === 'standalone' ? g.session.id : null))).toEqual(['newer', 'older'])
+  })
+
+  it('does not double-count sessions across groups', () => {
+    const parent = mkSession({ id: 'p', childIds: ['c'], threadId: 1 })
+    const child = mkSession({ id: 'c', parentId: 'p', threadId: 10, variantGroupId: 'maybe' })
+    const dag: ApiDagGraph = {
+      id: 'dag-p',
+      rootTaskId: '1',
+      status: 'running',
+      createdAt: '',
+      updatedAt: '',
+      nodes: {
+        a: { id: 'a', slug: 'c', status: 'running', dependencies: [], dependents: [], session: child },
+      },
+    }
+    const groups = buildSessionGroups([parent, child], [dag])
+    const seen = new Set<string>()
+    for (const g of groups) {
+      if (g.kind === 'dag') {
+        if (g.parent) seen.add(g.parent.id)
+        g.children.forEach((c) => seen.add(c.id))
+      } else if (g.kind === 'parent-child') {
+        seen.add(g.parent.id)
+        g.children.forEach((c) => seen.add(c.id))
+      } else if (g.kind === 'variant') {
+        g.sessions.forEach((c) => seen.add(c.id))
+      } else {
+        seen.add(g.session.id)
+      }
+    }
+    expect(seen.size).toBe(2)
+  })
+})


### PR DESCRIPTION
## Context

Six issues from last night's smoke test of the merged 7-PR minions-ui work:

1. **Crash** — `DiffTab.tsx:91: Cannot read properties of undefined (reading 'filesChanged')` on every diff view.
2. **Tab weirdness** — clicking the Screenshots tab "duplicates the session tab" (couldn't reproduce reliably; see open question below).
3. **Mystery UI** — the unlabelled `1 2 3 4` buttons in the task bar.
4. **Still looks like Telegram** — even though the PRs merged, the chat feels like a Telegram forum (static DAG status blobs in the timeline).
5. **No hierarchy** — flat session list; no way to see which sessions belong to which DAG.
6. **Static DAG state** — backend's "🔗 DAG: 7 tasks" / "📊 Status" posts don't update after `/retry`, because they're static conversation messages. The PWA has `store.dags` updating live from SSE but never reads it.

## What this PR does

### 1. DiffTab crash fix

Server returns `{ base, head, patch, truncated }`. The UI expected `{ branch, baseBranch, stats: {filesChanged, insertions, deletions} }` and crashed dereferencing `stats`.

- New `src/api/diff-stats.ts` with `computeDiffStats(patch)` — parses `diff --git` for files and `+ / -` lines (skipping `+++ ` / `--- ` file markers) for totals.
- `client.getDiff` maps the wire shape (`WireWorkspaceDiff`) to the UI shape (`WorkspaceDiff`) and decorates with derived stats.
- Drops the `sessionId` field the server never returned.

### 2. Variant-count label

`×1 ×2 ×3 ×4` with a `Variants` label and disabled tone when the minion doesn't advertise `parallel-variants`.

### 3. Live `DagStatusPanel`

Mounted above `ChatPane` when the active session owns a DAG. Reads `store.dags.value`, matches via `rootTaskId` or nested `node.session.id`, and renders one row per node with:
- Status dot (pulse for running, amber for CI, green / red for terminal)
- Tonal row background per state
- "← deps" breadcrumbs
- PR link when present
- Collapsible; remembers collapsed state per session

`/retry` updates this panel immediately.

### 4. Orchestrator filter

New `src/chat/orchestrator-filter.ts::isOrchestratorStatus(text)`. Hides server-authored orchestrator chatter (`🔗 DAG:`, `📊 Status`, `⚡ Starting:`, `🔄 waiting for CI`, `✅ completed:`, `❌ failed:`, `⚖️ Verdict`, `🗣 Advocate:`, ship-pipeline advance, pre-flight, etc.) from `ConversationView`. Human messages and agent output pass through.

Telegram users still see the same posts in their threads — this is a render filter only.

### 5. Sidebar hierarchy

New `src/state/hierarchy.ts::buildSessionGroups(sessions, dags)`. Assigns every session to exactly one of:
- **DAG** — parent + indented children
- **Parent/child** — non-DAG split trees
- **Variant** — grouped by `variantGroupId`
- **Standalone** — everything else

Vertical sidebar renders each group with a kind-coloured header (DAG = indigo, variants = fuchsia) and indents children behind a 16-px connector rail. Mobile (horizontal) layout stays flat.

### 6. State-change flash animations

`useFlashOnChange` tracks each session's `status` / `updatedAt` and toggles a `data-flash` attribute for 900ms on change. Three CSS keyframes in `src/index.css` fade the row background green on completion, red on failure, indigo on any other update. Pure CSS; no state machines.

## Tests

- `test/state/hierarchy.test.ts` — 5 cases covering DAG grouping, parent/child fallback, variant grouping, no double-count invariant, stable updatedAt ordering.
- `test/chat/orchestrator-filter.test.ts` — 21 cases covering every prefix the server emits plus human-authored pass-throughs.
- Updated `test/state/diff-stats.test.ts`, `test/api/client-extended.test.ts`, `test/api/mock-minion-integration.test.ts` to use wire-shape fixtures now that the client maps → UI shape.

## Verification

- `npm run typecheck` / `lint` — clean.
- `npm run test` — 434 passing, 1 pre-existing failure (`listScreenshots + fetchScreenshotBlob round-trip`, a Node Blob.arrayBuffer polyfill gap in jsdom; not introduced by this PR).

Manual checks against a live minion I'd like before merging:

- [ ] `/dag` flow — parent session opens, `DagStatusPanel` lists 7 nodes live, `/retry` advances the panel in real time.
- [ ] Sidebar shows the DAG group with indented children; variant groups when used; standalone for singletons.
- [ ] Status flip flashes the row (green/red) briefly.
- [ ] `ConversationView` for a DAG parent session is clean — no `🔗 DAG:` / `📊 Status` duplicates.
- [ ] Diff tab renders without console errors, header shows `branch vs base · N files +X -Y`.

## Open question

**Bug #2 — Screenshots tab "duplication"** isn't addressed here. I couldn't reproduce from a code read; suspect either a brief double-mount during tab swap or the perception of the session-row re-ordering caused by the `listScreenshots` fetch bumping `updatedAt`. The new flash animation should make whichever one it is obvious the next time it happens — will chase in a follow-up PR once we have a repro.