### PR TITLE
[minions] feat(markdown): add copy button to fenced code blocks

### DIFF
--- a/src/components/MarkdownView.tsx
+++ b/src/components/MarkdownView.tsx
@@ -37,6 +37,48 @@ export function MarkdownView({ source, class: className, 'data-testid': testId }
   useEffect(() => {
     const root = rootRef.current
     if (!root) return
+    const timers = new Map<HTMLButtonElement, ReturnType<typeof setTimeout>>()
+    const onClick = (e: Event) => {
+      const target = e.target
+      if (!(target instanceof Element)) return
+      const btn = target.closest<HTMLButtonElement>('button[data-copy]')
+      if (!btn || !root.contains(btn)) return
+      const code = btn.parentElement?.querySelector('pre > code')
+      if (!code) return
+      const text = code.textContent ?? ''
+      const showState = (label: string) => {
+        btn.textContent = label
+        const existing = timers.get(btn)
+        if (existing) clearTimeout(existing)
+        timers.set(
+          btn,
+          setTimeout(() => {
+            btn.textContent = 'Copy'
+            timers.delete(btn)
+          }, 1500),
+        )
+      }
+      const clip = navigator.clipboard
+      if (clip && typeof clip.writeText === 'function') {
+        clip.writeText(text).then(
+          () => showState('Copied'),
+          () => showState('Failed'),
+        )
+      } else {
+        showState('Failed')
+      }
+    }
+    root.addEventListener('click', onClick)
+    return () => {
+      root.removeEventListener('click', onClick)
+      for (const t of timers.values()) clearTimeout(t)
+      timers.clear()
+    }
+  }, [html])
+
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
     const blocks = Array.from(
       root.querySelectorAll<HTMLElement>('pre > code.language-mermaid'),
     )

--- a/src/components/markdown.ts
+++ b/src/components/markdown.ts
@@ -22,7 +22,12 @@ marked.use({
           ? `hljs language-${rawLang}`
           : 'hljs'
       const body = highlight(text, rawLang)
-      return `<pre><code class="${className}">${body}\n</code></pre>\n`
+      const button =
+        '<button type="button" data-copy aria-label="Copy code to clipboard" ' +
+        'class="code-copy-btn absolute top-2 right-2 text-[11px] leading-none px-2 py-1 rounded ' +
+        'bg-slate-700/70 hover:bg-slate-600 text-slate-100 select-none transition-colors ' +
+        'focus:outline-none focus:ring-2 focus:ring-indigo-400">Copy</button>'
+      return `<div class="code-block-wrap relative"><pre><code class="${className}">${body}\n</code></pre>${button}</div>\n`
     },
   },
 })
@@ -31,10 +36,10 @@ const ALLOWED_TAGS = [
   'p', 'br', 'strong', 'em', 'code', 'pre', 'blockquote',
   'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
   'a', 'hr', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
-  'del', 'ins', 'span', 'div',
+  'del', 'ins', 'span', 'div', 'button',
 ]
 
-const ALLOWED_ATTR = ['href', 'target', 'rel', 'class']
+const ALLOWED_ATTR = ['href', 'target', 'rel', 'class', 'type', 'aria-label', 'data-copy']
 
 export function renderMarkdown(text: string): string {
   const raw = marked.parse(text, { async: false }) as string

--- a/test/components/MarkdownView.test.tsx
+++ b/test/components/MarkdownView.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/preact'
+import { MarkdownView } from '../../src/components/MarkdownView'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('MarkdownView copy button', () => {
+  it('renders a Copy button on a fenced code block', () => {
+    render(<MarkdownView source={'```\nconst x = 1\n```'} />)
+    const btn = screen.getByRole('button', { name: /copy code to clipboard/i })
+    expect(btn).toBeTruthy()
+    expect(btn.textContent).toBe('Copy')
+  })
+
+  it('writes the code content to the clipboard and shows a Copied state', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    render(<MarkdownView source={'```ts\nconst x = 1\n```'} />)
+    const btn = screen.getByRole('button', { name: /copy code to clipboard/i })
+    fireEvent.click(btn)
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledTimes(1)
+    })
+    const [copied] = writeText.mock.calls[0]
+    expect(copied).toContain('const x = 1')
+    await waitFor(() => {
+      expect(btn.textContent).toBe('Copied')
+    })
+  })
+
+  it('shows a Failed state when the clipboard write rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    render(<MarkdownView source={'```\nhello\n```'} />)
+    const btn = screen.getByRole('button', { name: /copy code to clipboard/i })
+    fireEvent.click(btn)
+
+    await waitFor(() => {
+      expect(btn.textContent).toBe('Failed')
+    })
+  })
+})

--- a/test/components/markdown.test.ts
+++ b/test/components/markdown.test.ts
@@ -14,6 +14,19 @@ describe('renderMarkdown', () => {
     expect(out).toContain('const x = 1')
   })
 
+  it('wraps fenced code blocks with a copy-to-clipboard button', () => {
+    const out = renderMarkdown('```\nconst x = 1\n```')
+    expect(out).toContain('code-block-wrap')
+    expect(out).toContain('data-copy')
+    expect(out).toContain('aria-label="Copy code to clipboard"')
+  })
+
+  it('does not add a copy button to mermaid blocks', () => {
+    const out = renderMarkdown('```mermaid\ngraph TD; A-->B\n```')
+    expect(out).not.toContain('data-copy')
+    expect(out).not.toContain('code-block-wrap')
+  })
+
   it('applies syntax highlighting classes for fenced blocks with a known language', () => {
     const out = renderMarkdown('```ts\nconst x = 1\n```')
     expect(out).toContain('language-typescript')


### PR DESCRIPTION
## Summary
- Added a copy-to-clipboard button to all fenced code blocks in rendered markdown, positioned at the top-right corner
- Button shows "Copied" on success or "Failed" on clipboard error, reverting after 1.5s
- Mermaid blocks intentionally excluded from this feature
- DOMPurify allow-list extended to permit `button` elements and relevant attributes (`type`, `aria-label`, `data-copy`)

## Changes
- `src/components/markdown.ts`: Modified the fenced code renderer to wrap non-mermaid blocks in a relative container with an embedded copy button; updated ALLOWED_TAGS and ALLOWED_ATTR
- `src/components/MarkdownView.tsx`: Added a delegated click handler that detects copy button clicks, extracts code text via `code.textContent`, and writes to clipboard; manages label state transitions
- `test/components/markdown.test.ts`: Added assertion that rendered markup includes the wrapper div and button attributes; verified mermaid blocks are unaffected
- `test/components/MarkdownView.test.tsx` (new): Component tests covering button rendering, successful clipboard write with state transition, and clipboard write rejection

## Testing
Manual verification in a dev server was not possible in the sandbox environment (node_modules is read-only). Coverage relies on:
- **Unit tests**: `markdown.test.ts` verifies renderer output includes the wrapper and button markup
- **Component tests**: `MarkdownView.test.tsx` exercises the full flow (click → clipboard.writeText → label state flip) with mocked clipboard API
- **Type checking & linting**: All passed
- **E2E validation**: Playwright suite will verify the feature in CI on push

To manually test: hover over any fenced code block in the chat transcript; a "Copy" button sits at the top-right corner with a semi-transparent background. Click it to copy the block's text to clipboard; the label briefly changes to "Copied" or "Failed", then reverts.