### PR TITLE
fix: stabilize App tests and fix mobile drawer click interception

### DIFF
--- a/src/connections/ConnectionsDrawer.tsx
+++ b/src/connections/ConnectionsDrawer.tsx
@@ -64,7 +64,7 @@ export function ConnectionsDrawer({ onClose }: ConnectionsDrawerProps) {
 
   const inner = (
     <div
-      class={`flex flex-col h-full ${panelBg}`}
+      class={`flex flex-col flex-1 min-h-0 ${panelBg}`}
       data-testid="connections-drawer"
     >
       <header class={`flex items-center gap-2 px-4 py-3 border-b shrink-0 ${borderColor}`}>

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -1,7 +1,10 @@
-import { render, screen, fireEvent, within } from '@testing-library/preact'
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { installMockEventSource } from './sse-mock'
 import type { VersionInfo, ApiSession, ApiDagGraph } from '../src/api/types'
+import { connections, activeId, disposeAll } from '../src/connections/store'
+import App, { viewMode } from '../src/App'
+import { recordVariantGroup, resetVariantGroupsForTests } from '../src/groups/store'
 
 vi.mock('virtual:pwa-register/preact', () => ({
   useRegisterSW: vi.fn().mockReturnValue({}),
@@ -48,16 +51,29 @@ function session(over: Partial<ApiSession> = {}): ApiSession {
   }
 }
 
+function seedConnection() {
+  connections.value = [
+    { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+  ]
+  activeId.value = 'c1'
+}
+
 describe('App', () => {
   let mock: ReturnType<typeof installMockEventSource>
 
   beforeEach(() => {
     localStorage.clear()
     mock = installMockEventSource()
-    vi.resetModules()
+    viewMode.value = 'list'
   })
 
   afterEach(() => {
+    cleanup()
+    disposeAll()
+    connections.value = []
+    activeId.value = null
+    viewMode.value = 'list'
+    resetVariantGroupsForTests()
     mock.restore()
     vi.unstubAllGlobals()
     localStorage.clear()
@@ -65,37 +81,22 @@ describe('App', () => {
 
   it('renders empty state "Connect a minion" when no connections', async () => {
     stubFetch()
-    const App = (await import('../src/App')).default
     render(<App />)
     expect(screen.getByText('Connect a minion')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Add connection' })).toBeTruthy()
   })
 
   it('renders header and session list when connection exists', async () => {
-    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
-      version: 1,
-      connections: [
-        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
-      ],
-      activeId: 'c1',
-    }))
     stubFetch([session()])
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
     expect(screen.getByText('My Minion')).toBeTruthy()
     await screen.findByText('brave-fox')
   })
 
   it('clicking a session in the sidebar opens its conversation inline', async () => {
-    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
-      version: 1,
-      connections: [
-        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
-      ],
-      activeId: 'c1',
-    }))
     stubFetch([session({ conversation: [{ role: 'user', text: 'hello' }] })])
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     const item = await screen.findByTestId('session-item-s1')
@@ -106,28 +107,6 @@ describe('App', () => {
   })
 
   it('renders the variant group view when the hash is #/g/:groupId', async () => {
-    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
-      version: 1,
-      connections: [
-        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
-      ],
-      activeId: 'c1',
-    }))
-    localStorage.setItem(
-      'minions-ui:variant-groups:v1',
-      JSON.stringify({
-        version: 1,
-        byConnection: {
-          c1: [{
-            groupId: 'g-route',
-            prompt: 'routed prompt',
-            mode: 'task',
-            variantSessionIds: ['s1', 's2'],
-            createdAt: '2026-04-19T00:00:00Z',
-          }],
-        },
-      })
-    )
     const versionWithVariants: VersionInfo = {
       apiVersion: '1',
       libraryVersion: '1.111.0',
@@ -148,26 +127,28 @@ describe('App', () => {
       }
       return Promise.resolve({ ok: false, status: 404, statusText: 'NF', json: () => Promise.resolve({ data: null }) })
     }))
+    seedConnection()
+    recordVariantGroup('c1', {
+      groupId: 'g-route',
+      prompt: 'routed prompt',
+      mode: 'task',
+      variantSessionIds: ['s1', 's2'],
+      createdAt: '2026-04-19T00:00:00Z',
+    })
     window.location.hash = '#/g/g-route'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
     try {
-      const App = (await import('../src/App')).default
       render(<App />)
       const view = await screen.findByTestId('variant-group-view')
       expect(view).toBeTruthy()
       expect(screen.getByTestId('variant-group-prompt').textContent).toBe('routed prompt')
     } finally {
       window.location.hash = ''
+      window.dispatchEvent(new HashChangeEvent('hashchange'))
     }
   })
 
   it('renders attention pills and filters the session list when a pill is clicked', async () => {
-    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
-      version: 1,
-      connections: [
-        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
-      ],
-      activeId: 'c1',
-    }))
     stubFetch([
       session({
         id: 's1',
@@ -184,7 +165,7 @@ describe('App', () => {
       }),
       session({ id: 's3', slug: 'calm-owl' }),
     ])
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     await screen.findByTestId('attention-bar')
@@ -203,18 +184,11 @@ describe('App', () => {
   })
 
   it('switching sessions swaps the conversation pane', async () => {
-    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
-      version: 1,
-      connections: [
-        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
-      ],
-      activeId: 'c1',
-    }))
     stubFetch([
       session({ id: 's1', slug: 'brave-fox', conversation: [{ role: 'user', text: 'first' }] }),
       session({ id: 's2', slug: 'swift-cat', conversation: [{ role: 'user', text: 'second' }] }),
     ])
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     fireEvent.click(await screen.findByTestId('session-item-s1'))

--- a/test/App.viewToggle.test.tsx
+++ b/test/App.viewToggle.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen, fireEvent, within } from '@testing-library/preact'
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { installMockEventSource } from './sse-mock'
 import type { VersionInfo, ApiSession, ApiDagGraph } from '../src/api/types'
+import { connections, activeId, disposeAll } from '../src/connections/store'
+import App, { viewMode } from '../src/App'
 
 vi.mock('virtual:pwa-register/preact', () => ({
   useRegisterSW: vi.fn().mockReturnValue({}),
@@ -141,18 +143,10 @@ function session(over: Partial<ApiSession> = {}): ApiSession {
 }
 
 function seedConnection() {
-  localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
-    version: 1,
-    connections: [
-      { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
-    ],
-    activeId: 'c1',
-  }))
-}
-
-async function resetViewMode() {
-  const mod = await import('../src/App')
-  mod.viewMode.value = 'list'
+  connections.value = [
+    { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+  ]
+  activeId.value = 'c1'
 }
 
 describe('App view toggle', () => {
@@ -161,21 +155,24 @@ describe('App view toggle', () => {
   beforeEach(() => {
     localStorage.clear()
     mock = installMockEventSource()
-    vi.resetModules()
     setDesktop(true)
+    viewMode.value = 'list'
   })
 
   afterEach(() => {
+    cleanup()
+    disposeAll()
+    connections.value = []
+    activeId.value = null
+    viewMode.value = 'list'
     mock.restore()
     vi.unstubAllGlobals()
     localStorage.clear()
   })
 
   it('renders ViewToggle with List selected by default', async () => {
-    seedConnection()
     stubFetch([session()])
-    await resetViewMode()
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     const toggle = await screen.findByTestId('view-toggle')
@@ -186,13 +183,11 @@ describe('App view toggle', () => {
   })
 
   it('switches to canvas view when Canvas tab clicked on desktop', async () => {
-    seedConnection()
     stubFetch([session()])
-    await resetViewMode()
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
-    await screen.findByText('brave-fox')
+    await screen.findByTestId('session-item-s1')
     fireEvent.click(screen.getByTestId('view-toggle-canvas'))
 
     const canvasPane = await screen.findByTestId('canvas-pane')
@@ -201,10 +196,8 @@ describe('App view toggle', () => {
   })
 
   it('switching back to List hides the canvas pane', async () => {
-    seedConnection()
     stubFetch([session()])
-    await resetViewMode()
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     fireEvent.click(await screen.findByTestId('view-toggle-canvas'))
@@ -216,10 +209,8 @@ describe('App view toggle', () => {
   })
 
   it('clicking a node in canvas opens detail popup with Open Chat button', async () => {
-    seedConnection()
     stubFetch([session({ id: 's1', slug: 'brave-fox' })])
-    await resetViewMode()
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     fireEvent.click(await screen.findByTestId('view-toggle-canvas'))
@@ -229,10 +220,8 @@ describe('App view toggle', () => {
   })
 
   it('Open Chat from canvas popup switches to list and selects session', async () => {
-    seedConnection()
     stubFetch([session({ id: 's1', slug: 'brave-fox', conversation: [{ role: 'user', text: 'hello-from-canvas' }] })])
-    await resetViewMode()
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     fireEvent.click(await screen.findByTestId('view-toggle-canvas'))
@@ -247,10 +236,8 @@ describe('App view toggle', () => {
 
   it('renders mobile full-screen canvas modal with close button on mobile', async () => {
     setDesktop(false)
-    seedConnection()
     stubFetch([session()])
-    await resetViewMode()
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     fireEvent.click(await screen.findByTestId('view-toggle-canvas'))
@@ -264,10 +251,8 @@ describe('App view toggle', () => {
   })
 
   it('renders the Ship tab in the view toggle', async () => {
-    seedConnection()
     stubFetch([session()])
-    await resetViewMode()
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     const toggle = await screen.findByTestId('view-toggle')
@@ -275,7 +260,6 @@ describe('App view toggle', () => {
   })
 
   it('switches to ship view when Ship tab clicked on desktop', async () => {
-    seedConnection()
     const shipDag: ApiDagGraph = {
       id: 'ship-1',
       rootTaskId: 'n1',
@@ -287,8 +271,7 @@ describe('App view toggle', () => {
       updatedAt: '2024-01-01',
     }
     stubFetch([session()], [shipDag])
-    await resetViewMode()
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     fireEvent.click(await screen.findByTestId('view-toggle-ship'))
@@ -298,10 +281,8 @@ describe('App view toggle', () => {
   })
 
   it('shows the empty ship state when no DAG qualifies as a ship pipeline', async () => {
-    seedConnection()
     stubFetch([session()])
-    await resetViewMode()
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     fireEvent.click(await screen.findByTestId('view-toggle-ship'))
@@ -310,7 +291,6 @@ describe('App view toggle', () => {
 
   it('renders mobile full-screen ship modal with close button on mobile', async () => {
     setDesktop(false)
-    seedConnection()
     const shipDag: ApiDagGraph = {
       id: 'ship-m',
       rootTaskId: 'n1',
@@ -322,8 +302,7 @@ describe('App view toggle', () => {
       updatedAt: '2024-01-01',
     }
     stubFetch([session()], [shipDag])
-    await resetViewMode()
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     fireEvent.click(await screen.findByTestId('view-toggle-ship'))
@@ -335,10 +314,8 @@ describe('App view toggle', () => {
   })
 
   it('canvas sendReply callback calls /api/messages', async () => {
-    seedConnection()
     const { sendMessage } = stubFetch([session({ id: 's1', slug: 'brave-fox', quickActions: [{ type: 'retry', label: 'Retry', message: 'retry please' }] })])
-    await resetViewMode()
-    const App = (await import('../src/App')).default
+    seedConnection()
     render(<App />)
 
     fireEvent.click(await screen.findByTestId('view-toggle-canvas'))


### PR DESCRIPTION
## Summary
- Replace `vi.resetModules()` + dynamic import pattern in `App.test.tsx` and `App.viewToggle.test.tsx` with static imports and direct signal manipulation — eliminates 5-8s cold-start timeouts and cross-test state leaks
- Fix `ConnectionsDrawer` mobile layout: change inner container from `h-full` to `flex-1 min-h-0` so connection list items cannot overflow onto the header close button on small viewports (fixes E2E mobile-chromium multi-connection test)
- Use `recordVariantGroup()` and `resetVariantGroupsForTests()` APIs instead of localStorage seeding for variant group test, ensuring state is set on the live signal rather than depending on module-load-time reads

## Test plan
- [x] All 576 unit/component tests pass locally
- [x] Typecheck and lint pass
- [ ] CI E2E matrix (mobile-chromium, desktop-chromium, desktop-firefox)