### PR TITLE
fix(ui): prevent viewport scroll beyond 100dvh

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -68,6 +68,7 @@ html,
 body {
   margin: 0;
   height: 100%;
+  overflow: hidden;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Adds `overflow: hidden` to `html` and `body` elements to prevent scrolling past viewport height on mobile

## Problem
The UI could be scrolled beyond its intended height, leaving empty scrollable space at the bottom. While the `#app` container was properly constrained to `100dvh`, the root HTML elements allowed overflow.

## Solution
Apply `overflow: hidden` to the `html, body` selector in `index.css`, working with the existing `100dvh` height constraint to fully lock the viewport.

## Test plan
- [x] Verify no extra scrollable space on mobile
- [x] Lint passes
- [x] Unit tests pass (pre-existing timer flakes unrelated)