### PR TITLE
fix(plan-actions): read assistant_text events so /execute can extract DAG items

### DIFF
--- a/server/commands/plan-actions.test.ts
+++ b/server/commands/plan-actions.test.ts
@@ -182,6 +182,68 @@ describe("plan-actions gating", () => {
     expect(result.reason).toBe("no items extracted")
     expect(startedDagIds).toHaveLength(0)
   })
+
+  it("includes assistant_text events (final:true) in the extraction conversation", async () => {
+    const sessionId = insertSession(db)
+    const now = Date.now()
+    prepared.insertEvent(db, {
+      session_id: sessionId,
+      seq: 1,
+      turn: 0,
+      type: "user_message",
+      timestamp: now,
+      payload: { text: "please plan the work" },
+    })
+    prepared.insertEvent(db, {
+      session_id: sessionId,
+      seq: 2,
+      turn: 1,
+      type: "assistant_text",
+      timestamp: now + 1,
+      payload: { text: "DELTA_CHUNK_do_not_include", final: false },
+    })
+    prepared.insertEvent(db, {
+      session_id: sessionId,
+      seq: 3,
+      turn: 1,
+      type: "assistant_text",
+      timestamp: now + 2,
+      payload: { text: "FINAL_PLAN_build_the_schema", final: true },
+    })
+
+    const stdinWrites: string[] = []
+    mockSpawn.mockImplementation(() => ({
+      stdout: {
+        on: vi.fn((event: string, cb: (data: Buffer) => void) => {
+          if (event === "data") cb(Buffer.from("[]"))
+        }),
+      },
+      stderr: { on: vi.fn() },
+      stdin: {
+        write: vi.fn((data: string) => { stdinWrites.push(data) }),
+        end: vi.fn(),
+      },
+      on: vi.fn((event: string, cb: (code: number) => void) => {
+        if (event === "close") cb(0)
+      }),
+      kill: vi.fn(),
+    }))
+
+    const stopCalls: string[] = []
+    const startedDagIds: string[] = []
+    const ctx: PlanActionCtx = {
+      db,
+      registry: makeRegistry(stopCalls),
+      scheduler: makeScheduler(startedDagIds),
+    }
+
+    await handleExecute(sessionId, ctx)
+
+    const combined = stdinWrites.join("")
+    expect(combined).toContain("please plan the work")
+    expect(combined).toContain("FINAL_PLAN_build_the_schema")
+    expect(combined).not.toContain("DELTA_CHUNK_do_not_include")
+  })
 })
 
 describe("handleSplit", () => {

--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -44,7 +44,10 @@ function getConversationMessages(db: Database, sessionId: string): Array<{ role:
     }
     const text = typeof payload.text === "string" ? payload.text : ""
     if (!text) continue
-    if (row.type === "assistant_message" || row.type === "assistant") {
+    if (row.type === "assistant_text") {
+      if (payload.final !== true) continue
+      messages.push({ role: "assistant", text })
+    } else if (row.type === "assistant_message" || row.type === "assistant") {
       messages.push({ role: "assistant", text })
     } else if (row.type === "user_message" || row.type === "user") {
       messages.push({ role: "user", text })
@@ -55,13 +58,14 @@ function getConversationMessages(db: Database, sessionId: string): Array<{ role:
 
 function getLastAssistantMessage(db: Database, sessionId: string): string {
   const rows = db
-    .query<{ payload: string }, [string]>(
-      "SELECT payload FROM session_events WHERE session_id = ? AND type IN ('assistant_message','assistant') ORDER BY seq DESC LIMIT 1",
+    .query<{ type: string; payload: string }, [string]>(
+      "SELECT type, payload FROM session_events WHERE session_id = ? AND type IN ('assistant_text','assistant_message','assistant') ORDER BY seq DESC",
     )
     .all(sessionId)
   for (const row of rows) {
     try {
       const payload = JSON.parse(row.payload) as Record<string, unknown>
+      if (row.type === "assistant_text" && payload.final !== true) continue
       if (typeof payload.text === "string" && payload.text.length > 0) return payload.text
     } catch {
       continue

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -184,8 +184,16 @@ function ChatPane({
       })
       if (!ok) return
     }
-    await onSend(fullText, session.id)
-    setText('')
+    try {
+      await onSend(fullText, session.id)
+      setText('')
+    } catch (e) {
+      await confirm({
+        title: `${cmd.cmd} failed`,
+        message: e instanceof Error ? e.message : String(e),
+        mode: 'alert',
+      })
+    }
   }
 
   const handleStop = async () => {


### PR DESCRIPTION
## Summary
- `/execute`, `/split`, `/stack`, and `/dag` silently failed on completed `think`/`plan` sessions with \"no items extracted\" because `plan-actions.ts` only matched `assistant_message`/`assistant` event types, while the engine emits `assistant_text`. The reconstructed conversation was missing every assistant turn, so DAG extraction had nothing to analyze.
- Include `assistant_text` in `getConversationMessages` and `getLastAssistantMessage`, filtering to `final:true` so streaming deltas aren't double-counted.
- Surface slash-command errors in the UI via the existing `confirm({mode:'alert'})` path — the previous `onClick={() => void onCommand(...)}` swallowed failures so the user saw nothing on click.

## Test plan
- [x] New regression test in `server/commands/plan-actions.test.ts` seeds `assistant_text` deltas + final and asserts the extraction stdin contains the finalized text but not the delta chunk.
- [x] `npm run typecheck && npm run lint && npm run test` (707 pass).
- [x] `npm run test:server` (633 pass).