### PR TITLE
[minions] fix(ui): readable code blocks + syntax highlighting

### DIFF
--- a/src/components/highlight.ts
+++ b/src/components/highlight.ts
@@ -1,0 +1,383 @@
+export type TokenKind =
+  | 'comment'
+  | 'string'
+  | 'number'
+  | 'keyword'
+  | 'builtin'
+  | 'regex'
+  | 'operator'
+  | 'punctuation'
+  | 'tag'
+  | 'attr'
+  | 'property'
+  | 'insertion'
+  | 'deletion'
+  | 'hunk'
+
+interface Rule {
+  kind: TokenKind
+  re: RegExp
+}
+
+interface Language {
+  rules: Rule[]
+}
+
+const ALIASES: Record<string, string> = {
+  js: 'javascript',
+  javascript: 'javascript',
+  jsx: 'javascript',
+  ts: 'typescript',
+  typescript: 'typescript',
+  tsx: 'typescript',
+  py: 'python',
+  python: 'python',
+  sh: 'bash',
+  shell: 'bash',
+  bash: 'bash',
+  zsh: 'bash',
+  json: 'json',
+  yaml: 'yaml',
+  yml: 'yaml',
+  css: 'css',
+  html: 'html',
+  xml: 'html',
+  diff: 'diff',
+  patch: 'diff',
+  go: 'go',
+  rust: 'rust',
+  rs: 'rust',
+  sql: 'sql',
+  md: 'markdown',
+  markdown: 'markdown',
+}
+
+function kw(words: string[]): RegExp {
+  return new RegExp(`\\b(?:${words.join('|')})\\b`)
+}
+
+const JS_KEYWORDS = [
+  'const', 'let', 'var', 'function', 'class', 'if', 'else', 'for', 'while',
+  'return', 'export', 'import', 'from', 'as', 'default', 'new', 'this',
+  'super', 'extends', 'implements', 'interface', 'type', 'enum', 'null',
+  'undefined', 'true', 'false', 'async', 'await', 'try', 'catch', 'finally',
+  'throw', 'break', 'continue', 'switch', 'case', 'do', 'in', 'of', 'typeof',
+  'instanceof', 'void', 'yield', 'static', 'public', 'private', 'protected',
+  'readonly', 'abstract', 'declare', 'namespace', 'satisfies', 'keyof',
+]
+
+const JS_BUILTINS = [
+  'console', 'document', 'window', 'process', 'require', 'module', 'exports',
+  'JSON', 'Math', 'Array', 'Object', 'String', 'Number', 'Boolean', 'Promise',
+  'Error', 'Symbol', 'Map', 'Set', 'WeakMap', 'WeakSet', 'RegExp', 'Date',
+  'Buffer', 'globalThis',
+]
+
+const jsLike: Language = {
+  rules: [
+    { kind: 'comment', re: /\/\/[^\n]*/ },
+    { kind: 'comment', re: /\/\*[\s\S]*?\*\// },
+    { kind: 'string', re: /`(?:\\.|\$\{[^}]*\}|[^`\\])*`/ },
+    { kind: 'string', re: /"(?:\\.|[^"\\\n])*"/ },
+    { kind: 'string', re: /'(?:\\.|[^'\\\n])*'/ },
+    { kind: 'number', re: /\b(?:0x[\da-fA-F]+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?(?:[eE][+-]?\d+)?n?)\b/ },
+    { kind: 'keyword', re: kw(JS_KEYWORDS) },
+    { kind: 'builtin', re: kw(JS_BUILTINS) },
+    { kind: 'operator', re: /[+\-*/%=<>!&|^~?]+|=>/ },
+    { kind: 'punctuation', re: /[{}[\]();,.:]/ },
+  ],
+}
+
+const PYTHON_KEYWORDS = [
+  'def', 'class', 'if', 'elif', 'else', 'for', 'while', 'return', 'import',
+  'from', 'as', 'try', 'except', 'finally', 'raise', 'with', 'in', 'is',
+  'not', 'and', 'or', 'None', 'True', 'False', 'lambda', 'yield', 'pass',
+  'break', 'continue', 'global', 'nonlocal', 'async', 'await', 'del',
+  'assert',
+]
+
+const PYTHON_BUILTINS = [
+  'print', 'len', 'range', 'list', 'dict', 'set', 'tuple', 'str', 'int',
+  'float', 'bool', 'type', 'isinstance', 'getattr', 'setattr', 'hasattr',
+  'super', 'self', 'cls', 'open', 'input', 'map', 'filter', 'zip', 'enumerate',
+  'sorted', 'reversed', 'abs', 'min', 'max', 'sum', 'any', 'all',
+]
+
+const python: Language = {
+  rules: [
+    { kind: 'comment', re: /#[^\n]*/ },
+    { kind: 'string', re: /[rRbBuUfF]*'''[\s\S]*?'''/ },
+    { kind: 'string', re: /[rRbBuUfF]*"""[\s\S]*?"""/ },
+    { kind: 'string', re: /[rRbBuUfF]*"(?:\\.|[^"\\\n])*"/ },
+    { kind: 'string', re: /[rRbBuUfF]*'(?:\\.|[^'\\\n])*'/ },
+    { kind: 'number', re: /\b(?:0x[\da-fA-F]+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?(?:[eE][+-]?\d+)?j?)\b/ },
+    { kind: 'keyword', re: kw(PYTHON_KEYWORDS) },
+    { kind: 'builtin', re: kw(PYTHON_BUILTINS) },
+    { kind: 'operator', re: /[+\-*/%=<>!&|^~]+/ },
+    { kind: 'punctuation', re: /[{}[\]();,.:]/ },
+  ],
+}
+
+const BASH_KEYWORDS = [
+  'if', 'then', 'else', 'elif', 'fi', 'for', 'while', 'do', 'done', 'case',
+  'esac', 'in', 'function', 'return', 'export', 'local', 'source', 'alias',
+  'unset', 'set',
+]
+
+const BASH_BUILTINS = [
+  'echo', 'cd', 'ls', 'grep', 'cat', 'mkdir', 'rm', 'cp', 'mv', 'pwd', 'touch',
+  'sed', 'awk', 'curl', 'wget', 'npm', 'yarn', 'pnpm', 'git', 'docker',
+  'kubectl', 'python', 'python3', 'node', 'bash', 'sh', 'make', 'head', 'tail',
+  'find', 'xargs', 'chmod', 'chown', 'tar', 'zip', 'unzip',
+]
+
+const bash: Language = {
+  rules: [
+    { kind: 'comment', re: /#[^\n]*/ },
+    { kind: 'string', re: /"(?:\\.|[^"\\])*"/ },
+    { kind: 'string', re: /'[^']*'/ },
+    { kind: 'number', re: /\b\d+\b/ },
+    { kind: 'builtin', re: /\$[A-Za-z_][\w]*|\$\{[^}]+\}|\$\(\(?[^)]*\)?\)/ },
+    { kind: 'keyword', re: kw(BASH_KEYWORDS) },
+    { kind: 'builtin', re: kw(BASH_BUILTINS) },
+    { kind: 'operator', re: /[|&;<>]+/ },
+    { kind: 'operator', re: /--?[A-Za-z][\w-]*/ },
+  ],
+}
+
+const json: Language = {
+  rules: [
+    { kind: 'string', re: /"(?:\\.|[^"\\])*"(?=\s*:)/ },
+    { kind: 'property', re: /"(?:\\.|[^"\\])*"(?=\s*:)/ },
+    { kind: 'string', re: /"(?:\\.|[^"\\])*"/ },
+    { kind: 'number', re: /-?\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b/ },
+    { kind: 'keyword', re: /\b(?:true|false|null)\b/ },
+    { kind: 'punctuation', re: /[{}[\],:]/ },
+  ],
+}
+
+const yaml: Language = {
+  rules: [
+    { kind: 'comment', re: /#[^\n]*/ },
+    { kind: 'property', re: /^[\t ]*[A-Za-z_][\w-]*(?=:)/m },
+    { kind: 'string', re: /"(?:\\.|[^"\\])*"/ },
+    { kind: 'string', re: /'(?:[^']|'')*'/ },
+    { kind: 'number', re: /\b-?\d+(?:\.\d+)?\b/ },
+    { kind: 'keyword', re: /\b(?:true|false|null|yes|no|on|off)\b/i },
+    { kind: 'operator', re: /[-?:|>]/ },
+  ],
+}
+
+const css: Language = {
+  rules: [
+    { kind: 'comment', re: /\/\*[\s\S]*?\*\// },
+    { kind: 'string', re: /"(?:\\.|[^"\\])*"/ },
+    { kind: 'string', re: /'(?:\\.|[^'\\])*'/ },
+    { kind: 'number', re: /-?\b\d+(?:\.\d+)?(?:%|px|em|rem|vh|vw|ch|ex|pt|pc|in|cm|mm|deg|rad|turn|s|ms|fr)?\b/ },
+    { kind: 'keyword', re: /@[a-zA-Z-]+/ },
+    { kind: 'property', re: /[-a-zA-Z]+(?=\s*:)/ },
+    { kind: 'builtin', re: /#[0-9a-fA-F]{3,8}\b/ },
+    { kind: 'tag', re: /\.[-\w]+|#[-\w]+|&|::?[-\w]+/ },
+    { kind: 'punctuation', re: /[{};(),]/ },
+  ],
+}
+
+const html: Language = {
+  rules: [
+    { kind: 'comment', re: /<!--[\s\S]*?-->/ },
+    { kind: 'string', re: /"(?:\\.|[^"\\])*"/ },
+    { kind: 'string', re: /'(?:\\.|[^'\\])*'/ },
+    { kind: 'tag', re: /<\/?[A-Za-z][\w-]*/ },
+    { kind: 'tag', re: /\/?>/ },
+    { kind: 'attr', re: /\b[A-Za-z_:][\w:.-]*(?==)/ },
+    { kind: 'punctuation', re: /=/ },
+  ],
+}
+
+const GO_KEYWORDS = [
+  'break', 'case', 'chan', 'const', 'continue', 'default', 'defer', 'else',
+  'fallthrough', 'for', 'func', 'go', 'goto', 'if', 'import', 'interface',
+  'map', 'package', 'range', 'return', 'select', 'struct', 'switch', 'type',
+  'var', 'nil', 'true', 'false',
+]
+
+const GO_BUILTINS = [
+  'int', 'int8', 'int16', 'int32', 'int64', 'uint', 'uint8', 'uint16',
+  'uint32', 'uint64', 'float32', 'float64', 'string', 'bool', 'byte', 'rune',
+  'error', 'make', 'new', 'len', 'cap', 'append', 'copy', 'delete', 'panic',
+  'recover', 'print', 'println',
+]
+
+const go: Language = {
+  rules: [
+    { kind: 'comment', re: /\/\/[^\n]*/ },
+    { kind: 'comment', re: /\/\*[\s\S]*?\*\// },
+    { kind: 'string', re: /`[^`]*`/ },
+    { kind: 'string', re: /"(?:\\.|[^"\\\n])*"/ },
+    { kind: 'number', re: /\b(?:0x[\da-fA-F]+|\d+(?:\.\d+)?)\b/ },
+    { kind: 'keyword', re: kw(GO_KEYWORDS) },
+    { kind: 'builtin', re: kw(GO_BUILTINS) },
+    { kind: 'operator', re: /[+\-*/%=<>!&|^~]+|:=/ },
+    { kind: 'punctuation', re: /[{}[\]();,.:]/ },
+  ],
+}
+
+const RUST_KEYWORDS = [
+  'as', 'break', 'const', 'continue', 'crate', 'else', 'enum', 'extern',
+  'false', 'fn', 'for', 'if', 'impl', 'in', 'let', 'loop', 'match', 'mod',
+  'move', 'mut', 'pub', 'ref', 'return', 'self', 'Self', 'static', 'struct',
+  'super', 'trait', 'true', 'type', 'unsafe', 'use', 'where', 'while', 'async',
+  'await', 'dyn', 'box',
+]
+
+const RUST_BUILTINS = [
+  'i8', 'i16', 'i32', 'i64', 'i128', 'isize', 'u8', 'u16', 'u32', 'u64',
+  'u128', 'usize', 'f32', 'f64', 'bool', 'char', 'str', 'String', 'Vec',
+  'Option', 'Result', 'Box', 'Rc', 'Arc', 'Some', 'None', 'Ok', 'Err',
+]
+
+const rust: Language = {
+  rules: [
+    { kind: 'comment', re: /\/\/[^\n]*/ },
+    { kind: 'comment', re: /\/\*[\s\S]*?\*\// },
+    { kind: 'string', re: /"(?:\\.|[^"\\\n])*"/ },
+    { kind: 'string', re: /'(?:\\.|[^'\\])'/ },
+    { kind: 'number', re: /\b(?:0x[\da-fA-F_]+|\d[\d_]*(?:\.\d[\d_]*)?)(?:[iuf]\d+|usize|isize)?\b/ },
+    { kind: 'keyword', re: kw(RUST_KEYWORDS) },
+    { kind: 'builtin', re: kw(RUST_BUILTINS) },
+    { kind: 'operator', re: /[+\-*/%=<>!&|^~?]+/ },
+    { kind: 'punctuation', re: /[{}[\]();,.:]|::|->/ },
+  ],
+}
+
+const SQL_KEYWORDS = [
+  'SELECT', 'FROM', 'WHERE', 'INSERT', 'UPDATE', 'DELETE', 'INTO', 'VALUES',
+  'SET', 'JOIN', 'LEFT', 'RIGHT', 'INNER', 'OUTER', 'FULL', 'ON', 'GROUP',
+  'BY', 'ORDER', 'HAVING', 'LIMIT', 'OFFSET', 'AS', 'AND', 'OR', 'NOT',
+  'NULL', 'IS', 'IN', 'LIKE', 'BETWEEN', 'CREATE', 'TABLE', 'DROP', 'ALTER',
+  'INDEX', 'PRIMARY', 'KEY', 'FOREIGN', 'REFERENCES', 'DEFAULT', 'UNIQUE',
+  'DISTINCT', 'COUNT', 'SUM', 'AVG', 'MIN', 'MAX', 'UNION', 'ALL', 'WITH',
+  'CASE', 'WHEN', 'THEN', 'ELSE', 'END',
+]
+
+const sql: Language = {
+  rules: [
+    { kind: 'comment', re: /--[^\n]*/ },
+    { kind: 'comment', re: /\/\*[\s\S]*?\*\// },
+    { kind: 'string', re: /'(?:''|[^'])*'/ },
+    { kind: 'string', re: /"(?:""|[^"])*"/ },
+    { kind: 'number', re: /\b\d+(?:\.\d+)?\b/ },
+    { kind: 'keyword', re: new RegExp(`\\b(?:${SQL_KEYWORDS.join('|')})\\b`, 'i') },
+    { kind: 'operator', re: /[+\-*/%=<>!]+/ },
+    { kind: 'punctuation', re: /[(),;.]/ },
+  ],
+}
+
+const markdown: Language = {
+  rules: [
+    { kind: 'comment', re: /<!--[\s\S]*?-->/ },
+    { kind: 'keyword', re: /^#{1,6}[^\n]*/m },
+    { kind: 'string', re: /`[^`\n]+`/ },
+    { kind: 'string', re: /```[\s\S]*?```/ },
+    { kind: 'builtin', re: /\[[^\]]*\]\([^)]*\)/ },
+    { kind: 'property', re: /\*\*[^*\n]+\*\*|__[^_\n]+__/ },
+    { kind: 'property', re: /\*[^*\n]+\*|_[^_\n]+_/ },
+    { kind: 'operator', re: /^[-*+] |^\d+\. /m },
+  ],
+}
+
+const LANGS: Record<string, Language> = {
+  javascript: jsLike,
+  typescript: jsLike,
+  python,
+  bash,
+  json,
+  yaml,
+  css,
+  html,
+  go,
+  rust,
+  sql,
+  markdown,
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function tokenize(code: string, lang: Language): string {
+  const stickyRules = lang.rules.map((r) => ({
+    kind: r.kind,
+    re: new RegExp(r.re.source, r.re.flags.includes('y') ? r.re.flags : r.re.flags.replace('g', '') + 'y'),
+  }))
+  let out = ''
+  let plain = ''
+  let pos = 0
+  const flushPlain = () => {
+    if (plain) {
+      out += escapeHtml(plain)
+      plain = ''
+    }
+  }
+  while (pos < code.length) {
+    let matched = false
+    for (const r of stickyRules) {
+      r.re.lastIndex = pos
+      const m = r.re.exec(code)
+      if (m && m[0].length > 0) {
+        flushPlain()
+        out += `<span class="tok-${r.kind}">${escapeHtml(m[0])}</span>`
+        pos += m[0].length
+        matched = true
+        break
+      }
+    }
+    if (!matched) {
+      plain += code[pos]
+      pos++
+    }
+  }
+  flushPlain()
+  return out
+}
+
+function highlightDiff(code: string): string {
+  const lines = code.split('\n')
+  return lines
+    .map((line) => {
+      if (/^(?:---|\+\+\+)/.test(line)) {
+        return `<span class="tok-comment">${escapeHtml(line)}</span>`
+      }
+      if (line.startsWith('@@')) {
+        return `<span class="tok-hunk">${escapeHtml(line)}</span>`
+      }
+      if (line.startsWith('+')) {
+        return `<span class="tok-insertion">${escapeHtml(line)}</span>`
+      }
+      if (line.startsWith('-')) {
+        return `<span class="tok-deletion">${escapeHtml(line)}</span>`
+      }
+      return escapeHtml(line)
+    })
+    .join('\n')
+}
+
+export function resolveLanguage(lang: string | undefined): string | null {
+  if (!lang) return null
+  const normalized = lang.toLowerCase().trim().split(/\s+/)[0]
+  return ALIASES[normalized] ?? null
+}
+
+export function highlight(code: string, lang: string | undefined): string {
+  const resolved = resolveLanguage(lang)
+  if (!resolved) return escapeHtml(code)
+  if (resolved === 'diff') return highlightDiff(code)
+  const def = LANGS[resolved]
+  if (!def) return escapeHtml(code)
+  return tokenize(code, def)
+}

--- a/src/components/markdown.ts
+++ b/src/components/markdown.ts
@@ -1,7 +1,31 @@
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
+import { highlight, resolveLanguage } from './highlight'
 
 marked.setOptions({ gfm: true, breaks: true })
+
+marked.use({
+  renderer: {
+    code({ text, lang }) {
+      const rawLang = (lang ?? '').trim().split(/\s+/)[0]
+      if (rawLang === 'mermaid') {
+        const escaped = text
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+        return `<pre><code class="language-mermaid">${escaped}\n</code></pre>\n`
+      }
+      const resolved = resolveLanguage(rawLang)
+      const className = resolved
+        ? `hljs language-${resolved}`
+        : rawLang
+          ? `hljs language-${rawLang}`
+          : 'hljs'
+      const body = highlight(text, rawLang)
+      return `<pre><code class="${className}">${body}\n</code></pre>\n`
+    },
+  },
+})
 
 const ALLOWED_TAGS = [
   'p', 'br', 'strong', 'em', 'code', 'pre', 'blockquote',

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,67 @@
 
 @custom-variant dark (&:where([data-theme='dark'], [data-theme='dark'] *));
 
+:root {
+  --code-bg: #0f172a;
+  --code-fg: #e2e8f0;
+  --tok-comment: #8b949e;
+  --tok-string: #a5d6ff;
+  --tok-number: #79c0ff;
+  --tok-keyword: #ff7b72;
+  --tok-builtin: #ffa657;
+  --tok-operator: #ff7b72;
+  --tok-punctuation: #c9d1d9;
+  --tok-property: #7ee787;
+  --tok-tag: #7ee787;
+  --tok-attr: #ffa657;
+  --tok-regex: #a5d6ff;
+  --tok-insertion: #3fb950;
+  --tok-deletion: #ff7b72;
+  --tok-hunk: #79c0ff;
+  --inline-code-bg: #f1f5f9;
+  --inline-code-fg: #0f172a;
+}
+
+[data-theme='dark'] {
+  --inline-code-bg: #1e293b;
+  --inline-code-fg: #e2e8f0;
+}
+
+.prose pre {
+  background-color: var(--code-bg);
+  color: var(--code-fg);
+}
+
+.prose pre code,
+.prose pre code.hljs {
+  background-color: transparent !important;
+  color: inherit !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+.prose :not(pre) > code {
+  background-color: var(--inline-code-bg);
+  color: var(--inline-code-fg);
+}
+
+.tok-comment { color: var(--tok-comment); font-style: italic; }
+.tok-string { color: var(--tok-string); }
+.tok-number { color: var(--tok-number); }
+.tok-keyword { color: var(--tok-keyword); font-weight: 600; }
+.tok-builtin { color: var(--tok-builtin); }
+.tok-regex { color: var(--tok-regex); }
+.tok-operator { color: var(--tok-operator); }
+.tok-punctuation { color: var(--tok-punctuation); }
+.tok-property { color: var(--tok-property); }
+.tok-tag { color: var(--tok-tag); }
+.tok-attr { color: var(--tok-attr); }
+.tok-insertion { color: var(--tok-insertion); }
+.tok-deletion { color: var(--tok-deletion); }
+.tok-hunk { color: var(--tok-hunk); font-weight: 600; }
+
 html,
 body {
   margin: 0;

--- a/test/components/highlight.test.ts
+++ b/test/components/highlight.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { highlight, resolveLanguage } from '../../src/components/highlight'
+
+describe('resolveLanguage', () => {
+  it('maps common aliases', () => {
+    expect(resolveLanguage('ts')).toBe('typescript')
+    expect(resolveLanguage('tsx')).toBe('typescript')
+    expect(resolveLanguage('py')).toBe('python')
+    expect(resolveLanguage('sh')).toBe('bash')
+    expect(resolveLanguage('yml')).toBe('yaml')
+  })
+
+  it('returns null for unknown or empty lang', () => {
+    expect(resolveLanguage('')).toBe(null)
+    expect(resolveLanguage(undefined)).toBe(null)
+    expect(resolveLanguage('klingon')).toBe(null)
+  })
+})
+
+describe('highlight', () => {
+  it('escapes HTML when language is unknown', () => {
+    const out = highlight('<script>alert(1)</script>', undefined)
+    expect(out).toBe('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+
+  it('tokenizes typescript keywords and strings', () => {
+    const out = highlight('const x = "hello"', 'ts')
+    expect(out).toContain('<span class="tok-keyword">const</span>')
+    expect(out).toContain('<span class="tok-string">&quot;hello&quot;</span>')
+  })
+
+  it('tokenizes python comments and keywords', () => {
+    const out = highlight('# hi\ndef foo():\n    return None', 'python')
+    expect(out).toContain('<span class="tok-comment"># hi</span>')
+    expect(out).toContain('<span class="tok-keyword">def</span>')
+    expect(out).toContain('<span class="tok-keyword">return</span>')
+    expect(out).toContain('<span class="tok-keyword">None</span>')
+  })
+
+  it('tokenizes json keys, strings, numbers and literals', () => {
+    const out = highlight('{"ok": true, "n": 42, "s": "hi"}', 'json')
+    expect(out).toContain('<span class="tok-keyword">true</span>')
+    expect(out).toContain('<span class="tok-number">42</span>')
+    expect(out).toContain('<span class="tok-string">&quot;hi&quot;</span>')
+  })
+
+  it('marks diff insertions and deletions line-by-line', () => {
+    const out = highlight('- old\n+ new\n@@ hunk @@', 'diff')
+    expect(out).toContain('<span class="tok-deletion">- old</span>')
+    expect(out).toContain('<span class="tok-insertion">+ new</span>')
+    expect(out).toContain('<span class="tok-hunk">@@ hunk @@</span>')
+  })
+
+  it('does not double-escape already-escaped content', () => {
+    const out = highlight('"<b>"', 'json')
+    expect(out).toContain('&lt;b&gt;')
+    expect(out).not.toContain('&amp;lt;')
+  })
+})

--- a/test/components/markdown.test.ts
+++ b/test/components/markdown.test.ts
@@ -14,6 +14,19 @@ describe('renderMarkdown', () => {
     expect(out).toContain('const x = 1')
   })
 
+  it('applies syntax highlighting classes for fenced blocks with a known language', () => {
+    const out = renderMarkdown('```ts\nconst x = 1\n```')
+    expect(out).toContain('language-typescript')
+    expect(out).toContain('tok-keyword')
+    expect(out).toContain('tok-number')
+  })
+
+  it('preserves mermaid blocks without tokenization', () => {
+    const out = renderMarkdown('```mermaid\ngraph TD; A-->B\n```')
+    expect(out).toContain('language-mermaid')
+    expect(out).not.toContain('tok-keyword')
+  })
+
   it('strips <script> tags (XSS)', () => {
     const out = renderMarkdown('ok <script>alert(1)</script> still ok')
     expect(out).not.toContain('<script>')


### PR DESCRIPTION
## Summary
- Code blocks in markdown were unreadable on light theme — a light inner background was painted over light-colored text, making content invisible.
- Markdown code blocks had no syntax highlighting.

## What changed
- Scoped a CSS override in `src/index.css` so `<code>` inside `<pre>` inherits the `<pre>` palette instead of picking up the inline-code background.
- Added a lightweight sticky-regex tokenizer (`src/components/highlight.ts`) supporting ts/js, python, bash, json, yaml, css, html, go, rust, sql, diff, and markdown. Unknown languages fall through to plain escaped text.
- Hooked a custom `marked` code renderer in `src/components/markdown.ts` that emits `<span class="tok-*">` tokens and preserves `language-mermaid` blocks untouched so `MarkdownView`'s mermaid swap still works.
- Added dark-bg-optimized token colors via CSS variables; inline code has its own light/dark palette.

## Why this approach
No syntax-highlighting library is available in the sandbox (no `npm install` permitted), so a small custom tokenizer is the pragmatic choice. Code blocks remain dark in both themes (matching the pre-existing `prose-pre:bg-slate-900` choice), so only one token palette is needed.

## Test plan
- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run test\` passes (new unit tests in \`test/components/highlight.test.ts\` and extended \`markdown.test.ts\`)
- [x] \`npm run build\` succeeds
- [ ] Manual visual check in browser on light and dark themes