### PR TITLE
fix(dag): persist repo URL so DAG nodes can spawn workspaces

### DIFF
--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -91,6 +91,25 @@ describe("DagScheduler", () => {
     expect(created).toHaveLength(2)
   })
 
+  it("passes the DAG's repo URL to registry.create after save/load round-trip", async () => {
+    const repoUrl = "https://github.com/org/repo"
+    const graph = buildDag("dag-repo", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], 1, repoUrl)
+    saveDag(graph, db)
+
+    const repos: string[] = []
+    const registry = makeRegistry(async (opts) => {
+      repos.push(opts.repo)
+      return { session: makeSession("s-" + opts.prompt), runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-repo")
+
+    expect(repos).toEqual([repoUrl])
+  })
+
   it("respects MAX_DAG_CONCURRENCY limit", async () => {
     const nodes = Array.from({ length: 6 }, (_, i) => ({
       id: `n${i}`,

--- a/server/dag/store.ts
+++ b/server/dag/store.ts
@@ -4,10 +4,12 @@ import type { DagGraph, DagNode } from "./dag"
 import { prepared, getDb } from "../db/sqlite"
 
 function graphToRows(graph: DagGraph): { dagRow: Parameters<typeof prepared.insertDag>[1]; nodeRows: Parameters<typeof prepared.upsertDagNode>[1][] } {
+  const repo = graph.repoUrl ?? graph.repo ?? null
   const dagRow = {
     id: graph.id,
     root_task_id: String(graph.parentThreadId),
     status: "running" as const,
+    repo: repo && repo.length > 0 ? repo : null,
     created_at: graph.createdAt,
     updated_at: Date.now(),
   }
@@ -116,7 +118,7 @@ export function loadDag(id: string, db?: Database): DagGraph | null {
     id: dagRow.id,
     nodes,
     parentThreadId: Number(dagRow.root_task_id),
-    repo: "",
+    repo: dagRow.repo ?? "",
     createdAt: dagRow.created_at,
   }
 }
@@ -131,6 +133,7 @@ export function saveDag(graph: DagGraph, db?: Database): void {
       id: dagRow.id,
       root_task_id: dagRow.root_task_id,
       status: dagRow.status,
+      repo: dagRow.repo,
       updated_at: dagRow.updated_at,
     })
   } else {

--- a/server/db/migrations/0006_dag_repo.sql
+++ b/server/db/migrations/0006_dag_repo.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dags ADD COLUMN repo TEXT;

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS dags (
   id TEXT PRIMARY KEY,
   root_task_id TEXT NOT NULL,
   status TEXT NOT NULL CHECK (status IN ('pending','running','completed','failed')),
+  repo TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );

--- a/server/db/sqlite.ts
+++ b/server/db/sqlite.ts
@@ -81,6 +81,7 @@ interface DagRow {
   id: string
   root_task_id: string
   status: DagStatus
+  repo: string | null
   created_at: number
   updated_at: number
 }
@@ -397,14 +398,15 @@ export const prepared = {
     const c = stmts(db)
     if (!c.insertDag) {
       c.insertDag = db.prepare(
-        `INSERT INTO dags (id, root_task_id, status, created_at, updated_at)
-         VALUES ($id, $root_task_id, $status, $created_at, $updated_at)`,
+        `INSERT INTO dags (id, root_task_id, status, repo, created_at, updated_at)
+         VALUES ($id, $root_task_id, $status, $repo, $created_at, $updated_at)`,
       )
     }
     c.insertDag.run({
       $id: row.id,
       $root_task_id: row.root_task_id,
       $status: row.status,
+      $repo: row.repo,
       $created_at: row.created_at,
       $updated_at: row.updated_at,
     })
@@ -417,6 +419,7 @@ export const prepared = {
         `UPDATE dags SET
           root_task_id = COALESCE($root_task_id, root_task_id),
           status = COALESCE($status, status),
+          repo = COALESCE($repo, repo),
           updated_at = $updated_at
         WHERE id = $id`,
       )
@@ -425,6 +428,7 @@ export const prepared = {
       $id: row.id,
       $root_task_id: row.root_task_id ?? null,
       $status: row.status ?? null,
+      $repo: row.repo ?? null,
       $updated_at: row.updated_at,
     })
   },


### PR DESCRIPTION
## Summary

- `loadDag` hardcoded `repo: ""` because the `dags` table had no `repo` column. `buildAndStartDag` saves the graph then `scheduler.start()` reloads it — the reload dropped the URL, so every node's `registry.create` got `repo: ""`. That resolved to `bareDir = /workspace/.repos/.git`, the bare clone into `""` silently no-op'd, then the next `runGit` ran with a nonexistent cwd. Bun surfaces that as `ENOENT: posix_spawn 'git'`.
- Add `repo` column to `dags` via migration `0006`; persist in `saveDag`; restore in `loadDag`.
- New regression test in `scheduler.test.ts` asserting save/load round-trip preserves the repo URL down to `registry.create`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (707)
- [x] `npm run test:server` (633, +1 new)
- [ ] CI green
- [ ] End-to-end: on mini, run `/ship` and verify DAG nodes get real sessions