### PR TITLE
feat(ui): add image attachments to NewTaskBar

### DIFF
--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -211,6 +211,7 @@ export interface CreateSessionRequest {
   mode: CreateSessionMode
   repo?: string
   profileId?: string
+  images?: Array<{ mediaType: string; dataBase64: string }>
 }
 
 export interface CreateSessionVariantsRequest extends CreateSessionRequest {

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -1,9 +1,34 @@
 import { useSignal, useComputed } from '@preact/signals'
+import { useRef, useCallback } from 'preact/hooks'
 import type { ConnectionStore } from '../state/types'
 import type { CreateSessionMode } from '../api/types'
 import { hasFeature } from '../api/features'
 import { formatRoute } from '../routing/route'
 import { recordVariantGroup } from '../groups/store'
+
+export interface ImageAttachment {
+  mediaType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'
+  dataBase64: string
+  objectUrl: string
+}
+
+const VALID_IMAGE_TYPES = new Set<string>(['image/png', 'image/jpeg', 'image/gif', 'image/webp'])
+
+function readFileAsBase64(file: File): Promise<{ mediaType: string; dataBase64: string; objectUrl: string }> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      const comma = result.indexOf(',')
+      if (comma === -1) { reject(new Error('Invalid data URL')); return }
+      const dataBase64 = result.slice(comma + 1)
+      const objectUrl = URL.createObjectURL(file)
+      resolve({ mediaType: file.type, dataBase64, objectUrl })
+    }
+    reader.onerror = () => reject(reader.error ?? new Error('FileReader error'))
+    reader.readAsDataURL(file)
+  })
+}
 
 const COLLAPSE_KEY = 'minions-ui:newtaskbar-collapsed'
 
@@ -62,6 +87,9 @@ export function NewTaskBar({
   const variantCount = useSignal(1)
   const sending = useSignal(false)
   const error = useSignal<string | null>(null)
+  const attachments = useSignal<ImageAttachment[]>([])
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const version = store.version.value
   const repos = version?.repos ?? []
@@ -82,6 +110,58 @@ export function NewTaskBar({
     collapsed.value = next
     writeCollapsed(next)
   }
+
+  const addFiles = useCallback(async (files: File[]) => {
+    const valid = files.filter((f) => VALID_IMAGE_TYPES.has(f.type))
+    if (valid.length === 0) return
+    const results = await Promise.all(valid.map(readFileAsBase64))
+    attachments.value = [
+      ...attachments.value,
+      ...results.map((r) => ({
+        mediaType: r.mediaType as ImageAttachment['mediaType'],
+        dataBase64: r.dataBase64,
+        objectUrl: r.objectUrl,
+      })),
+    ]
+  }, [])
+
+  const handlePaste = useCallback(
+    (e: ClipboardEvent) => {
+      const items = e.clipboardData?.items
+      if (!items) return
+      const imageItems: File[] = []
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i]
+        if (!item) continue
+        if (item.kind === 'file' && VALID_IMAGE_TYPES.has(item.type)) {
+          const file = item.getAsFile()
+          if (file) imageItems.push(file)
+        }
+      }
+      if (imageItems.length > 0) {
+        e.preventDefault()
+        void addFiles(imageItems)
+      }
+    },
+    [addFiles],
+  )
+
+  const handleFileChange = useCallback(
+    (e: Event) => {
+      const input = e.target as HTMLInputElement
+      if (!input.files) return
+      void addFiles(Array.from(input.files))
+      input.value = ''
+    },
+    [addFiles],
+  )
+
+  const removeAttachment = useCallback((idx: number) => {
+    const next = [...attachments.value]
+    const removed = next.splice(idx, 1)
+    for (const r of removed) URL.revokeObjectURL(r.objectUrl)
+    attachments.value = next
+  }, [])
 
   if (!canCreate) {
     return (
@@ -107,12 +187,17 @@ export function NewTaskBar({
     error.value = null
     try {
       const selectedRepo = repo.value || undefined
+      const images =
+        attachments.value.length > 0
+          ? attachments.value.map((a) => ({ mediaType: a.mediaType, dataBase64: a.dataBase64 }))
+          : undefined
       if (wantVariants.value) {
         const out = await store.client.createSessionVariants({
           prompt: p,
           mode: mode.value,
           repo: selectedRepo,
           count: variantCount.value,
+          images,
         })
         const slugs: string[] = []
         const errors: string[] = []
@@ -134,6 +219,8 @@ export function NewTaskBar({
           createdAt: new Date().toISOString(),
         })
         prompt.value = ''
+        for (const a of attachments.value) URL.revokeObjectURL(a.objectUrl)
+        attachments.value = []
         if (errors.length > 0) {
           error.value = `${errors.length} variant${errors.length > 1 ? 's' : ''} failed to launch`
         }
@@ -143,9 +230,12 @@ export function NewTaskBar({
           prompt: p,
           mode: mode.value,
           repo: selectedRepo,
+          images,
         })
         store.applySessionCreated(created)
         prompt.value = ''
+        for (const a of attachments.value) URL.revokeObjectURL(a.objectUrl)
+        attachments.value = []
       }
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Send failed'
@@ -250,8 +340,55 @@ export function NewTaskBar({
         </select>
       </div>
 
+      {attachments.value.length > 0 && (
+        <div class="flex flex-wrap gap-2" data-testid="new-task-attachment-strip">
+          {attachments.value.map((a, idx) => (
+            <div
+              key={a.objectUrl}
+              class="relative w-16 h-16 rounded-md overflow-hidden border border-slate-200 dark:border-slate-700 flex-shrink-0"
+            >
+              <img
+                src={a.objectUrl}
+                alt={`attachment ${idx + 1}`}
+                class="w-full h-full object-cover"
+              />
+              <button
+                type="button"
+                onClick={() => removeAttachment(idx)}
+                class="absolute top-0 right-0 w-5 h-5 flex items-center justify-center bg-black/60 text-white text-[10px] rounded-bl"
+                aria-label={`Remove attachment ${idx + 1}`}
+                data-testid={`new-task-remove-attachment-${idx}`}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
       <div class="flex items-end gap-2">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          class="hidden"
+          onChange={handleFileChange}
+          data-testid="new-task-file-input"
+        />
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={sending.value}
+          aria-label="Attach image"
+          title="Attach image"
+          class="shrink-0 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors border shadow-sm disabled:opacity-50 disabled:cursor-not-allowed bg-white dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600"
+          data-testid="new-task-attach-btn"
+        >
+          <PaperclipIcon />
+        </button>
         <textarea
+          ref={textareaRef}
           value={prompt.value}
           onInput={(e) => { prompt.value = (e.currentTarget as HTMLTextAreaElement).value }}
           onKeyDown={(e) => {
@@ -260,6 +397,7 @@ export function NewTaskBar({
               void submit()
             }
           }}
+          onPaste={handlePaste}
           disabled={sending.value}
           rows={2}
           placeholder={`New ${mode.value}: describe what you want…`}
@@ -293,5 +431,17 @@ export function NewTaskBar({
         </div>
       )}
     </div>
+  )
+}
+
+function PaperclipIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4" aria-hidden="true">
+      <path
+        fillRule="evenodd"
+        d="M15.621 4.379a3 3 0 0 0-4.242 0l-7 7a1.5 1.5 0 0 0 2.122 2.122l6.5-6.5a.75.75 0 0 1 1.06 1.06l-6.5 6.5a3 3 0 0 1-4.242-4.243l7-7a4.5 4.5 0 0 1 6.364 6.364l-7 7a6 6 0 0 1-8.485-8.486l5.5-5.5a.75.75 0 0 1 1.06 1.061l-5.5 5.5a4.5 4.5 0 0 0 6.365 6.364l7-7a3 3 0 0 0 0-4.243Z"
+        clipRule="evenodd"
+      />
+    </svg>
   )
 }


### PR DESCRIPTION
## Summary
- Add image attachment support to new task creation flow
- Add paperclip button left of textarea for file selection
- Enable paste-to-attach for images (PNG, JPEG, GIF, WebP)
- Display thumbnail strip above input row with remove buttons
- Pass images to `createSession()` and `createSessionVariants()` endpoints
- Update `CreateSessionRequest` type to include optional `images` field

## Test plan
- [x] Run `npm run lint` — passes
- [x] Run `npm run test` — NewTaskBar tests pass (12/12)
- [ ] Manual: click paperclip, select image, verify thumbnail appears
- [ ] Manual: paste image into textarea, verify thumbnail appears
- [ ] Manual: click × on thumbnail to remove attachment
- [ ] Manual: submit task with image, verify it reaches the session
- [ ] Manual: create variants with images attached