### PR TITLE
[minions] feat(diff): add syntax highlighting to diffs

### DIFF
--- a/src/chat/DiffTab.tsx
+++ b/src/chat/DiffTab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import type { ApiClient } from '../api/client'
 import type { WorkspaceDiff } from '../api/types'
 import { parseUnifiedDiff, type DiffFile, countChanges, fileDisplayPath } from './diff-parse'
+import { detectLanguage, highlightLine, tokenClass } from './syntax-highlight'
 
 interface DiffTabProps {
   sessionId: string
@@ -124,6 +125,7 @@ export function DiffTab({ sessionId, sessionUpdatedAt, client }: DiffTabProps) {
 function DiffFileView({ file }: { file: DiffFile }) {
   const [collapsed, setCollapsed] = useState(false)
   const path = fileDisplayPath(file)
+  const lang = detectLanguage(path)
   const { insertions, deletions } = countChanges(file)
   const tag = file.isNew
     ? 'NEW'
@@ -195,7 +197,7 @@ function DiffFileView({ file }: { file: DiffFile }) {
                     </span>
                     <span class={`${signColor} w-3 shrink-0 select-none`}>{sign}</span>
                     <span class="flex-1 min-w-0 whitespace-pre-wrap break-all text-slate-800 dark:text-slate-200">
-                      {line.text || ' '}
+                      <HighlightedCode text={line.text} lang={lang} />
                     </span>
                   </div>
                 )
@@ -205,5 +207,24 @@ function DiffFileView({ file }: { file: DiffFile }) {
         </div>
       )}
     </div>
+  )
+}
+
+function HighlightedCode({ text, lang }: { text: string; lang: string | null }) {
+  if (!text) return <>{' '}</>
+  if (!lang) return <>{text}</>
+  const tokens = highlightLine(text, lang)
+  return (
+    <>
+      {tokens.map((tok, idx) => {
+        const cls = tokenClass(tok.type)
+        if (!cls) return <span key={idx}>{tok.text}</span>
+        return (
+          <span key={idx} class={cls}>
+            {tok.text}
+          </span>
+        )
+      })}
+    </>
   )
 }

--- a/src/chat/syntax-highlight.ts
+++ b/src/chat/syntax-highlight.ts
@@ -1,0 +1,399 @@
+export type TokenType =
+  | 'plain'
+  | 'keyword'
+  | 'string'
+  | 'comment'
+  | 'number'
+  | 'builtin'
+  | 'regex'
+
+export interface SyntaxToken {
+  type: TokenType
+  text: string
+}
+
+const EXT_TO_LANG: Record<string, string> = {
+  ts: 'ts',
+  tsx: 'ts',
+  mts: 'ts',
+  cts: 'ts',
+  js: 'js',
+  jsx: 'js',
+  mjs: 'js',
+  cjs: 'js',
+  py: 'py',
+  pyi: 'py',
+  go: 'go',
+  rs: 'rust',
+  java: 'java',
+  kt: 'kotlin',
+  kts: 'kotlin',
+  rb: 'ruby',
+  php: 'php',
+  cs: 'csharp',
+  cpp: 'cpp',
+  cxx: 'cpp',
+  cc: 'cpp',
+  hpp: 'cpp',
+  h: 'c',
+  c: 'c',
+  swift: 'swift',
+  json: 'json',
+  jsonc: 'json',
+  css: 'css',
+  scss: 'css',
+  sass: 'css',
+  less: 'css',
+  sh: 'sh',
+  bash: 'sh',
+  zsh: 'sh',
+  fish: 'sh',
+  sql: 'sql',
+}
+
+const TS_KEYWORDS = new Set([
+  'abstract', 'as', 'async', 'await', 'break', 'case', 'catch', 'class', 'const',
+  'continue', 'debugger', 'declare', 'default', 'delete', 'do', 'else', 'enum',
+  'export', 'extends', 'false', 'finally', 'for', 'from', 'function', 'get', 'if',
+  'implements', 'import', 'in', 'infer', 'instanceof', 'interface', 'is', 'keyof',
+  'let', 'namespace', 'never', 'new', 'null', 'of', 'package', 'private',
+  'protected', 'public', 'readonly', 'return', 'satisfies', 'set', 'static',
+  'super', 'switch', 'this', 'throw', 'true', 'try', 'type', 'typeof',
+  'undefined', 'var', 'void', 'while', 'with', 'yield',
+])
+
+const TS_BUILTINS = new Set([
+  'Array', 'Boolean', 'Date', 'Error', 'Map', 'Math', 'Number', 'Object',
+  'Promise', 'Record', 'RegExp', 'Set', 'String', 'Symbol', 'console',
+  'document', 'globalThis', 'window',
+])
+
+const PY_KEYWORDS = new Set([
+  'False', 'None', 'True', 'and', 'as', 'assert', 'async', 'await', 'break',
+  'class', 'continue', 'def', 'del', 'elif', 'else', 'except', 'finally', 'for',
+  'from', 'global', 'if', 'import', 'in', 'is', 'lambda', 'match', 'nonlocal',
+  'not', 'or', 'pass', 'raise', 'return', 'try', 'while', 'with', 'yield',
+])
+
+const PY_BUILTINS = new Set([
+  'bool', 'bytes', 'dict', 'float', 'frozenset', 'int', 'list', 'object',
+  'print', 'range', 'set', 'str', 'tuple', 'type', 'len', 'isinstance', 'self',
+])
+
+const GO_KEYWORDS = new Set([
+  'break', 'case', 'chan', 'const', 'continue', 'default', 'defer', 'else',
+  'fallthrough', 'for', 'func', 'go', 'goto', 'if', 'import', 'interface',
+  'map', 'package', 'range', 'return', 'select', 'struct', 'switch', 'type',
+  'var', 'true', 'false', 'nil',
+])
+
+const GO_BUILTINS = new Set([
+  'bool', 'byte', 'complex64', 'complex128', 'error', 'float32', 'float64',
+  'int', 'int8', 'int16', 'int32', 'int64', 'rune', 'string', 'uint', 'uint8',
+  'uint16', 'uint32', 'uint64', 'uintptr', 'make', 'new', 'len', 'cap',
+  'append', 'copy', 'close', 'panic', 'recover', 'print', 'println',
+])
+
+const RUST_KEYWORDS = new Set([
+  'as', 'async', 'await', 'break', 'const', 'continue', 'crate', 'dyn', 'else',
+  'enum', 'extern', 'false', 'fn', 'for', 'if', 'impl', 'in', 'let', 'loop',
+  'match', 'mod', 'move', 'mut', 'pub', 'ref', 'return', 'Self', 'self',
+  'static', 'struct', 'super', 'trait', 'true', 'type', 'union', 'unsafe',
+  'use', 'where', 'while',
+])
+
+const RUST_BUILTINS = new Set([
+  'bool', 'char', 'f32', 'f64', 'i8', 'i16', 'i32', 'i64', 'i128', 'isize',
+  'str', 'u8', 'u16', 'u32', 'u64', 'u128', 'usize', 'String', 'Vec', 'Option',
+  'Result', 'Some', 'None', 'Ok', 'Err', 'Box',
+])
+
+const SH_KEYWORDS = new Set([
+  'if', 'then', 'else', 'elif', 'fi', 'for', 'in', 'do', 'done', 'while',
+  'until', 'case', 'esac', 'function', 'return', 'break', 'continue', 'local',
+  'export', 'readonly', 'declare', 'source',
+])
+
+const SQL_KEYWORDS = new Set([
+  'select', 'from', 'where', 'group', 'by', 'order', 'limit', 'offset', 'join',
+  'left', 'right', 'inner', 'outer', 'on', 'as', 'and', 'or', 'not', 'in',
+  'is', 'null', 'true', 'false', 'insert', 'into', 'values', 'update', 'set',
+  'delete', 'create', 'table', 'drop', 'alter', 'index', 'with', 'returning',
+  'distinct', 'union', 'case', 'when', 'then', 'else', 'end', 'having',
+])
+
+const JSON_KEYWORDS = new Set(['true', 'false', 'null'])
+
+const JAVA_C_KEYWORDS = new Set([
+  'abstract', 'assert', 'auto', 'boolean', 'break', 'case', 'catch', 'char',
+  'class', 'const', 'continue', 'default', 'do', 'double', 'else', 'enum',
+  'extends', 'final', 'finally', 'float', 'for', 'goto', 'if', 'implements',
+  'import', 'instanceof', 'int', 'interface', 'long', 'native', 'new', 'null',
+  'package', 'private', 'protected', 'public', 'return', 'short', 'static',
+  'struct', 'super', 'switch', 'synchronized', 'this', 'throw', 'throws',
+  'transient', 'true', 'false', 'try', 'void', 'volatile', 'while', 'namespace',
+  'template', 'typename', 'typedef', 'union', 'using', 'virtual',
+])
+
+interface LangSpec {
+  keywords: Set<string>
+  builtins?: Set<string>
+  line?: string[]
+  block?: [string, string]
+  strings: string[]
+  identifierStart?: RegExp
+  identifierPart?: RegExp
+}
+
+const DEFAULT_ID_START = /[a-zA-Z_$]/
+const DEFAULT_ID_PART = /[a-zA-Z0-9_$]/
+
+const LANGS: Record<string, LangSpec> = {
+  ts: {
+    keywords: TS_KEYWORDS,
+    builtins: TS_BUILTINS,
+    line: ['//'],
+    block: ['/*', '*/'],
+    strings: ['"', "'", '`'],
+  },
+  js: {
+    keywords: TS_KEYWORDS,
+    builtins: TS_BUILTINS,
+    line: ['//'],
+    block: ['/*', '*/'],
+    strings: ['"', "'", '`'],
+  },
+  py: {
+    keywords: PY_KEYWORDS,
+    builtins: PY_BUILTINS,
+    line: ['#'],
+    strings: ['"', "'"],
+  },
+  go: {
+    keywords: GO_KEYWORDS,
+    builtins: GO_BUILTINS,
+    line: ['//'],
+    block: ['/*', '*/'],
+    strings: ['"', '`'],
+  },
+  rust: {
+    keywords: RUST_KEYWORDS,
+    builtins: RUST_BUILTINS,
+    line: ['//'],
+    block: ['/*', '*/'],
+    strings: ['"'],
+  },
+  java: {
+    keywords: JAVA_C_KEYWORDS,
+    line: ['//'],
+    block: ['/*', '*/'],
+    strings: ['"', "'"],
+  },
+  kotlin: {
+    keywords: JAVA_C_KEYWORDS,
+    line: ['//'],
+    block: ['/*', '*/'],
+    strings: ['"', "'"],
+  },
+  csharp: {
+    keywords: JAVA_C_KEYWORDS,
+    line: ['//'],
+    block: ['/*', '*/'],
+    strings: ['"', "'"],
+  },
+  cpp: {
+    keywords: JAVA_C_KEYWORDS,
+    line: ['//'],
+    block: ['/*', '*/'],
+    strings: ['"', "'"],
+  },
+  c: {
+    keywords: JAVA_C_KEYWORDS,
+    line: ['//'],
+    block: ['/*', '*/'],
+    strings: ['"', "'"],
+  },
+  swift: {
+    keywords: JAVA_C_KEYWORDS,
+    line: ['//'],
+    block: ['/*', '*/'],
+    strings: ['"'],
+  },
+  ruby: {
+    keywords: new Set([
+      'BEGIN', 'END', 'alias', 'and', 'begin', 'break', 'case', 'class', 'def',
+      'defined?', 'do', 'else', 'elsif', 'end', 'ensure', 'false', 'for', 'if',
+      'in', 'module', 'next', 'nil', 'not', 'or', 'redo', 'rescue', 'retry',
+      'return', 'self', 'super', 'then', 'true', 'undef', 'unless', 'until',
+      'when', 'while', 'yield',
+    ]),
+    line: ['#'],
+    strings: ['"', "'"],
+  },
+  php: {
+    keywords: new Set([
+      'abstract', 'and', 'array', 'as', 'break', 'callable', 'case', 'catch',
+      'class', 'clone', 'const', 'continue', 'declare', 'default', 'do', 'echo',
+      'else', 'elseif', 'empty', 'enddeclare', 'endfor', 'endforeach', 'endif',
+      'endswitch', 'endwhile', 'extends', 'final', 'finally', 'for', 'foreach',
+      'function', 'global', 'goto', 'if', 'implements', 'include', 'instanceof',
+      'interface', 'isset', 'list', 'namespace', 'new', 'null', 'or', 'print',
+      'private', 'protected', 'public', 'require', 'return', 'static', 'switch',
+      'throw', 'trait', 'try', 'unset', 'use', 'var', 'while', 'xor', 'yield',
+      'true', 'false',
+    ]),
+    line: ['//', '#'],
+    block: ['/*', '*/'],
+    strings: ['"', "'"],
+  },
+  sh: {
+    keywords: SH_KEYWORDS,
+    line: ['#'],
+    strings: ['"', "'"],
+  },
+  sql: {
+    keywords: SQL_KEYWORDS,
+    line: ['--'],
+    block: ['/*', '*/'],
+    strings: ['"', "'"],
+  },
+  json: {
+    keywords: JSON_KEYWORDS,
+    strings: ['"'],
+  },
+  css: {
+    keywords: new Set([]),
+    line: ['//'],
+    block: ['/*', '*/'],
+    strings: ['"', "'"],
+  },
+}
+
+export function detectLanguage(path: string): string | null {
+  if (!path) return null
+  const match = path.toLowerCase().match(/\.([a-z0-9]+)$/)
+  if (!match) return null
+  return EXT_TO_LANG[match[1]] ?? null
+}
+
+export function highlightLine(text: string, lang: string | null): SyntaxToken[] {
+  if (!lang) return [{ type: 'plain', text }]
+  const spec = LANGS[lang]
+  if (!spec) return [{ type: 'plain', text }]
+
+  const tokens: SyntaxToken[] = []
+  const idStart = spec.identifierStart ?? DEFAULT_ID_START
+  const idPart = spec.identifierPart ?? DEFAULT_ID_PART
+  const n = text.length
+  let i = 0
+
+  const push = (type: TokenType, s: string) => {
+    if (!s) return
+    const last = tokens[tokens.length - 1]
+    if (last && last.type === type) last.text += s
+    else tokens.push({ type, text: s })
+  }
+
+  while (i < n) {
+    if (spec.line) {
+      let matched = false
+      for (const prefix of spec.line) {
+        if (text.startsWith(prefix, i)) {
+          push('comment', text.slice(i))
+          i = n
+          matched = true
+          break
+        }
+      }
+      if (matched) break
+    }
+
+    if (spec.block && text.startsWith(spec.block[0], i)) {
+      const endIdx = text.indexOf(spec.block[1], i + spec.block[0].length)
+      if (endIdx >= 0) {
+        const end = endIdx + spec.block[1].length
+        push('comment', text.slice(i, end))
+        i = end
+      } else {
+        push('comment', text.slice(i))
+        i = n
+      }
+      continue
+    }
+
+    const c = text[i]
+
+    if (spec.strings.includes(c)) {
+      const quote = c
+      let j = i + 1
+      while (j < n) {
+        if (text[j] === '\\' && j + 1 < n) {
+          j += 2
+          continue
+        }
+        if (text[j] === quote) {
+          j++
+          break
+        }
+        j++
+      }
+      push('string', text.slice(i, j))
+      i = j
+      continue
+    }
+
+    if (c >= '0' && c <= '9') {
+      let j = i + 1
+      if ((text[j] === 'x' || text[j] === 'X') && c === '0') {
+        j++
+        while (j < n && /[0-9a-fA-F_]/.test(text[j])) j++
+      } else {
+        while (j < n && /[0-9._]/.test(text[j])) j++
+        if (text[j] === 'e' || text[j] === 'E') {
+          j++
+          if (text[j] === '+' || text[j] === '-') j++
+          while (j < n && /[0-9_]/.test(text[j])) j++
+        }
+      }
+      push('number', text.slice(i, j))
+      i = j
+      continue
+    }
+
+    if (idStart.test(c)) {
+      let j = i + 1
+      while (j < n && idPart.test(text[j])) j++
+      const word = text.slice(i, j)
+      const lowerForKw = lang === 'sql' ? word.toLowerCase() : word
+      if (spec.keywords.has(lowerForKw)) push('keyword', word)
+      else if (spec.builtins?.has(word)) push('builtin', word)
+      else push('plain', word)
+      i = j
+      continue
+    }
+
+    push('plain', c)
+    i++
+  }
+
+  return tokens
+}
+
+export function tokenClass(type: TokenType): string {
+  switch (type) {
+    case 'keyword':
+      return 'text-violet-700 dark:text-violet-300'
+    case 'string':
+      return 'text-amber-700 dark:text-amber-300'
+    case 'comment':
+      return 'italic text-slate-500 dark:text-slate-400'
+    case 'number':
+      return 'text-teal-700 dark:text-teal-300'
+    case 'builtin':
+      return 'text-sky-700 dark:text-sky-300'
+    case 'regex':
+      return 'text-rose-700 dark:text-rose-300'
+    default:
+      return ''
+  }
+}

--- a/src/chat/transcript/ToolResultBody.tsx
+++ b/src/chat/transcript/ToolResultBody.tsx
@@ -89,7 +89,7 @@ function ResultText({ text, format }: { text: string; format?: ToolResultEvent['
         class="px-3 py-2 max-h-96 overflow-auto whitespace-pre font-mono text-[11px] text-slate-700 dark:text-slate-300 leading-snug"
         data-testid="transcript-tool-result-diff"
       >
-        {colorizeDiff(text)}
+        {renderDiffLines(text)}
       </pre>
     )
   }
@@ -130,9 +130,31 @@ function formatBytes(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`
 }
 
-function colorizeDiff(text: string): string {
-  // Plain text rendering; the <pre> styling is enough for clarity.
-  return text
+function renderDiffLines(text: string) {
+  const lines = text.split('\n')
+  return lines.map((line, idx) => {
+    const nl = idx < lines.length - 1 ? '\n' : ''
+    let cls = ''
+    if (line.startsWith('+++') || line.startsWith('---')) {
+      cls = 'text-slate-500 dark:text-slate-400 font-semibold'
+    } else if (line.startsWith('@@')) {
+      cls = 'text-sky-700 dark:text-sky-300'
+    } else if (line.startsWith('+')) {
+      cls = 'text-green-700 dark:text-green-400'
+    } else if (line.startsWith('-')) {
+      cls = 'text-red-700 dark:text-red-400'
+    } else if (line.startsWith('diff --git')) {
+      cls = 'text-slate-500 dark:text-slate-400 font-semibold'
+    }
+    if (!cls) {
+      return <span key={idx}>{line + nl}</span>
+    }
+    return (
+      <span key={idx} class={cls}>
+        {line + nl}
+      </span>
+    )
+  })
 }
 
 function prettyJson(text: string): string {

--- a/test/chat/DiffTab.test.tsx
+++ b/test/chat/DiffTab.test.tsx
@@ -123,6 +123,36 @@ describe('DiffTab', () => {
     await waitFor(() => expect(screen.queryByTestId('diff-line-add')).toBeNull())
   })
 
+  it('syntax-highlights code tokens for known languages', async () => {
+    const tsDiff: WorkspaceDiff = {
+      branch: 'feature',
+      baseBranch: 'main',
+      patch: [
+        'diff --git a/foo.ts b/foo.ts',
+        '--- a/foo.ts',
+        '+++ b/foo.ts',
+        '@@ -1,1 +1,2 @@',
+        ' const x = 1',
+        '+const y = "hello"',
+      ].join('\n'),
+      truncated: false,
+      stats: { filesChanged: 1, insertions: 1, deletions: 0 },
+    }
+    const getDiff = vi.fn().mockResolvedValue(tsDiff)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    const addLine = screen.getByTestId('diff-line-add')
+    const kwSpan = Array.from(addLine.querySelectorAll('span')).find(
+      (s) => s.textContent === 'const' && s.className.includes('violet'),
+    )
+    expect(kwSpan).toBeTruthy()
+    const strSpan = Array.from(addLine.querySelectorAll('span')).find(
+      (s) => s.textContent === '"hello"' && s.className.includes('amber'),
+    )
+    expect(strSpan).toBeTruthy()
+  })
+
   it('shows empty state when no files changed', async () => {
     const getDiff = vi.fn().mockResolvedValue({
       ...SAMPLE_DIFF,

--- a/test/chat/syntax-highlight.test.ts
+++ b/test/chat/syntax-highlight.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import {
+  detectLanguage,
+  highlightLine,
+  tokenClass,
+} from '../../src/chat/syntax-highlight'
+
+describe('detectLanguage', () => {
+  it('maps common extensions', () => {
+    expect(detectLanguage('src/foo.ts')).toBe('ts')
+    expect(detectLanguage('src/foo.tsx')).toBe('ts')
+    expect(detectLanguage('foo.js')).toBe('js')
+    expect(detectLanguage('foo.py')).toBe('py')
+    expect(detectLanguage('foo.go')).toBe('go')
+    expect(detectLanguage('foo.rs')).toBe('rust')
+    expect(detectLanguage('package.json')).toBe('json')
+    expect(detectLanguage('styles.css')).toBe('css')
+    expect(detectLanguage('run.sh')).toBe('sh')
+  })
+
+  it('returns null for unknown or empty paths', () => {
+    expect(detectLanguage('')).toBeNull()
+    expect(detectLanguage('Makefile')).toBeNull()
+    expect(detectLanguage('foo.xyz')).toBeNull()
+  })
+})
+
+describe('highlightLine', () => {
+  const types = (text: string, lang: string | null) =>
+    highlightLine(text, lang).map((t) => t.type)
+  const byType = (text: string, lang: string | null, type: string) =>
+    highlightLine(text, lang)
+      .filter((t) => t.type === type)
+      .map((t) => t.text)
+
+  it('returns plain when lang is null', () => {
+    const out = highlightLine('const x = 1', null)
+    expect(out).toEqual([{ type: 'plain', text: 'const x = 1' }])
+  })
+
+  it('tags TS keywords, strings, and numbers', () => {
+    const text = 'const x: number = 42'
+    expect(byType(text, 'ts', 'keyword')).toContain('const')
+    expect(byType(text, 'ts', 'number')).toContain('42')
+  })
+
+  it('tags TS strings', () => {
+    expect(byType('const s = "hi"', 'ts', 'string')).toEqual(['"hi"'])
+    expect(byType("const s = 'hi'", 'ts', 'string')).toEqual(["'hi'"])
+    expect(byType('const s = `hi`', 'ts', 'string')).toEqual(['`hi`'])
+  })
+
+  it('handles line comments', () => {
+    expect(byType('// comment', 'ts', 'comment')).toEqual(['// comment'])
+    expect(byType('x = 1 # py comment', 'py', 'comment')).toEqual(['# py comment'])
+  })
+
+  it('handles block comments on a single line', () => {
+    expect(byType('/* block */ x', 'ts', 'comment')).toEqual(['/* block */'])
+  })
+
+  it('handles unterminated block comments', () => {
+    expect(byType('/* open', 'ts', 'comment')).toEqual(['/* open'])
+  })
+
+  it('does not treat keywords as substrings of identifiers', () => {
+    const out = highlightLine('constant x = 1', 'ts')
+    const kws = out.filter((t) => t.type === 'keyword').map((t) => t.text)
+    expect(kws).not.toContain('const')
+  })
+
+  it('tags TS builtins separately', () => {
+    expect(byType('Array.from()', 'ts', 'builtin')).toContain('Array')
+  })
+
+  it('tags hex numbers', () => {
+    expect(byType('const n = 0xff', 'ts', 'number')).toEqual(['0xff'])
+  })
+
+  it('tags Python keywords and booleans', () => {
+    const text = 'def foo(): return True'
+    const kws = byType(text, 'py', 'keyword')
+    expect(kws).toEqual(expect.arrayContaining(['def', 'return', 'True']))
+  })
+
+  it('tags Go keywords and builtins', () => {
+    const text = 'func foo() int { return 0 }'
+    expect(byType(text, 'go', 'keyword')).toEqual(expect.arrayContaining(['func', 'return']))
+    expect(byType(text, 'go', 'builtin')).toContain('int')
+  })
+
+  it('tags Rust keywords and builtins', () => {
+    const text = 'fn foo() -> String { }'
+    expect(byType(text, 'rust', 'keyword')).toContain('fn')
+    expect(byType(text, 'rust', 'builtin')).toContain('String')
+  })
+
+  it('tags SQL keywords case-insensitively', () => {
+    expect(byType('SELECT id FROM t', 'sql', 'keyword')).toEqual(
+      expect.arrayContaining(['SELECT', 'FROM']),
+    )
+  })
+
+  it('tags JSON literals', () => {
+    const text = '{"x": true, "y": null, "n": 1.5}'
+    expect(byType(text, 'json', 'keyword')).toEqual(expect.arrayContaining(['true', 'null']))
+    expect(byType(text, 'json', 'string')).toEqual(expect.arrayContaining(['"x"', '"y"', '"n"']))
+    expect(byType(text, 'json', 'number')).toContain('1.5')
+  })
+
+  it('handles escaped quotes inside strings', () => {
+    const out = highlightLine('"a\\"b"', 'ts')
+    expect(out).toEqual([{ type: 'string', text: '"a\\"b"' }])
+  })
+
+  it('returns empty tokens array for empty text', () => {
+    expect(highlightLine('', 'ts')).toEqual([])
+  })
+
+  it('returns plain when lang is unknown', () => {
+    expect(types('anything', 'cobol')).toEqual(['plain'])
+  })
+})
+
+describe('tokenClass', () => {
+  it('maps token types to classnames', () => {
+    expect(tokenClass('keyword')).toContain('violet')
+    expect(tokenClass('string')).toContain('amber')
+    expect(tokenClass('comment')).toContain('italic')
+    expect(tokenClass('number')).toContain('teal')
+    expect(tokenClass('builtin')).toContain('sky')
+    expect(tokenClass('plain')).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- New `src/chat/syntax-highlight.ts`: per-line tokenizer with language detection from file extension (TS/JS/Py/Go/Rust/Java/C++/Swift/Ruby/PHP/Shell/SQL/JSON/CSS). No external deps.
- `DiffTab` renders diff line text through the tokenizer; add/del/context row backgrounds are unchanged, so token colors sit on top of the existing green/red tints.
- Transcript `format=diff` output now colors lines by prefix (`+`, `-`, `@@`, `+++/---`).

## Why
Reading code diffs without any syntax color is noisy, especially for longer hunks.

## Test plan
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run test` — 670 pass (20 new tokenizer tests, plus a DiffTab test that asserts token `<span>` classes render for TS content)
- Playwright e2e deferred to CI per project CLAUDE.md.

## Notes
- Tokenizer is per-line (stateless) — multi-line strings / block comments that don't open-and-close on the same diff line fall back to plain. Acceptable tradeoff; stateful tokenization would require reconstructing each file and is out of scope.
- SQL keyword matching is case-insensitive; other languages are case-sensitive.