### PR TITLE
Allow closing completed/failed sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -221,7 +221,6 @@ function ChatPane({
   }
 
   const stoppable = session.status === 'running' || session.status === 'pending'
-  const closable = session.status !== 'completed' && session.status !== 'failed'
   const mobileFullscreen = !isDesktopPane.value && fullscreen
   const rootClass = mobileFullscreen
     ? 'fixed inset-0 z-40 flex flex-col bg-white dark:bg-slate-800'
@@ -280,8 +279,8 @@ function ChatPane({
           <button
             type="button"
             onClick={() => void handleClose()}
-            disabled={!closable || pending !== null}
-            title={closable ? 'Close this session permanently' : 'Session is already terminal'}
+            disabled={pending !== null}
+            title="Close this session permanently"
             class="rounded-md border border-red-300 dark:border-red-800 text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 px-2 py-1 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-900/50 disabled:opacity-40 disabled:cursor-not-allowed"
             data-testid="chat-close-btn"
           >

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -209,25 +209,25 @@ export function ContextMenu({ session, position, actions, onClose, dagContext }:
     }
   }
 
-  if (isRunning || isActive) {
+  if (isRunning) {
     if (items.length > 0) items.push('divider')
-    if (isRunning) {
-      items.push({
-        label: 'Stop Minion',
-        emoji: '⏹',
-        variant: 'danger',
-        onClick: handleStopClick,
-        disabled: actions.isActionLoading,
-      })
-    }
     items.push({
-      label: 'Close Session',
-      emoji: '✕',
+      label: 'Stop Minion',
+      emoji: '⏹',
       variant: 'danger',
-      onClick: handleCloseClick,
+      onClick: handleStopClick,
       disabled: actions.isActionLoading,
     })
   }
+
+  if (items.length > 0) items.push('divider')
+  items.push({
+    label: 'Close Session',
+    emoji: '✕',
+    variant: 'danger',
+    onClick: handleCloseClick,
+    disabled: actions.isActionLoading,
+  })
 
   const itemCount = items.filter((i) => i !== 'divider').length
   const dividerCount = items.filter((i) => i === 'divider').length

--- a/test/components/ContextMenu.test.tsx
+++ b/test/components/ContextMenu.test.tsx
@@ -127,7 +127,7 @@ describe('ContextMenu', () => {
     expect(screen.queryByText('Open in Telegram')).toBeNull()
   })
 
-  it('renders no items for completed sessions', () => {
+  it('renders close action for completed sessions', () => {
     render(
       <ContextMenu
         session={mockCompletedSession}
@@ -139,7 +139,7 @@ describe('ContextMenu', () => {
 
     expect(screen.queryByText('Send Reply')).toBeNull()
     expect(screen.queryByText('Stop Minion')).toBeNull()
-    expect(screen.queryByText('Close Session')).toBeNull()
+    expect(screen.getByText('Close Session')).toBeTruthy()
   })
 
   it('renders quick action items when session has quick actions', () => {


### PR DESCRIPTION
## Summary

Users can now dismiss completed and failed sessions from the UI. Previously, the close action was incorrectly gated behind session status, preventing cleanup of terminal sessions even though the backend supports it.

## Changes

- **ContextMenu**: Separated "Stop Minion" (running-only) from "Close Session" (always available)
- **ChatPane**: Removed `closable` gate that blocked completed/failed sessions
- **Test**: Updated to verify close action appears for completed sessions

## Technical details

Root cause was a port artifact from the Telegram Mini App where "stop work" and "dismiss UI" were conflated. The backend already supports closing any session via `sendCommand({ action: 'close', sessionId })` — this just unlocks it in the UI.

## Test plan

- [x] ESLint passes
- [x] Unit tests pass (test updated to match new behavior)
- [ ] Manual: Right-click completed session → "Close Session" appears
- [ ] Manual: Click close button in ChatPane for completed session → session dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)