### PR TITLE
fix(engine): stop crashing on restart; resume → fail-with-status; gate loops

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -19,6 +19,9 @@ ENABLE_GITHUB_MCP=true
 ENABLE_CONTEXT7_MCP=true
 ENABLE_SUPABASE_MCP=false
 
+# Background loop scheduler (digest, ci-babysit, etc.). Default off.
+ENABLE_LOOPS=false
+
 # For cloudflared profile
 CLOUDFLARE_TUNNEL_TOKEN=
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -22,6 +22,7 @@ services:
       ENABLE_GITHUB_MCP: ${ENABLE_GITHUB_MCP:-true}
       ENABLE_CONTEXT7_MCP: ${ENABLE_CONTEXT7_MCP:-true}
       ENABLE_SUPABASE_MCP: ${ENABLE_SUPABASE_MCP:-false}
+      ENABLE_LOOPS: ${ENABLE_LOOPS:-false}
     volumes:
       - workspace:/workspace
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,7 @@ export default tseslint.config(
       'node_modules/**',
       '.home/**',
       '.claude/**',
+      '.claire/**',
       'scripts/**',
       'playwright.config.js',
       'playwright.config.d.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,8 +52,7 @@
         "vitest": "^4.1.0",
         "workbox-core": "^7.0.0",
         "workbox-precaching": "^7.0.0",
-        "workbox-routing": "^7.0.0",
-        "workbox-strategies": "^7.0.0"
+        "workbox-routing": "^7.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/server/index.ts
+++ b/server/index.ts
@@ -118,7 +118,13 @@ dispatcher.register(digestHandler)
 dispatcher.register(ciBabysitHandler)
 dispatcher.register(parentNotifyHandler)
 
-loopScheduler.start()
+const loopsEnabled = (process.env['ENABLE_LOOPS'] ?? 'false').toLowerCase() === 'true'
+if (loopsEnabled) {
+  loopScheduler.start()
+  console.log('[minion] loop scheduler started')
+} else {
+  console.log('[minion] loop scheduler disabled (set ENABLE_LOOPS=true to enable)')
+}
 
 const resourceMonitor = new ResourceMonitor(bus)
 resourceMonitor.start()

--- a/server/session/registry.test.ts
+++ b/server/session/registry.test.ts
@@ -361,7 +361,7 @@ describe('SessionRegistry', () => {
   })
 
   describe('reconcileOnBoot', () => {
-    test('skips rows with null claude_session_id and marks them failed', async () => {
+    test('marks running sessions failed and emits a session_interrupted status event', async () => {
       const now = Date.now()
       db.run(
         `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, bare_dir, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation)
@@ -375,43 +375,42 @@ describe('SessionRegistry', () => {
       const row = db.query<{ status: string }, [string]>('SELECT status FROM sessions WHERE id = ?').get('recon-1')
       expect(row?.status).toBe('failed')
       expect(registry.get('recon-1')).toBeUndefined()
+
+      const events = db
+        .query<{ type: string; payload: string }, [string]>(
+          'SELECT type, payload FROM session_events WHERE session_id = ? ORDER BY seq',
+        )
+        .all('recon-1')
+      expect(events.map((e) => e.type)).toEqual(['status', 'turn_completed'])
+      const statusPayload = JSON.parse(events[0]!.payload) as { kind: string; severity: string }
+      expect(statusPayload.kind).toBe('session_interrupted')
+      expect(statusPayload.severity).toBe('error')
     })
 
-    test('resumes a session that has a claude_session_id', async () => {
-      const bare = trackedDir('bare-recon')
-      const work = trackedDir('work-recon')
-      const workspaceRoot = trackedDir('ws-recon')
-      await initLocalBareRepo(bare, work)
-
-      const repoName = path.basename(bare).replace(/\.git$/, '')
-      const bareDir = path.join(workspaceRoot, '.repos', `${repoName}.git`)
-
-      const handle = await import('../workspace/prepare').then((m) =>
-        m.prepareWorkspace({ slug: 'recon-slug', repoUrl: bare, workspaceRoot, bootstrap: false }),
-      )
-
+    test('does not resume sessions even when claude_session_id is present', async () => {
       const now = Date.now()
       db.run(
         `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, bare_dir, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation)
-         VALUES ('recon-2', 'recon-slug', 'running', 'resume task', 'task', ?, ?, ?, null, null, null, 'claude-session-xyz', ?, ?, ?, 0, '[]', '[]', '[]')`,
-        [bare, handle.branch, bareDir, workspaceRoot, now, now],
+         VALUES ('recon-2', 'recon-slug', 'running', 'resume task', 'task', null, null, null, null, null, null, 'claude-session-xyz', null, ?, ?, 0, '[]', '[]', '[]')`,
+        [now, now],
       )
 
-      let capturedArgs: string[] = []
+      let spawned = false
       const capturingSpawn: SpawnFn = (argv, opts) => {
-        capturedArgs = argv
+        spawned = true
         return makeNoopSpawnFn()(argv, opts)
       }
 
       const registry = createSessionRegistry({ getDb: () => db, spawnFn: capturingSpawn })
       await registry.reconcileOnBoot()
 
-      await new Promise<void>((r) => setTimeout(r, 200))
+      await new Promise<void>((r) => setTimeout(r, 100))
 
-      expect(capturedArgs).toContain('--resume')
-      const resumeIdx = capturedArgs.indexOf('--resume')
-      expect(capturedArgs[resumeIdx + 1]).toBe('claude-session-xyz')
-    }, 60_000)
+      expect(spawned).toBe(false)
+      const row = db.query<{ status: string }, [string]>('SELECT status FROM sessions WHERE id = ?').get('recon-2')
+      expect(row?.status).toBe('failed')
+      expect(registry.get('recon-2')).toBeUndefined()
+    })
   })
 
   describe('session.snapshot events', () => {

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import path from 'node:path'
-import type { ApiSession, CreateSessionMode, QuickAction } from '../../shared/api-types'
+import type { ApiSession, CreateSessionMode, QuickAction, TranscriptEvent } from '../../shared/api-types'
 import { SessionRuntime, type StartOpts as RuntimeStartOpts, type SpawnFn } from './runtime'
 import { prepareWorkspace, removeWorkspace, rebootstrapIfMissing } from '../workspace/prepare'
 import type { WorkspaceHandle } from '../workspace/types'
@@ -289,16 +289,64 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
       const row = prepared.getSession(db(), id)
       if (!row) continue
 
-      if (!row.claude_session_id || !row.workspace_root || !row.bare_dir || !row.branch) {
-        prepared.updateSession(db(), { id, status: 'failed', updated_at: Date.now() })
-        emitSnapshot(id)
-        continue
-      }
+      const now = Date.now()
+      const seq = prepared.nextSeq(db(), id)
+      const turn = currentTurn(id)
 
-      const runtime = await resumeRuntime(row, row.command)
-      void runtime.start()
+      const interrupted: TranscriptEvent = {
+        seq,
+        id: randomUUID(),
+        sessionId: id,
+        turn,
+        timestamp: now,
+        type: 'status',
+        severity: 'error',
+        kind: 'session_interrupted',
+        message: 'Session was interrupted by an engine restart and could not be resumed. Start a new session to continue.',
+      }
+      prepared.insertEvent(db(), {
+        session_id: id,
+        seq,
+        turn,
+        type: 'status',
+        timestamp: now,
+        payload: { ...interrupted },
+      })
+
+      const closeSeq = seq + 1
+      const closeEvt: TranscriptEvent = {
+        seq: closeSeq,
+        id: randomUUID(),
+        sessionId: id,
+        turn,
+        timestamp: now,
+        type: 'turn_completed',
+        durationMs: 0,
+        errored: true,
+      }
+      prepared.insertEvent(db(), {
+        session_id: id,
+        seq: closeSeq,
+        turn,
+        type: 'turn_completed',
+        timestamp: now,
+        payload: { ...closeEvt },
+      })
+
+      prepared.updateSession(db(), { id, status: 'failed', updated_at: now })
+      bus.emit({ kind: 'session.stream', sessionId: id, event: interrupted })
+      bus.emit({ kind: 'session.stream', sessionId: id, event: closeEvt })
       emitSnapshot(id)
     }
+  }
+
+  function currentTurn(sessionId: string): number {
+    const row = db()
+      .query<{ max_turn: number | null }, [string]>(
+        'SELECT MAX(turn) as max_turn FROM session_events WHERE session_id = ?',
+      )
+      .get(sessionId)
+    return row?.max_turn ?? 1
   }
 
   async function scheduleQuotaResume(sessionId: string, resetAt: number): Promise<void> {

--- a/src/chat/transcript/StatusBanner.tsx
+++ b/src/chat/transcript/StatusBanner.tsx
@@ -11,6 +11,23 @@ const TONE: Record<StatusEvent['severity'], string> = {
   error: 'border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300',
 }
 
+const KIND_LABELS: Record<string, string> = {
+  session_error: 'Session error',
+  session_interrupted: 'Session interrupted',
+  session_stalled: 'Session stalled',
+  session_resumed: 'Session resumed',
+  quota_exhausted: 'Quota exhausted',
+  stream_stalled: 'Stream stalled',
+}
+
+function formatKind(kind: string): string {
+  if (KIND_LABELS[kind]) return KIND_LABELS[kind]
+  return kind
+    .split('_')
+    .map((part) => (part.length === 0 ? part : part[0]!.toUpperCase() + part.slice(1)))
+    .join(' ')
+}
+
 export function StatusBanner({ event }: Props) {
   const tone = TONE[event.severity]
   return (
@@ -18,11 +35,12 @@ export function StatusBanner({ event }: Props) {
       class={`flex items-start gap-2 rounded-md border px-3 py-1.5 text-xs ${tone}`}
       data-testid="transcript-status"
       data-severity={event.severity}
+      data-kind={event.kind}
     >
       <StatusIcon severity={event.severity} class="w-3.5 h-3.5 mt-0.5 shrink-0" />
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
-          <span class="font-mono text-[10px] uppercase tracking-wider opacity-80">{event.kind}</span>
+          <span class="text-[11px] font-semibold tracking-wide">{formatKind(event.kind)}</span>
         </div>
         <div class="break-words whitespace-pre-wrap">{event.message}</div>
       </div>

--- a/src/chat/transcript/ToolCallCard.tsx
+++ b/src/chat/transcript/ToolCallCard.tsx
@@ -10,14 +10,18 @@ interface Props {
   result: ToolResultEvent | null
   defaultOpen?: boolean
   variant?: 'standalone' | 'grouped'
+  sessionTerminal?: boolean
 }
 
-export function ToolCallCard({ call, result, defaultOpen = false, variant = 'standalone' }: Props) {
+type DisplayStatus = 'pending' | 'ok' | 'error' | 'aborted'
+
+export function ToolCallCard({ call, result, defaultOpen = false, variant = 'standalone', sessionTerminal = false }: Props) {
   const [open, setOpen] = useState(defaultOpen)
   const [resultOpen, setResultOpen] = useState(() => !isBigResult(result))
   const summary = call.call
 
-  const status: 'pending' | 'ok' | 'error' = result?.result.status ?? 'pending'
+  const baseStatus = result?.result.status ?? 'pending'
+  const status: DisplayStatus = baseStatus === 'pending' && sessionTerminal ? 'aborted' : baseStatus
   const preview = buildResultPreview(result)
   const statusBadge = (
     <span
@@ -26,7 +30,9 @@ export function ToolCallCard({ call, result, defaultOpen = false, variant = 'sta
           ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
           : status === 'error'
             ? 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'
-            : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 animate-pulse'
+            : status === 'aborted'
+              ? 'bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-400'
+              : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 animate-pulse'
       }`}
       data-testid={`transcript-tool-status-${status}`}
     >
@@ -109,9 +115,9 @@ export function ToolCallCard({ call, result, defaultOpen = false, variant = 'sta
           ) : (
             <div
               class="border-t border-slate-200 dark:border-slate-700 px-3 py-2 text-[11px] italic text-slate-500 dark:text-slate-400"
-              data-testid="transcript-tool-call-pending"
+              data-testid={status === 'aborted' ? 'transcript-tool-call-aborted' : 'transcript-tool-call-pending'}
             >
-              Waiting for result…
+              {status === 'aborted' ? 'Aborted — session ended before tool finished.' : 'Waiting for result…'}
             </div>
           )}
         </div>

--- a/src/chat/transcript/Transcript.tsx
+++ b/src/chat/transcript/Transcript.tsx
@@ -21,6 +21,8 @@ export function Transcript({ store }: Props) {
   const events = store.events.value
   const loading = store.loading.value
   const error = store.error.value
+  const sessionInfo = store.session.value
+  const sessionTerminal = sessionInfo?.active === false
   const rows = useMemo(() => buildTranscriptRows(events).rows, [events])
 
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -97,9 +99,13 @@ export function Transcript({ store }: Props) {
         )}
         {groupRows(rows).map((item) =>
           item.kind === 'tool-group' ? (
-            <ToolGroup key={`tg:${item.items[0].call.call.toolUseId}`} items={item.items} />
+            <ToolGroup
+              key={`tg:${item.items[0].call.call.toolUseId}`}
+              items={item.items}
+              sessionTerminal={sessionTerminal}
+            />
           ) : (
-            <RowView key={rowKey(item.row)} row={item.row} />
+            <RowView key={rowKey(item.row)} row={item.row} sessionTerminal={sessionTerminal} />
           ),
         )}
       </div>
@@ -121,7 +127,7 @@ export function Transcript({ store }: Props) {
   )
 }
 
-function RowView({ row }: { row: TranscriptRow }) {
+function RowView({ row, sessionTerminal }: { row: TranscriptRow; sessionTerminal: boolean }) {
   switch (row.kind) {
     case 'turn-separator':
       return <TurnSeparator turn={row.turn} started={row.started} completed={row.completed} />
@@ -132,7 +138,7 @@ function RowView({ row }: { row: TranscriptRow }) {
     case 'thinking':
       return <ThinkingBlock event={row.event} />
     case 'tool-call':
-      return <ToolCallCard call={row.call} result={row.result} />
+      return <ToolCallCard call={row.call} result={row.result} sessionTerminal={sessionTerminal} />
     case 'tool-result-orphan':
       return <ToolResultOrphan event={row.event} />
 
@@ -167,15 +173,18 @@ function groupRows(rows: TranscriptRow[]): RenderItem[] {
   return out
 }
 
-function ToolGroup({ items }: { items: ToolCallRow[] }) {
+function ToolGroup({ items, sessionTerminal }: { items: ToolCallRow[]; sessionTerminal: boolean }) {
   const [open, setOpen] = useState(items.length <= TOOL_GROUP_COLLAPSE_THRESHOLD)
 
   let pending = 0
+  let aborted = 0
   let errors = 0
   for (const row of items) {
     const status = row.result?.result.status ?? 'pending'
-    if (status === 'pending') pending++
-    else if (status === 'error') errors++
+    if (status === 'pending') {
+      if (sessionTerminal) aborted++
+      else pending++
+    } else if (status === 'error') errors++
   }
 
   const label = `${items.length} tool ${items.length === 1 ? 'call' : 'calls'}`
@@ -203,6 +212,14 @@ function ToolGroup({ items }: { items: ToolCallRow[] }) {
             {pending} pending
           </span>
         )}
+        {aborted > 0 && (
+          <span
+            class="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-400"
+            data-testid="transcript-tool-group-aborted"
+          >
+            {aborted} aborted
+          </span>
+        )}
         {errors > 0 && (
           <span
             class="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300"
@@ -220,6 +237,7 @@ function ToolGroup({ items }: { items: ToolCallRow[] }) {
               call={row.call}
               result={row.result}
               variant="grouped"
+              sessionTerminal={sessionTerminal}
             />
           ))}
         </div>

--- a/test/chat/transcript/components.test.tsx
+++ b/test/chat/transcript/components.test.tsx
@@ -379,7 +379,7 @@ describe('ToolResultOrphan', () => {
 })
 
 describe('StatusBanner', () => {
-  it('renders kind and message and severity attribute', () => {
+  it('renders title-cased kind and message and severity attribute', () => {
     const event: StatusEvent = {
       ...baseEvent(1),
       type: 'status',
@@ -390,8 +390,22 @@ describe('StatusBanner', () => {
     render(<StatusBanner event={event} />)
     const banner = screen.getByTestId('transcript-status')
     expect(banner.getAttribute('data-severity')).toBe('warn')
-    expect(banner.textContent).toContain('rate_limit')
+    expect(banner.getAttribute('data-kind')).toBe('rate_limit')
+    expect(banner.textContent).toContain('Rate Limit')
     expect(banner.textContent).toContain('API rate limit approaching')
+  })
+
+  it('uses friendly label for known kinds', () => {
+    const event: StatusEvent = {
+      ...baseEvent(1),
+      type: 'status',
+      severity: 'error',
+      kind: 'session_interrupted',
+      message: 'Engine restarted',
+    }
+    render(<StatusBanner event={event} />)
+    const banner = screen.getByTestId('transcript-status')
+    expect(banner.textContent).toContain('Session interrupted')
   })
 })
 


### PR DESCRIPTION
## Summary

Three problems were stacked on top of each other in the failing screenshot you flagged:

- **Engine crashed on hot-reload / restart** with `SQLiteError: UNIQUE constraint failed: session_events.session_id, session_events.seq`. Root cause: `reconcileOnBoot` resumed any `running`/`waiting_input` session by re-emitting `turn_started` + `user_message` and piping the original prompt into a fresh `claude --resume`. Under `bun --hot` (used by `scripts/dev-local.sh`), two `SessionRuntime` instances briefly coexisted — both translators read the same `nextSeq()` from disk → seq collision. Cross-restart resume isn't reliably implementable, so this PR marks interrupted sessions `failed` and emits a `session_interrupted` status event explaining what happened. Removes the bug class entirely.
- **Pending tool calls render forever** even after the session terminates. They now flip to `aborted` (with a friendlier 'Aborted — session ended before tool finished' line) once the session is non-active. Plumbed via `TranscriptStore.session.value.active`.
- **`SESSION_ERROR` / `Unknown error`** is raw enum jargon. `StatusBanner` now title-cases the kind and uses a friendly label map (`session_error` → 'Session error', `session_interrupted` → 'Session interrupted', etc.).

Loop scheduler is now gated behind `ENABLE_LOOPS=true` (default off) so background loops don't kick automatically. `docker/.env.example` and `docker/compose.yaml` updated to surface the var.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` — 707 / 707 passing
- [x] `bun test server/ shared/` — 631 / 632 passing (1 skip, 0 fail)
- [x] Updated `reconcileOnBoot` tests assert sessions are marked failed and a `session_interrupted` status event is persisted
- [x] Updated `StatusBanner` test asserts friendly label and `data-kind` attribute