### PR TITLE
[minions] fix(chat): dedup tool_call rows and tighten transcript density

### DIFF
--- a/src/chat/transcript/ToolCallCard.tsx
+++ b/src/chat/transcript/ToolCallCard.tsx
@@ -40,7 +40,7 @@ export function ToolCallCard({ call, result, defaultOpen = false }: Props) {
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        class="w-full flex flex-col items-stretch gap-0.5 px-3 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700/40"
+        class="w-full flex flex-col items-stretch gap-0.5 px-3 py-1.5 text-left hover:bg-slate-50 dark:hover:bg-slate-700/40"
         aria-expanded={open}
         data-testid="transcript-tool-call-toggle"
       >

--- a/src/chat/transcript/Transcript.tsx
+++ b/src/chat/transcript/Transcript.tsx
@@ -61,7 +61,7 @@ export function Transcript({ store }: Props) {
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        class="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-2.5 bg-slate-50 dark:bg-slate-900"
+        class="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-1.5 bg-slate-50 dark:bg-slate-900"
         data-testid="transcript"
       >
         {error && (
@@ -133,7 +133,7 @@ function RowView({ row }: { row: TranscriptRow }) {
           class="rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800/60 overflow-hidden"
           data-testid="transcript-tool-result-orphan"
         >
-          <div class="px-3 py-1.5 text-[10px] uppercase tracking-wide font-semibold text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40">
+          <div class="px-3 py-1 text-[10px] uppercase tracking-wide font-semibold text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40">
             Tool result (no matching call)
           </div>
           <ToolResultBody event={row.event} />

--- a/src/chat/transcript/utils.ts
+++ b/src/chat/transcript/utils.ts
@@ -127,7 +127,14 @@ export function buildTranscriptRows(events: TranscriptEvent[]): BuildRowsResult 
       case 'tool_call': {
         const result = resultsByToolUseId.get(e.call.toolUseId) ?? null
         if (result) handledResultIds.add(result.id)
-        rows.push({ kind: 'tool-call', turn: e.turn, seq: e.seq, call: e, result })
+        const idx = rows.findIndex(
+          (r) => r.kind === 'tool-call' && r.call.call.toolUseId === e.call.toolUseId,
+        )
+        if (idx >= 0) {
+          rows[idx] = { kind: 'tool-call', turn: e.turn, seq: e.seq, call: e, result }
+        } else {
+          rows.push({ kind: 'tool-call', turn: e.turn, seq: e.seq, call: e, result })
+        }
         break
       }
       case 'tool_result':

--- a/test/chat/transcript/utils.test.ts
+++ b/test/chat/transcript/utils.test.ts
@@ -208,6 +208,35 @@ describe('buildTranscriptRows', () => {
     expect(rows.filter((r) => r.kind === 'tool-result-orphan')).toHaveLength(0)
   })
 
+  it('deduplicates repeated tool_call events with the same toolUseId', () => {
+    const events: TranscriptEvent[] = [
+      toolCall(1, 'tu1', 'Read', 'read'),
+      toolCall(2, 'tu1', 'Read', 'read'),
+      toolCall(3, 'tu1', 'Read', 'read'),
+    ]
+    const { rows } = buildTranscriptRows(events)
+    const callRows = rows.filter((r) => r.kind === 'tool-call')
+    expect(callRows).toHaveLength(1)
+    if (callRows[0].kind === 'tool-call') {
+      expect(callRows[0].seq).toBe(3)
+    }
+  })
+
+  it('still pairs a late tool_result when tool_call events repeat', () => {
+    const events: TranscriptEvent[] = [
+      toolCall(1, 'tu1', 'Read', 'read'),
+      toolCall(2, 'tu1', 'Read', 'read'),
+      toolResult(3, 'tu1', 'ok', 'done'),
+    ]
+    const { rows } = buildTranscriptRows(events)
+    const callRows = rows.filter((r) => r.kind === 'tool-call')
+    expect(callRows).toHaveLength(1)
+    expect(rows.filter((r) => r.kind === 'tool-result-orphan')).toHaveLength(0)
+    if (callRows[0].kind === 'tool-call') {
+      expect(callRows[0].result?.result.text).toBe('done')
+    }
+  })
+
   it('emits an orphan row for tool_result without a matching tool_call', () => {
     const events: TranscriptEvent[] = [toolResult(1, 'missing', 'ok', 'lonely')]
     const { rows } = buildTranscriptRows(events)


### PR DESCRIPTION
## Summary
- Dedup `tool_call` events by `toolUseId` in `buildTranscriptRows` so repeated calls update the existing row instead of stacking a new bordered card — mirrors the existing `assistant_text` / `thinking` pattern.
- Tighten transcript vertical density: transcript column `gap-2.5` → `gap-1.5`, `ToolCallCard` collapsed button `py-2` → `py-1.5`, orphan header `py-1.5` → `py-1`.

## Why
Long sessions were rendering as a wall of stacked horizontal lines — the visible pattern came from many tool-call / tool-result / tool-result-orphan cards each drawing their own `rounded-md border` at dense vertical spacing. The dedup gap also meant a single `toolUseId` re-emission could silently double cards. This addresses the visual density and hardens against repeated `tool_call` events.

## What was not changed
- Stuck "pending" tool_call state — that requires a library-side change per the original research thread; out of scope here.
- Tool-result-orphan rendering — kept, only compacted its header.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run test/chat/transcript/utils.test.ts` (27 passed, includes 2 new dedup tests)
- [x] `npx vitest run test/chat/transcript/components.test.tsx` (26 passed)
- [ ] Verify on a long session that the wall-of-lines effect is gone