### PR TITLE
fix(ui): stop header overflow-hidden from clipping picker dropdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,11 +132,12 @@ function ConnectionStatusBadge({
 
   return (
     <span
-      class="flex items-center gap-1 sm:gap-1.5 text-xs text-slate-600 dark:text-slate-400 min-w-0"
+      class="flex items-center gap-1 sm:gap-1.5 text-xs text-slate-600 dark:text-slate-400 shrink-0"
       data-testid="connection-status-badge"
+      title={label}
     >
       <span class={`inline-block h-2 w-2 shrink-0 rounded-full ${color}`} />
-      <span class="truncate" data-testid="connection-status-label">{label}</span>
+      <span class="hidden sm:inline truncate" data-testid="connection-status-label">{label}</span>
     </span>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,12 +132,11 @@ function ConnectionStatusBadge({
 
   return (
     <span
-      class="flex items-center gap-1 sm:gap-1.5 text-xs text-slate-600 dark:text-slate-400 shrink-0"
+      class="flex items-center gap-1 sm:gap-1.5 text-xs text-slate-600 dark:text-slate-400 min-w-0 shrink"
       data-testid="connection-status-badge"
-      title={label}
     >
       <span class={`inline-block h-2 w-2 shrink-0 rounded-full ${color}`} />
-      <span class="hidden sm:inline truncate" data-testid="connection-status-label">{label}</span>
+      <span class="truncate" data-testid="connection-status-label">{label}</span>
     </span>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -672,7 +672,7 @@ function ActiveView() {
           Offline — showing last snapshot
         </div>
       )}
-      <header class="flex items-center gap-1.5 sm:gap-2 px-2 sm:px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0 overflow-hidden">
+      <header class="flex items-center gap-1.5 sm:gap-2 px-2 sm:px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0 overflow-x-clip">
         <ConnectionPicker onManage={() => { showDrawer.value = true }} />
         <ConnectionStatusBadge status={store.status.value} reconnectAt={store.reconnectAt.value} />
         <div class="ml-auto flex items-center gap-1 sm:gap-1.5 shrink-0">

--- a/src/connections/ConnectionPicker.tsx
+++ b/src/connections/ConnectionPicker.tsx
@@ -65,13 +65,13 @@ export function ConnectionPicker({ onManage }: ConnectionPickerProps) {
   }, [open.value, open])
 
   return (
-    <div class="relative min-w-0 shrink" ref={containerRef}>
+    <div class="relative min-w-0 flex-1 max-w-[14rem]" ref={containerRef}>
       <button
         data-testid="connection-picker-trigger"
         onClick={handleToggle}
         aria-haspopup="listbox"
         aria-expanded={open.value}
-        class="flex items-center gap-1.5 rounded-full border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 sm:px-3 py-1.5 text-sm font-medium text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors min-w-0"
+        class="w-full flex items-center gap-1.5 rounded-full border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 sm:px-3 py-1.5 text-sm font-medium text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors min-w-0"
       >
         {activeConn ? (
           <>
@@ -80,12 +80,12 @@ export function ConnectionPicker({ onManage }: ConnectionPickerProps) {
               style={{ backgroundColor: activeConn.color }}
               data-testid="picker-active-dot"
             />
-            <span class="max-w-[80px] sm:max-w-[140px] truncate">{activeConn.label}</span>
+            <span class="flex-1 min-w-0 truncate text-left">{activeConn.label}</span>
           </>
         ) : (
-          <span class="text-slate-500">No connection</span>
+          <span class="flex-1 min-w-0 truncate text-left text-slate-500">No connection</span>
         )}
-        <span class="text-slate-400 text-xs">{open.value ? '▲' : '▼'}</span>
+        <span class="text-slate-400 text-xs shrink-0">{open.value ? '▲' : '▼'}</span>
       </button>
 
       {open.value && (


### PR DESCRIPTION
## Summary

Follow-up to #54. The ConnectionPicker dropdown is absolute-positioned below its trigger. With \`overflow-hidden\` on the parent header (added in PR #48 to guard against horizontal overflow), the dropdown gets clipped as soon as it extends past the header's bottom edge — so tapping the picker looked like nothing happened. The user interpreted this as \"it's behind the New task thingy\" because the thing visually below the header IS the New Task bar.

Switch to \`overflow-x-clip\`: still prevents the horizontal-overflow regression PR #48 was after, but lets vertically-overflowing descendants (the picker dropdown, any future menus anchored in the header) render past the header's bottom border.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test\` — 669 pass
- [ ] Manually: tap the connection picker on mobile, confirm the dropdown appears below the header and isn't clipped by the New Task bar
- [ ] Manually: confirm the header itself doesn't scroll horizontally at 360×640 (PR #48's regression test still covers this in CI)