### PR TITLE
fix(chat): group consecutive tool calls into a single frame

### DIFF
--- a/src/chat/transcript/ToolCallCard.tsx
+++ b/src/chat/transcript/ToolCallCard.tsx
@@ -7,9 +7,10 @@ interface Props {
   call: ToolCallEvent
   result: ToolResultEvent | null
   defaultOpen?: boolean
+  variant?: 'standalone' | 'grouped'
 }
 
-export function ToolCallCard({ call, result, defaultOpen = false }: Props) {
+export function ToolCallCard({ call, result, defaultOpen = false, variant = 'standalone' }: Props) {
   const [open, setOpen] = useState(defaultOpen)
   const summary = call.call
 
@@ -30,9 +31,14 @@ export function ToolCallCard({ call, result, defaultOpen = false }: Props) {
     </span>
   )
 
+  const containerClass =
+    variant === 'grouped'
+      ? 'bg-transparent overflow-hidden'
+      : 'rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800/60 overflow-hidden'
+
   return (
     <div
-      class="rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800/60 overflow-hidden"
+      class={containerClass}
       data-testid="transcript-tool-call"
       data-tool-kind={summary.kind}
       data-tool-status={status}
@@ -40,7 +46,7 @@ export function ToolCallCard({ call, result, defaultOpen = false }: Props) {
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        class="w-full flex flex-col items-stretch gap-0.5 px-3 py-1.5 text-left hover:bg-slate-50 dark:hover:bg-slate-700/40"
+        class="w-full flex flex-col items-stretch gap-0.5 px-3 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700/40"
         aria-expanded={open}
         data-testid="transcript-tool-call-toggle"
       >

--- a/src/chat/transcript/Transcript.tsx
+++ b/src/chat/transcript/Transcript.tsx
@@ -61,7 +61,7 @@ export function Transcript({ store }: Props) {
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        class="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-1.5 bg-slate-50 dark:bg-slate-900"
+        class="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-2.5 bg-slate-50 dark:bg-slate-900"
         data-testid="transcript"
       >
         {error && (
@@ -93,9 +93,13 @@ export function Transcript({ store }: Props) {
             No transcript activity yet.
           </div>
         )}
-        {rows.map((row) => (
-          <RowView key={rowKey(row)} row={row} />
-        ))}
+        {groupRows(rows).map((item) =>
+          item.kind === 'tool-group' ? (
+            <ToolGroup key={`tg:${item.items[0].call.call.toolUseId}`} items={item.items} />
+          ) : (
+            <RowView key={rowKey(item.row)} row={item.row} />
+          ),
+        )}
       </div>
       {!following && rows.length > 0 && (
         <button
@@ -142,6 +146,50 @@ function RowView({ row }: { row: TranscriptRow }) {
     case 'status':
       return <StatusBanner event={row.event} />
   }
+}
+
+type ToolCallRow = Extract<TranscriptRow, { kind: 'tool-call' }>
+type RenderItem =
+  | { kind: 'single'; row: TranscriptRow }
+  | { kind: 'tool-group'; items: ToolCallRow[] }
+
+function groupRows(rows: TranscriptRow[]): RenderItem[] {
+  const out: RenderItem[] = []
+  let buf: ToolCallRow[] = []
+  function flush() {
+    if (buf.length === 0) return
+    if (buf.length === 1) out.push({ kind: 'single', row: buf[0] })
+    else out.push({ kind: 'tool-group', items: buf })
+    buf = []
+  }
+  for (const row of rows) {
+    if (row.kind === 'tool-call') {
+      buf.push(row)
+      continue
+    }
+    flush()
+    out.push({ kind: 'single', row })
+  }
+  flush()
+  return out
+}
+
+function ToolGroup({ items }: { items: ToolCallRow[] }) {
+  return (
+    <div
+      class="rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800/60 overflow-hidden divide-y divide-slate-200 dark:divide-slate-700"
+      data-testid="transcript-tool-group"
+    >
+      {items.map((row) => (
+        <ToolCallCard
+          key={row.call.call.toolUseId}
+          call={row.call}
+          result={row.result}
+          variant="grouped"
+        />
+      ))}
+    </div>
+  )
 }
 
 function rowKey(row: TranscriptRow): string {

--- a/test/chat/transcript/Transcript.test.tsx
+++ b/test/chat/transcript/Transcript.test.tsx
@@ -132,6 +132,48 @@ describe('Transcript', () => {
     expect(screen.getByTestId('transcript-streaming-indicator')).toBeTruthy()
   })
 
+  it('wraps consecutive tool calls in a single grouped frame', async () => {
+    const calls: ToolCallEvent[] = [1, 2, 3].map((i) => ({
+      ...baseEvent(i),
+      type: 'tool_call',
+      call: {
+        toolUseId: `tu${i}`,
+        name: 'Bash',
+        kind: 'bash',
+        title: `cmd ${i}`,
+        input: {},
+      },
+    }))
+    const client = makeClient(snapshot(calls))
+    const store = createTranscriptStore({ client, slug: 's' })
+    render(<Transcript store={store} />)
+    await flush()
+    await waitFor(() => expect(screen.getAllByTestId('transcript-tool-call').length).toBe(3))
+    const groups = screen.getAllByTestId('transcript-tool-group')
+    expect(groups.length).toBe(1)
+    expect(groups[0].querySelectorAll('[data-testid="transcript-tool-call"]').length).toBe(3)
+  })
+
+  it('renders a lone tool call as a standalone card, not grouped', async () => {
+    const call: ToolCallEvent = {
+      ...baseEvent(1),
+      type: 'tool_call',
+      call: {
+        toolUseId: 'tu1',
+        name: 'Bash',
+        kind: 'bash',
+        title: 'echo',
+        input: {},
+      },
+    }
+    const client = makeClient(snapshot([call]))
+    const store = createTranscriptStore({ client, slug: 's' })
+    render(<Transcript store={store} />)
+    await flush()
+    await waitFor(() => expect(screen.getByTestId('transcript-tool-call')).toBeTruthy())
+    expect(screen.queryByTestId('transcript-tool-group')).toBeNull()
+  })
+
   it('renders an error banner when fetch fails and exposes Retry', async () => {
     let attempts = 0
     const client = {


### PR DESCRIPTION
## Summary

Tool-call cards each rendered their own rounded border, so a run of tool calls stacked into an indistinct wall of horizontal strips — easy to mistake for a single garbled element (user report: *"they render like a bunch of lines one in front of the other"*). PR #50 tightened padding/gap to try to hide this but only made it worse.

- Wrap consecutive tool-call rows in a single bordered container with thin dividers between them (\`ToolGroup\` in \`Transcript.tsx\`).
- Add a \`variant: 'standalone' | 'grouped'\` prop to \`ToolCallCard\` that strips the outer border when it lives inside a group.
- Lone tool calls still render as a standalone card (unchanged).
- Restore transcript row gap from \`gap-1.5\` back to \`gap-2.5\` so grouped frames and other transcript rows have room to breathe.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test\` — 669 pass (2 new tests covering grouped vs. standalone rendering)
- [ ] Manually verify on mobile that long runs of Bash/Read/Edit calls read as a tidy list instead of a wall of lines