### PR TITLE
docs: track telegram-minions library versions for UI feature gating

### DIFF
--- a/docs/library-versions.md
+++ b/docs/library-versions.md
@@ -1,0 +1,19 @@
+# telegram-minions Library Versions
+
+Notable library versions and the changes they introduce. Use this to gate UI features or show version requirement messages.
+
+## v1.120.0 (2026-04-23)
+
+**Enriched error events**
+- Error events now include `phase`, `detail`, `exitCode`, and `subtype` fields
+- Telegram formatter shows phase badge, bold headline, exit/subtype metadata line
+- Detail text truncated at 1200 chars in `<pre>` blocks
+- PR: https://github.com/tprei/telegram-minions/pull/517
+- Type changes in `GooseStreamEvent` error variant
+- **Backward compatible**: old UI ignores new fields
+- **No feature flag**: changes are additive to internal event stream
+- UI can show richer error messages when available; otherwise falls back to generic error display
+
+## Earlier versions
+
+See `package.json` in https://github.com/tprei/telegram-minions for version history.


### PR DESCRIPTION
## Summary
- Adds `docs/library-versions.md` to track notable `@tprei/telegram-minions` releases
- Documents v1.120.0 with enriched error events (phase, detail, exitCode, subtype)
- Reference for future UI feature gating and version requirement messages

## Context
- telegram-minions v1.120.0 published: https://github.com/tprei/telegram-minions/pull/517
- Error events now include richer debugging context
- Backward compatible — no UI changes required
- Future UI work can reference this doc for "Needs library ≥ X.Y" messaging

## Test plan
- [x] Documentation only — no code changes