### PR TITLE
[minions] fix(chat): accumulate streaming transcript deltas & polish rendering

### DIFF
--- a/src/chat/transcript/ThinkingBlock.tsx
+++ b/src/chat/transcript/ThinkingBlock.tsx
@@ -9,6 +9,8 @@ interface Props {
 
 export function ThinkingBlock({ event, defaultOpen = false }: Props) {
   const [open, setOpen] = useState(defaultOpen)
+  const trimmed = event.text.trim()
+  if (event.final && trimmed.length === 0) return null
   const preview = event.text.slice(0, 80).replace(/\s+/g, ' ').trim()
   const shouldTruncate = event.text.length > 80
   return (

--- a/src/chat/transcript/ToolCallCard.tsx
+++ b/src/chat/transcript/ToolCallCard.tsx
@@ -14,6 +14,7 @@ export function ToolCallCard({ call, result, defaultOpen = false }: Props) {
   const summary = call.call
 
   const status: 'pending' | 'ok' | 'error' = result?.result.status ?? 'pending'
+  const preview = buildResultPreview(result)
   const statusBadge = (
     <span
       class={`text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded ${
@@ -39,24 +40,34 @@ export function ToolCallCard({ call, result, defaultOpen = false }: Props) {
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        class="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700/40"
+        class="w-full flex flex-col items-stretch gap-0.5 px-3 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700/40"
         aria-expanded={open}
         data-testid="transcript-tool-call-toggle"
       >
-        <ChevronIcon open={open} class="w-3 h-3 text-slate-400" />
-        <ToolKindIcon kind={summary.kind} class="w-3.5 h-3.5 text-slate-500 dark:text-slate-400" />
-        <span class="font-mono text-[11px] uppercase tracking-wide text-slate-500 dark:text-slate-400 shrink-0">
-          {summary.name}
-        </span>
-        <span class="text-xs font-medium text-slate-800 dark:text-slate-200 truncate">
-          {summary.title}
-        </span>
-        {summary.subtitle && (
-          <span class="text-[11px] text-slate-500 dark:text-slate-400 truncate font-mono">
-            {summary.subtitle}
+        <div class="flex items-center gap-2 min-w-0">
+          <ChevronIcon open={open} class="w-3 h-3 text-slate-400 shrink-0" />
+          <ToolKindIcon kind={summary.kind} class="w-3.5 h-3.5 text-slate-500 dark:text-slate-400 shrink-0" />
+          <span class="font-mono text-[11px] uppercase tracking-wide text-slate-500 dark:text-slate-400 shrink-0">
+            {summary.name}
           </span>
+          <span class="text-xs font-medium text-slate-800 dark:text-slate-200 truncate">
+            {summary.title}
+          </span>
+          {summary.subtitle && (
+            <span class="text-[11px] text-slate-500 dark:text-slate-400 truncate font-mono">
+              {summary.subtitle}
+            </span>
+          )}
+          <span class="ml-auto flex items-center gap-2 shrink-0">{statusBadge}</span>
+        </div>
+        {!open && preview && (
+          <div
+            class="pl-[1.375rem] text-[11px] text-slate-500 dark:text-slate-400 font-mono truncate"
+            data-testid="transcript-tool-call-preview"
+          >
+            {preview}
+          </div>
         )}
-        <span class="ml-auto flex items-center gap-2">{statusBadge}</span>
       </button>
       {open && (
         <div
@@ -123,4 +134,31 @@ function formatValue(v: unknown): string {
   } catch {
     return String(v)
   }
+}
+
+function buildResultPreview(result: Props['result']): string | null {
+  if (!result) return null
+  const { result: payload } = result
+  if (payload.status === 'error') {
+    const msg = payload.error || payload.text
+    if (!msg) return null
+    return firstLine(msg, 160)
+  }
+  if (payload.status === 'pending') return null
+  if (!payload.text) {
+    if (payload.images && payload.images.length > 0) {
+      return payload.images.length === 1 ? '1 image' : `${payload.images.length} images`
+    }
+    return null
+  }
+  return firstLine(payload.text, 160)
+}
+
+function firstLine(text: string, max: number): string | null {
+  const trimmed = text.replace(/\r/g, '').replace(/^\s+/, '')
+  if (trimmed.length === 0) return null
+  const nl = trimmed.indexOf('\n')
+  const line = nl >= 0 ? trimmed.slice(0, nl) : trimmed
+  if (line.length <= max) return line
+  return line.slice(0, max - 1).trimEnd() + '…'
 }

--- a/src/chat/transcript/Transcript.tsx
+++ b/src/chat/transcript/Transcript.tsx
@@ -128,7 +128,17 @@ function RowView({ row }: { row: TranscriptRow }) {
     case 'tool-call':
       return <ToolCallCard call={row.call} result={row.result} />
     case 'tool-result-orphan':
-      return <ToolResultBody event={row.event} />
+      return (
+        <div
+          class="rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800/60 overflow-hidden"
+          data-testid="transcript-tool-result-orphan"
+        >
+          <div class="px-3 py-1.5 text-[10px] uppercase tracking-wide font-semibold text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40">
+            Tool result (no matching call)
+          </div>
+          <ToolResultBody event={row.event} />
+        </div>
+      )
     case 'status':
       return <StatusBanner event={row.event} />
   }

--- a/src/chat/transcript/utils.ts
+++ b/src/chat/transcript/utils.ts
@@ -82,7 +82,19 @@ export function buildTranscriptRows(events: TranscriptEvent[]): BuildRowsResult 
           const idx = rows.findIndex(
             (r) => r.kind === 'assistant-text' && r.blockId === e.blockId,
           )
-          if (idx >= 0) rows[idx] = { kind: 'assistant-text', blockId: e.blockId, turn: e.turn, seq: e.seq, event: e }
+          if (idx >= 0) {
+            const prev = rows[idx]
+            if (prev.kind === 'assistant-text') {
+              const mergedText = e.final ? e.text : (prev.event.text ?? '') + (e.text ?? '')
+              rows[idx] = {
+                kind: 'assistant-text',
+                blockId: e.blockId,
+                turn: e.turn,
+                seq: e.seq,
+                event: { ...e, text: mergedText },
+              }
+            }
+          }
         } else {
           rows.push({ kind: 'assistant-text', blockId: e.blockId, turn: e.turn, seq: e.seq, event: e })
         }
@@ -93,7 +105,19 @@ export function buildTranscriptRows(events: TranscriptEvent[]): BuildRowsResult 
         const prevSeq = blockSeen.get(e.blockId)
         if (prevSeq !== undefined) {
           const idx = rows.findIndex((r) => r.kind === 'thinking' && r.blockId === e.blockId)
-          if (idx >= 0) rows[idx] = { kind: 'thinking', blockId: e.blockId, turn: e.turn, seq: e.seq, event: e }
+          if (idx >= 0) {
+            const prev = rows[idx]
+            if (prev.kind === 'thinking') {
+              const mergedText = e.final ? e.text : (prev.event.text ?? '') + (e.text ?? '')
+              rows[idx] = {
+                kind: 'thinking',
+                blockId: e.blockId,
+                turn: e.turn,
+                seq: e.seq,
+                event: { ...e, text: mergedText },
+              }
+            }
+          }
         } else {
           rows.push({ kind: 'thinking', blockId: e.blockId, turn: e.turn, seq: e.seq, event: e })
         }

--- a/test/chat/transcript/components.test.tsx
+++ b/test/chat/transcript/components.test.tsx
@@ -196,6 +196,18 @@ describe('ToolCallCard', () => {
     fireEvent.click(screen.getByTestId('transcript-tool-call-toggle'))
     expect(screen.getByTestId('transcript-tool-call-pending')).toBeTruthy()
   })
+
+  it('shows an inline result preview when collapsed', () => {
+    render(<ToolCallCard call={makeCall()} result={makeResult('ok', '127.0.0.1 localhost\nanother line')} />)
+    const preview = screen.getByTestId('transcript-tool-call-preview')
+    expect(preview.textContent).toBe('127.0.0.1 localhost')
+  })
+
+  it('hides the inline preview once expanded', () => {
+    render(<ToolCallCard call={makeCall()} result={makeResult('ok', 'inline preview text')} />)
+    fireEvent.click(screen.getByTestId('transcript-tool-call-toggle'))
+    expect(screen.queryByTestId('transcript-tool-call-preview')).toBeNull()
+  })
 })
 
 describe('ToolResultBody', () => {

--- a/test/chat/transcript/utils.test.ts
+++ b/test/chat/transcript/utils.test.ts
@@ -133,10 +133,12 @@ describe('buildTranscriptRows', () => {
     expect(separators).toHaveLength(2)
   })
 
-  it('coalesces streaming assistant_text events with the same blockId, keeping latest text', () => {
+  it('accumulates streaming assistant_text deltas and replaces with full text on final', () => {
     const events: TranscriptEvent[] = [
       assistantText(1, 'b1', 'Hel', false),
-      assistantText(2, 'b1', 'Hello world', true),
+      assistantText(2, 'b1', 'lo ', false),
+      assistantText(3, 'b1', 'world', false),
+      assistantText(4, 'b1', 'Hello world', true),
     ]
     const { rows } = buildTranscriptRows(events)
     const textRows = rows.filter((r) => r.kind === 'assistant-text')
@@ -147,10 +149,26 @@ describe('buildTranscriptRows', () => {
     }
   })
 
-  it('coalesces streaming thinking events with the same blockId', () => {
+  it('accumulates partial assistant_text deltas even before the final event arrives', () => {
     const events: TranscriptEvent[] = [
-      thinking(1, 'th1', 'partial', false),
-      thinking(2, 'th1', 'partial more', true),
+      assistantText(1, 'b1', 'Hel', false),
+      assistantText(2, 'b1', 'lo', false),
+    ]
+    const { rows } = buildTranscriptRows(events)
+    const textRows = rows.filter((r) => r.kind === 'assistant-text')
+    expect(textRows).toHaveLength(1)
+    if (textRows[0].kind === 'assistant-text') {
+      expect(textRows[0].event.text).toBe('Hello')
+      expect(textRows[0].event.final).toBe(false)
+    }
+  })
+
+  it('accumulates streaming thinking deltas', () => {
+    const events: TranscriptEvent[] = [
+      thinking(1, 'th1', 'part', false),
+      thinking(2, 'th1', 'ial', false),
+      thinking(3, 'th1', ' more', false),
+      thinking(4, 'th1', 'partial more', true),
     ]
     const { rows } = buildTranscriptRows(events)
     const thRows = rows.filter((r) => r.kind === 'thinking')


### PR DESCRIPTION
## Summary
- **Streaming deltas were not accumulating.** The server emits each `assistant_text` / `thinking` event carrying only the *delta* chunk (`text: chunk`, `final: false`), then a final flush event with the fully accumulated text (`final: true`). `buildTranscriptRows` was replacing the stored row with each new event — so during streaming the UI only saw the last chunk. That explains empty/garbled thinking blocks, visibly-empty assistant text mid-stream, and mid-conversation "stray code blocks" (markdown parsing an unterminated ``` fence from a single delta).
  - Fix: concat non-final deltas onto the stored row's text; final events replace with the server's full text (so snapshot reload still works).
- **Redacted thinking blocks were showing "empty thinking block" placeholders.** Now hidden entirely when `final && text.trim() === ''`.
- **Tool cards hid the result behind expansion.** Added a single-line inline preview (first line of result text, image count, or error message) under the collapsed card header — so Read / Bash / Grep etc. show *what* they returned at a glance.
- **Orphan tool_results (result with no matching call, e.g. from a dropped SSE event) rendered as a bare `<pre>` in the conversation flow.** Now wrapped in a framed card with a "Tool result (no matching call)" header so it's visually attributed.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test` (transcript suite): 59/59 passed (updated 3 delta-accumulation cases in utils.test.ts, added 2 inline-preview cases in components.test.tsx)
- [ ] Pre-existing failing tests in `test/App.*.test.tsx` are unrelated to this PR
- [ ] Deliberately scoped OUT: server-side `tool-classifier.ts` additions for tools like `AskUserQuestion`, `ExitPlanMode`, `ToolSearch`. Those live in the `telegram-minions` repo — separate PR there.
- [ ] Playwright E2E not run locally per CLAUDE.md. CI will cover it.