### PR TITLE
fix(chat): drop hard-coded library version from TranscriptUpgradeNotice

### DIFF
--- a/src/chat/transcript/TranscriptUpgradeNotice.tsx
+++ b/src/chat/transcript/TranscriptUpgradeNotice.tsx
@@ -1,7 +1,5 @@
 import type { ConnectionStore } from '../../state/types'
 
-export const MIN_LIBRARY_VERSION = '1.119'
-
 export interface TranscriptUpgradeNoticeProps {
   store: ConnectionStore
 }
@@ -33,12 +31,17 @@ export function TranscriptUpgradeNotice({ store }: TranscriptUpgradeNoticeProps)
           This minion needs a library update
         </h2>
         <p class="text-xs leading-relaxed text-slate-600 dark:text-slate-300">
-          The conductor-style chat view needs{' '}
+          The conductor-style chat view needs a{' '}
           <code class="font-mono text-slate-800 dark:text-slate-200">
-            @tprei/telegram-minions ≥ {MIN_LIBRARY_VERSION}
-          </code>
-          . This minion reports{' '}
-          <code class="font-mono text-slate-800 dark:text-slate-200">{running}</code>.
+            @tprei/telegram-minions
+          </code>{' '}
+          build that advertises the{' '}
+          <code class="font-mono text-slate-800 dark:text-slate-200">transcript</code>{' '}
+          feature on{' '}
+          <code class="font-mono text-slate-800 dark:text-slate-200">/api/version</code>.
+          This minion reports version{' '}
+          <code class="font-mono text-slate-800 dark:text-slate-200">{running}</code> and
+          did not advertise that flag.
         </p>
         <p class="text-xs leading-relaxed text-slate-600 dark:text-slate-300">
           Redeploy with the latest image (

--- a/src/chat/transcript/index.ts
+++ b/src/chat/transcript/index.ts
@@ -1,5 +1,5 @@
 export { Transcript } from './Transcript'
-export { TranscriptUpgradeNotice, MIN_LIBRARY_VERSION } from './TranscriptUpgradeNotice'
+export { TranscriptUpgradeNotice } from './TranscriptUpgradeNotice'
 export { TurnSeparator } from './TurnSeparator'
 export { UserMessageCard } from './UserMessageCard'
 export { AssistantTextBlock } from './AssistantTextBlock'

--- a/test/chat/transcript/TranscriptUpgradeNotice.test.tsx
+++ b/test/chat/transcript/TranscriptUpgradeNotice.test.tsx
@@ -1,10 +1,7 @@
 import { render, screen } from '@testing-library/preact'
 import { signal } from '@preact/signals'
 import { describe, it, expect, vi } from 'vitest'
-import {
-  TranscriptUpgradeNotice,
-  MIN_LIBRARY_VERSION,
-} from '../../../src/chat/transcript/TranscriptUpgradeNotice'
+import { TranscriptUpgradeNotice } from '../../../src/chat/transcript/TranscriptUpgradeNotice'
 import type { ConnectionStore } from '../../../src/state/types'
 import type { VersionInfo, ApiSession, ApiDagGraph } from '../../../src/api/types'
 
@@ -29,12 +26,13 @@ function makeStore(version: VersionInfo | null): ConnectionStore {
 }
 
 describe('TranscriptUpgradeNotice', () => {
-  it('reports the minimum library version the conductor view needs', () => {
-    const store = makeStore({ apiVersion: '1', libraryVersion: '1.110.0', features: [] })
+  it('explains the missing transcript feature flag and echoes the running version', () => {
+    const store = makeStore({ apiVersion: '1', libraryVersion: '1.118.7', features: [] })
     render(<TranscriptUpgradeNotice store={store} />)
     const notice = screen.getByTestId('transcript-upgrade-notice')
-    expect(notice.textContent).toContain(MIN_LIBRARY_VERSION)
-    expect(notice.textContent).toContain('1.110.0')
+    expect(notice.textContent).toContain('transcript')
+    expect(notice.textContent).toContain('/api/version')
+    expect(notice.textContent).toContain('1.118.7')
   })
 
   it('falls back to "unknown" when the minion has not reported a version yet', () => {


### PR DESCRIPTION
## Summary

The conductor chat pane already gates on \`hasFeature(store, 'transcript')\` — a feature-flag check, not a version-string check. The upgrade notice was separately hard-coding \`≥ 1.119\` in its copy, which is wrong: the transcript REST + SSE endpoints landed in \`telegram-minions\` master after \`v1.118.7\` was cut, so no released tagged version actually has \`1.119\` anywhere on it.

Result the user saw: minion running a \`1.118.x\` build hit the upgrade notice and was told it needs \`≥ 1.119\` — a version that doesn't exist yet.

## Fix

Rewrite the notice to explain in feature-flag terms: the minion must advertise the \`transcript\` feature on \`/api/version\`, regardless of the printed version string. Drop the exported \`MIN_LIBRARY_VERSION\` constant and its re-export from \`src/chat/transcript/index.ts\`, plus the test assertion that depended on it. Test now asserts the notice mentions the feature name and echoes the running version string back.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run test\` — 660/660 passing
- [ ] CI green