### PR TITLE
docs: fix stale documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Standalone PWA that replaces the Telegram Mini App frontend for [`@tprei/telegra
 
 | Command | Description |
 |---|---|
-| `npm run dev` | Start the dev server at http://localhost:5173 |
+| `npm run dev` | Start the dev server (UI + server) at http://localhost:3000 |
 | `npm run build` | Type-check and produce a production build in `dist/` |
 | `npm run preview` | Serve the production build locally |
 | `npm run typecheck` | Run `tsc --noEmit` |
@@ -17,7 +17,7 @@ Standalone PWA that replaces the Telegram Mini App frontend for [`@tprei/telegra
 
 ## Dev proxy
 
-In development, requests to `/api/*` are proxied to `http://localhost:8080` — the default port for `telegram-minions`.
+In development, the `npm run dev` command starts both the Vite dev server (UI on port 3000) and the backend server (API on port 8080). The Vite dev server proxies `/api/*` requests to `http://localhost:8080`.
 
 ## Architecture
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -6,7 +6,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 GITHUB_TOKEN=ghp_...
 
 # Optional
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+CORS_ALLOWED_ORIGINS=http://localhost:3000
 ENGINE_PORT=8080
 
 # Default repo URL used when /api/messages receives a /task, /plan, etc.

--- a/docs/2026-04-21-feature-parity.md
+++ b/docs/2026-04-21-feature-parity.md
@@ -26,8 +26,8 @@ Wave coverage: A1–A3 (DAG, ship, completion chain), B1–B3 (judge, GitHub, CI
 | GET | `/api/sessions/:slug/screenshots/:filename` | `server/api/routes.ts` | **DONE** | |
 | GET | `/api/sessions/:slug/transcript?after=<seq>` | `server/api/routes.ts` | **DONE** | SQLite-backed |
 | GET | `/api/sessions/:slug/pr` | `server/api/routes.ts` | **DONE** | `server/github/pr-preview.ts` |
-| GET | `/api/dags` | `server/api/routes.ts` | **PARTIAL** | returns `[]`; real DAG list via `server/dag/store.ts` not wired to HTTP yet |
-| GET | `/api/dags/:id` | `server/api/routes.ts` | **PARTIAL** | always 404; store exists |
+| GET | `/api/dags` | `server/api/routes.ts` | **DONE** | wired to `server/dag/store.ts` |
+| GET | `/api/dags/:id` | `server/api/routes.ts` | **DONE** | wired to `server/dag/store.ts` |
 | POST | `/api/commands` | `server/api/routes.ts` | **DONE** | reply/stop/close/plan_action |
 | POST | `/api/messages` | `server/api/routes.ts` | **DONE** | 25 slash commands + plain reply |
 | GET | `/api/events` | `server/api/sse.ts` | **DONE** | SSE stream with keepalive |
@@ -166,10 +166,9 @@ Wave coverage: A1–A3 (DAG, ship, completion chain), B1–B3 (judge, GitHub, CI
 
 ## Remaining TODO seams
 
-1. **`GET /api/dags` and `GET /api/dags/:id`** — `server/dag/store.ts` (`listDags`, `loadDag`) exists and is tested, but `server/api/routes.ts` still returns stub `[]` / 404. Wire `listDags` and `loadDag` to these routes + emit `dag_created`/`dag_updated` via `dagToApi` mapper.
-2. **`session_needs_attention` over SSE** — `server/session/attention-emit.ts` emits attention reasons and triggers push, but the `session_needs_attention` SSE event type is not yet forwarded to connected SSE clients. Low impact since `session_updated` carries `needsAttention: true`.
-3. **`/judge`, `/land`, `/retry`, `/force` slash commands** — wired through `POST /api/messages` but not yet listed in `SLASH_MODES` (they call into their own handler modules directly). Confirmed functional via handler unit tests.
-4. **`SENTRY_DSN`** — decided DROP for now; platform error reporting is out of scope for this rewrite.
+1. **`session_needs_attention` over SSE** — `server/session/attention-emit.ts` emits attention reasons and triggers push, but the `session_needs_attention` SSE event type is not yet forwarded to connected SSE clients. Low impact since `session_updated` carries `needsAttention: true`.
+2. **`/judge`, `/land`, `/retry`, `/force` slash commands** — wired through `POST /api/messages` but not yet listed in `SLASH_MODES` (they call into their own handler modules directly). Confirmed functional via handler unit tests.
+3. **`SENTRY_DSN`** — decided DROP for now; platform error reporting is out of scope for this rewrite.
 
 ## How to measure parity end-to-end
 

--- a/docs/two-repo-prs.md
+++ b/docs/two-repo-prs.md
@@ -40,11 +40,24 @@ Land changes in this order, one PR at a time:
 - Add the flag in the same PR as the feature. Never advertise a flag without implementing the behavior.
 - Remove deprecated flags only in a new `apiVersion` bump.
 
-## Current `features` advertised by the library (as of v1.110.x)
+## Current `features` advertised by the server
 
+The minions-ui server advertises these features via `GET /api/version`:
+
+- `sessions-create` — `POST /api/sessions` for creating sessions
 - `messages` — `POST /api/messages` with slash-command parsing
+- `transcript` — `GET /api/sessions/:slug/transcript` for paginated transcript events
 - `auth` — `Authorization: Bearer` + `?token=` query param
 - `cors-allowlist` — `CORS_ALLOWED_ORIGINS` env var echoes allowlisted origins
+- `dag` — DAG endpoints and SSE events
+- `ship-pipeline` — `/ship` mode with judge/verify stages
+- `variants` — `POST /api/sessions/variants` for parallel session creation
+- `push` — Web Push notifications via VAPID
+- `screenshots` — Playwright screenshot capture and retrieval
+- `diff` — `GET /api/sessions/:slug/diff` for workspace diffs
+- `pr-preview` — `GET /api/sessions/:slug/pr` for PR metadata
+- `resource-tracking` — CPU/memory/disk metrics via SSE
+- `runtime-config` — `GET/PATCH /api/config/runtime` for runtime overrides
 
 ## Library version bumps
 


### PR DESCRIPTION
Fixes documentation inaccuracies found during audit:

## Changes
- **README.md**: Fix dev server port (5173 → 3000) and clarify that `npm run dev` starts both UI and server
- **docker/.env.example**: Remove stale port 5173 from CORS example
- **docs/two-repo-prs.md**: Update features list from 3 to all 14 currently implemented features
- **docs/2026-04-21-feature-parity.md**: Mark DAG endpoints as DONE (they are fully implemented)

## Validation
- Ran `npm run lint` — passed
- Ran `npm run test` — passed (4 pre-existing flaky timeout tests, unrelated to docs changes)
- Verified all claims against implementation in `server/api/routes.ts` and `vite.config.ts`