### PR TITLE
feat(engine): add 20 MB total payload limit for inbound images

### DIFF
--- a/server/api/routes.inbound-images.test.ts
+++ b/server/api/routes.inbound-images.test.ts
@@ -200,4 +200,32 @@ describe('POST /api/messages — inbound images', () => {
 
     expect(res.status).toBe(400)
   })
+
+  test('rejects total payload exceeding 20 MB with 400', async () => {
+    const { spawnFn } = makeCapturingSpawnFn()
+    const app = new Hono()
+    const registry = createSessionRegistry({ getDb: () => testDb, spawnFn })
+    registerApiRoutes(app, registry, () => testDb)
+
+    const image4MB = 'A'.repeat(Math.ceil((4 * 1024 * 1024 * 4) / 3))
+    const res = await app.fetch(new Request('http://localhost/api/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        text: 'hello',
+        images: [
+          { mediaType: 'image/png', dataBase64: image4MB },
+          { mediaType: 'image/jpeg', dataBase64: image4MB },
+          { mediaType: 'image/gif', dataBase64: image4MB },
+          { mediaType: 'image/webp', dataBase64: image4MB },
+          { mediaType: 'image/png', dataBase64: image4MB },
+          { mediaType: 'image/jpeg', dataBase64: image4MB },
+        ],
+      }),
+    }))
+
+    expect(res.status).toBe(400)
+    const body = await json<{ error: string }>(res)
+    expect(body.error).toContain('20 MB')
+  })
 })

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -74,6 +74,7 @@ const CommandSchema = z.discriminatedUnion('action', [
 ])
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+const MAX_TOTAL_IMAGE_BYTES = 20 * 1024 * 1024
 
 const ImageSchema = z.object({
   mediaType: z.enum(['image/png', 'image/jpeg', 'image/gif', 'image/webp']),
@@ -276,11 +277,16 @@ export function registerApiRoutes(
     const { text, sessionId, images } = parsed.data
 
     if (images) {
+      let totalBytes = 0
       for (const img of images) {
         const byteCount = Math.floor((img.dataBase64.length * 3) / 4)
         if (byteCount > MAX_IMAGE_BYTES) {
           return c.json({ error: `Image exceeds 5 MB limit (decoded ~${byteCount} bytes)` }, 400)
         }
+        totalBytes += byteCount
+      }
+      if (totalBytes > MAX_TOTAL_IMAGE_BYTES) {
+        return c.json({ error: `Total image payload exceeds 20 MB limit (decoded ~${totalBytes} bytes)` }, 400)
       }
     }
 


### PR DESCRIPTION
## Summary
- Adds validation to reject image payloads exceeding 20 MB total across all images
- Complements existing per-image 5 MB limit and media-type whitelist (png/jpeg/gif/webp)
- Returns 400 with descriptive error message when limit is exceeded

## Test plan
- [x] Added test case for 20 MB total payload rejection
- [x] All 69 server API tests pass
- [x] ESLint passes with no issues
- [x] Validated error message format matches existing per-image validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)