### PR TITLE
feat(api): sync wire contract with transcript pipeline

### DIFF
--- a/e2e/fixtures/mock-minion.ts
+++ b/e2e/fixtures/mock-minion.ts
@@ -204,13 +204,15 @@ export async function createMockMinion(opts?: {
       lastCreateVariantsRequests.push(payload)
       const groupId = `group-${Date.now()}-${Math.floor(Math.random() * 1000)}`
       const variants: ApiSession[] = []
+      const results: Array<{ sessionId: string; slug: string; threadId: number }> = []
       for (let i = 0; i < payload.count; i++) {
         const s = makeSession(payload)
         s.variantGroupId = groupId
         variants.push(s)
+        results.push({ sessionId: s.slug, slug: s.slug, threadId: s.threadId ?? 0 })
       }
       sessions = [...sessions, ...variants]
-      sendJson(res, 200, { data: { groupId, sessions: variants } })
+      sendJson(res, 200, { data: { sessions: results } })
       return
     }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -77,21 +77,25 @@ export interface VersionInfo {
   repos?: RepoEntry[]
 }
 
-export type CreateSessionMode = 'task' | 'plan' | 'think' | 'dag' | 'split' | 'stack' | 'ship' | 'doctor'
+export type CreateSessionMode = 'task' | 'plan' | 'think' | 'review' | 'ship-think'
 
 export interface CreateSessionRequest {
   prompt: string
   mode: CreateSessionMode
   repo?: string
+  profileId?: string
 }
 
 export interface CreateSessionVariantsRequest extends CreateSessionRequest {
   count: number
 }
 
+export type CreateSessionVariantResult =
+  | { sessionId: string; slug: string; threadId: number }
+  | { error: string }
+
 export interface CreateSessionVariantsResult {
-  groupId: string
-  sessions: ApiSession[]
+  sessions: CreateSessionVariantResult[]
 }
 
 export type PrState = 'open' | 'closed' | 'merged'

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -27,7 +27,7 @@ export const NEW_TASK_MODES: ModeOption[] = [
   { value: 'task', label: 'Task', hint: 'Execute end-to-end' },
   { value: 'plan', label: 'Plan', hint: 'Produce a plan; no execution' },
   { value: 'think', label: 'Think', hint: 'Deliberate; no side effects' },
-  { value: 'ship', label: 'Ship', hint: 'Finish with a PR' },
+  { value: 'ship-think', label: 'Ship', hint: 'Finish with a PR' },
 ]
 
 export const VARIANT_COUNTS: ReadonlyArray<number> = [1, 2, 3, 4]
@@ -35,6 +35,7 @@ export const VARIANT_COUNTS: ReadonlyArray<number> = [1, 2, 3, 4]
 export interface NewTaskBarProps {
   store: ConnectionStore
   navigate?: (hash: string) => void
+  generateGroupId?: () => string
 }
 
 function defaultNavigate(hash: string): void {
@@ -43,7 +44,18 @@ function defaultNavigate(hash: string): void {
   }
 }
 
-export function NewTaskBar({ store, navigate = defaultNavigate }: NewTaskBarProps) {
+function defaultGenerateGroupId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `g-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e6).toString(36)}`
+}
+
+export function NewTaskBar({
+  store,
+  navigate = defaultNavigate,
+  generateGroupId = defaultGenerateGroupId,
+}: NewTaskBarProps) {
   const mode = useSignal<CreateSessionMode>('task')
   const prompt = useSignal('')
   const repo = useSignal('')
@@ -102,16 +114,30 @@ export function NewTaskBar({ store, navigate = defaultNavigate }: NewTaskBarProp
           repo: selectedRepo,
           count: variantCount.value,
         })
+        const slugs: string[] = []
+        const errors: string[] = []
+        for (const result of out.sessions) {
+          if ('slug' in result) slugs.push(result.slug)
+          else errors.push(result.error)
+        }
+        if (slugs.length === 0) {
+          error.value = errors[0] ?? 'Failed to create variants'
+          return
+        }
+        const groupId = generateGroupId()
         recordVariantGroup(store.connectionId, {
-          groupId: out.groupId,
+          groupId,
           prompt: p,
           mode: mode.value,
           repo: selectedRepo,
-          variantSessionIds: out.sessions.map((s) => s.id),
+          variantSessionIds: slugs,
           createdAt: new Date().toISOString(),
         })
         prompt.value = ''
-        navigate(formatRoute({ name: 'group', groupId: out.groupId }))
+        if (errors.length > 0) {
+          error.value = `${errors.length} variant${errors.length > 1 ? 's' : ''} failed to launch`
+        }
+        navigate(formatRoute({ name: 'group', groupId }))
       } else {
         await store.client.createSession({
           prompt: p,

--- a/test/api/client-extended.test.ts
+++ b/test/api/client-extended.test.ts
@@ -78,10 +78,12 @@ describe('ApiClient — createSession', () => {
 })
 
 describe('ApiClient — createSessionVariants', () => {
-  it('POSTs to /api/sessions/variants and unwraps group result', async () => {
+  it('POSTs to /api/sessions/variants and unwraps the variants result', async () => {
     const result: CreateSessionVariantsResult = {
-      groupId: 'group-1',
-      sessions: [SAMPLE_SESSION, { ...SAMPLE_SESSION, id: 's-2' }],
+      sessions: [
+        { sessionId: 's-1', slug: 's-1', threadId: 1 },
+        { sessionId: 's-2', slug: 's-2', threadId: 2 },
+      ],
     }
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: result }))
     vi.stubGlobal('fetch', fetchMock)

--- a/test/api/mock-minion-integration.test.ts
+++ b/test/api/mock-minion-integration.test.ts
@@ -34,11 +34,12 @@ describe('mock-minion integration', () => {
     expect(minion.lastCreateSessionRequests[before]).toEqual({ prompt: 'hello', mode: 'task', repo: 'example' })
   })
 
-  it('createSessionVariants returns a group of N sessions sharing a groupId', async () => {
+  it('createSessionVariants returns N successful slug/threadId tuples', async () => {
     minion.setVersion({ features: ['sessions-variants'] })
     const out = await client.createSessionVariants({ prompt: 'parallel', mode: 'task', count: 3 })
     expect(out.sessions).toHaveLength(3)
-    expect(new Set(out.sessions.map((s) => s.variantGroupId))).toEqual(new Set([out.groupId]))
+    const slugs = out.sessions.map((s) => ('slug' in s ? s.slug : null))
+    expect(slugs.every((s) => typeof s === 'string' && s.length > 0)).toBe(true)
   })
 
   it('gated endpoints return 404 with a feature-disabled error when flag off', async () => {

--- a/test/chat/NewTaskBar.test.tsx
+++ b/test/chat/NewTaskBar.test.tsx
@@ -60,10 +60,11 @@ function makeStore(opts: {
       .mockImplementation(
         opts.createVariantsImpl ??
           (async (req) => ({
-            groupId: 'g-xyz',
-            sessions: Array.from({ length: req.count }, (_, i) =>
-              makeSession({ id: `sv-${i + 1}`, variantGroupId: 'g-xyz' })
-            ),
+            sessions: Array.from({ length: req.count }, (_, i) => ({
+              sessionId: `sv-${i + 1}`,
+              slug: `sv-${i + 1}`,
+              threadId: 100 + i,
+            })),
           }))
       ),
     sendCommand: vi.fn<(cmd: MinionCommand) => Promise<CommandResult>>(),
@@ -116,7 +117,7 @@ describe('NewTaskBar', () => {
     expect(screen.getByTestId('mode-task')).toBeTruthy()
     expect(screen.getByTestId('mode-plan')).toBeTruthy()
     expect(screen.getByTestId('mode-think')).toBeTruthy()
-    expect(screen.getByTestId('mode-ship')).toBeTruthy()
+    expect(screen.getByTestId('mode-ship-think')).toBeTruthy()
     expect(screen.getByTestId('mode-task').getAttribute('aria-checked')).toBe('true')
   })
 
@@ -192,7 +193,7 @@ describe('NewTaskBar', () => {
       repos: [{ alias: 'primary', url: 'https://github.com/org/primary' }],
     })
     const navigate = vi.fn<(hash: string) => void>()
-    render(<NewTaskBar store={store} navigate={navigate} />)
+    render(<NewTaskBar store={store} navigate={navigate} generateGroupId={() => 'g-xyz'} />)
     fireEvent.click(screen.getByTestId('variant-3'))
     const textarea = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
     fireEvent.input(textarea, { target: { value: 'split it' } })
@@ -231,7 +232,7 @@ describe('NewTaskBar', () => {
       repos: [{ alias: 'primary', url: 'https://github.com/org/primary' }],
     })
     const navigate = vi.fn<(hash: string) => void>()
-    render(<NewTaskBar store={store} navigate={navigate} />)
+    render(<NewTaskBar store={store} navigate={navigate} generateGroupId={() => 'g-xyz'} />)
     fireEvent.click(screen.getByTestId('variant-2'))
     const textarea = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
     fireEvent.input(textarea, { target: { value: 'compare approaches' } })
@@ -243,7 +244,7 @@ describe('NewTaskBar', () => {
     expect(recorded?.prompt).toBe('compare approaches')
     expect(recorded?.mode).toBe('task')
     expect(recorded?.repo).toBe('primary')
-    expect(recorded?.variantSessionIds).toHaveLength(2)
+    expect(recorded?.variantSessionIds).toEqual(['sv-1', 'sv-2'])
   })
 
   it('Launch button label reflects variant count', async () => {


### PR DESCRIPTION
## Summary

- Mirrors the `TranscriptEvent` types (8-variant discriminated union, `ToolCallSummary`, `ToolResultPayload`, `TranscriptSessionInfo`, `TranscriptSnapshot`, `TRANSCRIPT_TRUNCATION_BUDGET`, `isTranscriptEventOfType`) from `telegram-minions/src/transcript/types.ts`, adds the `transcript_event` SSE variant, the `transcript` feature flag, `ApiClient.getTranscript(slug, after)`, an optional `onTranscriptEvent` SSE handler, and optional `transcriptUrl` on `ApiSession`.
- Fixes long-standing `CreateSessionMode` drift (removes fabricated `dag|split|stack|ship|doctor`; the real server modes are `task|plan|think|review|ship-think`). Adds optional `profileId` on `CreateSessionRequest`.
- Reshapes `CreateSessionVariantsResult` to match the real server envelope — `{ sessions: Array<{ sessionId, slug, threadId } | { error }> }` — and teaches `NewTaskBar` to generate the group id client-side and treat variant slugs as session ids.

First of 5 sequenced PRs that move `minions-ui` onto the conductor-shaped transcript pipeline. No UI surface changes land here — PR 2 wires the store and PR 3 builds the renderer.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test` — 576/576 passing
- [x] `npm run build` emits a working `dist/`
- [ ] CI (including the `e2e` Playwright matrix) must be green before merge