### PR TITLE
[minions] feat(chat): markdown + fullscreen toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,6 +151,15 @@ function ChatPane({
   const [text, setText] = useState('')
   const [pending, setPending] = useState<'stop' | 'close' | null>(null)
   const [activeTab, setActiveTab] = useState<SessionTabId>('chat')
+  const isDesktopPane = useMediaQuery('(min-width: 768px)')
+  const [fullscreen, setFullscreen] = useState<boolean>(() =>
+    typeof localStorage !== 'undefined' && localStorage.getItem('minions-ui:chat-fullscreen') === 'true',
+  )
+  const toggleFullscreen = () => {
+    const next = !fullscreen
+    setFullscreen(next)
+    try { localStorage.setItem('minions-ui:chat-fullscreen', String(next)) } catch { /* ignore */ }
+  }
   const handleSend = (t: string) => onSend(t, session.id)
   const handleQuickAction = (action: QuickAction) => onSend(action.message, session.id)
 
@@ -202,9 +211,13 @@ function ChatPane({
 
   const stoppable = session.status === 'running' || session.status === 'pending'
   const closable = session.status !== 'completed' && session.status !== 'failed'
+  const mobileFullscreen = !isDesktopPane.value && fullscreen
+  const rootClass = mobileFullscreen
+    ? 'fixed inset-0 z-40 flex flex-col bg-white dark:bg-slate-800'
+    : 'flex flex-col flex-1 min-h-0 bg-white dark:bg-slate-800'
 
   return (
-    <div class="flex flex-col flex-1 min-h-0 bg-white dark:bg-slate-800">
+    <div class={rootClass} data-testid="chat-pane" data-fullscreen={mobileFullscreen ? 'true' : 'false'}>
       <header class="flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-700 shrink-0">
         <span class={`inline-block h-2 w-2 rounded-full ${statusDot(session.status)}`} />
         <span class="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">{session.slug}</span>
@@ -223,6 +236,18 @@ function ChatPane({
           </a>
         )}
         <div class="ml-auto flex items-center gap-1.5">
+          {!isDesktopPane.value && (
+            <button
+              type="button"
+              onClick={toggleFullscreen}
+              title={fullscreen ? 'Exit full screen' : 'Expand chat to full screen'}
+              aria-label={fullscreen ? 'Exit full screen' : 'Expand chat to full screen'}
+              class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+              data-testid="chat-fullscreen-btn"
+            >
+              {fullscreen ? 'Collapse' : 'Expand'}
+            </button>
+          )}
           <button
             type="button"
             onClick={() => void handleStop()}

--- a/src/chat/transcript/UserMessageCard.tsx
+++ b/src/chat/transcript/UserMessageCard.tsx
@@ -1,4 +1,5 @@
 import type { UserMessageEvent } from '../../api/types'
+import { MarkdownView } from '../../components/MarkdownView'
 
 interface Props {
   event: UserMessageEvent
@@ -8,8 +9,11 @@ export function UserMessageCard({ event }: Props) {
   const hasImages = event.images && event.images.length > 0
   return (
     <div class="group flex gap-3 justify-end" data-testid="transcript-user-message">
-      <div class="max-w-[80%] rounded-lg px-3 py-2 text-sm bg-slate-900 dark:bg-slate-700 text-slate-100 whitespace-pre-wrap break-words font-mono">
-        {event.text}
+      <div class="max-w-[85%] rounded-lg px-3 py-2 text-sm bg-slate-900 dark:bg-slate-700 text-slate-100">
+        <MarkdownView
+          source={event.text}
+          class="prose prose-sm prose-invert max-w-none prose-p:my-1 prose-pre:bg-slate-950 prose-pre:text-slate-100 prose-pre:rounded-md prose-pre:px-2 prose-pre:py-1.5 prose-pre:text-xs prose-code:before:content-none prose-code:after:content-none prose-code:bg-slate-800 prose-code:text-slate-100 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-headings:text-slate-100 prose-headings:my-1 prose-a:text-indigo-300 text-slate-100"
+        />
         {hasImages && (
           <div class="mt-2 flex flex-wrap gap-1.5">
             {event.images!.map((url, i) => (


### PR DESCRIPTION
## Summary

- **UserMessageCard**: Render user message text through `MarkdownView` instead of hard-coded code block, with `prose-invert` styling for dark bubbles. Fixes CI-fix attempt payloads (injected as markdown events) rendering as mono blobs.
- **ChatPane**: Add mobile-only Expand/Collapse button to header; toggles full-screen overlay with localStorage persistence (`minions-ui:chat-fullscreen`). Mirrors existing Canvas/Ship mobile pattern.
- User message max-width widened from 80% to 85%.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 480 passed
- Manual inspection: user messages now render markdown correctly; fullscreen toggle appears on mobile and persists preference.