### PR TITLE
[minions] feat(ui): add header Clean button to prune unused resources

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -582,6 +582,30 @@ function ActiveView() {
     viewMode.value = 'list'
   }, [])
 
+  const [cleaning, setCleaning] = useState(false)
+  const handleClean = useCallback(async () => {
+    if (!store) return
+    const ok = await confirm({
+      title: 'Clean unused resources?',
+      message: 'Runs /clean to prune unused worktrees, branches, and session state on the minion.',
+      destructive: true,
+      confirmLabel: 'Clean',
+    })
+    if (!ok) return
+    setCleaning(true)
+    try {
+      await store.client.sendMessage('/clean')
+    } catch (e) {
+      await confirm({
+        title: 'Clean failed',
+        message: e instanceof Error ? e.message : 'Unknown error',
+        mode: 'alert',
+      })
+    } finally {
+      setCleaning(false)
+    }
+  }, [store])
+
   if (!store || !conn) return null
 
   const selected = sessionId ? sessions.find((s) => s.id === sessionId) ?? null : null
@@ -623,6 +647,18 @@ function ActiveView() {
         <div class="ml-auto flex items-center gap-1.5">
           <ViewToggle mode={mode} onChange={(m) => { viewMode.value = m }} />
           <ThemeToggle />
+          {hasFeature(store, 'messages') && (
+            <button
+              type="button"
+              onClick={() => void handleClean()}
+              disabled={cleaning}
+              class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Clean unused worktrees, branches, and session state"
+              data-testid="header-clean-btn"
+            >
+              {cleaning ? 'Cleaning…' : 'Clean'}
+            </button>
+          )}
           <button
             type="button"
             onClick={() => void store.refresh()}

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -203,6 +203,72 @@ describe('App', () => {
     expect(screen.getByTestId('session-item-s3')).toBeTruthy()
   })
 
+  it('hides the Clean button when the minion does not advertise the messages feature', { timeout: 15000 }, async () => {
+    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
+      version: 1,
+      connections: [
+        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+      ],
+      activeId: 'c1',
+    }))
+    stubFetch([session()])
+    const App = (await import('../src/App')).default
+    render(<App />)
+    await screen.findByText('My Minion')
+    expect(screen.queryByTestId('header-clean-btn')).toBeNull()
+  })
+
+  it('clicking Clean sends /clean via /api/messages after confirmation', { timeout: 15000 }, async () => {
+    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
+      version: 1,
+      connections: [
+        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+      ],
+      activeId: 'c1',
+    }))
+    const versionWithMessages: VersionInfo = {
+      apiVersion: '1',
+      libraryVersion: '1.110.0',
+      features: ['messages'],
+    }
+    const postedBodies: unknown[] = []
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/api/version')) {
+        return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: versionWithMessages }) })
+      }
+      if (url.includes('/api/sessions')) {
+        return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: [session()] }) })
+      }
+      if (url.includes('/api/dags')) {
+        return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: [] }) })
+      }
+      if (url.includes('/api/messages') && init?.method === 'POST') {
+        postedBodies.push(JSON.parse(String(init.body)))
+        return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: { ok: true, sessionId: null } }) })
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'NF', json: () => Promise.resolve({ data: null }) })
+    }))
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    const cleanBtn = await screen.findByTestId('header-clean-btn')
+    fireEvent.click(cleanBtn)
+
+    const dialog = await screen.findByRole('dialog')
+    const confirmBtn = Array.from(dialog.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Clean',
+    )
+    expect(confirmBtn).toBeTruthy()
+    fireEvent.click(confirmBtn!)
+
+    await vi.waitFor(() => {
+      expect(postedBodies.length).toBeGreaterThan(0)
+    })
+    const body = postedBodies[0] as { text: string; sessionId?: string }
+    expect(body.text).toBe('/clean')
+    expect(body.sessionId).toBeUndefined()
+  })
+
   it('switching sessions keeps the chat pane mounted', async () => {
     localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
       version: 1,


### PR DESCRIPTION
## Summary

Adds a "Clean" button in the app header (next to Refresh and Theme toggle) that calls the minion's `/clean` command, allowing users to prune unused worktrees, branches, and session state directly from the PWA.

- Gated behind minion's "messages" feature flag to ensure wire compatibility with library ≥ 1.110.x
- Reuses existing `confirm()` dialog for destructive-action prompt
- Shows alert on failure
- Two new unit tests validate feature-gating and POST payload format

## Test plan

- [x] Typecheck, lint, and unit tests pass locally
- [x] New tests verify button is hidden when "messages" feature is absent
- [x] New tests verify /api/messages POST payload with no sessionId
- [ ] CI Playwright suite covers E2E behavior