### PR TITLE
fix(ui): narrow orchestrator filter so status timeline isn't dropped

### DIFF
--- a/src/chat/orchestrator-filter.ts
+++ b/src/chat/orchestrator-filter.ts
@@ -1,44 +1,20 @@
-// Server-authored orchestrator status messages arrive in TopicSession.conversation
-// via `ctx.postStatus` (see telegram-minions/src/engine/engine-context.ts). Telegram
-// users see them in their thread; the PWA hides them in favour of the live DAG /
-// status panels that read from `store.dags` and `store.sessions` directly.
-//
-// The filter matches plain-text prefixes the server emits. Lines authored by
-// humans (e.g. `/retry`, a user reply) don't match these patterns and pass
-// through untouched.
+// Server-authored orchestrator status messages arrive in
+// TopicSession.conversation via `ctx.postStatus`. Most of these are valuable
+// timeline events (CI waits, child completions, merge-conflict warnings, DAG
+// progress) that Conductor-style timelines keep visible. The PWA only hides
+// the two verbose *snapshot* dumps that the live DagStatusPanel already
+// renders at the top of the chat — showing them in the conversation would
+// duplicate the panel for the same moment in time.
 
 const ORCHESTRATOR_PREFIXES = [
-  '🔗 DAG:',
-  '🔗 DAG ',
   '📊 🔗 DAG Status',
-  '📊 DAG complete:',
-  '📚 Stack:',
-  '⚡ Starting:',
-  '⚡ DAG recovered after restart',
-  '🔄 ',
-  '📊 ',
-  '✅ Ship complete',
-  '🚢 Ship:',
-  '⚖️ Verdict',
-  '🗣 Advocate:',
-  '⏳ Pipeline is advancing',
-]
-
-const ORCHESTRATOR_REGEX_TESTS: RegExp[] = [
-  /^✅ [\w-]+ (?:\(https?:\/\/[^)]+\) )?completed:/,
-  /^❌ [\w-]+ (?:\(https?:\/\/[^)]+\) )?failed:/,
-  /^⚠️ [\w-]+ completed without a PR/,
-  /^⚠️ Pre-flight failed/,
-  /^🔍 Pre-flight check/,
+  '📊 📚 Stack Status',
 ]
 
 export function isOrchestratorStatus(text: string): boolean {
   const trimmed = text.trimStart()
   for (const prefix of ORCHESTRATOR_PREFIXES) {
     if (trimmed.startsWith(prefix)) return true
-  }
-  for (const regex of ORCHESTRATOR_REGEX_TESTS) {
-    if (regex.test(trimmed)) return true
   }
   return false
 }

--- a/test/chat/orchestrator-filter.test.ts
+++ b/test/chat/orchestrator-filter.test.ts
@@ -3,18 +3,24 @@ import { isOrchestratorStatus } from '../../src/chat/orchestrator-filter'
 
 describe('isOrchestratorStatus', () => {
   const blocked = [
-    '🔗 DAG: 7 tasks  ·  🏷 rich-shore',
-    '🔗 DAG · rich-shore · minions-ui',
     '📊 🔗 DAG Status',
+    '📊 🔗 DAG Status\n  ⏳ alpha\n  ▶️ beta',
+    '📊 📚 Stack Status',
+    '📊 📚 Stack Status\n  ▶️ one\n  ⏳ two',
+  ]
+
+  const passed = [
+    '/retry',
+    '/land',
+    'Here is my actual reply.',
+    '🔗 DAG: 7 tasks  ·  🏷 rich-shore',
     '📊 DAG complete: 7/7 succeeded',
-    '📊 5/7 complete',
     '📊 5/7 complete, 1 running',
     '⚡ Starting: API foundation (api-foundation)',
-    '⚡ DAG recovered after restart — some nodes were transitioned.',
     '🔄 salt-cap waiting for CI: …',
-    '✅ salt-cap completed: API foundation',
-    '✅ salt-cap (https://t.me/c/3816475740/24754) completed: API foundation: types',
+    '✅ salt-cap (https://t.me/c/3816475740/24754) completed: API foundation',
     '❌ gold-tor failed: PR preview card',
+    '⚠️ Merge conflicts in 1 file(s) for …',
     '⚠️ full-rock completed without a PR — spawning recovery session…',
     '🚢 Ship: dag complete · 🏷 rich-shore',
     '⚖️ Verdict',
@@ -24,15 +30,6 @@ describe('isOrchestratorStatus', () => {
     '⏳ Pipeline is advancing to the next phase.',
     '📚 Stack: 4 tasks',
     '✅ Ship complete · 🏷 rich-shore',
-  ]
-
-  const passed = [
-    '/retry',
-    '/land',
-    'Here is my actual reply.',
-    'Working on something useful.',
-    '- [x] plan complete',
-    '⚙️ something custom the model typed',
   ]
 
   for (const t of blocked) {


### PR DESCRIPTION
## Summary

The PWA was hiding every orchestrator status post the server sent —
child completions, CI waits, merge-conflict warnings, DAG progress,
DAG-complete — expecting the live \`DagStatusPanel\` to cover the same
ground. It doesn't: the panel shows *current* per-node state, not a
timeline of transitions. Users watching a DAG in the PWA saw a silent
chat while Telegram got the running commentary.

Narrow \`isOrchestratorStatus\` to just the two verbose node-by-node
snapshot dumps (\`📊 🔗 DAG Status\`, \`📊 📚 Stack Status\`) that really
are duplicative with the panel. Everything else passes through to
\`ConversationView\`.

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run test\` — 432/432 green
- [ ] Smoke: with a DAG running, the PWA chat should now show incremental
  events (child completed, waiting for CI, DAG complete, merge-conflict
  warnings) the same way Telegram does