### PR TITLE
fix(test): add 15s timeout to all App integration tests

### DIFF
--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -63,7 +63,7 @@ describe('App', () => {
     localStorage.clear()
   })
 
-  it('renders empty state "Connect a minion" when no connections', async () => {
+  it('renders empty state "Connect a minion" when no connections', { timeout: 15000 }, async () => {
     stubFetch()
     const App = (await import('../src/App')).default
     render(<App />)
@@ -71,7 +71,7 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: 'Add connection' })).toBeTruthy()
   })
 
-  it('renders header and session list when connection exists', async () => {
+  it('renders header and session list when connection exists', { timeout: 15000 }, async () => {
     localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
       version: 1,
       connections: [
@@ -86,7 +86,7 @@ describe('App', () => {
     await screen.findByText('brave-fox')
   })
 
-  it('clicking a session in the sidebar opens the chat pane inline', async () => {
+  it('clicking a session in the sidebar opens the chat pane inline', { timeout: 15000 }, async () => {
     localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
       version: 1,
       connections: [
@@ -106,7 +106,7 @@ describe('App', () => {
     await screen.findByTestId('transcript-upgrade-notice')
   })
 
-  it('renders the variant group view when the hash is #/g/:groupId', async () => {
+  it('renders the variant group view when the hash is #/g/:groupId', { timeout: 15000 }, async () => {
     localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
       version: 1,
       connections: [
@@ -161,7 +161,7 @@ describe('App', () => {
     }
   })
 
-  it('renders attention pills and filters the session list when a pill is clicked', async () => {
+  it('renders attention pills and filters the session list when a pill is clicked', { timeout: 15000 }, async () => {
     localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
       version: 1,
       connections: [
@@ -269,7 +269,7 @@ describe('App', () => {
     expect(body.sessionId).toBeUndefined()
   })
 
-  it('switching sessions keeps the chat pane mounted', async () => {
+  it('switching sessions keeps the chat pane mounted', { timeout: 15000 }, async () => {
     localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
       version: 1,
       connections: [

--- a/test/App.viewToggle.test.tsx
+++ b/test/App.viewToggle.test.tsx
@@ -171,7 +171,7 @@ describe('App view toggle', () => {
     localStorage.clear()
   })
 
-  it('renders ViewToggle with List selected by default', async () => {
+  it('renders ViewToggle with List selected by default', { timeout: 15000 }, async () => {
     seedConnection()
     stubFetch([session()])
     await resetViewMode()
@@ -185,7 +185,7 @@ describe('App view toggle', () => {
     expect(canvasBtn.getAttribute('aria-selected')).toBe('false')
   })
 
-  it('switches to canvas view when Canvas tab clicked on desktop', async () => {
+  it('switches to canvas view when Canvas tab clicked on desktop', { timeout: 15000 }, async () => {
     seedConnection()
     stubFetch([session()])
     await resetViewMode()
@@ -200,7 +200,7 @@ describe('App view toggle', () => {
     expect(within(canvasPane).getByTestId('universe-canvas')).toBeTruthy()
   })
 
-  it('switching back to List hides the canvas pane', async () => {
+  it('switching back to List hides the canvas pane', { timeout: 15000 }, async () => {
     seedConnection()
     stubFetch([session()])
     await resetViewMode()
@@ -215,7 +215,7 @@ describe('App view toggle', () => {
     await screen.findByTestId('session-item-s1')
   })
 
-  it('clicking a node in canvas opens detail popup with Open Chat button', async () => {
+  it('clicking a node in canvas opens detail popup with Open Chat button', { timeout: 15000 }, async () => {
     seedConnection()
     stubFetch([session({ id: 's1', slug: 'brave-fox' })])
     await resetViewMode()
@@ -228,7 +228,7 @@ describe('App view toggle', () => {
     expect(await screen.findByText('Open Chat')).toBeTruthy()
   })
 
-  it('Open Chat from canvas popup switches to list and selects session', async () => {
+  it('Open Chat from canvas popup switches to list and selects session', { timeout: 15000 }, async () => {
     seedConnection()
     stubFetch([session({ id: 's1', slug: 'brave-fox' })])
     await resetViewMode()
@@ -246,7 +246,7 @@ describe('App view toggle', () => {
     expect(screen.queryByTestId('canvas-pane')).toBeNull()
   })
 
-  it('renders mobile full-screen canvas modal with close button on mobile', async () => {
+  it('renders mobile full-screen canvas modal with close button on mobile', { timeout: 15000 }, async () => {
     setDesktop(false)
     seedConnection()
     stubFetch([session()])
@@ -264,7 +264,7 @@ describe('App view toggle', () => {
     expect(screen.queryByTestId('canvas-mobile-modal')).toBeNull()
   })
 
-  it('renders the Ship tab in the view toggle', async () => {
+  it('renders the Ship tab in the view toggle', { timeout: 15000 }, async () => {
     seedConnection()
     stubFetch([session()])
     await resetViewMode()
@@ -275,7 +275,7 @@ describe('App view toggle', () => {
     expect(within(toggle).getByTestId('view-toggle-ship')).toBeTruthy()
   })
 
-  it('switches to ship view when Ship tab clicked on desktop', async () => {
+  it('switches to ship view when Ship tab clicked on desktop', { timeout: 15000 }, async () => {
     seedConnection()
     const shipDag: ApiDagGraph = {
       id: 'ship-1',
@@ -298,7 +298,7 @@ describe('App view toggle', () => {
     expect(within(shipPane).getByTestId('ship-pipeline-board-ship-1')).toBeTruthy()
   })
 
-  it('shows the empty ship state when no DAG qualifies as a ship pipeline', async () => {
+  it('shows the empty ship state when no DAG qualifies as a ship pipeline', { timeout: 15000 }, async () => {
     seedConnection()
     stubFetch([session()])
     await resetViewMode()
@@ -309,7 +309,7 @@ describe('App view toggle', () => {
     expect(await screen.findByTestId('ship-pipeline-empty')).toBeTruthy()
   })
 
-  it('renders mobile full-screen ship modal with close button on mobile', async () => {
+  it('renders mobile full-screen ship modal with close button on mobile', { timeout: 15000 }, async () => {
     setDesktop(false)
     seedConnection()
     const shipDag: ApiDagGraph = {
@@ -335,7 +335,7 @@ describe('App view toggle', () => {
     expect(screen.queryByTestId('ship-mobile-modal')).toBeNull()
   })
 
-  it('canvas sendReply callback calls /api/messages', async () => {
+  it('canvas sendReply callback calls /api/messages', { timeout: 15000 }, async () => {
     seedConnection()
     const { sendMessage } = stubFetch([session({ id: 's1', slug: 'brave-fox', quickActions: [{ type: 'retry', label: 'Retry', message: 'retry please' }] })])
     await resetViewMode()


### PR DESCRIPTION
## Summary

App integration tests use `vi.resetModules()` which forces a full re-import of the entire App module tree on every test. This takes approximately 11 seconds in CI, exceeding the default 5-second vitest timeout.

Added `{ timeout: 15000 }` to:
- 6 tests in test/App.test.tsx (3 that were originally missing + 3 for consistency)
- 11 tests in test/App.viewToggle.test.tsx (all were missing)

This fixes test timeout failures on PR #45.

## Why

The module re-import pattern is necessary for test isolation (each test needs a fresh component state), but CI environments run slower than local development. 15 seconds provides a safe margin.