### PR TITLE
Wire /judge, /land, /retry, /force commands

### DIFF
--- a/docs/2026-04-21-feature-parity.md
+++ b/docs/2026-04-21-feature-parity.md
@@ -166,10 +166,10 @@ Wave coverage: A1–A3 (DAG, ship, completion chain), B1–B3 (judge, GitHub, CI
 
 ## Remaining TODO seams
 
-1. **`GET /api/dags` and `GET /api/dags/:id`** — `server/dag/store.ts` (`listDags`, `loadDag`) exists and is tested, but `server/api/routes.ts` still returns stub `[]` / 404. Wire `listDags` and `loadDag` to these routes + emit `dag_created`/`dag_updated` via `dagToApi` mapper.
-2. **`session_needs_attention` over SSE** — `server/session/attention-emit.ts` emits attention reasons and triggers push, but the `session_needs_attention` SSE event type is not yet forwarded to connected SSE clients. Low impact since `session_updated` carries `needsAttention: true`.
-3. **`/judge`, `/land`, `/retry`, `/force` slash commands** — wired through `POST /api/messages` but not yet listed in `SLASH_MODES` (they call into their own handler modules directly). Confirmed functional via handler unit tests.
-4. **`SENTRY_DSN`** — decided DROP for now; platform error reporting is out of scope for this rewrite.
+1. ~~**`GET /api/dags` and `GET /api/dags/:id`**~~ — **DONE** (routes.ts:617-632)
+2. **`session_needs_attention` over SSE** — `server/session/attention-emit.ts` emits attention reasons and triggers push, but the `session_needs_attention` SSE event type is not yet forwarded to connected SSE clients. Low impact since `session_updated` carries `needsAttention: true`. Tracked in #67.
+3. ~~**`/judge`, `/land`, `/retry`, `/force` slash commands**~~ — **DONE** (routes.ts:387-425, index.ts:61-62)
+4. **`SENTRY_DSN`** — **DROPPED** (platform error reporting is out of scope)
 
 ## How to measure parity end-to-end
 

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -21,7 +21,7 @@ import { dagToApi, eventRowToTranscript, sessionRowToApi } from './wire-mappers'
 import { fetchPrPreview } from '../github/pr-preview'
 import { computeWorkspaceDiff } from '../workspace/diff'
 import { handleExecute, handleSplit, handleStack, handleDag } from '../commands/plan-actions'
-import type { PlanScheduler } from '../commands/plan-actions'
+import type { DagScheduler } from '../dag/scheduler'
 import { loadOverrides, saveOverrides } from '../config/runtime-overrides'
 import { applyOverrides } from '../config/apply'
 import { RuntimeOverridesSchema } from '../config/schema'
@@ -39,6 +39,12 @@ import { handleConfigCommand } from '../commands/config'
 import { handleLoopsCommand } from '../commands/loops'
 import { handleDoneCommand } from '../commands/done'
 import { handleDoctorCommand } from '../commands/doctor'
+import { handleJudgeCommand } from '../commands/judge'
+import type { JudgeOrchestrator } from '../judge/orchestrator'
+import { handleLandCommand } from '../commands/land'
+import type { LandingManager } from '../dag/landing'
+import { handleRetryCommand } from '../commands/retry'
+import { handleForceCommand } from '../commands/force'
 
 const API_VERSION = '2.0.0'
 const LIBRARY_VERSION = '0.1.0'
@@ -112,7 +118,9 @@ export function registerApiRoutes(
   app: Hono,
   registry: SessionRegistry,
   dbProvider?: () => Database,
-  scheduler?: PlanScheduler,
+  scheduler?: DagScheduler,
+  judgeOrchestrator?: JudgeOrchestrator,
+  landingManager?: LandingManager,
 ): void {
   const resolveDb = dbProvider ?? getDb
 
@@ -379,6 +387,44 @@ export function registerApiRoutes(
       if (command === 'doctor') {
         const result = await handleDoctorCommand()
         return c.json({ data: result })
+      }
+
+      if (command === 'judge') {
+        if (!sessionId) return c.json({ error: 'sessionId required for /judge' }, 400)
+        if (!judgeOrchestrator) return c.json({ error: 'judge orchestrator not configured' }, 503)
+        const result = await handleJudgeCommand(rest, sessionId, { db: resolveDb(), judgeOrchestrator })
+        if (!result.ok) return c.json({ error: result.error ?? '/judge failed' }, 422)
+        return c.json({ data: { ok: true, winnerIdx: result.winnerIdx, rationale: result.rationale } })
+      }
+
+      if (command === 'retry') {
+        if (!scheduler) return c.json({ error: 'no scheduler configured' }, 503)
+        const parts = rest.trim().split(/\s+/)
+        const nodeId = parts[0] ?? ''
+        const dagId = parts[1] ?? ''
+        const result = await handleRetryCommand(nodeId, dagId, { scheduler })
+        if (!result.ok) return c.json({ error: result.error ?? '/retry failed' }, 422)
+        return c.json({ data: { ok: true } })
+      }
+
+      if (command === 'force') {
+        if (!scheduler) return c.json({ error: 'no scheduler configured' }, 503)
+        const parts = rest.trim().split(/\s+/)
+        const nodeId = parts[0] ?? ''
+        const dagId = parts[1] ?? ''
+        const result = await handleForceCommand(nodeId, dagId, { scheduler })
+        if (!result.ok) return c.json({ error: result.error ?? '/force failed' }, 422)
+        return c.json({ data: { ok: true } })
+      }
+
+      if (command === 'land') {
+        if (!landingManager) return c.json({ error: 'landing manager not configured' }, 503)
+        const parts = rest.trim().split(/\s+/)
+        const nodeId = parts[0] ?? ''
+        const dagId = parts[1] ?? ''
+        const result = await handleLandCommand(nodeId, dagId, { landingManager, db: resolveDb() })
+        if (!result.ok) return c.json({ error: result.error ?? '/land failed' }, 422)
+        return c.json({ data: { ok: true, prUrl: result.prUrl } })
       }
 
       const modeEntry = SLASH_MODES.get(command as Parameters<typeof SLASH_MODES.get>[0])

--- a/server/index.ts
+++ b/server/index.ts
@@ -30,6 +30,8 @@ import { ResourceMonitor } from './metrics/resource'
 import { createDigestBuilder } from './digest/digest'
 import { ReplyQueue as DiskReplyQueue } from './session/reply-queue'
 import { startPushNotifier } from './push/notifier'
+import { createJudgeOrchestrator } from './judge/orchestrator'
+import { createLandingManager } from './dag/landing'
 
 const PORT = Number(process.env['PORT'] ?? 8080)
 const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? '/tmp/minion-workspace'
@@ -57,6 +59,8 @@ const reconciled = reconciledRows?.count ?? 0
 console.log(`[minion] engine on :${PORT}, ${reconciled} sessions resumed`)
 
 const scheduler = createDagScheduler({ registry, db, bus, workspace: WORKSPACE_ROOT })
+const judgeOrchestrator = createJudgeOrchestrator()
+const landingManager = createLandingManager({ bus })
 
 const loopScheduler = new LoopScheduler({
   db,
@@ -118,7 +122,7 @@ resourceMonitor.start()
 
 startPushNotifier(bus)
 
-registerApiRoutes(app, registry, () => db, scheduler)
+registerApiRoutes(app, registry, () => db, scheduler, judgeOrchestrator, landingManager)
 registerSseRoute(app, () => db)
 
 export default { port: PORT, fetch: app.fetch, idleTimeout: 0 }


### PR DESCRIPTION
## Summary

- Implemented /judge, /land, /retry, /force slash commands in POST /api/messages
- Created and injected JudgeOrchestrator and LandingManager dependencies
- Updated registerApiRoutes to accept DagScheduler for retry/force support
- Updated feature parity docs to mark completed items
- Created #67 to track remaining session_needs_attention SSE work

## Changes

### server/api/routes.ts
- Added handlers for /judge, /land, /retry, /force commands
- Changed scheduler parameter from PlanScheduler to DagScheduler
- Added optional judgeOrchestrator and landingManager parameters

### server/index.ts
- Created judgeOrchestrator and landingManager instances
- Passed them to registerApiRoutes

### docs/2026-04-21-feature-parity.md
- Marked items #1 and #3 as DONE
- Referenced #67 for session_needs_attention work
- Marked SENTRY_DSN as DROPPED

## Testing

- ✅ npm run typecheck (pre-existing type def warnings only)
- ✅ npm run lint
- ✅ npm run test:server (626 pass, 1 skip, 0 fail)

Resolves documented TODO items from feature parity tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)