### PR TITLE
[minions] feat(chat): syntax highlight JSON/diff/text tool results

### DIFF
--- a/src/chat/transcript/ToolResultBody.tsx
+++ b/src/chat/transcript/ToolResultBody.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from 'preact/hooks'
 import type { ToolResultEvent } from '../../api/types'
 import { MarkdownView } from '../../components/MarkdownView'
+import { highlight, resolveLanguage } from '../../components/highlight'
 
 interface Props {
   event: ToolResultEvent
@@ -58,7 +60,7 @@ function renderBody(event: ToolResultEvent) {
             class="max-w-[200px] max-h-[200px] rounded border border-slate-200 dark:border-slate-700"
           />
         ))}
-        {result.text && <ResultText text={result.text} format={result.format} />}
+        {result.text && <ResultText event={event} />}
       </div>
     )
   }
@@ -69,10 +71,13 @@ function renderBody(event: ToolResultEvent) {
       </div>
     )
   }
-  return <ResultText text={result.text} format={result.format} />
+  return <ResultText event={event} />
 }
 
-function ResultText({ text, format }: { text: string; format?: ToolResultEvent['result']['format'] }) {
+function ResultText({ event }: { event: ToolResultEvent }) {
+  const { result } = event
+  const text = result.text ?? ''
+  const format = result.format
   if (format === 'markdown') {
     return (
       <div class="px-3 py-2 max-h-96 overflow-auto" data-testid="transcript-tool-result-markdown">
@@ -84,24 +89,14 @@ function ResultText({ text, format }: { text: string; format?: ToolResultEvent['
     )
   }
   if (format === 'diff') {
-    return (
-      <pre
-        class="px-3 py-2 max-h-96 overflow-auto whitespace-pre font-mono text-[11px] text-slate-700 dark:text-slate-300 leading-snug"
-        data-testid="transcript-tool-result-diff"
-      >
-        {renderDiffLines(text)}
-      </pre>
-    )
+    return <CodeBlock text={text} lang="diff" testId="transcript-tool-result-diff" />
   }
   if (format === 'json') {
-    return (
-      <pre
-        class="px-3 py-2 max-h-96 overflow-auto whitespace-pre font-mono text-[11px] text-slate-700 dark:text-slate-300 leading-snug"
-        data-testid="transcript-tool-result-json"
-      >
-        {prettyJson(text)}
-      </pre>
-    )
+    return <CodeBlock text={prettyJson(text)} lang="json" testId="transcript-tool-result-json" />
+  }
+  const langHint = readLanguageHint(result.meta)
+  if (langHint && resolveLanguage(langHint)) {
+    return <CodeBlock text={text} lang={langHint} testId="transcript-tool-result-text" wrap />
   }
   return (
     <pre
@@ -111,6 +106,37 @@ function ResultText({ text, format }: { text: string; format?: ToolResultEvent['
       {text}
     </pre>
   )
+}
+
+function CodeBlock({
+  text,
+  lang,
+  testId,
+  wrap = false,
+}: {
+  text: string
+  lang: string
+  testId?: string
+  wrap?: boolean
+}) {
+  const html = useMemo(() => highlight(text, lang), [text, lang])
+  const resolved = resolveLanguage(lang)
+  const codeClass = resolved ? `hljs language-${resolved}` : 'hljs'
+  const whitespace = wrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre'
+  return (
+    <pre
+      class={`px-3 py-2 max-h-96 overflow-auto font-mono text-[11px] leading-snug bg-slate-900 text-slate-100 ${whitespace}`}
+      data-testid={testId}
+    >
+      <code class={codeClass} dangerouslySetInnerHTML={{ __html: html }} />
+    </pre>
+  )
+}
+
+function readLanguageHint(meta: Record<string, unknown> | undefined): string | undefined {
+  if (!meta) return undefined
+  const raw = meta.language
+  return typeof raw === 'string' && raw.trim() ? raw : undefined
 }
 
 function ResultMeta({ event }: { event: ToolResultEvent }) {
@@ -128,33 +154,6 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`
-}
-
-function renderDiffLines(text: string) {
-  const lines = text.split('\n')
-  return lines.map((line, idx) => {
-    const nl = idx < lines.length - 1 ? '\n' : ''
-    let cls = ''
-    if (line.startsWith('+++') || line.startsWith('---')) {
-      cls = 'text-slate-500 dark:text-slate-400 font-semibold'
-    } else if (line.startsWith('@@')) {
-      cls = 'text-sky-700 dark:text-sky-300'
-    } else if (line.startsWith('+')) {
-      cls = 'text-green-700 dark:text-green-400'
-    } else if (line.startsWith('-')) {
-      cls = 'text-red-700 dark:text-red-400'
-    } else if (line.startsWith('diff --git')) {
-      cls = 'text-slate-500 dark:text-slate-400 font-semibold'
-    }
-    if (!cls) {
-      return <span key={idx}>{line + nl}</span>
-    }
-    return (
-      <span key={idx} class={cls}>
-        {line + nl}
-      </span>
-    )
-  })
 }
 
 function prettyJson(text: string): string {

--- a/src/components/highlight.ts
+++ b/src/components/highlight.ts
@@ -147,7 +147,6 @@ const bash: Language = {
 
 const json: Language = {
   rules: [
-    { kind: 'string', re: /"(?:\\.|[^"\\])*"(?=\s*:)/ },
     { kind: 'property', re: /"(?:\\.|[^"\\])*"(?=\s*:)/ },
     { kind: 'string', re: /"(?:\\.|[^"\\])*"/ },
     { kind: 'number', re: /-?\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b/ },

--- a/test/chat/transcript/components.test.tsx
+++ b/test/chat/transcript/components.test.tsx
@@ -247,9 +247,63 @@ describe('ToolResultBody', () => {
     expect(screen.getByTestId('transcript-tool-result-diff')).toBeTruthy()
   })
 
+  it('syntax highlights diff lines with token classes', () => {
+    render(
+      <ToolResultBody
+        event={ev({
+          status: 'ok',
+          text: '--- a/foo\n+++ b/foo\n@@ -1,2 +1,2 @@\n-old line\n+new line',
+          format: 'diff',
+        })}
+      />,
+    )
+    const pre = screen.getByTestId('transcript-tool-result-diff')
+    expect(pre.querySelector('.tok-insertion')).toBeTruthy()
+    expect(pre.querySelector('.tok-deletion')).toBeTruthy()
+    expect(pre.querySelector('.tok-hunk')).toBeTruthy()
+  })
+
   it('pretty-prints JSON', () => {
     render(<ToolResultBody event={ev({ status: 'ok', text: '{"a":1,"b":2}', format: 'json' })} />)
     expect(screen.getByTestId('transcript-tool-result-json').textContent).toContain('"a": 1')
+  })
+
+  it('syntax highlights JSON tokens', () => {
+    render(<ToolResultBody event={ev({ status: 'ok', text: '{"a":1,"b":"x"}', format: 'json' })} />)
+    const pre = screen.getByTestId('transcript-tool-result-json')
+    expect(pre.querySelector('.tok-property')).toBeTruthy()
+    expect(pre.querySelector('.tok-number')).toBeTruthy()
+    expect(pre.querySelector('.tok-string')).toBeTruthy()
+  })
+
+  it('syntax highlights plain text when meta.language is set', () => {
+    render(
+      <ToolResultBody
+        event={ev({
+          status: 'ok',
+          text: 'const x = 1',
+          meta: { language: 'typescript' },
+        })}
+      />,
+    )
+    const pre = screen.getByTestId('transcript-tool-result-text')
+    expect(pre.querySelector('.tok-keyword')).toBeTruthy()
+    expect(pre.querySelector('.tok-number')).toBeTruthy()
+  })
+
+  it('falls back to plain text when meta.language is unknown', () => {
+    render(
+      <ToolResultBody
+        event={ev({
+          status: 'ok',
+          text: 'const x = 1',
+          meta: { language: 'not-a-real-language' },
+        })}
+      />,
+    )
+    const pre = screen.getByTestId('transcript-tool-result-text')
+    expect(pre.querySelector('.tok-keyword')).toBeNull()
+    expect(pre.textContent).toBe('const x = 1')
   })
 
   it('shows truncated badge when result.truncated', () => {


### PR DESCRIPTION
## Summary
- Route tool_result payloads through the existing `highlight()` tokenizer so JSON, diff, and language-hinted text outputs render with colored tokens on a dark slate code background, matching how markdown code blocks already render.
- Replace the bespoke `renderDiffLines` span renderer in `ToolResultBody` with the shared diff tokenizer (`tok-insertion` / `tok-deletion` / `tok-hunk`) for a single source of truth.
- Add a `meta.language` opt-in for plain-text results. When present and resolvable (e.g. `typescript`, `python`, `go`), the text is highlighted; otherwise it falls back to the existing plain `<pre>`.
- Fix a latent bug in `src/components/highlight.ts`: the JSON grammar had a duplicate string rule shadowing the property rule, so object keys never matched `tok-property`.

## Why
The chat transcript shows a lot of tool output that is effectively code — shell output, JSON blobs, diffs, file contents. Rendering it as flat monospaced text makes it hard to scan. The highlight infrastructure was already in place for markdown code fences; reusing it keeps the bundle size flat and the color palette consistent.

## Compatibility
No change to wire types. `meta.language` is an optional hint — if telegram-minions doesn't set it, tool results render exactly as before. JSON and diff formats were already being special-cased; they now just use the shared tokenizer.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run test/components/highlight.test.ts test/chat/transcript/components.test.tsx` (38/38 pass, including new tests that assert `.tok-property` / `.tok-number` / `.tok-string` for JSON, `.tok-insertion/deletion/hunk` for diff, and `.tok-keyword` for `meta.language: typescript`)
- [ ] Pre-existing `test/api/mock-minion-integration.test.ts` failures are ECONNREFUSED in the sandbox — unrelated to this change.