### PR TITLE
fix(engine): close deletes the session row; /done merges PR before closing

### DIFF
--- a/server/commands/done.test.ts
+++ b/server/commands/done.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from 'bun:test'
 import { Database } from 'bun:sqlite'
 import { readFileSync } from 'node:fs'
 import { runMigrations } from '../db/sqlite'
-import { handleDoneCommand } from './done'
+import { handleDoneCommand, type DoneExecFn } from './done'
 import type { SessionRegistry } from '../session/registry'
 
 function makeDb(): Database {
@@ -13,45 +13,101 @@ function makeDb(): Database {
   return db
 }
 
-function seedSession(db: Database, id: string, status: string): void {
+function seedSession(db: Database, id: string, status: string, prUrl: string | null = null): void {
   const now = Date.now()
   db.run(
-    `INSERT INTO sessions (id, slug, status, command, mode, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation, quota_retry_count, metadata, pipeline_advancing)
-     VALUES (?, ?, ?, 'cmd', 'task', ?, ?, 0, '[]', '[]', '[]', 0, '{}', 0)`,
-    [id, `slug-${id}`, status, now, now],
+    `INSERT INTO sessions (id, slug, status, command, mode, pr_url, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation, quota_retry_count, metadata, pipeline_advancing)
+     VALUES (?, ?, ?, 'cmd', 'task', ?, ?, ?, 0, '[]', '[]', '[]', 0, '{}', 0)`,
+    [id, `slug-${id}`, status, prUrl, now, now],
   )
 }
 
-function makeRegistry(): SessionRegistry {
+interface TrackedRegistry extends SessionRegistry {
+  closedIds: string[]
+}
+
+function makeRegistry(): TrackedRegistry {
+  const closedIds: string[] = []
   return {
+    closedIds,
     async create() { throw new Error('not implemented') },
     get() { return undefined },
     getBySlug() { return undefined },
     list() { return [] },
     snapshot() { return undefined },
     async stop() {},
-    async close() {},
+    async close(id: string) { closedIds.push(id) },
     async reply() { return true },
     async reconcileOnBoot() {},
     async scheduleQuotaResume() {},
   }
 }
 
+function makeExec(behavior: 'success' | 'fail'): { exec: DoneExecFn; calls: Array<{ cmd: string; args: string[] }> } {
+  const calls: Array<{ cmd: string; args: string[] }> = []
+  const exec: DoneExecFn = async (cmd, args) => {
+    calls.push({ cmd, args })
+    if (behavior === 'fail') throw new Error('gh pr merge: conflicts')
+    return { stdout: '', stderr: '' }
+  }
+  return { exec, calls }
+}
+
 describe('handleDoneCommand', () => {
-  test('marks known session as completed', async () => {
+  test('merges PR via gh and closes session when pr_url is set', async () => {
     const db = makeDb()
-    seedSession(db, 's1', 'running')
-    const result = await handleDoneCommand('s1', { registry: makeRegistry(), db })
+    seedSession(db, 's1', 'running', 'https://github.com/org/repo/pull/42')
+    const registry = makeRegistry()
+    const { exec, calls } = makeExec('success')
+
+    const result = await handleDoneCommand('s1', { registry, db, execFile: exec })
+
     expect(result.ok).toBe(true)
-    expect(result.sessionId).toBe('s1')
-    const row = db.query<{ status: string }, []>('SELECT status FROM sessions').get()
-    expect(row?.status).toBe('completed')
+    expect(result.merged).toBe(true)
+    expect(result.prUrl).toBe('https://github.com/org/repo/pull/42')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.cmd).toBe('gh')
+    expect(calls[0]?.args).toEqual(['pr', 'merge', 'https://github.com/org/repo/pull/42', '--squash', '--delete-branch'])
+    expect(registry.closedIds).toEqual(['s1'])
+    db.close()
+  })
+
+  test('returns error without closing when session has no PR', async () => {
+    const db = makeDb()
+    seedSession(db, 's1', 'running', null)
+    const registry = makeRegistry()
+    const { exec, calls } = makeExec('success')
+
+    const result = await handleDoneCommand('s1', { registry, db, execFile: exec })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('no PR to merge')
+    expect(calls).toHaveLength(0)
+    expect(registry.closedIds).toEqual([])
+    db.close()
+  })
+
+  test('returns error without closing when gh pr merge fails', async () => {
+    const db = makeDb()
+    seedSession(db, 's1', 'running', 'https://github.com/org/repo/pull/42')
+    const registry = makeRegistry()
+    const { exec } = makeExec('fail')
+
+    const result = await handleDoneCommand('s1', { registry, db, execFile: exec })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('merge failed')
+    expect(registry.closedIds).toEqual([])
     db.close()
   })
 
   test('unknown sessionId returns error', async () => {
     const db = makeDb()
-    const result = await handleDoneCommand('no-such', { registry: makeRegistry(), db })
+    const registry = makeRegistry()
+    const { exec } = makeExec('success')
+
+    const result = await handleDoneCommand('no-such', { registry, db, execFile: exec })
+
     expect(result.ok).toBe(false)
     expect(result.error).toBeTruthy()
     db.close()
@@ -59,16 +115,25 @@ describe('handleDoneCommand', () => {
 
   test('no sessionId uses active session', async () => {
     const db = makeDb()
-    seedSession(db, 'active-1', 'running')
-    const result = await handleDoneCommand(undefined, { registry: makeRegistry(), db })
+    seedSession(db, 'active-1', 'running', 'https://github.com/org/repo/pull/7')
+    const registry = makeRegistry()
+    const { exec } = makeExec('success')
+
+    const result = await handleDoneCommand(undefined, { registry, db, execFile: exec })
+
     expect(result.ok).toBe(true)
     expect(result.sessionId).toBe('active-1')
+    expect(registry.closedIds).toEqual(['active-1'])
     db.close()
   })
 
   test('no sessionId with no active session returns error', async () => {
     const db = makeDb()
-    const result = await handleDoneCommand(undefined, { registry: makeRegistry(), db })
+    const registry = makeRegistry()
+    const { exec } = makeExec('success')
+
+    const result = await handleDoneCommand(undefined, { registry, db, execFile: exec })
+
     expect(result.ok).toBe(false)
     expect(result.error).toContain('no active session')
     db.close()

--- a/server/commands/done.ts
+++ b/server/commands/done.ts
@@ -1,15 +1,31 @@
+import { execFile as execFileCb } from 'node:child_process'
+import { promisify } from 'node:util'
 import type { SessionRegistry } from '../session/registry'
 import type { Database } from 'bun:sqlite'
 import { prepared } from '../db/sqlite'
 
+const execFileP = promisify(execFileCb)
+
+export type DoneExecFn = (
+  cmd: string,
+  args: string[],
+  opts: { timeout: number; encoding: 'utf-8' },
+) => Promise<{ stdout: string; stderr: string }>
+
+const defaultExec: DoneExecFn = (cmd, args, opts) =>
+  execFileP(cmd, args, opts) as Promise<{ stdout: string; stderr: string }>
+
 export interface DoneCommandCtx {
   registry: SessionRegistry
   db: Database
+  execFile?: DoneExecFn
 }
 
 export interface DoneCommandResult {
   ok: boolean
   sessionId?: string
+  prUrl?: string
+  merged?: boolean
   error?: string
 }
 
@@ -28,8 +44,25 @@ export async function handleDoneCommand(
   const row = prepared.getSession(ctx.db, resolvedId)
   if (!row) return { ok: false, error: `session ${resolvedId} not found` }
 
-  await ctx.registry.stop(resolvedId)
-  prepared.updateSession(ctx.db, { id: resolvedId, status: 'completed', updated_at: Date.now() })
+  if (!row.pr_url) {
+    return {
+      ok: false,
+      sessionId: resolvedId,
+      error: `session ${resolvedId} has no PR to merge; use /close to discard`,
+    }
+  }
 
-  return { ok: true, sessionId: resolvedId }
+  const exec = ctx.execFile ?? defaultExec
+  try {
+    await exec('gh', ['pr', 'merge', row.pr_url, '--squash', '--delete-branch'], {
+      timeout: 120_000,
+      encoding: 'utf-8',
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { ok: false, sessionId: resolvedId, prUrl: row.pr_url, error: `merge failed: ${msg}` }
+  }
+
+  await ctx.registry.close(resolvedId)
+  return { ok: true, sessionId: resolvedId, prUrl: row.pr_url, merged: true }
 }

--- a/server/session/registry.test.ts
+++ b/server/session/registry.test.ts
@@ -221,7 +221,7 @@ describe('SessionRegistry', () => {
   })
 
   describe('close', () => {
-    test('removes workspace directory and runtime from map', async () => {
+    test('removes workspace directory, runtime from map, and deletes the DB row', async () => {
       const bare = trackedDir('bare-close')
       const work = trackedDir('work-close')
       const workspaceRoot = trackedDir('ws-close')
@@ -238,6 +238,27 @@ describe('SessionRegistry', () => {
 
       expect(registry.get(session.id)).toBeUndefined()
       expect(fs.existsSync(workDir)).toBe(false)
+
+      const row = db.query<{ id: string }, [string]>('SELECT id FROM sessions WHERE id = ?').get(session.id)
+      expect(row).toBeNull()
+    }, 30_000)
+
+    test('emits session.deleted event', async () => {
+      const bare = trackedDir('bare-close-evt')
+      const work = trackedDir('work-close-evt')
+      const workspaceRoot = trackedDir('ws-close-evt')
+      await initLocalBareRepo(bare, work)
+
+      const bus = getEventBus()
+      const deleted: string[] = []
+      bus.onKind('session.deleted', (e) => { deleted.push(e.sessionId) })
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn() })
+      const { session } = await registry.create({ mode: 'task', prompt: 'evt', repo: bare, workspaceRoot })
+
+      await registry.close(session.id)
+
+      expect(deleted).toContain(session.id)
     }, 30_000)
   })
 

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -210,8 +210,8 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
       await removeWorkspace(handle)
     }
 
-    prepared.updateSession(db(), { id: sessionId, status: 'completed', updated_at: Date.now() })
-    emitSnapshot(sessionId)
+    prepared.deleteSession(db(), sessionId)
+    bus.emit({ kind: 'session.deleted', sessionId })
   }
 
   async function resumeRuntime(


### PR DESCRIPTION
## Summary

Two related fixes around session termination semantics:

**`close` actually removes the session now.** `registry.close()` was setting status to `'completed'` and emitting a snapshot. The row stayed in SQLite, so the next SSE reconnect refetched `/api/sessions` and brought the "closed" session back into the PWA list. Because the PWA's `closable` predicate is `status !== 'completed'`, the Close action was then disabled — users were stuck with phantom completed threads they couldn't clear. Fix: `close()` now `prepared.deleteSession()` + emits `session.deleted`. The SSE projection and PWA store both already handle that event end-to-end.

**`/done` merges the PR first.** `handleDoneCommand` was only stopping the runtime and marking the row completed — no merge, same phantom-session issue. `/done` now requires a `pr_url`, runs `gh pr merge <url> --squash --delete-branch`, then calls `registry.close()`. If merge fails (conflicts, branch protection, etc.), the session stays so the user can fix and retry. If there's no PR, returns an error pointing at `/close` to discard.

## Test plan

- [x] `bunx tsc -p tsconfig.server.json --noEmit` — 0 errors
- [x] `npm run typecheck && npm run lint` — 0 errors
- [x] `bun test server/ shared/` — 631 pass (+3 new: close deletes row, close emits session.deleted, /done merges-then-closes with injectable exec)
- [x] `npm run test` — 706 pass (unchanged)
- [ ] Deploy on mini, verify closing a thread removes it for good and `/done` on a session with a PR merges + cleans up