### PR TITLE
fix(engine): auto-resume sessions on reply when runtime is missing

### DIFF
--- a/server/api/routes.inbound-images.test.ts
+++ b/server/api/routes.inbound-images.test.ts
@@ -170,7 +170,7 @@ describe('POST /api/messages — inbound images', () => {
 
     expect(res.status).toBe(500)
     const body = await json<{ error: string }>(res)
-    expect(body.error).toContain('No runtime for session no-such-session')
+    expect(body.error).toContain('Session no-such-session not found')
   })
 
   test('serializeUserMessage includes image content blocks', () => {

--- a/server/session/registry.test.ts
+++ b/server/session/registry.test.ts
@@ -242,10 +242,64 @@ describe('SessionRegistry', () => {
   })
 
   describe('reply', () => {
-    test('throws when runtime not found', async () => {
+    test('throws when session does not exist', async () => {
       const registry = createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn() })
-      await expect(registry.reply('missing-id', 'hello')).rejects.toThrow('No runtime for session missing-id')
+      await expect(registry.reply('missing-id', 'hello')).rejects.toThrow('Session missing-id not found')
     })
+
+    test('throws when session has no claude_session_id to resume from', async () => {
+      const now = Date.now()
+      db.run(
+        `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, bare_dir, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation)
+         VALUES ('reply-no-claude', 'reply-no-claude-slug', 'running', 'task', 'task', null, null, null, null, null, null, null, null, ?, ?, 0, '[]', '[]', '[]')`,
+        [now, now],
+      )
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn() })
+      await expect(registry.reply('reply-no-claude', 'hello')).rejects.toThrow('has no claude_session_id to resume from')
+    })
+
+    test('resumes a dead session via --resume when runtime is missing', async () => {
+      const bare = trackedDir('bare-reply-resume')
+      const work = trackedDir('work-reply-resume')
+      const workspaceRoot = trackedDir('ws-reply-resume')
+      await initLocalBareRepo(bare, work)
+
+      const repoName = path.basename(bare).replace(/\.git$/, '')
+      const bareDir = path.join(workspaceRoot, '.repos', `${repoName}.git`)
+
+      const handle = await import('../workspace/prepare').then((m) =>
+        m.prepareWorkspace({ slug: 'reply-resume-slug', repoUrl: bare, workspaceRoot, bootstrap: false }),
+      )
+
+      const now = Date.now()
+      db.run(
+        `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, bare_dir, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation)
+         VALUES ('reply-resume', 'reply-resume-slug', 'running', 'original prompt', 'task', ?, ?, ?, null, null, null, 'claude-abc', ?, ?, ?, 0, '[]', '[]', '[]')`,
+        [bare, handle.branch, bareDir, workspaceRoot, now, now],
+      )
+
+      let capturedArgs: string[] = []
+      const capturingSpawn: SpawnFn = (argv, opts) => {
+        capturedArgs = argv
+        return makeNoopSpawnFn()(argv, opts)
+      }
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: capturingSpawn })
+
+      expect(registry.get('reply-resume')).toBeUndefined()
+
+      const ok = await registry.reply('reply-resume', 'the new user reply')
+      expect(ok).toBe(true)
+
+      await new Promise<void>((r) => setTimeout(r, 200))
+
+      expect(capturedArgs).toContain('--resume')
+      const resumeIdx = capturedArgs.indexOf('--resume')
+      expect(capturedArgs[resumeIdx + 1]).toBe('claude-abc')
+
+      expect(registry.get('reply-resume')).toBeDefined()
+    }, 60_000)
 
     test('returns false when runtime proc has already exited', async () => {
       const bare = trackedDir('bare-reply')

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -214,13 +214,65 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
     emitSnapshot(sessionId)
   }
 
+  async function resumeRuntime(
+    row: SessionRow,
+    initialPrompt: string,
+    initialImages?: Array<{ mediaType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'; dataBase64: string }>,
+  ): Promise<SessionRuntime> {
+    if (!row.claude_session_id) {
+      throw new Error(`Session ${row.id} has no claude_session_id to resume from`)
+    }
+    if (!row.workspace_root || !row.bare_dir || !row.branch) {
+      throw new Error(`Session ${row.id} is missing workspace metadata required to resume`)
+    }
+
+    const cwd = path.join(row.workspace_root, row.slug)
+    const handle: WorkspaceHandle = {
+      slug: row.slug,
+      cwd,
+      bareDir: row.bare_dir,
+      branch: row.branch,
+      baseRef: row.branch.replace(/^minion\//, ''),
+    }
+
+    if (row.repo) {
+      const repoName = extractRepoName(row.repo)
+      await rebootstrapIfMissing(cwd, repoName, row.workspace_root)
+    }
+
+    const runtime = makeRuntime({
+      sessionId: row.id,
+      mode: row.mode as CreateSessionMode,
+      cwd,
+      initialPrompt,
+      initialImages,
+      resumeClaudeSessionId: row.claude_session_id,
+    })
+
+    handles.set(row.id, handle)
+    runtimes.set(row.id, runtime)
+    wireCompletionHandler(row.id)
+
+    return runtime
+  }
+
   async function reply(
     sessionId: string,
     text: string,
     images?: Array<{ mediaType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'; dataBase64: string }>,
   ): Promise<boolean> {
-    const runtime = runtimes.get(sessionId)
-    if (!runtime) throw new Error(`No runtime for session ${sessionId}`)
+    let runtime = runtimes.get(sessionId)
+    if (!runtime) {
+      const row = prepared.getSession(db(), sessionId)
+      if (!row) throw new Error(`Session ${sessionId} not found`)
+      if (!row.claude_session_id) {
+        throw new Error(`Session ${sessionId} has no claude_session_id to resume from`)
+      }
+      runtime = await resumeRuntime(row, text, images)
+      void runtime.start()
+      prepared.updateSession(db(), { id: sessionId, updated_at: Date.now() })
+      return true
+    }
     const ok = await runtime.injectInput(text, images)
     prepared.updateSession(db(), { id: sessionId, updated_at: Date.now() })
     return ok
@@ -228,54 +280,23 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
 
   async function reconcileOnBoot(): Promise<void> {
     const rows = db()
-      .query<{ id: string; slug: string; status: string; claude_session_id: string | null; workspace_root: string | null; repo: string | null; branch: string | null; bare_dir: string | null; command: string; mode: string }, []>(
-        "SELECT id, slug, status, claude_session_id, workspace_root, repo, branch, bare_dir, command, mode FROM sessions WHERE status IN ('running','waiting_input') ORDER BY updated_at",
+      .query<{ id: string }, []>(
+        "SELECT id FROM sessions WHERE status IN ('running','waiting_input') ORDER BY updated_at",
       )
       .all()
 
-    for (const row of rows) {
-      const { id, slug, claude_session_id, workspace_root, repo, branch, bare_dir, command, mode } = row
+    for (const { id } of rows) {
+      const row = prepared.getSession(db(), id)
+      if (!row) continue
 
-      if (!claude_session_id) {
+      if (!row.claude_session_id || !row.workspace_root || !row.bare_dir || !row.branch) {
         prepared.updateSession(db(), { id, status: 'failed', updated_at: Date.now() })
         emitSnapshot(id)
         continue
       }
 
-      if (!workspace_root || !bare_dir || !branch) {
-        prepared.updateSession(db(), { id, status: 'failed', updated_at: Date.now() })
-        emitSnapshot(id)
-        continue
-      }
-
-      const cwd = path.join(workspace_root, slug)
-      const handle: WorkspaceHandle = {
-        slug,
-        cwd,
-        bareDir: bare_dir,
-        branch,
-        baseRef: branch.replace(/^minion\//, ''),
-      }
-
-      if (repo) {
-        const repoName = extractRepoName(repo)
-        await rebootstrapIfMissing(cwd, repoName, workspace_root)
-      }
-
-      const runtime = makeRuntime({
-        sessionId: id,
-        mode: mode as CreateSessionMode,
-        cwd,
-        initialPrompt: command,
-        resumeClaudeSessionId: claude_session_id,
-      })
-
-      handles.set(id, handle)
-      runtimes.set(id, runtime)
-      wireCompletionHandler(id)
-
+      const runtime = await resumeRuntime(row, row.command)
       void runtime.start()
-
       emitSnapshot(id)
     }
   }


### PR DESCRIPTION
## Summary

When a session's claude-CLI process exits (completion, quota, 15-min stall), its runtime is dropped from the in-memory `runtimes` map. Any subsequent reply via `POST /api/messages` hit `Error: No runtime for session <id>` and the user's only recourse was to start a new session, losing history.

The session row in SQLite still holds `claude_session_id` — claude CLI's `--resume <id>` can rehydrate the conversation. `reconcileOnBoot` already uses this path on engine restart, so `reply()` now uses the same path when the runtime is missing. The user's reply text becomes the next turn on the resumed claude session.

- Extracted `resumeRuntime(row, initialPrompt, images?)` helper shared by `reconcileOnBoot` and `reply`.
- `reply()` falls back to `resumeRuntime` when `runtimes.get(sessionId)` returns undefined.
- New error messages distinguish "session not found" vs "no claude_session_id to resume from".

## Test plan

- [x] `bunx tsc -p tsconfig.server.json --noEmit` — 0 errors
- [x] `npm run typecheck && npm run lint` — 0 errors
- [x] `bun test server/ shared/` — 628 pass (+3 new registry tests: non-existent session, missing claude_session_id, successful resume-on-reply with spawnFn capture of `--resume`)
- [x] `npm run test` — 706 pass
- [ ] Deploy on mini and retry dead session `23985103-56fd-4926-ad83-935e2f0e6578` via PWA reply