### PR TITLE
fix(ci): unbreak main build — align stale mocks + first-PR fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -34,6 +34,24 @@ function findParentSession(sessions: ApiSession[], dag: ApiDagGraph): ApiSession
   return null
 }
 
+// Returns the PR URL from the earliest node in topological order that has one.
+// Nodes without dependencies come first (stack/DAG base), then nodes whose
+// dependencies are already covered. `Object.values(graph.nodes)` iteration
+// order already follows insertion order, which the server emits topologically,
+// so a light dependency check is enough to skip isolated mid-chain entries.
+function firstNodePrUrl(nodes: ApiDagNode[]): string | undefined {
+  const covered = new Set<string>()
+  for (const n of nodes) {
+    const ready = n.dependencies.every((d) => covered.has(d))
+    if (ready && n.session?.prUrl) return n.session.prUrl
+    covered.add(n.id)
+  }
+  for (const n of nodes) {
+    if (n.session?.prUrl) return n.session.prUrl
+  }
+  return undefined
+}
+
 const DAG_NODE_COLORS: Record<ApiDagNode['status'], string> = {
   pending: 'bg-slate-300 dark:bg-slate-600',
   running: 'bg-blue-500 animate-pulse',
@@ -90,6 +108,13 @@ export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps
 
   const parentClickable = !!parent && !!onSelect && !isViewingParent
   const parentLabel = parent ? parent.slug || parent.id : `dag-${graph.id.replace(/^dag-/, '')}`
+
+  // Parent orchestrators (`/plan`, `/dag`) usually don't own a PR — each
+  // child does. Fall back to the first node's PR (topological base of the
+  // stack/DAG) so users can always jump to a representative PR from the
+  // panel header.
+  const headerPrUrl = parent?.prUrl ?? firstNodePrUrl(nodes)
+  const headerPrLabel = parent?.prUrl ? 'Parent PR' : 'First PR'
 
   return (
     <div
@@ -162,16 +187,18 @@ export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps
             )}
           </span>
         </button>
-        {parent?.prUrl && (
+        {headerPrUrl && (
           <a
-            href={parent.prUrl}
+            href={headerPrUrl}
             target="_blank"
             rel="noopener noreferrer"
-            class="flex items-center px-3 text-[11px] font-medium text-indigo-600 dark:text-indigo-400 hover:underline shrink-0"
+            class="flex items-center gap-1 px-3 text-[11px] font-medium text-indigo-600 dark:text-indigo-400 hover:underline shrink-0"
             data-testid="dag-status-parent-pr"
-            title="Open parent PR on GitHub"
+            title={`Open ${headerPrLabel.toLowerCase()} on GitHub`}
           >
-            PR ↗
+            <span class="hidden sm:inline">{headerPrLabel}</span>
+            <span class="sm:hidden">PR</span>
+            <span aria-hidden="true">↗</span>
           </a>
         )}
       </div>

--- a/test/chat/DiffTab.test.tsx
+++ b/test/chat/DiffTab.test.tsx
@@ -28,7 +28,6 @@ function makeClient(overrides: Partial<ApiClient> = {}): ApiClient {
 }
 
 const SAMPLE_DIFF: WorkspaceDiff = {
-  sessionId: 's-1',
   branch: 'feature',
   baseBranch: 'main',
   patch: [

--- a/test/chat/NewTaskBar.test.tsx
+++ b/test/chat/NewTaskBar.test.tsx
@@ -78,6 +78,8 @@ function makeStore(opts: {
     error: signal<string | null>(null),
     version: signal<VersionInfo | null>(version),
     stale: signal(false),
+    diffStatsBySessionId: signal(new Map()),
+    loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi.fn(async () => ({ success: true })),
     dispose: vi.fn(),

--- a/test/components/WorktreeHeader.test.tsx
+++ b/test/components/WorktreeHeader.test.tsx
@@ -37,6 +37,7 @@ function makeStore(opts: {
   })
   const diffStatsBySessionId = signal<Map<string, DiffStats>>(opts.initialStats ?? new Map())
   return {
+    connectionId: 'test-conn',
     client: {} as ConnectionStore['client'],
     sessions: signal([]),
     dags: signal([]),

--- a/test/groups/VariantGroupView.test.tsx
+++ b/test/groups/VariantGroupView.test.tsx
@@ -55,6 +55,8 @@ function makeStore(opts: {
     error: signal<string | null>(null),
     version: signal<VersionInfo | null>(version),
     stale: signal(false),
+    diffStatsBySessionId: signal(new Map()),
+    loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi
       .fn<(cmd: MinionCommand) => Promise<CommandResult>>()


### PR DESCRIPTION
## Summary

CI + Cloudflare Pages builds on main have been red since 11:57 UTC.
Root cause: four test files had mock shapes that hadn't been updated
after recent ConnectionStore / WorkspaceDiff refactors. \`tsc -b\`
(which CI and Cloudflare Pages both run via \`npm run build\`) walks
referenced projects including \`test/\`, but \`npm run typecheck\` was
pinned to \`tsc --noEmit\` which skips references, so pre-commit didn't
catch it.

- Drop removed \`sessionId\` from \`SAMPLE_DIFF\` in DiffTab test
- Add \`diffStatsBySessionId\` + \`loadDiffStats\` to NewTaskBar and
  VariantGroupView mock stores
- Add \`connectionId\` to WorktreeHeader mock store
- Change \`typecheck\` script to \`tsc -b --noEmit\` so local pre-commit
  matches what CI runs

Also adds a small DAG panel improvement that was in flight: when the
parent orchestrator has no PR of its own (which is the normal case for
\`/plan\` and \`/dag\` sessions), the header chip now falls back to the
earliest DAG node's PR and labels it "First PR" instead of "Parent
PR". Users asked for a PR link from the panel header; this unblocks
that even for orchestrator parents.

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run test && npm run build\` — all green
- [ ] Watch CI + Cloudflare Pages rebuild after merge