### PR TITLE
feat(resource-tracking): live metrics chip + runtime-config drawer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import { connections, activeId, getActiveStore } from './connections/store'
 import { ConnectionSettings } from './connections/ConnectionSettings'
 import { ConnectionPicker } from './connections/ConnectionPicker'
 import { ConnectionsDrawer } from './connections/ConnectionsDrawer'
+import { ResourceChip } from './components/ResourceChip'
+import { RuntimeConfigDrawer, type RuntimeTab } from './settings/RuntimeConfigDrawer'
 import { Transcript, TranscriptUpgradeNotice } from './chat/transcript'
 import { MessageInput } from './chat/MessageInput'
 import { NewTaskBar } from './chat/NewTaskBar'
@@ -39,6 +41,7 @@ export type ViewMode = 'list' | 'canvas' | 'ship'
 
 const showSettings = signal(false)
 const showDrawer = signal(false)
+const showRuntime = signal<RuntimeTab | null>(null)
 export const viewMode = signal<ViewMode>('list')
 
 function ViewToggle({ mode, onChange }: { mode: ViewMode; onChange: (m: ViewMode) => void }) {
@@ -687,9 +690,24 @@ function ActiveView() {
       <header class="flex items-center gap-1.5 sm:gap-2 px-2 sm:px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0 overflow-x-clip">
         <ConnectionPicker onManage={() => { showDrawer.value = true }} />
         <ConnectionStatusBadge status={store.status.value} reconnectAt={store.reconnectAt.value} />
+        {hasFeature(store, 'resource-metrics') && (
+          <ResourceChip store={store} onOpen={() => { showRuntime.value = 'resources' }} />
+        )}
         <div class="ml-auto flex items-center gap-1 sm:gap-1.5 shrink-0">
           <ViewToggle mode={mode} onChange={(m) => { viewMode.value = m }} />
           <ThemeToggle />
+          {hasFeature(store, 'runtime-config') && (
+            <button
+              type="button"
+              onClick={() => { showRuntime.value = 'config' }}
+              class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
+              title="Runtime config"
+              aria-label="Open runtime config"
+              data-testid="header-runtime-config-btn"
+            >
+              <span aria-hidden="true">⚙️</span>
+            </button>
+          )}
           {hasFeature(store, 'messages') && (
             <button
               type="button"
@@ -821,6 +839,13 @@ function ActiveView() {
       )}
       {showDrawer.value && (
         <ConnectionsDrawer onClose={() => { showDrawer.value = false }} />
+      )}
+      {showRuntime.value !== null && (
+        <RuntimeConfigDrawer
+          store={store}
+          initialTab={showRuntime.value}
+          onClose={() => { showRuntime.value = null }}
+        />
       )}
     </div>
   )

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -10,6 +10,9 @@ import type {
   PrPreview,
   PushSubscribeAck,
   PushSubscriptionJSON,
+  ResourceSnapshot,
+  RuntimeConfigResponse,
+  RuntimeOverrides,
   ScreenshotList,
   TranscriptSnapshot,
   VapidPublicKey,
@@ -47,6 +50,9 @@ export interface ApiClient {
   getVapidKey(): Promise<VapidPublicKey>
   subscribePush(sub: PushSubscriptionJSON): Promise<PushSubscribeAck>
   unsubscribePush(endpoint: string): Promise<{ ok: true }>
+  getMetrics(): Promise<ResourceSnapshot>
+  getRuntimeConfig(): Promise<RuntimeConfigResponse>
+  patchRuntimeConfig(patch: RuntimeOverrides): Promise<RuntimeConfigResponse>
   openEventStream(handlers: SseHandlers): EventStreamHandle
   baseUrl: string
   token: string
@@ -78,6 +84,19 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
   async function post<T>(path: string, data: unknown): Promise<T> {
     const res = await fetch(`${baseUrl}${path}`, {
       method: 'POST',
+      headers: headers(),
+      body: JSON.stringify(data),
+    })
+    const body = (await res.json()) as ApiResponse<T>
+    if (!res.ok || body.error) {
+      throw new ApiError(res.status, body.error ?? res.statusText)
+    }
+    return body.data
+  }
+
+  async function patch<T>(path: string, data: unknown): Promise<T> {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: 'PATCH',
       headers: headers(),
       body: JSON.stringify(data),
     })
@@ -177,6 +196,18 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
 
     unsubscribePush(endpoint: string) {
       return del<{ ok: true }>('/api/push-subscribe', { endpoint })
+    },
+
+    getMetrics() {
+      return get<ResourceSnapshot>('/api/metrics')
+    },
+
+    getRuntimeConfig() {
+      return get<RuntimeConfigResponse>('/api/config/runtime')
+    },
+
+    patchRuntimeConfig(patchBody: RuntimeOverrides) {
+      return patch<RuntimeConfigResponse>('/api/config/runtime', patchBody)
     },
 
     openEventStream(handlers: SseHandlers): EventStreamHandle {

--- a/src/api/features.ts
+++ b/src/api/features.ts
@@ -11,6 +11,8 @@ export type FeatureName =
   | 'web-push'
   | 'worktree-stats'
   | 'transcript'
+  | 'resource-metrics'
+  | 'runtime-config'
 
 export function hasFeature(
   source: ConnectionStore | VersionInfo | null | undefined,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -58,6 +58,111 @@ export type SseEvent =
   | { type: 'dag_updated'; dag: ApiDagGraph }
   | { type: 'dag_deleted'; dagId: string }
   | { type: 'transcript_event'; sessionId: string; event: TranscriptEvent }
+  | { type: 'resource'; snapshot: ResourceSnapshot }
+
+export type LimitSource = 'cgroup' | 'host'
+
+export interface CpuSnapshot {
+  usagePercent: number
+  cpuCount: number
+  source: LimitSource
+}
+
+export interface MemorySnapshot {
+  usedBytes: number
+  limitBytes: number
+  rssBytes: number
+  source: LimitSource
+}
+
+export interface DiskSnapshot {
+  path: string
+  usedBytes: number
+  totalBytes: number
+}
+
+export interface CountsSnapshot {
+  activeSessions: number
+  maxSessions: number
+  activeLoops: number
+  maxLoops: number
+}
+
+export interface ResourceSnapshot {
+  ts: number
+  cpu: CpuSnapshot
+  memory: MemorySnapshot
+  disk: DiskSnapshot
+  eventLoopLagMs: number
+  counts: CountsSnapshot
+}
+
+export type OverrideFieldType = 'number' | 'boolean'
+export type OverrideApply = 'live' | 'restart'
+export type OverrideCategory = 'loops' | 'concurrency' | 'features'
+
+export interface OverrideField {
+  key: string
+  label: string
+  type: OverrideFieldType
+  category: OverrideCategory
+  apply: OverrideApply
+  min?: number
+  max?: number
+  integer?: boolean
+  description?: string
+}
+
+export interface LoopMeta {
+  id: string
+  name: string
+  defaultIntervalMs: number
+  defaultEnabled: boolean
+}
+
+export interface RuntimeOverridesSchema {
+  fields: OverrideField[]
+  loops: LoopMeta[]
+}
+
+export interface LoopOverride {
+  enabled?: boolean
+  intervalMs?: number
+}
+
+export interface RuntimeOverrides {
+  loops?: Record<string, LoopOverride>
+  workspace?: {
+    maxConcurrentSessions?: number
+  }
+  loopsConfig?: {
+    maxConcurrentLoops?: number
+    reservedInteractiveSlots?: number
+  }
+  mcp?: {
+    browserEnabled?: boolean
+    githubEnabled?: boolean
+    context7Enabled?: boolean
+    sentryEnabled?: boolean
+    supabaseEnabled?: boolean
+    flyEnabled?: boolean
+    zaiEnabled?: boolean
+  }
+  ci?: {
+    babysitEnabled?: boolean
+  }
+  quota?: {
+    retryMax?: number
+    defaultSleepMs?: number
+  }
+}
+
+export interface RuntimeConfigResponse {
+  base: Record<string, unknown>
+  overrides: RuntimeOverrides
+  schema: RuntimeOverridesSchema
+  requiresRestart?: string[]
+}
 
 export type MinionCommand =
   | { action: 'reply'; sessionId: string; message: string }

--- a/src/components/ResourceChip.tsx
+++ b/src/components/ResourceChip.tsx
@@ -1,0 +1,70 @@
+import type { ConnectionStore } from '../state/types'
+
+interface Props {
+  store: ConnectionStore
+  onOpen?: () => void
+}
+
+export function ResourceChip({ store, onOpen }: Props) {
+  const snap = store.resourceSnapshot.value
+  if (!snap) {
+    return (
+      <button
+        type="button"
+        onClick={onOpen}
+        class="rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 h-7 px-2 flex items-center gap-1 text-[10px] font-medium text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700"
+        data-testid="resource-chip"
+        title="Resource metrics — waiting for first snapshot"
+      >
+        <span class="inline-block h-2 w-2 rounded-full bg-slate-400" />
+        <span class="hidden sm:inline">waiting…</span>
+      </button>
+    )
+  }
+  const cpuPct = snap.cpu.usagePercent
+  const memPct = snap.memory.limitBytes > 0 ? (snap.memory.usedBytes / snap.memory.limitBytes) * 100 : 0
+  const worst = Math.max(cpuPct, memPct)
+  const dot =
+    worst >= 85 ? 'bg-red-500'
+    : worst >= 50 ? 'bg-amber-500'
+    : 'bg-green-500'
+
+  const memLabel = formatBytesCompact(snap.memory.usedBytes) + '/' + formatBytesCompact(snap.memory.limitBytes)
+
+  const titleLines = [
+    `CPU ${cpuPct.toFixed(0)}% (${snap.cpu.cpuCount} × ${snap.cpu.source})`,
+    `Mem ${memLabel} (${snap.memory.source})`,
+    `Disk ${formatBytesCompact(snap.disk.usedBytes)}/${formatBytesCompact(snap.disk.totalBytes)}`,
+    `Loop lag ${snap.eventLoopLagMs.toFixed(1)}ms`,
+    `Sessions ${snap.counts.activeSessions}/${snap.counts.maxSessions}`,
+    `Loops ${snap.counts.activeLoops}/${snap.counts.maxLoops}`,
+  ].join('\n')
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      class="rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 h-7 px-2 flex items-center gap-1.5 text-[10px] font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 tabular-nums"
+      data-testid="resource-chip"
+      title={titleLines}
+      aria-label="Open resource metrics"
+    >
+      <span class={`inline-block h-2 w-2 rounded-full ${dot}`} />
+      <span class="hidden sm:inline">{cpuPct.toFixed(0)}%</span>
+      <span class="hidden md:inline text-slate-400 dark:text-slate-500">·</span>
+      <span class="hidden md:inline">{memPct.toFixed(0)}%</span>
+    </button>
+  )
+}
+
+function formatBytesCompact(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '—'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit++
+  }
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`
+}

--- a/src/components/ResourcePanel.tsx
+++ b/src/components/ResourcePanel.tsx
@@ -1,0 +1,103 @@
+import type { ResourceSnapshot } from '../api/types'
+
+interface Props {
+  snapshot: ResourceSnapshot | null
+}
+
+export function ResourcePanel({ snapshot }: Props) {
+  if (!snapshot) {
+    return (
+      <div class="p-4 text-sm text-slate-500 dark:text-slate-400" data-testid="resource-panel-empty">
+        Waiting for the first snapshot…
+      </div>
+    )
+  }
+
+  const cpuPct = snapshot.cpu.usagePercent
+  const memPct = snapshot.memory.limitBytes > 0
+    ? (snapshot.memory.usedBytes / snapshot.memory.limitBytes) * 100
+    : 0
+  const diskPct = snapshot.disk.totalBytes > 0
+    ? (snapshot.disk.usedBytes / snapshot.disk.totalBytes) * 100
+    : 0
+
+  return (
+    <div class="p-4 space-y-4" data-testid="resource-panel">
+      <Bar
+        label="CPU"
+        percent={cpuPct}
+        suffix={`${cpuPct.toFixed(1)}% of ${snapshot.cpu.cpuCount} ${snapshot.cpu.cpuCount === 1 ? 'core' : 'cores'} (${snapshot.cpu.source})`}
+      />
+      <Bar
+        label="Memory"
+        percent={memPct}
+        suffix={`${formatBytes(snapshot.memory.usedBytes)} / ${formatBytes(snapshot.memory.limitBytes)} (${snapshot.memory.source === 'cgroup' ? 'container limit' : 'no container limit — host total'})`}
+      />
+      <Bar
+        label={`Disk (${snapshot.disk.path})`}
+        percent={diskPct}
+        suffix={`${formatBytes(snapshot.disk.usedBytes)} / ${formatBytes(snapshot.disk.totalBytes)}`}
+      />
+
+      <dl class="grid grid-cols-2 gap-2 text-xs">
+        <Stat label="Process RSS" value={formatBytes(snapshot.memory.rssBytes)} />
+        <Stat label="Event-loop lag" value={`${snapshot.eventLoopLagMs.toFixed(2)} ms`} />
+        <Stat
+          label="Active sessions"
+          value={`${snapshot.counts.activeSessions} / ${snapshot.counts.maxSessions}`}
+        />
+        <Stat
+          label="Active loops"
+          value={`${snapshot.counts.activeLoops} / ${snapshot.counts.maxLoops}`}
+        />
+      </dl>
+
+      <div class="text-[10px] text-slate-500 dark:text-slate-400">
+        Last update: {new Date(snapshot.ts).toLocaleTimeString()}
+      </div>
+    </div>
+  )
+}
+
+function Bar({ label, percent, suffix }: { label: string; percent: number; suffix: string }) {
+  const clamped = Math.max(0, Math.min(100, percent))
+  const color =
+    clamped >= 85 ? 'bg-red-500'
+    : clamped >= 50 ? 'bg-amber-500'
+    : 'bg-green-500'
+  return (
+    <div>
+      <div class="flex items-center justify-between text-xs text-slate-700 dark:text-slate-200 mb-1">
+        <span class="font-medium">{label}</span>
+        <span class="text-slate-500 dark:text-slate-400 tabular-nums">{suffix}</span>
+      </div>
+      <div class="h-2 rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden">
+        <div
+          class={`h-full ${color} transition-all`}
+          style={{ width: `${clamped}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div class="flex flex-col gap-0.5 rounded-md border border-slate-200 dark:border-slate-700 p-2">
+      <dt class="text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</dt>
+      <dd class="text-sm font-medium tabular-nums text-slate-900 dark:text-slate-100">{value}</dd>
+    </div>
+  )
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit++
+  }
+  return `${value < 10 ? value.toFixed(2) : value.toFixed(1)} ${units[unit]}`
+}

--- a/src/settings/RuntimeConfigDrawer.tsx
+++ b/src/settings/RuntimeConfigDrawer.tsx
@@ -1,0 +1,180 @@
+import { useSignal } from '@preact/signals'
+import { useEffect, useCallback } from 'preact/hooks'
+import type { ConnectionStore } from '../state/types'
+import { useMediaQuery } from '../hooks/useMediaQuery'
+import { useTheme } from '../hooks/useTheme'
+import { ResourcePanel } from '../components/ResourcePanel'
+import { RuntimeConfigForm } from './RuntimeConfigForm'
+import { hasFeature } from '../api/features'
+
+interface Props {
+  store: ConnectionStore
+  initialTab?: RuntimeTab
+  onClose: () => void
+}
+
+export type RuntimeTab = 'resources' | 'config'
+
+export function RuntimeConfigDrawer({ store, initialTab = 'resources', onClose }: Props) {
+  const theme = useTheme()
+  const isDark = theme.value === 'dark'
+  const isDesktop = useMediaQuery('(min-width: 768px)')
+  const tab = useSignal<RuntimeTab>(initialTab)
+
+  const hasConfig = hasFeature(store, 'runtime-config')
+  const hasMetrics = hasFeature(store, 'resource-metrics')
+
+  useEffect(() => {
+    if (hasConfig && !store.runtimeConfig.value) {
+      void store.refreshRuntimeConfig()
+    }
+  }, [hasConfig])
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  const handleSubmit = useCallback(
+    async (patch: Parameters<ConnectionStore['updateRuntimeConfig']>[0]) => {
+      await store.updateRuntimeConfig(patch)
+    },
+    [store],
+  )
+
+  const panelBg = isDark ? 'bg-gray-800' : 'bg-white'
+  const borderColor = isDark ? 'border-gray-700' : 'border-gray-200'
+
+  const inner = (
+    <div class={`flex flex-col h-full ${panelBg}`} data-testid="runtime-config-drawer">
+      <header class={`flex items-center gap-2 px-4 py-3 border-b shrink-0 ${borderColor}`}>
+        <span class={`flex-1 font-semibold text-sm ${isDark ? 'text-white' : 'text-slate-900'}`}>
+          Runtime
+        </span>
+        <button
+          onClick={onClose}
+          class={`w-7 h-7 flex items-center justify-center rounded-full transition-colors ${isDark ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-100 text-slate-500'}`}
+          aria-label="Close drawer"
+          data-testid="runtime-config-close"
+        >
+          <span class="text-lg leading-none">&times;</span>
+        </button>
+      </header>
+
+      <div class={`flex border-b shrink-0 ${borderColor}`}>
+        <TabButton
+          label="Resources"
+          active={tab.value === 'resources'}
+          disabled={!hasMetrics}
+          onClick={() => { tab.value = 'resources' }}
+          testId="runtime-tab-resources"
+        />
+        <TabButton
+          label="Config"
+          active={tab.value === 'config'}
+          disabled={!hasConfig}
+          onClick={() => { tab.value = 'config' }}
+          testId="runtime-tab-config"
+        />
+      </div>
+
+      <div class="flex-1 overflow-y-auto">
+        {tab.value === 'resources' && (
+          hasMetrics ? (
+            <ResourcePanel snapshot={store.resourceSnapshot.value} />
+          ) : (
+            <UnavailableNotice label="Resource metrics" />
+          )
+        )}
+        {tab.value === 'config' && (
+          hasConfig ? (
+            store.runtimeConfig.value ? (
+              <div class="p-4">
+                <RuntimeConfigForm
+                  config={store.runtimeConfig.value}
+                  onSubmit={handleSubmit}
+                />
+              </div>
+            ) : (
+              <div class="p-4 text-sm text-slate-500 dark:text-slate-400">Loading…</div>
+            )
+          ) : (
+            <UnavailableNotice label="Runtime config" />
+          )
+        )}
+      </div>
+    </div>
+  )
+
+  if (isDesktop.value) {
+    return (
+      <div class="fixed inset-x-0 top-0 z-50 flex h-[100dvh]">
+        <div
+          class="absolute inset-0 bg-black/50"
+          data-testid="runtime-config-backdrop"
+          onClick={onClose}
+        />
+        <div class={`relative ml-auto w-full max-w-md h-full shadow-2xl flex flex-col border-l ${borderColor} ${panelBg}`}>
+          {inner}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div class="fixed inset-x-0 top-0 z-50 h-[100dvh]">
+      <div
+        class="absolute inset-0 bg-black/50"
+        data-testid="runtime-config-backdrop"
+        onClick={onClose}
+      />
+      <div class={`absolute bottom-0 left-0 right-0 rounded-t-2xl shadow-2xl flex flex-col border-t max-h-[85dvh] ${borderColor} ${panelBg}`}>
+        <div class="flex justify-center pt-2 pb-1 shrink-0">
+          <div class={`w-10 h-1 rounded-full ${isDark ? 'bg-gray-600' : 'bg-gray-300'}`} />
+        </div>
+        {inner}
+      </div>
+    </div>
+  )
+}
+
+function TabButton({
+  label,
+  active,
+  disabled,
+  onClick,
+  testId,
+}: {
+  label: string
+  active: boolean
+  disabled?: boolean
+  onClick: () => void
+  testId: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      class={`flex-1 px-3 py-2 text-xs font-medium border-b-2 transition-colors ${
+        active
+          ? 'border-indigo-600 text-indigo-700 dark:text-indigo-300'
+          : 'border-transparent text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-200'
+      } ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
+      data-testid={testId}
+    >
+      {label}
+    </button>
+  )
+}
+
+function UnavailableNotice({ label }: { label: string }) {
+  return (
+    <div class="p-4 text-xs text-slate-500 dark:text-slate-400">
+      {label} is not available on this minion (backend library is out of date).
+    </div>
+  )
+}

--- a/src/settings/RuntimeConfigForm.tsx
+++ b/src/settings/RuntimeConfigForm.tsx
@@ -1,0 +1,329 @@
+import { useSignal, useComputed } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import type {
+  LoopOverride,
+  OverrideField,
+  RuntimeConfigResponse,
+  RuntimeOverrides,
+} from '../api/types'
+
+interface Props {
+  config: RuntimeConfigResponse
+  onSubmit: (patch: RuntimeOverrides) => Promise<void>
+  onDirtyChange?: (dirty: boolean) => void
+}
+
+type DraftValue = number | boolean
+
+export function RuntimeConfigForm({ config, onSubmit, onDirtyChange }: Props) {
+  const draft = useSignal<Record<string, DraftValue>>(buildInitialDraft(config))
+  const saving = useSignal(false)
+  const errorMessage = useSignal<string | null>(null)
+  const successKey = useSignal(0)
+
+  useEffect(() => {
+    draft.value = buildInitialDraft(config)
+    errorMessage.value = null
+  }, [config.base, config.overrides, config.schema])
+
+  const dirty = useComputed(() => hasDirtyFields(draft.value, config))
+  useEffect(() => {
+    onDirtyChange?.(dirty.value)
+  }, [dirty.value])
+
+  const byCategory = useComputed(() => {
+    const map = new Map<string, OverrideField[]>()
+    for (const f of config.schema.fields) {
+      const arr = map.get(f.category) ?? []
+      arr.push(f)
+      map.set(f.category, arr)
+    }
+    return map
+  })
+
+  const restartTouched = useComputed(() => {
+    return config.schema.fields
+      .filter((f) => f.apply === 'restart')
+      .filter((f) => fieldIsDirty(f, draft.value, config))
+      .map((f) => f.key)
+  })
+
+  async function save() {
+    saving.value = true
+    errorMessage.value = null
+    try {
+      const patch = buildPatch(draft.value, config)
+      await onSubmit(patch)
+      successKey.value += 1
+    } catch (err) {
+      errorMessage.value = err instanceof Error ? err.message : String(err)
+    } finally {
+      saving.value = false
+    }
+  }
+
+  function reset() {
+    draft.value = buildInitialDraft(config)
+    errorMessage.value = null
+  }
+
+  return (
+    <div class="flex flex-col gap-4" data-testid="runtime-config-form">
+      {(config.requiresRestart ?? []).length > 0 && (
+        <div
+          class="rounded-md border border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-200 p-3 text-xs"
+          data-testid="runtime-config-restart-banner"
+          key={successKey.value}
+        >
+          <div class="font-medium">Restart required to apply:</div>
+          <ul class="mt-1 list-disc list-inside">
+            {(config.requiresRestart ?? []).map((k) => (
+              <li key={k}><code>{k}</code></li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {['loops', 'concurrency', 'features'].map((cat) => {
+        const fields = byCategory.value.get(cat) ?? []
+        if (fields.length === 0) return null
+        return (
+          <section key={cat} data-testid={`runtime-config-section-${cat}`}>
+            <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">
+              {cat === 'loops' ? 'Loops' : cat === 'concurrency' ? 'Concurrency & quota' : 'Feature toggles'}
+            </h3>
+            <div class="flex flex-col gap-3">
+              {fields.map((field) => (
+                <FieldRow
+                  key={field.key}
+                  field={field}
+                  value={draft.value[field.key]}
+                  base={baseValueFor(field, config)}
+                  hasOverride={overrideValueFor(field, config) !== undefined}
+                  onChange={(val) => {
+                    draft.value = { ...draft.value, [field.key]: val }
+                  }}
+                  onClear={() => {
+                    const next = { ...draft.value, [field.key]: baseValueFor(field, config) as DraftValue }
+                    draft.value = next
+                  }}
+                />
+              ))}
+            </div>
+          </section>
+        )
+      })}
+
+      {restartTouched.value.length > 0 && (
+        <div class="text-xs text-amber-700 dark:text-amber-300" data-testid="runtime-config-dirty-restart">
+          Pending: {restartTouched.value.join(', ')} will take effect on next container restart.
+        </div>
+      )}
+
+      {errorMessage.value && (
+        <div class="rounded-md border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-200 px-3 py-2 text-xs" data-testid="runtime-config-error">
+          {errorMessage.value}
+        </div>
+      )}
+
+      <div class="flex items-center gap-2 sticky bottom-0 bg-white dark:bg-slate-800 pt-2">
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={!dirty.value || saving.value}
+          class="rounded-md bg-indigo-600 text-white px-3 py-1.5 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-indigo-700"
+          data-testid="runtime-config-save"
+        >
+          {saving.value ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          type="button"
+          onClick={reset}
+          disabled={!dirty.value || saving.value}
+          class="rounded-md border border-slate-300 dark:border-slate-600 px-3 py-1.5 text-sm font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          data-testid="runtime-config-reset"
+        >
+          Revert
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function FieldRow({
+  field,
+  value,
+  base,
+  hasOverride,
+  onChange,
+  onClear,
+}: {
+  field: OverrideField
+  value: DraftValue
+  base: DraftValue
+  hasOverride: boolean
+  onChange: (val: DraftValue) => void
+  onClear: () => void
+}) {
+  const isBoolean = field.type === 'boolean'
+  const isInterval = field.key.endsWith('.intervalMs')
+
+  return (
+    <label class="flex flex-col gap-1" data-testid={`runtime-config-field-${field.key}`}>
+      <div class="flex items-center justify-between gap-2">
+        <span class="text-sm text-slate-800 dark:text-slate-100">{field.label}</span>
+        <div class="flex items-center gap-1">
+          {field.apply === 'restart' && (
+            <span class="text-[10px] font-medium uppercase tracking-wide rounded bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300 px-1.5 py-0.5">
+              restart
+            </span>
+          )}
+          {hasOverride && (
+            <button
+              type="button"
+              onClick={onClear}
+              class="text-[10px] text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white underline"
+              data-testid={`runtime-config-reset-${field.key}`}
+            >
+              reset
+            </button>
+          )}
+        </div>
+      </div>
+      {isBoolean ? (
+        <input
+          type="checkbox"
+          class="h-4 w-4 self-start"
+          checked={Boolean(value)}
+          onChange={(e) => onChange((e.target as HTMLInputElement).checked)}
+        />
+      ) : (
+        <div class="flex items-center gap-2">
+          <input
+            type="number"
+            class="w-32 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1 text-sm font-mono"
+            value={Number(value)}
+            min={field.min}
+            max={field.max}
+            step={field.integer ? 1 : undefined}
+            onInput={(e) => {
+              const raw = (e.target as HTMLInputElement).value
+              const n = Number(raw)
+              if (Number.isFinite(n)) onChange(field.integer ? Math.trunc(n) : n)
+            }}
+          />
+          {isInterval && typeof value === 'number' && (
+            <span class="text-[10px] text-slate-500 dark:text-slate-400">≈ {humanizeInterval(value)}</span>
+          )}
+          <span class="text-[10px] text-slate-400 dark:text-slate-500">default {String(base)}</span>
+        </div>
+      )}
+      {field.description && (
+        <span class="text-[10px] text-slate-500 dark:text-slate-400">{field.description}</span>
+      )}
+    </label>
+  )
+}
+
+function buildInitialDraft(config: RuntimeConfigResponse): Record<string, DraftValue> {
+  const draft: Record<string, DraftValue> = {}
+  for (const field of config.schema.fields) {
+    const override = overrideValueFor(field, config)
+    draft[field.key] = (override ?? baseValueFor(field, config)) as DraftValue
+  }
+  return draft
+}
+
+function baseValueFor(field: OverrideField, config: RuntimeConfigResponse): DraftValue {
+  const parts = field.key.split('.')
+  if (parts[0] === 'loops' && parts.length === 3) {
+    const meta = config.schema.loops.find((l) => l.id === parts[1])
+    const baseLoops = (config.base.loops ?? {}) as Record<string, { enabled?: boolean; intervalMs?: number }>
+    const baseLoop = baseLoops[parts[1]]
+    if (parts[2] === 'enabled') return baseLoop?.enabled ?? meta?.defaultEnabled ?? true
+    if (parts[2] === 'intervalMs') return baseLoop?.intervalMs ?? meta?.defaultIntervalMs ?? 60_000
+  }
+  const v = getAtPath(config.base, parts)
+  if (field.type === 'boolean') return Boolean(v)
+  return typeof v === 'number' ? v : 0
+}
+
+function overrideValueFor(field: OverrideField, config: RuntimeConfigResponse): DraftValue | undefined {
+  const parts = field.key.split('.')
+  const v = getAtPath(config.overrides as unknown as Record<string, unknown>, parts)
+  if (v === undefined) return undefined
+  if (field.type === 'boolean') return Boolean(v)
+  return typeof v === 'number' ? v : undefined
+}
+
+function hasDirtyFields(draft: Record<string, DraftValue>, config: RuntimeConfigResponse): boolean {
+  for (const field of config.schema.fields) {
+    if (fieldIsDirty(field, draft, config)) return true
+  }
+  return false
+}
+
+function fieldIsDirty(
+  field: OverrideField,
+  draft: Record<string, DraftValue>,
+  config: RuntimeConfigResponse,
+): boolean {
+  const effective = overrideValueFor(field, config) ?? baseValueFor(field, config)
+  return draft[field.key] !== effective
+}
+
+function buildPatch(
+  draft: Record<string, DraftValue>,
+  config: RuntimeConfigResponse,
+): RuntimeOverrides {
+  const patch: RuntimeOverrides = {}
+  for (const field of config.schema.fields) {
+    if (!fieldIsDirty(field, draft, config)) continue
+    const base = baseValueFor(field, config)
+    const value = draft[field.key]
+    const parts = field.key.split('.')
+
+    if (parts[0] === 'loops' && parts.length === 3) {
+      patch.loops = patch.loops ?? {}
+      const loopPatch: LoopOverride = patch.loops[parts[1]] ?? {}
+      if (parts[2] === 'enabled') loopPatch.enabled = Boolean(value)
+      if (parts[2] === 'intervalMs') loopPatch.intervalMs = Number(value)
+      patch.loops[parts[1]] = loopPatch
+      continue
+    }
+
+    if (value === base) continue
+    assignAtPath(patch as unknown as Record<string, unknown>, parts, value)
+  }
+  return patch
+}
+
+function getAtPath(root: Record<string, unknown> | undefined, parts: string[]): unknown {
+  let cursor: unknown = root
+  for (const p of parts) {
+    if (!cursor || typeof cursor !== 'object') return undefined
+    cursor = (cursor as Record<string, unknown>)[p]
+  }
+  return cursor
+}
+
+function assignAtPath(
+  root: Record<string, unknown>,
+  parts: string[],
+  value: DraftValue,
+): void {
+  let cursor: Record<string, unknown> = root
+  for (let i = 0; i < parts.length - 1; i++) {
+    const p = parts[i]
+    if (!cursor[p] || typeof cursor[p] !== 'object') cursor[p] = {}
+    cursor = cursor[p] as Record<string, unknown>
+  }
+  cursor[parts[parts.length - 1]] = value
+}
+
+function humanizeInterval(ms: number): string {
+  if (ms < 60_000) return `${(ms / 1000).toFixed(0)}s`
+  if (ms < 3_600_000) return `${(ms / 60_000).toFixed(0)}m`
+  if (ms < 86_400_000) return `${(ms / 3_600_000).toFixed(1)}h`
+  return `${(ms / 86_400_000).toFixed(1)}d`
+}

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,6 +1,11 @@
 import { signal } from '@preact/signals'
 import type { ApiClient } from '../api/client'
-import type { SseEvent } from '../api/types'
+import type {
+  ResourceSnapshot,
+  RuntimeConfigResponse,
+  RuntimeOverrides,
+  SseEvent,
+} from '../api/types'
 import type { SseStatus } from '../api/sse'
 import type { ConnectionStore, DiffStats } from './types'
 import { loadSnapshot, saveSnapshot } from './persist'
@@ -16,6 +21,8 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
   const diffStatsBySessionId = signal<Map<string, DiffStats>>(new Map())
   const diffStatsInFlight = new Set<string>()
   const transcripts = new Map<string, TranscriptStore>()
+  const resourceSnapshot = signal<ResourceSnapshot | null>(null)
+  const runtimeConfig = signal<RuntimeConfigResponse | null>(null)
 
   function getTranscript(sessionId: string): TranscriptStore | null {
     const existing = transcripts.get(sessionId)
@@ -157,7 +164,23 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
         if (store) store.applyEvent(event.event)
         break
       }
+      case 'resource':
+        resourceSnapshot.value = event.snapshot
+        break
     }
+  }
+
+  async function refreshRuntimeConfig() {
+    try {
+      runtimeConfig.value = await client.getRuntimeConfig()
+    } catch (e) {
+      if (e instanceof Error && e.message.includes('not enabled')) return
+      // Non-fatal — the drawer just won't open until this succeeds.
+    }
+  }
+
+  async function updateRuntimeConfig(patch: RuntimeOverrides): Promise<void> {
+    runtimeConfig.value = await client.patchRuntimeConfig(patch)
   }
 
   const handle = client.openEventStream({
@@ -220,6 +243,8 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
     version,
     stale,
     diffStatsBySessionId,
+    resourceSnapshot,
+    runtimeConfig,
     loadDiffStats,
     refresh,
     sendCommand(cmd) {
@@ -228,6 +253,8 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
     getTranscript,
     applySessionCreated,
     applySessionDeleted,
+    refreshRuntimeConfig,
+    updateRuntimeConfig,
     dispose() {
       if (snapshotTimer !== null) {
         clearTimeout(snapshotTimer)

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,5 +1,14 @@
 import type { ReadonlySignal } from '@preact/signals'
-import type { ApiDagGraph, ApiSession, CommandResult, MinionCommand, VersionInfo } from '../api/types'
+import type {
+  ApiDagGraph,
+  ApiSession,
+  CommandResult,
+  MinionCommand,
+  ResourceSnapshot,
+  RuntimeConfigResponse,
+  RuntimeOverrides,
+  VersionInfo,
+} from '../api/types'
 import type { SseStatus } from '../api/sse'
 import type { ApiClient } from '../api/client'
 import type { TranscriptStore } from './transcript'
@@ -24,11 +33,15 @@ export interface ConnectionStore {
   version: ReadonlySignal<VersionInfo | null>
   stale: ReadonlySignal<boolean>
   diffStatsBySessionId: ReadonlySignal<Map<string, DiffStats>>
+  resourceSnapshot: ReadonlySignal<ResourceSnapshot | null>
+  runtimeConfig: ReadonlySignal<RuntimeConfigResponse | null>
   loadDiffStats(sessionId: string): Promise<void>
   refresh(): Promise<void>
   sendCommand(cmd: MinionCommand): Promise<CommandResult>
   getTranscript(sessionId: string): TranscriptStore | null
   applySessionCreated(session: ApiSession): void
   applySessionDeleted(sessionId: string): void
+  refreshRuntimeConfig(): Promise<void>
+  updateRuntimeConfig(patch: RuntimeOverrides): Promise<void>
   dispose(): void
 }

--- a/test/chat/NewTaskBar.test.tsx
+++ b/test/chat/NewTaskBar.test.tsx
@@ -81,12 +81,16 @@ function makeStore(opts: {
     version: signal<VersionInfo | null>(version),
     stale: signal(false),
     diffStatsBySessionId: signal(new Map()),
+    resourceSnapshot: signal(null),
+    runtimeConfig: signal(null),
     loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi.fn(async () => ({ success: true })),
     getTranscript: vi.fn(() => null),
     applySessionCreated: vi.fn(),
     applySessionDeleted: vi.fn(),
+    refreshRuntimeConfig: vi.fn(async () => {}),
+    updateRuntimeConfig: vi.fn(async () => {}),
     dispose: vi.fn(),
   }
   return { store, client }

--- a/test/chat/transcript/TranscriptUpgradeNotice.test.tsx
+++ b/test/chat/transcript/TranscriptUpgradeNotice.test.tsx
@@ -17,12 +17,16 @@ function makeStore(version: VersionInfo | null): ConnectionStore {
     version: signal<VersionInfo | null>(version),
     stale: signal(false),
     diffStatsBySessionId: signal(new Map()),
+    resourceSnapshot: signal(null),
+    runtimeConfig: signal(null),
     loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi.fn(async () => ({ success: true })),
     getTranscript: vi.fn(() => null),
     applySessionCreated: vi.fn(),
     applySessionDeleted: vi.fn(),
+    refreshRuntimeConfig: vi.fn(async () => {}),
+    updateRuntimeConfig: vi.fn(async () => {}),
     dispose: vi.fn(),
   }
 }

--- a/test/components/ResourceChip.test.tsx
+++ b/test/components/ResourceChip.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/preact'
+import { signal } from '@preact/signals'
+import { describe, it, expect, vi } from 'vitest'
+import { ResourceChip } from '../../src/components/ResourceChip'
+import type { ConnectionStore } from '../../src/state/types'
+import type { ApiDagGraph, ApiSession, ResourceSnapshot, VersionInfo } from '../../src/api/types'
+
+function makeStore(snapshot: ResourceSnapshot | null): ConnectionStore {
+  return {
+    connectionId: 'c1',
+    client: {} as ConnectionStore['client'],
+    sessions: signal<ApiSession[]>([]),
+    dags: signal<ApiDagGraph[]>([]),
+    status: signal('live'),
+    reconnectAt: signal<number | null>(null),
+    error: signal<string | null>(null),
+    version: signal<VersionInfo | null>(null),
+    stale: signal(false),
+    diffStatsBySessionId: signal(new Map()),
+    resourceSnapshot: signal(snapshot),
+    runtimeConfig: signal(null),
+    loadDiffStats: vi.fn(async () => {}),
+    refresh: vi.fn(async () => {}),
+    sendCommand: vi.fn(async () => ({ success: true })),
+    getTranscript: vi.fn(() => null),
+    applySessionCreated: vi.fn(),
+    applySessionDeleted: vi.fn(),
+    refreshRuntimeConfig: vi.fn(async () => {}),
+    updateRuntimeConfig: vi.fn(async () => {}),
+    dispose: vi.fn(),
+  }
+}
+
+const sample = (cpu: number, memPct: number): ResourceSnapshot => ({
+  ts: 0,
+  cpu: { usagePercent: cpu, cpuCount: 2, source: 'cgroup' },
+  memory: {
+    usedBytes: Math.round((memPct / 100) * 1000),
+    limitBytes: 1000,
+    rssBytes: 100,
+    source: 'cgroup',
+  },
+  disk: { path: '/workspace', usedBytes: 1, totalBytes: 10 },
+  eventLoopLagMs: 0,
+  counts: { activeSessions: 0, maxSessions: 1, activeLoops: 0, maxLoops: 1 },
+})
+
+describe('ResourceChip', () => {
+  it('shows waiting state when no snapshot', () => {
+    render(<ResourceChip store={makeStore(null)} />)
+    expect(screen.getByTestId('resource-chip').textContent).toMatch(/waiting/i)
+  })
+
+  it('renders CPU percent when snapshot present', () => {
+    render(<ResourceChip store={makeStore(sample(37, 20))} />)
+    const chip = screen.getByTestId('resource-chip')
+    expect(chip.textContent).toContain('37%')
+  })
+
+  it('invokes onOpen when clicked', () => {
+    const onOpen = vi.fn()
+    render(<ResourceChip store={makeStore(sample(10, 10))} onOpen={onOpen} />)
+    const chip = screen.getByTestId('resource-chip')
+    chip.click()
+    expect(onOpen).toHaveBeenCalled()
+  })
+})

--- a/test/components/WorktreeHeader.test.tsx
+++ b/test/components/WorktreeHeader.test.tsx
@@ -47,12 +47,16 @@ function makeStore(opts: {
     version,
     stale: signal(false),
     diffStatsBySessionId,
+    resourceSnapshot: signal(null),
+    runtimeConfig: signal(null),
     loadDiffStats: opts.loadDiffStats ?? (async () => {}),
     refresh: async () => {},
     sendCommand: async () => ({ success: true }),
     getTranscript: () => null,
     applySessionCreated: () => {},
     applySessionDeleted: () => {},
+    refreshRuntimeConfig: async () => {},
+    updateRuntimeConfig: async () => {},
     dispose: () => {},
   }
 }

--- a/test/groups/VariantGroupView.test.tsx
+++ b/test/groups/VariantGroupView.test.tsx
@@ -57,6 +57,8 @@ function makeStore(opts: {
     version: signal<VersionInfo | null>(version),
     stale: signal(false),
     diffStatsBySessionId: signal(new Map()),
+    resourceSnapshot: signal(null),
+    runtimeConfig: signal(null),
     loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi
@@ -65,6 +67,8 @@ function makeStore(opts: {
     getTranscript: vi.fn(() => null),
     applySessionCreated: vi.fn(),
     applySessionDeleted: vi.fn(),
+    refreshRuntimeConfig: vi.fn(async () => {}),
+    updateRuntimeConfig: vi.fn(async () => {}),
     dispose: vi.fn(),
   }
 }


### PR DESCRIPTION
## Summary

- Mirrors the new `telegram-minions` surface (SSE `resource` variant, `GET /api/metrics`, `GET` / `PATCH /api/config/runtime`, `"resource-metrics"` + `"runtime-config"` feature flags) in `src/api/types.ts`, `src/api/features.ts`, `src/api/client.ts`.
- Extends `ConnectionStore` with `resourceSnapshot` + `runtimeConfig` signals and `refreshRuntimeConfig` / `updateRuntimeConfig` methods; SSE handler routes the new event into the signal.
- **ResourceChip** in the persistent header (next to `ConnectionStatusBadge`) — compact CPU% · mem% with a colored dot (green < 50 %, amber ≥ 50 %, red ≥ 85 %). Click opens the drawer on the Resources tab.
- **⚙️ Runtime button** in the right-side header cluster, feature-gated via `hasFeature(store, 'runtime-config')`.
- **RuntimeConfigDrawer** — desktop right-sheet + mobile bottom-sheet, mirrors `ConnectionsDrawer` pattern. Two tabs: Resources (bars + counters + RSS / event-loop lag) and Config (schema-driven form grouped by Loops / Concurrency & quota / Feature toggles, per-field Reset, dirty-tracked Save / Revert, visible "restart required" banner for MCP + CI flags).

Why: pairs with the backend PR so we can see whether we're near CPU / memory limits inside Docker and toggle loops / concurrency / MCP flags without a redeploy.

## Depends on

`tprei/telegram-minions` PR for `@tprei/telegram-minions` must merge + publish first; bump the library pin before landing this PR. Every new UI surface is feature-gated, so the PWA degrades cleanly against older library versions.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (`--max-warnings=0`)
- [x] `npm run test` — 683 / 683 pass (includes new `test/components/ResourceChip.test.tsx`)
- [ ] CI `e2e` matrix (not run locally per repo policy)
- [ ] Manual against a local minion that ships the library PR: chip updates every ~2 s, values move under load; open drawer → toggle a loop off → Save → verify backend state; flip an `ENABLE_*_MCP` flag → confirm the orange "restart required" banner appears