### PR TITLE
[minions] feat(chat): auto-highlight JSON/diff tool results (incl. orphans)

### DIFF
--- a/src/chat/transcript/ToolResultBody.tsx
+++ b/src/chat/transcript/ToolResultBody.tsx
@@ -98,6 +98,15 @@ function ResultText({ event }: { event: ToolResultEvent }) {
   if (langHint && resolveLanguage(langHint)) {
     return <CodeBlock text={text} lang={langHint} testId="transcript-tool-result-text" wrap />
   }
+  if (format === undefined) {
+    const detected = detectFormat(text)
+    if (detected === 'json') {
+      return <CodeBlock text={prettyJson(text)} lang="json" testId="transcript-tool-result-json" />
+    }
+    if (detected === 'diff') {
+      return <CodeBlock text={text} lang="diff" testId="transcript-tool-result-diff" />
+    }
+  }
   return (
     <pre
       class="px-3 py-2 max-h-96 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] text-slate-700 dark:text-slate-300 leading-snug"
@@ -106,6 +115,30 @@ function ResultText({ event }: { event: ToolResultEvent }) {
       {text}
     </pre>
   )
+}
+
+function detectFormat(text: string): 'json' | 'diff' | undefined {
+  const trimmed = text.trim()
+  if (!trimmed) return undefined
+  if (
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  ) {
+    try {
+      JSON.parse(trimmed)
+      return 'json'
+    } catch {
+      // not JSON — fall through
+    }
+  }
+  if (
+    /^diff --git /m.test(text) ||
+    /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/m.test(text) ||
+    (/^---[ \t]/m.test(text) && /^\+\+\+[ \t]/m.test(text))
+  ) {
+    return 'diff'
+  }
+  return undefined
 }
 
 function CodeBlock({

--- a/test/chat/transcript/components.test.tsx
+++ b/test/chat/transcript/components.test.tsx
@@ -5,6 +5,7 @@ import { AssistantTextBlock } from '../../../src/chat/transcript/AssistantTextBl
 import { ThinkingBlock } from '../../../src/chat/transcript/ThinkingBlock'
 import { ToolCallCard } from '../../../src/chat/transcript/ToolCallCard'
 import { ToolResultBody } from '../../../src/chat/transcript/ToolResultBody'
+import { ToolResultOrphan } from '../../../src/chat/transcript/ToolResultOrphan'
 import { StatusBanner } from '../../../src/chat/transcript/StatusBanner'
 import { TurnSeparator } from '../../../src/chat/transcript/TurnSeparator'
 import type {
@@ -306,6 +307,34 @@ describe('ToolResultBody', () => {
     expect(pre.textContent).toBe('const x = 1')
   })
 
+  it('auto-detects JSON payloads without an explicit format', () => {
+    render(<ToolResultBody event={ev({ status: 'ok', text: '{"a":1,"b":"x"}' })} />)
+    const pre = screen.getByTestId('transcript-tool-result-json')
+    expect(pre.querySelector('.tok-property')).toBeTruthy()
+    expect(pre.querySelector('.tok-number')).toBeTruthy()
+    expect(pre.textContent).toContain('"a": 1')
+  })
+
+  it('auto-detects unified diff payloads without an explicit format', () => {
+    render(
+      <ToolResultBody
+        event={ev({
+          status: 'ok',
+          text: '--- a/foo\n+++ b/foo\n@@ -1,2 +1,2 @@\n-old\n+new',
+        })}
+      />,
+    )
+    const pre = screen.getByTestId('transcript-tool-result-diff')
+    expect(pre.querySelector('.tok-insertion')).toBeTruthy()
+    expect(pre.querySelector('.tok-deletion')).toBeTruthy()
+  })
+
+  it('leaves non-json, non-diff text as plain when no format is set', () => {
+    render(<ToolResultBody event={ev({ status: 'ok', text: 'not json { oops' })} />)
+    const pre = screen.getByTestId('transcript-tool-result-text')
+    expect(pre.textContent).toBe('not json { oops')
+  })
+
   it('shows truncated badge when result.truncated', () => {
     render(<ToolResultBody event={ev({ status: 'ok', text: 'x', truncated: true, originalBytes: 5000 })} />)
     expect(screen.getByText('truncated')).toBeTruthy()
@@ -317,6 +346,35 @@ describe('ToolResultBody', () => {
     const imgs = screen.getByTestId('transcript-tool-result-images').querySelectorAll('img')
     expect(imgs).toHaveLength(1)
     expect(imgs[0].getAttribute('src')).toBe('https://example.com/x.png')
+  })
+})
+
+describe('ToolResultOrphan', () => {
+  function orphan(result: ToolResultEvent['result']): ToolResultEvent {
+    return {
+      ...baseEvent(1),
+      type: 'tool_result',
+      toolUseId: 'tu-missing',
+      result,
+    }
+  }
+
+  it('syntax highlights JSON bodies even when there is no matching call', () => {
+    render(<ToolResultOrphan event={orphan({ status: 'ok', text: '{"x":1}' })} />)
+    const pre = screen.getByTestId('transcript-tool-result-json')
+    expect(pre.querySelector('.tok-property')).toBeTruthy()
+    expect(pre.querySelector('.tok-number')).toBeTruthy()
+  })
+
+  it('honors the explicit diff format on orphaned results', () => {
+    render(
+      <ToolResultOrphan
+        event={orphan({ status: 'ok', text: '+ added\n- removed', format: 'diff' })}
+      />,
+    )
+    const pre = screen.getByTestId('transcript-tool-result-diff')
+    expect(pre.querySelector('.tok-insertion')).toBeTruthy()
+    expect(pre.querySelector('.tok-deletion')).toBeTruthy()
   })
 })
 


### PR DESCRIPTION
## Summary

Tool result events without an explicit `format` field now get automatic JSON or diff highlighting via content sniffing. This is especially valuable for orphaned tool results where the renderer has no tool-call context but can still infer the appropriate visual treatment by examining the content itself, matching the behavior already applied when `format` is explicitly set.

## Changes

- Added `detectFormat()` function to `ToolResultBody` to sniff content for JSON or diff patterns
- Updated `ToolResultBody` to apply detected format when explicit format is missing
- Added comprehensive tests for auto-detection path and `ToolResultOrphan` scenarios

## Test plan

- All existing tests pass (687 passed, 56 files)
- Type checking clean (`npx tsc --noEmit`)
- Linting clean (`npm run lint`)
- New tests validate JSON and diff auto-detection for both regular and orphaned tool results

🤖 Generated with Claude Code