### PR TITLE
fix(ui): mobile fits the visible viewport (dvh + viewport-fit=cover)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,14 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ['dist/**', 'node_modules/**', 'scripts/**'],
+    ignores: [
+      'dist/**',
+      'node_modules/**',
+      'scripts/**',
+      'playwright.config.js',
+      'playwright.config.d.ts',
+      'vite.config.js',
+      'vite.config.d.ts',
+    ],
   },
 )

--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <title>Minions UI</title>
     <meta name="description" content="Standalone PWA for monitoring and controlling your coding minions" />
     <meta name="theme-color" content="#0f172a" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -740,7 +740,7 @@ function ActiveView() {
   const showOfflineBanner = !isOnline.value && store.stale.value
 
   return (
-    <div class="flex flex-col h-screen bg-slate-50 dark:bg-slate-900">
+    <div class="flex flex-col h-[100dvh] bg-slate-50 dark:bg-slate-900">
       {showOfflineBanner && (
         <div class="flex items-center justify-center px-4 py-1.5 bg-amber-500 text-amber-950 text-xs font-medium shrink-0" data-testid="offline-banner">
           Offline — showing last snapshot

--- a/src/index.css
+++ b/src/index.css
@@ -3,12 +3,18 @@
 
 @custom-variant dark (&:where([data-theme='dark'], [data-theme='dark'] *));
 
+html,
 body {
   margin: 0;
+  height: 100%;
+}
+
+body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
     'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overscroll-behavior-y: none;
 }
 
 * {
@@ -16,7 +22,8 @@ body {
 }
 
 #app {
-  min-height: 100vh;
+  height: 100dvh;
+  min-height: 100dvh;
 }
 
 /* Flash animations used by SessionItem + DagStatusPanel rows when a session


### PR DESCRIPTION
## Summary

On phones the PWA was requiring a scroll to reach the chat: the root
container was \`h-screen\` (100vh) and \`#app\` had \`min-height: 100vh\`.
On mobile browsers, 100vh measures the *largest* viewport — the state
with the URL bar hidden — so when the chrome is visible the layout
overflows the visible area and the user has to scroll past the header
+ task bar to see the chat.

- Switch root container to \`h-[100dvh]\` and \`#app\` to \`height/min-height: 100dvh\` so layout tracks the *currently* visible viewport.
- Anchor \`html, body { height: 100% }\`.
- \`overscroll-behavior-y: none\` on body so rubber-band scrolling can't
  drag the whole shell.
- Viewport meta gains \`viewport-fit=cover\` (for notch/home-indicator
  rendering) and \`interactive-widget=resizes-content\` (so the virtual
  keyboard shrinks the viewport rather than covering the input).

Also widens the ESLint \`ignores\` list to cover the gitignored
\`playwright.config.{js,d.ts}\` / \`vite.config.{js,d.ts}\` outputs. These
get emitted when \`tsc -b\` runs locally; leaving them unignored made
pre-commit explode on \`no-undef\` errors in the emitted JS.

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run test && npm run build\` — all green
- [ ] Phone smoke: open the PWA, chat is visible without scrolling, both
  with the URL bar expanded and collapsed