### PR TITLE
feat(ui): surface parent PR link in DagStatusPanel header

### DIFF
--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -115,7 +115,7 @@ export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps
           onClick={() => {
             if (parentClickable && onSelect && parent) onSelect(parent.id)
           }}
-          class={`flex-1 flex items-center gap-2 pr-4 py-2 text-left ${
+          class={`flex-1 min-w-0 flex items-center gap-2 py-2 text-left ${
             parentClickable
               ? 'hover:bg-slate-50 dark:hover:bg-slate-700/50 cursor-pointer'
               : 'cursor-default'
@@ -162,6 +162,18 @@ export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps
             )}
           </span>
         </button>
+        {parent?.prUrl && (
+          <a
+            href={parent.prUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex items-center px-3 text-[11px] font-medium text-indigo-600 dark:text-indigo-400 hover:underline shrink-0"
+            data-testid="dag-status-parent-pr"
+            title="Open parent PR on GitHub"
+          >
+            PR ↗
+          </a>
+        )}
       </div>
       {!collapsed.value && (
         <ul class="px-4 pb-3 pt-1 flex flex-col gap-1.5" data-testid="dag-status-node-list">


### PR DESCRIPTION
## Summary

Child rows in \`DagStatusPanel\` already render a \`PR ↗\` link when the
node's session has a \`prUrl\`. The parent-header row didn't, so the
only way to reach the parent's PR from a child session was to click
through to the parent session first and then open its PR preview
card. Add a matching \`PR ↗\` chip on the header strip when
\`parent.prUrl\` is set.

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run test\` — 432/432 green
- [ ] Smoke: open a child session whose parent has a landing PR — the
  header shows \`PR ↗\`, opens the parent's PR in a new tab, and
  clicking it doesn't trigger the parent-navigation button