### PR TITLE
fix(engine): one-shot dag-task mode so DAG nodes exit cleanly

### DIFF
--- a/server/dag/dag.ts
+++ b/server/dag/dag.ts
@@ -30,6 +30,7 @@ export interface DagNode {
   dependsOn: string[]
   status: DagNodeStatus
   threadId?: number
+  sessionId?: string
   branch?: string
   prUrl?: string
   error?: string

--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -4,18 +4,19 @@ import { buildDag } from "./dag"
 import { saveDag } from "./store"
 import { createDagScheduler } from "./scheduler"
 import { EngineEventBus } from "../events/bus"
-import { openDatabase } from "../db/sqlite"
+import { openDatabase, prepared, runMigrations } from "../db/sqlite"
 import type { SessionRegistry, CreateSessionOpts } from "../session/registry"
 import type { SessionRuntime } from "../session/runtime"
 import type { ApiSession } from "../../shared/api-types"
 
 function makeTestDb(): Database {
   const db = openDatabase(":memory:")
+  runMigrations(db)
   return db
 }
 
-function makeSession(id: string): ApiSession {
-  return {
+function makeSession(id: string, db?: Database): ApiSession {
+  const session: ApiSession = {
     id,
     slug: `test-${id}`,
     status: "running",
@@ -28,14 +29,43 @@ function makeSession(id: string): ApiSession {
     needsAttention: false,
     attentionReasons: [],
     quickActions: [],
-    mode: "task",
+    mode: "dag-task",
     conversation: [],
   }
+  if (db) {
+    const now = Date.now()
+    prepared.insertSession(db, {
+      id,
+      slug: session.slug,
+      status: "running",
+      command: session.command,
+      mode: session.mode,
+      repo: session.repo ?? null,
+      branch: session.branch ?? null,
+      bare_dir: null,
+      pr_url: null,
+      parent_id: null,
+      variant_group_id: null,
+      claude_session_id: null,
+      workspace_root: null,
+      created_at: now,
+      updated_at: now,
+      needs_attention: false,
+      attention_reasons: [],
+      quick_actions: [],
+      conversation: [],
+      quota_sleep_until: null,
+      quota_retry_count: 0,
+      metadata: {},
+      pipeline_advancing: false,
+    })
+  }
+  return session
 }
 
-function makeRegistry(createFn?: (opts: CreateSessionOpts) => Promise<{ session: ApiSession; runtime: SessionRuntime }>) {
+function makeRegistry(db: Database, createFn?: (opts: CreateSessionOpts) => Promise<{ session: ApiSession; runtime: SessionRuntime }>) {
   const registry: SessionRegistry = {
-    create: createFn ?? (async () => ({ session: makeSession("mock-session-" + Math.random().toString(36).slice(2)), runtime: {} as SessionRuntime })),
+    create: createFn ?? (async () => ({ session: makeSession("mock-session-" + Math.random().toString(36).slice(2), db), runtime: {} as SessionRuntime })),
     get: () => undefined,
     getBySlug: () => undefined,
     list: () => [],
@@ -79,8 +109,8 @@ describe("DagScheduler", () => {
     saveDag(graph, db)
 
     const created: string[] = []
-    const registry = makeRegistry(async (opts) => {
-      const session = makeSession(`session-${opts.prompt.split("\n")[0]}`)
+    const registry = makeRegistry(db, async (opts) => {
+      const session = makeSession(`session-${opts.prompt.split("\n")[0]}`, db)
       created.push(opts.prompt.split("\n")[0]!)
       return { session, runtime: {} as never }
     })
@@ -99,9 +129,9 @@ describe("DagScheduler", () => {
     saveDag(graph, db)
 
     const repos: string[] = []
-    const registry = makeRegistry(async (opts) => {
+    const registry = makeRegistry(db, async (opts) => {
       repos.push(opts.repo)
-      return { session: makeSession("s-" + opts.prompt), runtime: {} as never }
+      return { session: makeSession("s-" + opts.prompt, db), runtime: {} as never }
     })
 
     const scheduler = makeScheduler(registry)
@@ -123,12 +153,12 @@ describe("DagScheduler", () => {
     let concurrent = 0
     let maxConcurrent = 0
 
-    const registry = makeRegistry(async () => {
+    const registry = makeRegistry(db, async () => {
       concurrent++
       maxConcurrent = Math.max(maxConcurrent, concurrent)
       await new Promise<void>((r) => setTimeout(r, 0))
       concurrent--
-      return { session: makeSession("s" + Math.random()), runtime: {} as never }
+      return { session: makeSession("s" + Math.random(), db), runtime: {} as never }
     })
 
     const scheduler = makeScheduler(registry)
@@ -145,8 +175,8 @@ describe("DagScheduler", () => {
     saveDag(graph, db)
 
     const createdSessions: string[] = []
-    const registry = makeRegistry(async () => {
-      const session = makeSession(`session-${createdSessions.length}`)
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`session-${createdSessions.length}`, db)
       createdSessions.push(session.id)
       return { session, runtime: {} as never }
     })
@@ -169,8 +199,8 @@ describe("DagScheduler", () => {
     saveDag(graph, db)
 
     const createdSessions: string[] = []
-    const registry = makeRegistry(async () => {
-      const session = makeSession(`session-${createdSessions.length}`)
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`session-${createdSessions.length}`, db)
       createdSessions.push(session.id)
       return { session, runtime: {} as never }
     })
@@ -198,7 +228,7 @@ describe("DagScheduler", () => {
     const events: Array<{ kind: string; nodeId: string }> = []
     bus.onKind("dag.node.started", (e) => events.push({ kind: e.kind, nodeId: e.nodeId }))
 
-    const registry = makeRegistry()
+    const registry = makeRegistry(db)
     const scheduler = makeScheduler(registry)
     await scheduler.start("dag-events")
 
@@ -216,8 +246,8 @@ describe("DagScheduler", () => {
     bus.onKind("dag.node.completed", (e) => events.push({ kind: e.kind, state: e.state }))
 
     const sessions: string[] = []
-    const registry = makeRegistry(async () => {
-      const session = makeSession(`s${sessions.length}`)
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
       sessions.push(session.id)
       return { session, runtime: {} as never }
     })
@@ -238,8 +268,8 @@ describe("DagScheduler", () => {
 
     const stopped: string[] = []
     const sessions: string[] = []
-    const registry = makeRegistry(async () => {
-      const session = makeSession(`s${sessions.length}`)
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
       sessions.push(session.id)
       return { session, runtime: {} as never }
     })
@@ -264,8 +294,8 @@ describe("DagScheduler", () => {
     saveDag(graph, db)
 
     const sessions: string[] = []
-    const registry = makeRegistry(async () => {
-      const session = makeSession(`s${sessions.length}`)
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
       sessions.push(session.id)
       return { session, runtime: {} as never }
     })
@@ -293,8 +323,8 @@ describe("DagScheduler", () => {
     saveDag(graph, db)
 
     const sessions: string[] = []
-    const registry = makeRegistry(async () => {
-      const session = makeSession(`s${sessions.length}`)
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
       sessions.push(session.id)
       return { session, runtime: {} as never }
     })
@@ -313,7 +343,7 @@ describe("DagScheduler", () => {
   })
 
   it("status returns empty nodes for unknown dag", () => {
-    const scheduler = makeScheduler(makeRegistry())
+    const scheduler = makeScheduler(makeRegistry(db))
     const s = scheduler.status("nonexistent")
     expect(s.dagId).toBe("nonexistent")
     expect(s.nodes).toHaveLength(0)
@@ -326,8 +356,8 @@ describe("DagScheduler", () => {
     saveDag(graph, db)
 
     const sessions: string[] = []
-    const registry = makeRegistry(async () => {
-      const session = makeSession(`s${sessions.length}`)
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
       sessions.push(session.id)
       return { session, runtime: {} as never }
     })

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -102,13 +102,15 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
 
     try {
       const { session } = await registry.create({
-        mode: "task",
+        mode: "dag-task",
         prompt,
         repo: graph.repoUrl ?? graph.repo,
         startRef: upstreamBranches[upstreamBranches.length - 1],
+        metadata: { dagId: graph.id, dagNodeId: node.id },
       })
 
       node.status = "running"
+      node.sessionId = session.id
       nodeToSession.set(node.id, session.id)
       nodeToGraph.set(session.id, graph.id)
 

--- a/server/dag/store.ts
+++ b/server/dag/store.ts
@@ -25,7 +25,7 @@ function graphToRows(graph: DagGraph): { dagRow: Parameters<typeof prepared.inse
       id: node.id,
       slug: node.id,
       status: mapNodeStatus(node.status),
-      session_id: null,
+      session_id: node.sessionId ?? null,
       dependencies: node.dependsOn,
       dependents,
       payload: nodeToPayload(node),
@@ -111,6 +111,7 @@ export function loadDag(id: string, db?: Database): DagGraph | null {
       headSha: fields.headSha,
       prCommentId: fields.prCommentId,
       threadId: fields.threadId,
+      sessionId: row.session_id ?? undefined,
     }
   })
 

--- a/server/session/prompts.ts
+++ b/server/session/prompts.ts
@@ -32,6 +32,12 @@ export const MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
     disallowedTools: [],
     autoExitOnComplete: false,
   },
+  'dag-task': {
+    systemPrompt: DEFAULT_TASK_PROMPT,
+    model: envModel('CLAUDE_TASK_MODEL', 'claude-sonnet-4-5-20250929'),
+    disallowedTools: [],
+    autoExitOnComplete: true,
+  },
   plan: {
     systemPrompt: DEFAULT_PLAN_PROMPT,
     model: envModel('CLAUDE_PLAN_MODEL', 'claude-opus-4-1-20250805'),

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -59,6 +59,7 @@ export interface CreateSessionOpts {
   workspaceRoot?: string
   startRef?: string
   initialImages?: Array<{ mediaType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'; dataBase64: string }>
+  metadata?: Record<string, unknown>
 }
 
 export interface SessionRegistry {
@@ -140,7 +141,7 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
       conversation: [],
       quota_sleep_until: null,
       quota_retry_count: 0,
-      metadata: {},
+      metadata: createOpts.metadata ?? {},
       pipeline_advancing: false,
     }
 

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -199,6 +199,7 @@ export interface VersionInfo {
 
 export type CreateSessionMode =
   | 'task'
+  | 'dag-task'
   | 'plan'
   | 'think'
   | 'review'


### PR DESCRIPTION
## Summary

\`task\` mode has \`autoExitOnComplete: false\` so the Claude subprocess stays idle after \`turn_complete\`, waiting for more input. For DAG-spawned nodes that means \`session.completed\` never fires and the DAG scheduler's \`onSessionCompleted\` is never invoked — downstream nodes never run. Observed today on mini: four DAG branches all reached \`turn_completed\` and sat in \"running\" indefinitely.

- Add a \`dag-task\` mode that reuses \`task\`'s prompt/tools with \`autoExitOnComplete: true\`. Scheduler's \`spawnNode\` uses it instead of \`task\`.
- Thread \`metadata\` through \`CreateSessionOpts\` and persist \`{ dagId, dagNodeId }\` on spawned sessions so \`parent-notify-handler\` can route their completion back to the DAG scheduler.
- Persist \`sessionId\` on each DAG node (new field on \`DagNode\`, \`session_id\` column already existed) so retries and UI navigation can find the thread. Update \`loadDag\` to restore it.
- Drop a stale \`.home/tmp/...\` file that was tracked before PR #84 added \`.home/\` to \`.gitignore\`.

## Test plan

- [x] typecheck / lint / vitest / bun tests all green
- [x] new assertion: \`DagScheduler\` test harness now seeds sessions into DB so FK on \`dag_nodes.session_id\` holds
- [ ] CI green
- [ ] End-to-end on mini: fresh \`/ship\` should advance through ship-think → ship-plan → DAG, and DAG leaves should auto-exit when done