### PR TITLE
[minions] feat(chat): add voice input to message composer

### DIFF
--- a/src/chat/MessageInput.tsx
+++ b/src/chat/MessageInput.tsx
@@ -1,5 +1,6 @@
 import { useRef, useCallback, useState } from 'preact/hooks'
 import type { ApiSession } from '../api/types'
+import { useSpeechRecognition } from '../hooks/useSpeechRecognition'
 
 const PLACEHOLDER = 'Send instructions to the agent — Enter to send, Shift+Enter for newline'
 
@@ -15,6 +16,9 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
   const [errorText, setErrorText] = useState<string | null>(null)
   const pendingRef = useRef<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const baseTextRef = useRef('')
+  const valueRef = useRef(value)
+  valueRef.current = value
 
   const adjustHeight = useCallback(() => {
     const el = textareaRef.current
@@ -24,6 +28,43 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
     const maxLines = 8
     el.style.height = `${Math.min(el.scrollHeight, lineHeight * maxLines)}px`
   }, [])
+
+  const handleFinal = useCallback(
+    (transcript: string) => {
+      const base = baseTextRef.current
+      const sep = base && !/\s$/.test(base) ? ' ' : ''
+      const next = `${base}${sep}${transcript.trim()}`
+      baseTextRef.current = next
+      onValueChange(next)
+      requestAnimationFrame(adjustHeight)
+    },
+    [onValueChange, adjustHeight],
+  )
+
+  const handleInterim = useCallback(
+    (interim: string) => {
+      const base = baseTextRef.current
+      const sep = base && !/\s$/.test(base) ? ' ' : ''
+      onValueChange(`${base}${sep}${interim}`)
+      requestAnimationFrame(adjustHeight)
+    },
+    [onValueChange, adjustHeight],
+  )
+
+  const handleVoiceError = useCallback((message: string) => {
+    setErrorText(message)
+  }, [])
+
+  const {
+    supported: micSupported,
+    recording,
+    start: startRecording,
+    stop: stopRecording,
+  } = useSpeechRecognition({
+    onFinal: handleFinal,
+    onInterim: handleInterim,
+    onError: handleVoiceError,
+  })
 
   const submit = useCallback(
     async (text: string) => {
@@ -60,11 +101,23 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
 
   const handleInput = useCallback(
     (e: Event) => {
-      onValueChange((e.target as HTMLTextAreaElement).value)
+      const next = (e.target as HTMLTextAreaElement).value
+      onValueChange(next)
+      if (!recording) baseTextRef.current = next
       adjustHeight()
     },
-    [onValueChange, adjustHeight],
+    [onValueChange, adjustHeight, recording],
   )
+
+  const handleMicClick = useCallback(() => {
+    if (recording) {
+      stopRecording()
+      return
+    }
+    setErrorText(null)
+    baseTextRef.current = valueRef.current
+    startRecording()
+  }, [recording, startRecording, stopRecording])
 
   const handleRetry = useCallback(() => {
     const saved = pendingRef.current
@@ -86,17 +139,24 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
       {errorText && (
         <div class="flex items-center gap-2 text-xs text-red-600 dark:text-red-400">
           <span>{errorText}</span>
-          <button
-            type="button"
-            onClick={handleRetry}
-            class="underline font-medium"
-            data-testid="retry-btn"
-          >
-            Retry
-          </button>
+          {pendingRef.current && (
+            <button
+              type="button"
+              onClick={handleRetry}
+              class="underline font-medium"
+              data-testid="retry-btn"
+            >
+              Retry
+            </button>
+          )}
         </div>
       )}
-      <ComposerToolbar charCount={charCount} isSlash={isSlash} sending={sending} />
+      <ComposerToolbar
+        charCount={charCount}
+        isSlash={isSlash}
+        sending={sending}
+        recording={recording}
+      />
       <div class="flex items-end gap-2">
         <textarea
           ref={textareaRef}
@@ -110,6 +170,24 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
           style={{ minHeight: '40px', maxHeight: '160px' }}
           data-testid="message-textarea"
         />
+        {micSupported && (
+          <button
+            type="button"
+            onClick={handleMicClick}
+            disabled={sending}
+            aria-pressed={recording}
+            aria-label={recording ? 'Stop voice input' : 'Start voice input'}
+            title={recording ? 'Stop voice input' : 'Start voice input'}
+            class={`shrink-0 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors border shadow-sm disabled:opacity-50 disabled:cursor-not-allowed ${
+              recording
+                ? 'bg-red-600 hover:bg-red-700 active:bg-red-800 text-white border-red-600'
+                : 'bg-white dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600'
+            }`}
+            data-testid="mic-btn"
+          >
+            <MicIcon recording={recording} />
+          </button>
+        )}
         <button
           type="button"
           onClick={() => void submit(value)}
@@ -129,10 +207,12 @@ function ComposerToolbar({
   charCount,
   isSlash,
   sending,
+  recording,
 }: {
   charCount: number
   isSlash: boolean
   sending: boolean
+  recording: boolean
 }) {
   return (
     <div
@@ -155,6 +235,15 @@ function ComposerToolbar({
         </span>
       )}
       <span class="ml-auto flex items-center gap-1.5">
+        {recording && (
+          <span
+            class="inline-flex items-center gap-1 text-red-600 dark:text-red-400"
+            data-testid="composer-recording-indicator"
+          >
+            <span class="inline-block h-1.5 w-1.5 rounded-full bg-red-500 animate-pulse" />
+            listening
+          </span>
+        )}
         {sending && (
           <span class="inline-flex items-center gap-1 text-indigo-600 dark:text-indigo-300">
             <span class="inline-block h-1.5 w-1.5 rounded-full bg-indigo-500 animate-pulse" />
@@ -176,5 +265,15 @@ function Kbd({ children }: { children: string }) {
     <kbd class="rounded border border-slate-300 dark:border-slate-600 bg-slate-100 dark:bg-slate-700 px-1 py-px font-mono text-[10px] text-slate-600 dark:text-slate-300">
       {children}
     </kbd>
+  )
+}
+
+function MicIcon({ recording }: { recording: boolean }) {
+  return (
+    <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4" aria-hidden="true">
+      <path d="M10 2a3 3 0 0 0-3 3v5a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+      <path d="M5 10a1 1 0 0 1 2 0 3 3 0 0 0 6 0 1 1 0 1 1 2 0 5 5 0 0 1-4 4.9V17h2a1 1 0 1 1 0 2H7a1 1 0 1 1 0-2h2v-2.1A5 5 0 0 1 5 10Z" />
+      {recording && <circle cx="16" cy="4" r="2" fill="#ef4444" />}
+    </svg>
   )
 }

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+
+export interface UseSpeechRecognitionOptions {
+  lang?: string
+  onFinal: (text: string) => void
+  onInterim?: (text: string) => void
+  onError?: (message: string) => void
+}
+
+export interface UseSpeechRecognitionResult {
+  supported: boolean
+  recording: boolean
+  start: () => void
+  stop: () => void
+}
+
+function getConstructor(): SpeechRecognitionConstructor | undefined {
+  if (typeof window === 'undefined') return undefined
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition
+}
+
+function friendlyError(code: string): string {
+  switch (code) {
+    case 'not-allowed':
+    case 'service-not-allowed':
+      return 'Microphone permission denied'
+    case 'no-speech':
+      return 'No speech detected'
+    case 'audio-capture':
+      return 'No microphone available'
+    case 'network':
+      return 'Network error during transcription'
+    case 'language-not-supported':
+      return 'Language not supported'
+    case 'aborted':
+      return ''
+    default:
+      return `Voice input error: ${code}`
+  }
+}
+
+export function useSpeechRecognition(
+  options: UseSpeechRecognitionOptions,
+): UseSpeechRecognitionResult {
+  const { lang, onFinal, onInterim, onError } = options
+  const Ctor = getConstructor()
+  const supported = Boolean(Ctor)
+  const [recording, setRecording] = useState(false)
+  const recRef = useRef<SpeechRecognition | null>(null)
+  const onFinalRef = useRef(onFinal)
+  const onInterimRef = useRef(onInterim)
+  const onErrorRef = useRef(onError)
+
+  useEffect(() => {
+    onFinalRef.current = onFinal
+    onInterimRef.current = onInterim
+    onErrorRef.current = onError
+  }, [onFinal, onInterim, onError])
+
+  const stop = useCallback(() => {
+    const rec = recRef.current
+    if (!rec) return
+    try {
+      rec.stop()
+    } catch {
+      /* noop */
+    }
+  }, [])
+
+  const start = useCallback(() => {
+    if (!Ctor || recRef.current) return
+    const rec = new Ctor()
+    rec.continuous = true
+    rec.interimResults = true
+    rec.maxAlternatives = 1
+    rec.lang = lang ?? navigator.language ?? 'en-US'
+
+    rec.onstart = () => {
+      setRecording(true)
+    }
+    rec.onresult = (event: SpeechRecognitionEvent) => {
+      let interim = ''
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i]
+        const transcript = result[0]?.transcript ?? ''
+        if (result.isFinal) {
+          if (transcript) onFinalRef.current(transcript)
+        } else {
+          interim += transcript
+        }
+      }
+      if (interim) onInterimRef.current?.(interim)
+    }
+    rec.onerror = (event: SpeechRecognitionErrorEvent) => {
+      const message = friendlyError(event.error)
+      if (message) onErrorRef.current?.(message)
+    }
+    rec.onend = () => {
+      recRef.current = null
+      setRecording(false)
+    }
+
+    recRef.current = rec
+    try {
+      rec.start()
+    } catch (err) {
+      recRef.current = null
+      setRecording(false)
+      onErrorRef.current?.(err instanceof Error ? err.message : 'Could not start voice input')
+    }
+  }, [Ctor, lang])
+
+  useEffect(() => {
+    return () => {
+      const rec = recRef.current
+      if (!rec) return
+      try {
+        rec.abort()
+      } catch {
+        /* noop */
+      }
+      recRef.current = null
+    }
+  }, [])
+
+  return { supported, recording, start, stop }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -8,3 +8,65 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+interface SpeechRecognitionAlternative {
+  readonly transcript: string
+  readonly confidence: number
+}
+
+interface SpeechRecognitionResult {
+  readonly length: number
+  readonly isFinal: boolean
+  item(index: number): SpeechRecognitionAlternative
+  [index: number]: SpeechRecognitionAlternative
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number
+  item(index: number): SpeechRecognitionResult
+  [index: number]: SpeechRecognitionResult
+}
+
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number
+  readonly results: SpeechRecognitionResultList
+}
+
+type SpeechRecognitionErrorCode =
+  | 'no-speech'
+  | 'aborted'
+  | 'audio-capture'
+  | 'network'
+  | 'not-allowed'
+  | 'service-not-allowed'
+  | 'bad-grammar'
+  | 'language-not-supported'
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: SpeechRecognitionErrorCode
+  readonly message: string
+}
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean
+  interimResults: boolean
+  lang: string
+  maxAlternatives: number
+  onstart: ((this: SpeechRecognition, ev: Event) => void) | null
+  onend: ((this: SpeechRecognition, ev: Event) => void) | null
+  onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null
+  onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null
+  start(): void
+  stop(): void
+  abort(): void
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognition
+  prototype: SpeechRecognition
+}
+
+interface Window {
+  SpeechRecognition?: SpeechRecognitionConstructor
+  webkitSpeechRecognition?: SpeechRecognitionConstructor
+}

--- a/test/chat/MessageInput.test.tsx
+++ b/test/chat/MessageInput.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/preact'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useState } from 'preact/hooks'
 import { MessageInput } from '../../src/chat/MessageInput'
 import type { ApiSession } from '../../src/api/types'
@@ -137,5 +137,120 @@ describe('MessageInput', () => {
     const placeholder = getTextarea().getAttribute('placeholder') ?? ''
     expect(placeholder.toLowerCase()).not.toContain('telegram')
     expect(placeholder).toContain('agent')
+  })
+})
+
+describe('MessageInput · voice input', () => {
+  const w = window as Window & {
+    SpeechRecognition?: SpeechRecognitionConstructor
+    webkitSpeechRecognition?: SpeechRecognitionConstructor
+  }
+  const originalSR = w.SpeechRecognition
+  const originalWebkit = w.webkitSpeechRecognition
+
+  afterEach(() => {
+    w.SpeechRecognition = originalSR
+    w.webkitSpeechRecognition = originalWebkit
+  })
+
+  it('hides mic button when SpeechRecognition is unsupported', () => {
+    delete w.SpeechRecognition
+    delete w.webkitSpeechRecognition
+    render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} />)
+    expect(screen.queryByTestId('mic-btn')).toBeNull()
+  })
+
+  it('shows mic button and toggles recording state when supported', async () => {
+    class FakeRec extends EventTarget implements SpeechRecognition {
+      continuous = false
+      interimResults = false
+      lang = ''
+      maxAlternatives = 1
+      onstart: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null = null
+      onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null = null
+      onend: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      start() {
+        this.onstart?.call(this, new Event('start'))
+      }
+      stop() {
+        this.onend?.call(this, new Event('end'))
+      }
+      abort() {
+        this.onend?.call(this, new Event('end'))
+      }
+    }
+    w.SpeechRecognition = FakeRec as unknown as SpeechRecognitionConstructor
+    delete w.webkitSpeechRecognition
+    render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} />)
+    const mic = screen.getByTestId('mic-btn') as HTMLButtonElement
+    expect(mic.getAttribute('aria-pressed')).toBe('false')
+    act(() => {
+      fireEvent.click(mic)
+    })
+    await waitFor(() => expect(mic.getAttribute('aria-pressed')).toBe('true'))
+    expect(screen.getByTestId('composer-recording-indicator')).toBeTruthy()
+    act(() => {
+      fireEvent.click(mic)
+    })
+    await waitFor(() => expect(mic.getAttribute('aria-pressed')).toBe('false'))
+  })
+
+  it('appends final transcript to existing input', async () => {
+    const instances: SpeechRecognition[] = []
+    class FakeRec extends EventTarget implements SpeechRecognition {
+      continuous = false
+      interimResults = false
+      lang = ''
+      maxAlternatives = 1
+      onstart: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null = null
+      onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null = null
+      onend: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      start() {
+        this.onstart?.call(this, new Event('start'))
+      }
+      stop() {
+        this.onend?.call(this, new Event('end'))
+      }
+      abort() {
+        this.onend?.call(this, new Event('end'))
+      }
+    }
+    const Ctor = function () {
+      const rec = new FakeRec()
+      instances.push(rec)
+      return rec
+    } as unknown as SpeechRecognitionConstructor
+    w.SpeechRecognition = Ctor
+    delete w.webkitSpeechRecognition
+    render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} />)
+    fireEvent.input(getTextarea(), { target: { value: 'hello' } })
+    act(() => {
+      fireEvent.click(screen.getByTestId('mic-btn'))
+    })
+    await waitFor(() => expect(instances.length).toBe(1))
+    const rec = instances[0]
+    act(() => {
+      const result = Object.assign([{ transcript: 'world', confidence: 1 }], {
+        isFinal: true,
+        length: 1,
+        item() {
+          return { transcript: 'world', confidence: 1 }
+        },
+      })
+      const results = Object.assign([result], {
+        length: 1,
+        item() {
+          return result
+        },
+      }) as unknown as SpeechRecognitionResultList
+      const event = Object.assign(new Event('result'), {
+        resultIndex: 0,
+        results,
+      }) as unknown as SpeechRecognitionEvent
+      rec.onresult?.call(rec, event)
+    })
+    await waitFor(() => expect(getTextarea().value).toBe('hello world'))
   })
 })


### PR DESCRIPTION
## Summary
- Adds a microphone button to the chat composer using the browser-native Web Speech API via a new `useSpeechRecognition` hook
- Feature-detected: button is hidden when neither `SpeechRecognition` nor `webkitSpeechRecognition` is exposed
- Interim transcripts preview in the textarea; finals append to the text the user had already typed (preserved via a baseline snapshot)
- Red pulse "listening" indicator in the composer toolbar while recording
- Friendly error mapping for `not-allowed` / `no-speech` / `audio-capture` / `network`

## Why
Makes the mobile composer usable one-handed — typing long prompts on phones is painful. The API is client-side only, so no backend changes to `telegram-minions` and no new endpoints to gate on `/api/version.features`.

## Notes / limitations
- Browser mic permission prompt fires on first use; denial surfaces a friendly message
- Web Speech does NOT work inside an installed iOS PWA (Safari tab works). Android Chrome installed PWAs work normally. No workaround — accepted limitation
- Requires network connectivity (both Chrome and Safari upload audio to cloud STT)
- Playwright E2E coverage intentionally deferred to CI per the project's "don't run playwright locally" policy in CLAUDE.md

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run test -- --run\` — 652 passed (3 new tests for mic visibility, toggle, and transcript append)
- [ ] Manual: grant mic permission, dictate into composer, confirm transcript appends and send works
- [ ] Manual: deny mic permission, confirm friendly error copy appears