### PR TITLE
fix(tsconfig): remove unused baseUrl and paths configuration

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,11 +18,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src", "test", "e2e/fixtures"]
 }


### PR DESCRIPTION
## Summary

- Remove `baseUrl` and the `@/*` path alias from tsconfig.app.json
- The path alias was never used in the codebase
- `baseUrl` triggers TS5101 deprecation error in TypeScript 5.8+
- Resolves quality gate failures on the project

## Test plan

- [x] No TypeScript errors
- [x] No lint errors  
- [x] No unused configuration remains

Generated with Claude Code