### PR TITLE
docs(mini-deploy): use the built-in cloudflared compose profile

### DIFF
--- a/docs/mini-deploy.md
+++ b/docs/mini-deploy.md
@@ -1,8 +1,8 @@
 # Deploying the engine to `mini` (home server)
 
-Target: run the engine as a long-lived service on `minions@mini` and expose it to the PWA (hosted on Cloudflare Pages) via a Cloudflare Tunnel. Engine state lives at `~/meta-minion/`.
+Target: run the engine as a long-lived service on `minions@mini` and expose it to the PWA via a Cloudflare Tunnel. Engine state lives at `~/meta-minion/`. The PWA connects to `https://<your-tunnel>.<your-domain>/api` with a bearer token.
 
-The PWA connects to `https://<your-tunnel>.<your-domain>/api` with a bearer token it stores locally.
+The compose file ships a `cloudflared` service under the `tunnel` profile — you don't install `cloudflared` on the host.
 
 ## One-time setup on `mini`
 
@@ -10,84 +10,66 @@ The PWA connects to `https://<your-tunnel>.<your-domain>/api` with a bearer toke
 
 ```sh
 ssh minions@mini
-mkdir -p ~/meta-minion && cd ~/meta-minion
-git clone https://github.com/tprei/minions-ui.git .
-```
-
-### 2. Configure environment
-
-```sh
+git clone git@github.com:tprei/minions-ui.git ~/meta-minion
 cd ~/meta-minion/docker
 cp .env.example .env
 ```
 
-Edit `.env`:
+### 2. Fill `.env`
 
 ```sh
-MINION_API_TOKEN=<openssl rand -hex 32>
-ANTHROPIC_API_KEY=<your key>                     # or mount ~/.claude, see below
-GITHUB_TOKEN=<gh PAT with repo scope>
-DEFAULT_REPO=https://github.com/<org>/<repo>.git # the repo minion will work on
+MINION_API_TOKEN=$(openssl rand -hex 32)          # any random string
+# ANTHROPIC_API_KEY stays blank if you mount ~/.claude (see compose.mini.yaml below)
+GITHUB_TOKEN=<gh PAT, repo scope>
+DEFAULT_REPO=https://github.com/<org>/<repo>.git  # what the minion works on
 CORS_ALLOWED_ORIGINS=https://<your-tunnel>.<your-domain>,https://<your-pages>.pages.dev
+CLOUDFLARE_TUNNEL_TOKEN=                          # filled in step 4
 ```
 
-If you authenticated `claude` on `mini` with `claude login`, you can skip `ANTHROPIC_API_KEY` and instead mount `~/.claude` into the container — see `docker/README.md` for the dev compose override.
+### 3. Mount `~/.claude` for claude-CLI auth (optional but recommended)
 
-### 3. Build + start
+If you ran `claude login` on mini, create `docker/compose.mini.yaml`:
+
+```yaml
+services:
+  engine:
+    volumes:
+      - ${HOME}/.claude:/workspace/home/.claude
+```
+
+This lets the in-container claude CLI reuse your host login instead of needing an `ANTHROPIC_API_KEY`.
+
+### 4. Create a Cloudflare Tunnel
+
+- Open https://one.dash.cloudflare.com → Networks → Tunnels → **Create a tunnel** → *Cloudflared* → name it (e.g. `minions-engine`).
+- Cloudflare shows a token on the next screen. Copy it, paste into `docker/.env` as `CLOUDFLARE_TUNNEL_TOKEN=<token>`.
+- In the tunnel's **Public Hostnames** tab, add: `Type=HTTP`, `URL=engine:8080`, `Hostname=minions.<your-domain>` (or any subdomain). Save.
+
+### 5. Build + start
 
 ```sh
 cd ~/meta-minion
-docker build -f docker/engine.Dockerfile -t minions-engine:latest .
-docker compose -f docker/compose.yaml up -d
+docker build -f docker/engine.Dockerfile -t minions-engine:local .
+docker compose -f docker/compose.yaml -f docker/compose.mini.yaml --profile tunnel up -d
 ```
 
-The engine now listens on `http://localhost:8080`. Verify:
+Verify locally:
 
 ```sh
 curl -s http://localhost:8080/api/version | jq
-curl -s -H "Authorization: Bearer $(grep MINION_API_TOKEN docker/.env | cut -d= -f2)" http://localhost:8080/api/sessions | jq
+TOKEN=$(grep ^MINION_API_TOKEN docker/.env | cut -d= -f2)
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/sessions | jq
 ```
 
-### 4. Cloudflare Tunnel
-
-Install `cloudflared` on `mini` (once):
+Verify through the tunnel:
 
 ```sh
-curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o /tmp/cloudflared.deb
-sudo dpkg -i /tmp/cloudflared.deb
+curl -s https://minions.<your-domain>/api/version | jq
 ```
 
-Log in and create a named tunnel (once):
+### 6. Connect the PWA
 
-```sh
-cloudflared tunnel login
-cloudflared tunnel create minions-engine
-```
-
-Write `~/.cloudflared/config.yml`:
-
-```yaml
-tunnel: minions-engine
-credentials-file: /home/minions/.cloudflared/<tunnel-uuid>.json
-ingress:
-  - hostname: minions.<your-domain>
-    service: http://localhost:8080
-  - service: http_status:404
-```
-
-Route DNS + install as a systemd service:
-
-```sh
-cloudflared tunnel route dns minions-engine minions.<your-domain>
-sudo cloudflared service install
-sudo systemctl enable --now cloudflared
-```
-
-The engine is now reachable at `https://minions.<your-domain>/api`.
-
-### 5. Connect the PWA
-
-In the PWA, open the connection picker and add:
+In the PWA's connection picker add:
 
 - **Base URL:** `https://minions.<your-domain>`
 - **Token:** the `MINION_API_TOKEN` from `docker/.env`
@@ -98,13 +80,14 @@ In the PWA, open the connection picker and add:
 ssh minions@mini
 cd ~/meta-minion
 git pull
-docker compose -f docker/compose.yaml build
-docker compose -f docker/compose.yaml up -d
+docker compose -f docker/compose.yaml -f docker/compose.mini.yaml build engine
+docker compose -f docker/compose.yaml -f docker/compose.mini.yaml --profile tunnel up -d
 ```
 
 ## Troubleshooting
 
-- `docker compose logs -f minion-engine` — stream engine logs.
-- `bun run server/cli/index.ts doctor` inside the container — runs the diagnostic grid (Node, workspace, port, token, gh, claude).
-- Tunnel health: `cloudflared tunnel info minions-engine`.
-- Engine won't start? Check `docker/.env` has `MINION_API_TOKEN`, `ANTHROPIC_API_KEY` (or `~/.claude` mount), and `GITHUB_TOKEN`.
+- `docker compose -f docker/compose.yaml -f docker/compose.mini.yaml logs -f engine` — engine logs.
+- `docker compose -f docker/compose.yaml -f docker/compose.mini.yaml logs -f cloudflared` — tunnel logs.
+- `docker exec docker-engine-1 bun run server/cli/index.ts doctor` — in-container diagnostic grid.
+- Engine won't start? Check `docker/.env` has `MINION_API_TOKEN` (required), `GITHUB_TOKEN`, and either `ANTHROPIC_API_KEY` or the `~/.claude` mount via `compose.mini.yaml`.
+- Tunnel returning 502? The Public Hostname service URL must be `http://engine:8080` (the compose service name), not `localhost:8080`.


### PR DESCRIPTION
## Summary

- The original `docs/mini-deploy.md` had you install `cloudflared` on the host and set up a systemd unit. `docker/compose.yaml` already ships a `cloudflared` container under the `tunnel` profile that only needs a `CLOUDFLARE_TUNNEL_TOKEN`. Use that instead.
- Documents the `compose.mini.yaml` local override for bind-mounting `~/.claude` so the in-container claude CLI reuses your host login without `ANTHROPIC_API_KEY`.

## Test plan

- [x] Matches the flow already running on `minions@mini`.
- [ ] Follow the doc on a fresh box end-to-end.