### PR TITLE
[minions] docs: skip local Playwright runs, prefer CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ Always `/prepare` before entering plan mode unless the user provided a repomix b
 - Read the files you intend to change. Build context with `rg`, `git ls-files`, and file reads before writing.
 - Run existing tests before and after your change.
 - `npm run typecheck && npm run lint && npm run test` is the baseline gate.
+- **Skip Playwright locally.** Do not run `npm run test:e2e` / `npx playwright test` as part of routine validation — the CI `e2e` matrix (`.github/workflows/ci.yml`) runs it on every push and PR. Push the branch and let CI cover it. Only run Playwright locally when the user explicitly asks, or when debugging a specific E2E failure they've flagged.
 - Type-check or lint failures are blockers — never bypass with `eslint-disable` / `@ts-ignore`.
 
 ## Finish implementations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,12 @@ Standalone PWA that replaces the Telegram Mini App frontend for [`@tprei/telegra
 | `npm run lint` | ESLint across `src/` and `test/`. |
 | `npm run test` | Unit + component tests (vitest). |
 | `npm run test:watch` | Same, watch mode. |
-| `npm run test:e2e` | Playwright E2E suite. |
+| `npm run test:e2e` | Playwright E2E suite. **Do not run locally unless the user explicitly asks** — prefer pushing and letting CI cover it. |
 | `npm run format` | Prettier. |
 
 Always run `npm run typecheck && npm run lint && npm run test` before committing.
+
+**Do not run `npm run test:e2e` / `npx playwright test` locally as part of routine validation.** Playwright runs are slow, flaky against sandboxed environments, and already covered by the `e2e` matrix in `.github/workflows/ci.yml` on every push and PR. Push the branch and rely on CI; only run Playwright locally when the user explicitly asks or when iterating on an E2E-specific failure they've pointed to.
 
 ## Directory map
 


### PR DESCRIPTION
## Summary

Updated project guidance to instruct agents (and developers) to skip local Playwright E2E runs as part of routine validation. CI already runs the full test matrix on every push and PR, making local runs redundant.

- Playwright tests are slow and flaky in sandboxed environments
- CI pipeline (`.github/workflows/ci.yml`) covers the full e2e matrix: `desktop-chromium`, `desktop-firefox`, `mobile-chromium`
- Local push is the preferred path; let CI validate

The guidance still allows Playwright runs when explicitly requested or when debugging a specific E2E failure.

## Changes

- **CLAUDE.md**: Annotated `npm run test:e2e` in the Scripts table; added new guidance paragraph below the typecheck/lint/test baseline
- **AGENTS.md**: Added "Skip Playwright locally" bullet in Evidence-driven implementation section

## Related

- CI workflow: `.github/workflows/ci.yml` — authoritative E2E matrix
- No source code, tests, or CI configuration changed