### PR TITLE
fix(engine): auto-advance ship sessions through phases

### DIFF
--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -30,7 +30,7 @@ function sleep(ms: number): Promise<void> {
 function getConversationMessages(db: Database, sessionId: string): Array<{ role: string; text: string }> {
   const rows = db
     .query<{ type: string; payload: string }, [string]>(
-      "SELECT type, payload FROM session_events WHERE session_id = ? ORDER BY seq ASC",
+      "SELECT type, payload FROM session_events WHERE session_id = ? AND type IN ('user_message','assistant_text') ORDER BY seq ASC",
     )
     .all(sessionId)
 
@@ -44,34 +44,47 @@ function getConversationMessages(db: Database, sessionId: string): Array<{ role:
     }
     const text = typeof payload.text === "string" ? payload.text : ""
     if (!text) continue
-    if (row.type === "assistant_text") {
-      if (payload.final !== true) continue
-      messages.push({ role: "assistant", text })
-    } else if (row.type === "assistant_message" || row.type === "assistant") {
-      messages.push({ role: "assistant", text })
-    } else if (row.type === "user_message" || row.type === "user") {
+    if (row.type === "user_message") {
       messages.push({ role: "user", text })
+    } else if (row.type === "assistant_text" && payload.final === true) {
+      messages.push({ role: "assistant", text })
     }
   }
   return messages
 }
 
 function getLastAssistantMessage(db: Database, sessionId: string): string {
-  const rows = db
-    .query<{ type: string; payload: string }, [string]>(
-      "SELECT type, payload FROM session_events WHERE session_id = ? AND type IN ('assistant_text','assistant_message','assistant') ORDER BY seq DESC",
+  const maxTurnRow = db
+    .query<{ max_turn: number | null }, [string]>(
+      "SELECT MAX(turn) as max_turn FROM session_events WHERE session_id = ? AND type = 'assistant_text'",
     )
-    .all(sessionId)
+    .get(sessionId)
+  const lastTurn = maxTurnRow?.max_turn ?? null
+  if (lastTurn === null) return ""
+
+  const rows = db
+    .query<{ payload: string }, [string, number]>(
+      "SELECT payload FROM session_events WHERE session_id = ? AND type = 'assistant_text' AND turn = ? ORDER BY seq ASC",
+    )
+    .all(sessionId, lastTurn)
+
+  const blocks = new Map<string, string>()
   for (const row of rows) {
+    let payload: Record<string, unknown>
     try {
-      const payload = JSON.parse(row.payload) as Record<string, unknown>
-      if (row.type === "assistant_text" && payload.final !== true) continue
-      if (typeof payload.text === "string" && payload.text.length > 0) return payload.text
+      payload = JSON.parse(row.payload) as Record<string, unknown>
     } catch {
       continue
     }
+    const blockId = typeof payload.blockId === "string" ? payload.blockId : ""
+    const text = typeof payload.text === "string" ? payload.text : ""
+    const final = payload.final === true
+    if (!blockId || !text) continue
+    if (final) blocks.set(blockId, text)
+    else if (!blocks.has(blockId)) blocks.set(blockId, text)
   }
-  return ""
+
+  return Array.from(blocks.values()).filter((t) => t.length > 0).join("\n\n")
 }
 
 async function gate(sessionId: string, ctx: PlanActionCtx): Promise<string | null> {
@@ -79,6 +92,13 @@ async function gate(sessionId: string, ctx: PlanActionCtx): Promise<string | nul
   if (!row) return "session not found"
   if (row.pipeline_advancing) return "pipeline already advancing"
   return null
+}
+
+function setPipelineAdvancing(ctx: PlanActionCtx, sessionId: string, value: boolean): void {
+  ctx.db.run(
+    "UPDATE sessions SET pipeline_advancing = ?, updated_at = ? WHERE id = ?",
+    [value ? 1 : 0, Date.now(), sessionId],
+  )
 }
 
 async function killAndWait(sessionId: string, ctx: PlanActionCtx): Promise<void> {
@@ -132,22 +152,35 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
   const row = prepared.getSession(ctx.db, sessionId)
   const mode = row?.mode
 
-  await killAndWait(sessionId, ctx)
+  setPipelineAdvancing(ctx, sessionId, true)
 
-  if (mode === "ship-think") {
-    return handoffShipPhase(sessionId, "ship-plan", ctx)
+  let result: PlanActionResult
+  try {
+    await killAndWait(sessionId, ctx)
+
+    if (mode === "ship-think") {
+      result = await handoffShipPhase(sessionId, "ship-plan", ctx)
+    } else {
+      const conversation = getConversationMessages(ctx.db, sessionId)
+      const typedConversation = conversation.map((m) => ({
+        role: m.role as "user" | "assistant",
+        text: m.text,
+      }))
+
+      const extraction = await extractDagItems(typedConversation)
+      if (extraction.error) {
+        result = { ok: false, reason: extraction.errorMessage ?? extraction.error }
+      } else {
+        result = await buildAndStartDag(extraction.items, sessionId, ctx)
+      }
+    }
+  } catch (err) {
+    setPipelineAdvancing(ctx, sessionId, false)
+    throw err
   }
 
-  const conversation = getConversationMessages(ctx.db, sessionId)
-  const typedConversation = conversation.map((m) => ({
-    role: m.role as "user" | "assistant",
-    text: m.text,
-  }))
-
-  const result = await extractDagItems(typedConversation)
-  if (result.error) return { ok: false, reason: result.errorMessage ?? result.error }
-
-  return buildAndStartDag(result.items, sessionId, ctx)
+  if (!result.ok) setPipelineAdvancing(ctx, sessionId, false)
+  return result
 }
 
 export async function handleSplit(sessionId: string, ctx: PlanActionCtx): Promise<PlanActionResult> {

--- a/server/handlers/parent-notify-handler.test.ts
+++ b/server/handlers/parent-notify-handler.test.ts
@@ -20,6 +20,7 @@ function makeScheduler(calls: Array<{ sessionId: string; state: string }>): DagS
     onSessionCompleted: async (sessionId, state) => {
       calls.push({ sessionId, state })
     },
+    start: async () => {},
   }
 }
 

--- a/server/handlers/ship-advance-handler.test.ts
+++ b/server/handlers/ship-advance-handler.test.ts
@@ -1,10 +1,17 @@
-import { describe, test, expect, beforeEach } from 'bun:test'
+import { describe, test, expect, beforeEach, mock, vi } from 'bun:test'
 import { Database } from 'bun:sqlite'
+
+mock.module('node:child_process', () => ({
+  spawn: vi.fn(),
+}))
+
 import { EngineEventBus, resetEventBus } from '../events/bus'
 import { openDatabase, runMigrations } from '../db/sqlite'
 import { shipAdvanceHandler } from './ship-advance-handler'
-import type { HandlerCtx, SessionCompletedEvent, DagScheduler } from './types'
-import { createSessionRegistry } from '../session/registry'
+import type { HandlerCtx, SessionCompletedEvent } from './types'
+import type { SessionRegistry } from '../session/registry'
+import type { SpawnedChild } from '../dag/claude-extract'
+import { spawn } from 'node:child_process'
 import {
   createNoopLoopScheduler,
   createNoopQualityGates,
@@ -15,21 +22,75 @@ import {
   createDefaultConfig,
 } from './stubs'
 
-function makeScheduler(calls: string[]): DagScheduler {
+const mockSpawn = spawn as ReturnType<typeof vi.fn>
+
+function makeEmptyChild(): SpawnedChild {
   return {
-    onSessionCompleted: async (sessionId: string) => {
-      calls.push(sessionId)
+    stdout: {
+      on: vi.fn((event: string, cb: (data: Buffer) => void) => {
+        if (event === 'data') cb(Buffer.from('[]'))
+      }),
     },
+    stderr: { on: vi.fn() },
+    stdin: { write: vi.fn(), end: vi.fn() },
+    on: vi.fn((event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(0)
+    }),
+    kill: vi.fn(),
   }
 }
 
-function makeCtx(db: Database, schedulerCalls: string[]): HandlerCtx {
+function makeRegistry(calls: {
+  stop: string[]
+  create: Array<{ mode: string; prompt: string; parentId?: string }>
+}): SessionRegistry {
+  return {
+    create: async (opts) => {
+      calls.create.push({ mode: opts.mode, prompt: opts.prompt, parentId: opts.parentId })
+      return {
+        session: {
+          id: `spawned-${calls.create.length}`,
+          slug: `spawned-slug-${calls.create.length}`,
+          status: 'running',
+          command: opts.prompt,
+          mode: opts.mode,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          childIds: [],
+          needsAttention: false,
+          attentionReasons: [],
+          quickActions: [],
+          conversation: [],
+        },
+        runtime: undefined as never,
+      }
+    },
+    get: () => undefined,
+    getBySlug: () => undefined,
+    list: () => [],
+    snapshot: () => undefined,
+    stop: async (sessionId: string) => { calls.stop.push(sessionId) },
+    close: async () => {},
+    reply: async () => true,
+    reconcileOnBoot: async () => {},
+    scheduleQuotaResume: async () => {},
+  }
+}
+
+function makeCtx(
+  db: Database,
+  registryCalls: { stop: string[]; create: Array<{ mode: string; prompt: string; parentId?: string }> },
+  schedulerCalls: { start: string[]; onSessionCompleted: string[] },
+): HandlerCtx {
   const bus = new EngineEventBus()
   return {
     db,
-    registry: createSessionRegistry({ getDb: () => db }),
+    registry: makeRegistry(registryCalls),
     bus,
-    scheduler: makeScheduler(schedulerCalls),
+    scheduler: {
+      async start(dagId: string) { schedulerCalls.start.push(dagId) },
+      async onSessionCompleted(sessionId: string) { schedulerCalls.onSessionCompleted.push(sessionId) },
+    },
     loopScheduler: createNoopLoopScheduler(),
     ciBabysitter: createNoopCIBabysitter(),
     qualityGates: createNoopQualityGates(),
@@ -44,8 +105,17 @@ function seedSession(db: Database, id: string, mode: string, pipelineAdvancing =
   const now = Date.now()
   db.run(
     `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, bare_dir, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation, quota_sleep_until, quota_retry_count, metadata, pipeline_advancing)
-     VALUES (?, 'test-slug', 'completed', 'cmd', ?, null, null, null, null, null, null, null, null, ?, ?, 0, '[]', '[]', '[]', null, 0, '{}', ?)`,
-    [id, mode, now, now, pipelineAdvancing ? 1 : 0],
+     VALUES (?, ?, 'completed', 'cmd', ?, 'https://github.com/org/repo', null, null, null, null, null, null, null, ?, ?, 0, '[]', '[]', '[]', null, 0, '{}', ?)`,
+    [id, `slug-${id}`, mode, now, now, pipelineAdvancing ? 1 : 0],
+  )
+}
+
+function seedAssistantMessage(db: Database, sessionId: string, text: string): void {
+  const now = Date.now()
+  db.run(
+    `INSERT INTO session_events (session_id, seq, turn, type, timestamp, payload)
+     VALUES (?, 1, 1, 'assistant_text', ?, ?)`,
+    [sessionId, now, JSON.stringify({ blockId: 'block-1', text, final: true })],
   )
 }
 
@@ -56,6 +126,9 @@ describe('shipAdvanceHandler', () => {
     resetEventBus()
     db = openDatabase(':memory:')
     runMigrations(db)
+    vi.clearAllMocks()
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    mockSpawn.mockImplementation(() => makeEmptyChild())
   })
 
   test('priority is 30', () => {
@@ -70,76 +143,60 @@ describe('shipAdvanceHandler', () => {
     expect(shipAdvanceHandler.matches(errEv)).toBe(false)
   })
 
-  test('calls scheduler for ship mode sessions', async () => {
-    seedSession(db, 'sess-ship', 'ship-think')
-    const calls: string[] = []
-    const ctx = makeCtx(db, calls)
+  test('spawns ship-plan session when ship-think completes', async () => {
+    seedSession(db, 'sess-think', 'ship-think')
+    seedAssistantMessage(db, 'sess-think', 'Design doc: build an auth service')
 
-    const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-ship', state: 'completed', durationMs: 0 }
+    const registryCalls = { stop: [] as string[], create: [] as Array<{ mode: string; prompt: string; parentId?: string }> }
+    const schedulerCalls = { start: [] as string[], onSessionCompleted: [] as string[] }
+    const ctx = makeCtx(db, registryCalls, schedulerCalls)
+
+    const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-think', state: 'completed', durationMs: 0 }
     await shipAdvanceHandler.handle(ev, ctx)
 
-    expect(calls).toContain('sess-ship')
+    expect(registryCalls.create).toHaveLength(1)
+    expect(registryCalls.create[0]?.mode).toBe('ship-plan')
+    expect(registryCalls.create[0]?.prompt).toContain('Design doc')
+    expect(registryCalls.create[0]?.parentId).toBe('sess-think')
+    expect(schedulerCalls.start).toHaveLength(0)
   })
 
-  test('skips non-ship mode sessions', async () => {
+  test('skips non-ship-advance modes', async () => {
     seedSession(db, 'sess-task', 'task')
-    const calls: string[] = []
-    const ctx = makeCtx(db, calls)
+    const registryCalls = { stop: [] as string[], create: [] as Array<{ mode: string; prompt: string; parentId?: string }> }
+    const schedulerCalls = { start: [] as string[], onSessionCompleted: [] as string[] }
+    const ctx = makeCtx(db, registryCalls, schedulerCalls)
 
     const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-task', state: 'completed', durationMs: 0 }
     await shipAdvanceHandler.handle(ev, ctx)
 
-    expect(calls).toHaveLength(0)
+    expect(registryCalls.create).toHaveLength(0)
+    expect(schedulerCalls.start).toHaveLength(0)
+  })
+
+  test('skips ship-verify (handled elsewhere)', async () => {
+    seedSession(db, 'sess-verify', 'ship-verify')
+    const registryCalls = { stop: [] as string[], create: [] as Array<{ mode: string; prompt: string; parentId?: string }> }
+    const schedulerCalls = { start: [] as string[], onSessionCompleted: [] as string[] }
+    const ctx = makeCtx(db, registryCalls, schedulerCalls)
+
+    const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-verify', state: 'completed', durationMs: 0 }
+    await shipAdvanceHandler.handle(ev, ctx)
+
+    expect(registryCalls.create).toHaveLength(0)
+    expect(schedulerCalls.start).toHaveLength(0)
   })
 
   test('skips when pipeline_advancing is already set', async () => {
     seedSession(db, 'sess-advancing', 'ship-think', true)
-    const calls: string[] = []
-    const ctx = makeCtx(db, calls)
+    const registryCalls = { stop: [] as string[], create: [] as Array<{ mode: string; prompt: string; parentId?: string }> }
+    const schedulerCalls = { start: [] as string[], onSessionCompleted: [] as string[] }
+    const ctx = makeCtx(db, registryCalls, schedulerCalls)
 
     const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-advancing', state: 'completed', durationMs: 0 }
     await shipAdvanceHandler.handle(ev, ctx)
 
-    expect(calls).toHaveLength(0)
-  })
-
-  test('clears pipeline_advancing flag after scheduler call', async () => {
-    seedSession(db, 'sess-flag', 'ship-think')
-    const calls: string[] = []
-    const ctx = makeCtx(db, calls)
-
-    const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-flag', state: 'completed', durationMs: 0 }
-    await shipAdvanceHandler.handle(ev, ctx)
-
-    const row = db.query<{ pipeline_advancing: number }, [string]>('SELECT pipeline_advancing FROM sessions WHERE id = ?').get('sess-flag')
-    expect(row!.pipeline_advancing).toBe(0)
-  })
-
-  test('clears pipeline_advancing even when scheduler throws', async () => {
-    seedSession(db, 'sess-err', 'ship-think')
-    const calls: string[] = []
-    const bus = new EngineEventBus()
-    const ctx: HandlerCtx = {
-      db,
-      registry: createSessionRegistry({ getDb: () => db }),
-      bus,
-      scheduler: {
-        onSessionCompleted: async () => { throw new Error('scheduler error') },
-      },
-      loopScheduler: createNoopLoopScheduler(),
-      ciBabysitter: createNoopCIBabysitter(),
-      qualityGates: createNoopQualityGates(),
-      digest: createNoopDigestBuilder(),
-      profileStore: createNoopProfileStore(),
-      replyQueue: createNoopReplyQueueFactory(),
-      config: createDefaultConfig(),
-    }
-
-    const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-err', state: 'completed', durationMs: 0 }
-    await expect(shipAdvanceHandler.handle(ev, ctx)).rejects.toThrow('scheduler error')
-
-    const row = db.query<{ pipeline_advancing: number }, [string]>('SELECT pipeline_advancing FROM sessions WHERE id = ?').get('sess-err')
-    expect(row!.pipeline_advancing).toBe(0)
-    void calls
+    expect(registryCalls.create).toHaveLength(0)
+    expect(schedulerCalls.start).toHaveLength(0)
   })
 })

--- a/server/handlers/ship-advance-handler.ts
+++ b/server/handlers/ship-advance-handler.ts
@@ -1,4 +1,7 @@
 import type { CompletionHandler, HandlerCtx, SessionCompletedEvent } from './types'
+import { handleExecute } from '../commands/plan-actions'
+
+const SHIP_ADVANCE_MODES = new Set(['ship-think', 'ship-plan'])
 
 export const shipAdvanceHandler: CompletionHandler = {
   name: 'ship-advance',
@@ -15,21 +18,18 @@ export const shipAdvanceHandler: CompletionHandler = {
       )
       .get(ev.sessionId)
 
-    if (!row || !row.mode.startsWith('ship-')) return
+    if (!row || !SHIP_ADVANCE_MODES.has(row.mode)) return
     if (row.pipeline_advancing !== 0) return
 
-    ctx.db.run(
-      'UPDATE sessions SET pipeline_advancing = 1, updated_at = ? WHERE id = ?',
-      [Date.now(), ev.sessionId],
-    )
-
     try {
-      await ctx.scheduler.onSessionCompleted(ev.sessionId, ev.state)
-    } finally {
-      ctx.db.run(
-        'UPDATE sessions SET pipeline_advancing = 0, updated_at = ? WHERE id = ?',
-        [Date.now(), ev.sessionId],
-      )
+      await handleExecute(ev.sessionId, {
+        db: ctx.db,
+        registry: ctx.registry,
+        scheduler: ctx.scheduler,
+      })
+    } catch (err) {
+      console.error(`[ship-advance] failed to advance session ${ev.sessionId} (mode=${row.mode}):`, err)
+      throw err
     }
   },
 }

--- a/server/handlers/stubs.ts
+++ b/server/handlers/stubs.ts
@@ -18,6 +18,7 @@ import type { Database } from 'bun:sqlite'
 export function createNoopDagScheduler(): DagScheduler {
   return {
     async onSessionCompleted(): Promise<void> {},
+    async start(): Promise<void> {},
   }
 }
 

--- a/server/handlers/types.ts
+++ b/server/handlers/types.ts
@@ -15,6 +15,7 @@ export interface CompletionHandler {
 
 export interface DagScheduler {
   onSessionCompleted(sessionId: string, state: string): Promise<void>
+  start(dagId: string): Promise<void>
 }
 
 export interface LoopScheduler {

--- a/server/session/prompts.ts
+++ b/server/session/prompts.ts
@@ -54,19 +54,19 @@ export const MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
     systemPrompt: DEFAULT_SHIP_THINK_PROMPT,
     model: envModel('CLAUDE_SHIP_THINK_MODEL', 'claude-opus-4-1-20250805'),
     disallowedTools: [...READONLY_DISALLOWED_TOOLS],
-    autoExitOnComplete: false,
+    autoExitOnComplete: true,
   },
   'ship-plan': {
     systemPrompt: DEFAULT_SHIP_PLAN_PROMPT,
     model: envModel('CLAUDE_SHIP_PLAN_MODEL', 'claude-opus-4-1-20250805'),
     disallowedTools: [...READONLY_DISALLOWED_TOOLS],
-    autoExitOnComplete: false,
+    autoExitOnComplete: true,
   },
   'ship-verify': {
     systemPrompt: DEFAULT_SHIP_VERIFY_PROMPT,
     model: envModel('CLAUDE_SHIP_VERIFY_MODEL', 'claude-sonnet-4-5-20250929'),
     disallowedTools: [],
-    autoExitOnComplete: false,
+    autoExitOnComplete: true,
   },
   'ci-fix': {
     systemPrompt: DEFAULT_CI_FIX_PROMPT,


### PR DESCRIPTION
## Summary

- Set `autoExitOnComplete: true` for `ship-think`/`ship-plan`/`ship-verify` so the subprocess exits after a turn completes and `session.completed` fires (previously the session stayed stuck in RUNNING).
- Rewire `shipAdvanceHandler` to call `handleExecute` from `plan-actions.ts`. `handleExecute` already knows how to hand off `ship-think` -> `ship-plan` and extract a DAG from `ship-plan`, so ship sessions now auto-advance on completion instead of only on manual /execute.
- Move the `pipeline_advancing` set/clear into `handleExecute`. If a user invokes /execute concurrently with the completion event, only one advance wins.
- `getLastAssistantMessage` joins every `final:true` block from the last turn; ship-think outputs often span multiple text blocks split by tool calls, so returning just the last one dropped most of the design.
- Widen `DagScheduler` to expose `start(dagId)` (previously only `onSessionCompleted`); handler/stubs/tests updated.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (707/707)
- [x] `npm run test:server` (631/631 + 1 intentional skip)
- [ ] CI green