### PR TITLE
fix(engine): wire completion dispatcher and fix ship-advance

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -35,5 +35,13 @@ services:
     depends_on:
       - engine
 
+  cloudflared-quick:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    profiles: ["quick-tunnel"]
+    command: tunnel --no-autoupdate --url http://engine:8080
+    depends_on:
+      - engine
+
 volumes:
   workspace:

--- a/docs/mini-deploy.md
+++ b/docs/mini-deploy.md
@@ -39,13 +39,32 @@ services:
 
 This lets the in-container claude CLI reuse your host login instead of needing an `ANTHROPIC_API_KEY`.
 
-### 4. Create a Cloudflare Tunnel
+### 4. Expose the engine
+
+Two options — pick one.
+
+#### 4a. Quick tunnel (free, no domain, random URL)
+
+Uses Cloudflare's `*.trycloudflare.com`. No account, no domain, no token. The URL rotates on every container restart, so you re-paste it into the PWA each time.
+
+```sh
+cd ~/meta-minion
+docker build -f docker/engine.Dockerfile -t minions-engine:local .
+docker compose -f docker/compose.yaml -f docker/compose.mini.yaml --profile quick-tunnel up -d
+docker compose -f docker/compose.yaml -f docker/compose.mini.yaml logs cloudflared-quick | grep trycloudflare.com
+```
+
+The last command prints the random `https://<words>.trycloudflare.com` URL.
+
+#### 4b. Named tunnel (needs a domain on Cloudflare, stable URL)
 
 - Open https://one.dash.cloudflare.com → Networks → Tunnels → **Create a tunnel** → *Cloudflared* → name it (e.g. `minions-engine`).
 - Cloudflare shows a token on the next screen. Copy it, paste into `docker/.env` as `CLOUDFLARE_TUNNEL_TOKEN=<token>`.
-- In the tunnel's **Public Hostnames** tab, add: `Type=HTTP`, `URL=engine:8080`, `Hostname=minions.<your-domain>` (or any subdomain). Save.
+- In the tunnel's **Public Hostnames** tab, add: `Type=HTTP`, `URL=engine:8080`, `Hostname=minions.<your-domain>`. Save.
 
 ### 5. Build + start
+
+If you used 4a, you already ran this. For 4b:
 
 ```sh
 cd ~/meta-minion

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,13 @@
         "@reactflow/minimap": "^11.7.14",
         "dagre": "^0.8.5",
         "dompurify": "^3.4.0",
+        "hono": "^4.6.12",
         "idb-keyval": "^6.2.1",
         "marked": "^18.0.2",
         "mermaid": "^11.14.0",
-        "preact": "^10.26.4"
+        "preact": "^10.26.4",
+        "web-push": "^3.6.7",
+        "zod": "^3.24.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -28,10 +31,13 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.0.15",
         "@testing-library/preact": "^3.2.4",
+        "@types/bun": "^1.1.0",
         "@types/dagre": "^0.7.52",
         "@types/dompurify": "^3.0.5",
         "@types/node": "^22.14.0",
+        "@types/web-push": "^3.6.4",
         "autoprefixer": "^10.4.21",
+        "concurrently": "^9.0.0",
         "eslint": "^10.1.0",
         "husky": "^9.1.7",
         "jsdom": "^26.1.0",
@@ -3952,6 +3958,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bun": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.12.tgz",
+      "integrity": "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.12"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -4290,6 +4306,16 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.2",
@@ -4693,7 +4719,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -4789,6 +4814,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/assertion-error": {
@@ -4956,6 +4993,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -5010,12 +5053,28 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.12.tgz",
+      "integrity": "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
@@ -5149,6 +5208,21 @@
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -5209,6 +5283,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/confbox": {
@@ -5925,7 +6040,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6154,6 +6268,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -6176,6 +6299,13 @@
       "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -6888,6 +7018,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -7146,6 +7286,15 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -7157,6 +7306,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -7177,7 +7335,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -7247,6 +7404,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -7455,6 +7618,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -7898,6 +8071,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/katex": {
@@ -8391,6 +8585,12 @@
         "node": ">= 20"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -8405,6 +8605,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -8433,7 +8642,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -9115,6 +9323,16 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -9223,6 +9441,16 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -9247,7 +9475,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9470,6 +9697,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -9683,6 +9923,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -9783,6 +10038,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-comments": {
@@ -9992,6 +10260,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -10019,8 +10297,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10620,6 +10897,25 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -11213,6 +11509,24 @@
         "workbox-core": "7.4.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -11252,12 +11566,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -11278,6 +11631,15 @@
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/zustand": {
       "version": "4.5.7",

--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -100,11 +100,39 @@ async function buildAndStartDag(
   return { ok: true, dagId }
 }
 
+async function handoffShipPhase(
+  sessionId: string,
+  nextMode: "ship-plan" | "ship-verify",
+  ctx: PlanActionCtx,
+): Promise<PlanActionResult> {
+  const sessionRow = prepared.getSession(ctx.db, sessionId)
+  if (!sessionRow) return { ok: false, reason: "session not found" }
+
+  const design = getLastAssistantMessage(ctx.db, sessionId)
+  if (!design) return { ok: false, reason: "no design output from previous phase to hand off" }
+
+  const { session } = await ctx.registry.create({
+    mode: nextMode,
+    prompt: design,
+    repo: sessionRow.repo ?? "",
+    parentId: sessionId,
+  })
+
+  return { ok: true, dagId: session.id }
+}
+
 export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Promise<PlanActionResult> {
   const rejection = await gate(sessionId, ctx)
   if (rejection) return { ok: false, reason: rejection }
 
+  const row = prepared.getSession(ctx.db, sessionId)
+  const mode = row?.mode
+
   await killAndWait(sessionId, ctx)
+
+  if (mode === "ship-think") {
+    return handoffShipPhase(sessionId, "ship-plan", ctx)
+  }
 
   const conversation = getConversationMessages(ctx.db, sessionId)
   const typedConversation = conversation.map((m) => ({

--- a/server/handlers/ship-advance-handler.test.ts
+++ b/server/handlers/ship-advance-handler.test.ts
@@ -71,7 +71,7 @@ describe('shipAdvanceHandler', () => {
   })
 
   test('calls scheduler for ship mode sessions', async () => {
-    seedSession(db, 'sess-ship', 'ship')
+    seedSession(db, 'sess-ship', 'ship-think')
     const calls: string[] = []
     const ctx = makeCtx(db, calls)
 
@@ -93,7 +93,7 @@ describe('shipAdvanceHandler', () => {
   })
 
   test('skips when pipeline_advancing is already set', async () => {
-    seedSession(db, 'sess-advancing', 'ship', true)
+    seedSession(db, 'sess-advancing', 'ship-think', true)
     const calls: string[] = []
     const ctx = makeCtx(db, calls)
 
@@ -104,7 +104,7 @@ describe('shipAdvanceHandler', () => {
   })
 
   test('clears pipeline_advancing flag after scheduler call', async () => {
-    seedSession(db, 'sess-flag', 'ship')
+    seedSession(db, 'sess-flag', 'ship-think')
     const calls: string[] = []
     const ctx = makeCtx(db, calls)
 
@@ -116,7 +116,7 @@ describe('shipAdvanceHandler', () => {
   })
 
   test('clears pipeline_advancing even when scheduler throws', async () => {
-    seedSession(db, 'sess-err', 'ship')
+    seedSession(db, 'sess-err', 'ship-think')
     const calls: string[] = []
     const bus = new EngineEventBus()
     const ctx: HandlerCtx = {

--- a/server/handlers/ship-advance-handler.ts
+++ b/server/handlers/ship-advance-handler.ts
@@ -15,7 +15,7 @@ export const shipAdvanceHandler: CompletionHandler = {
       )
       .get(ev.sessionId)
 
-    if (!row || row.mode !== 'ship') return
+    if (!row || !row.mode.startsWith('ship-')) return
     if (row.pipeline_advancing !== 0) return
 
     ctx.db.run(

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,11 +1,40 @@
+import path from 'node:path'
 import { Hono } from 'hono'
 import { getDb, runMigrations } from './db/sqlite'
 import { createSessionRegistry } from './session/registry'
 import { corsMiddleware } from './api/cors'
 import { registerApiRoutes } from './api/routes'
 import { registerSseRoute } from './api/sse'
+import { getEventBus } from './events/bus'
+import { CompletionDispatcher } from './events/completion-dispatcher'
+import type { HandlerCtx, ReplyQueue, ReplyQueueFactory } from './handlers/types'
+import { statsHandler } from './handlers/stats-handler'
+import { quotaHandler } from './handlers/quota-handler'
+import { shipAdvanceHandler } from './handlers/ship-advance-handler'
+import { modeCompletionHandler } from './handlers/mode-completion-handler'
+import { loopCompletionHandler } from './handlers/loop-completion-handler'
+import { taskCompletionHandler } from './handlers/task-completion-handler'
+import { qualityGateHandler } from './handlers/quality-gate-handler'
+import { digestHandler } from './handlers/digest-handler'
+import { ciBabysitHandler } from './handlers/ci-babysit-handler'
+import { parentNotifyHandler } from './handlers/parent-notify-handler'
+import {
+  createRealCIBabysitter,
+  createRealQualityGates,
+  createNoopProfileStore,
+  createDefaultConfig,
+} from './handlers/stubs'
+import { createDagScheduler } from './dag/scheduler'
+import { LoopScheduler } from './loops/scheduler'
+import { ResourceMonitor } from './metrics/resource'
+import { createDigestBuilder } from './digest/digest'
+import { ReplyQueue as DiskReplyQueue } from './session/reply-queue'
+import { startPushNotifier } from './push/notifier'
 
 const PORT = Number(process.env['PORT'] ?? 8080)
+const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? '/tmp/minion-workspace'
+const DEFAULT_REPO = process.env['DEFAULT_REPO'] ?? ''
+const MAX_CONCURRENT_SESSIONS = Number(process.env['MAX_CONCURRENT_SESSIONS'] ?? 10)
 
 const app = new Hono()
 app.use('*', corsMiddleware())
@@ -14,17 +43,82 @@ const db = getDb()
 runMigrations(db)
 
 const registry = createSessionRegistry({ getDb: () => db })
+const bus = getEventBus()
 
 await registry.reconcileOnBoot()
 
 const reconciledRows = db
-  .query<{ count: number }, []>("SELECT COUNT(*) as count FROM sessions WHERE status IN ('running','waiting_input')")
+  .query<{ count: number }, []>(
+    "SELECT COUNT(*) as count FROM sessions WHERE status IN ('running','waiting_input')",
+  )
   .get()
 
 const reconciled = reconciledRows?.count ?? 0
 console.log(`[minion] engine on :${PORT}, ${reconciled} sessions resumed`)
 
-registerApiRoutes(app, registry, () => db)
+const scheduler = createDagScheduler({ registry, db, bus, workspace: WORKSPACE_ROOT })
+
+const loopScheduler = new LoopScheduler({
+  db,
+  registry,
+  workspaceRoot: WORKSPACE_ROOT,
+  repo: DEFAULT_REPO,
+  maxConcurrentSessions: MAX_CONCURRENT_SESSIONS,
+  getInteractiveSessionCount: () =>
+    registry.list().filter((s) => s.mode !== 'loop').length,
+})
+
+const replyQueueFactory: ReplyQueueFactory = {
+  forSession: (sessionId: string): ReplyQueue => {
+    const cwd = path.join(WORKSPACE_ROOT, sessionId)
+    const disk = new DiskReplyQueue(sessionId, cwd)
+    return {
+      async pending(): Promise<string[]> {
+        return disk.pending().map((q) => q.text)
+      },
+      async drain(): Promise<string[]> {
+        const items = disk.pending()
+        for (const item of items) disk.markDelivered(item.seq)
+        return items.map((q) => q.text)
+      },
+    }
+  },
+}
+
+const ctx: HandlerCtx = {
+  db,
+  registry,
+  bus,
+  scheduler,
+  loopScheduler,
+  ciBabysitter: createRealCIBabysitter(registry, db),
+  qualityGates: createRealQualityGates(),
+  digest: createDigestBuilder(),
+  profileStore: createNoopProfileStore(),
+  replyQueue: replyQueueFactory,
+  config: createDefaultConfig(),
+}
+
+const dispatcher = new CompletionDispatcher(bus, ctx)
+dispatcher.register(statsHandler)
+dispatcher.register(quotaHandler)
+dispatcher.register(shipAdvanceHandler)
+dispatcher.register(modeCompletionHandler)
+dispatcher.register(loopCompletionHandler)
+dispatcher.register(taskCompletionHandler)
+dispatcher.register(qualityGateHandler)
+dispatcher.register(digestHandler)
+dispatcher.register(ciBabysitHandler)
+dispatcher.register(parentNotifyHandler)
+
+loopScheduler.start()
+
+const resourceMonitor = new ResourceMonitor(bus)
+resourceMonitor.start()
+
+startPushNotifier(bus)
+
+registerApiRoutes(app, registry, () => db, scheduler)
 registerSseRoute(app, () => db)
 
 export default { port: PORT, fetch: app.fetch, idleTimeout: 0 }

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -197,7 +197,14 @@ export interface VersionInfo {
   repos?: RepoEntry[]
 }
 
-export type CreateSessionMode = 'task' | 'plan' | 'think' | 'review' | 'ship-think'
+export type CreateSessionMode =
+  | 'task'
+  | 'plan'
+  | 'think'
+  | 'review'
+  | 'ship-think'
+  | 'ship-plan'
+  | 'ship-verify'
 
 export interface CreateSessionRequest {
   prompt: string


### PR DESCRIPTION
## Summary

Three integration gaps surfaced at runtime after PR #61 — nothing reactive fired because `server/index.ts` only booted the HTTP layer.

1. **`shipAdvanceHandler` predicate**: checked `mode === 'ship'` but real sessions carry `ship-think` / `ship-plan` / `ship-verify`. Switched to a `ship-` prefix check.

2. **Dispatcher never wired**: `CompletionDispatcher` + all 11 handlers exist but weren't instantiated. Also `DagScheduler`, `LoopScheduler`, `ResourceMonitor`, push notifier — all idle. Wired them in `server/index.ts` and passed the scheduler down to `registerApiRoutes` so `/execute`, `/split`, `/stack`, `/dag` can actually drive it.

3. **`/execute` on ship-think**: `handleExecute` unconditionally extracted DAG items from the last assistant message, but for ship-think that message is a design doc. Added a ship-specific branch that hands off to a fresh `ship-plan` session with the design as the initial prompt.

Added `ship-plan` and `ship-verify` to `CreateSessionMode` so the registry can spawn those phases.

## Test plan

- [x] `bunx tsc -p tsconfig.server.json --noEmit` — 0 errors.
- [x] `npm run typecheck && npm run lint` — 0 errors.
- [x] `bun test server/ shared/` — 626 pass, 1 skip, 0 fail.
- [x] `npm run test` — 706 pass.
- [ ] Deploy to mini, `/task hi` completes cleanly, `/ship ... → /execute` hands off to ship-plan.