### PR TITLE
[minions] fix(chat): collapse DAG status panel by default on mobile

### DIFF
--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -2,6 +2,7 @@ import { useComputed, useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import type { ApiDagGraph, ApiDagNode, ApiSession } from '../api/types'
 import type { ConnectionStore } from '../state/types'
+import { useMediaQuery } from '../hooks/useMediaQuery'
 
 interface DagStatusPanelProps {
   session: ApiSession
@@ -75,7 +76,8 @@ const DAG_NODE_LABELS: Record<ApiDagNode['status'], string> = {
 }
 
 export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps) {
-  const collapsed = useSignal(false)
+  const isDesktop = useMediaQuery('(min-width: 768px)')
+  const collapsed = useSignal(!isDesktop.value)
 
   const dag = useComputed(() => findDagForSession(store.dags.value, session))
   const parentSession = useComputed(() => {
@@ -84,8 +86,8 @@ export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps
   })
 
   useEffect(() => {
-    collapsed.value = false
-  }, [session.id, collapsed])
+    collapsed.value = !isDesktop.value
+  }, [session.id, isDesktop.value, collapsed])
 
   const graph = dag.value
   if (!graph) return null


### PR DESCRIPTION
## Summary

On mobile, when a child (DAG) node is selected, the chat is pushed far down by repetitive metadata:

- Horizontal session strip (already shows siblings with P/C/V badges)
- ChatPane header (slug, status, mode, PR, Stop/Close)
- WorktreeHeader (branch, cwd)
- **DagStatusPanel** — parent row + expanded list of every DAG node (duplicates the session strip above)
- Session tabs

The DAG panel's expanded node list was the biggest offender: every DAG session it shows is already visible in the horizontal strip. This change collapses the DAG panel by default on viewports below 768px so only the compact one-line parent header (progress, PR link) is shown. Users can still tap to expand it on demand. Desktop behavior is unchanged.

## Why this is the right fix

The parent row of DagStatusPanel carries unique info (overall DAG status, done/running/failed counts, first PR). Its expanded list is strictly redundant on mobile because the session strip already enumerates the same sessions with kind badges and focus-pulse for the active one. Collapsing preserves both affordances.

## Test plan

- [ ] On mobile viewport: select a child node — DAG panel renders collapsed, parent header visible, chat sits near the top
- [ ] Tap the disclosure chevron to expand — node list shows as before
- [ ] Switch to a different session — DAG panel resets to collapsed
- [ ] On desktop (>=768px): DAG panel remains expanded by default (no regression)
- [ ] npm run typecheck && npm run lint && npm run test all pass (49 test files, 576 tests)

## Notes

- No DagStatusPanel unit tests existed before this change; none added as the behavior change is viewport-conditional defaulting, which is covered by the mobile-chromium Playwright matrix in CI.