### PR TITLE
fix(engine): put text before images in multi-block messages

### DIFF
--- a/server/session/stream-json.test.ts
+++ b/server/session/stream-json.test.ts
@@ -385,7 +385,7 @@ describe('serializeUserMessage', () => {
     expect(parsed.parent_tool_use_id).toBe('tu-parent')
   })
 
-  test('with images: image blocks first, text last', () => {
+  test('with images: text first, image blocks after', () => {
     const line = serializeUserMessage('caption', [
       { mediaType: 'image/png', dataBase64: 'abc==' },
       { mediaType: 'image/jpeg', dataBase64: 'def==' },
@@ -393,15 +393,15 @@ describe('serializeUserMessage', () => {
     const parsed = JSON.parse(line)
     const content = parsed.message.content as unknown[]
     expect(content).toHaveLength(3)
-    expect(content[0]).toEqual({
+    expect(content[0]).toEqual({ type: 'text', text: 'caption' })
+    expect(content[1]).toEqual({
       type: 'image',
       source: { type: 'base64', media_type: 'image/png', data: 'abc==' },
     })
-    expect(content[1]).toEqual({
+    expect(content[2]).toEqual({
       type: 'image',
       source: { type: 'base64', media_type: 'image/jpeg', data: 'def==' },
     })
-    expect(content[2]).toEqual({ type: 'text', text: 'caption' })
   })
 
   test('empty images array produces text-only content', () => {

--- a/server/session/stream-json.ts
+++ b/server/session/stream-json.ts
@@ -155,11 +155,13 @@ export function serializeUserMessage(
     })
   }
 
-  const content: unknown[] = images.map((img) => ({
-    type: 'image',
-    source: { type: 'base64', media_type: img.mediaType, data: img.dataBase64 },
-  }))
-  content.push({ type: 'text', text })
+  const content: unknown[] = [{ type: 'text', text }]
+  for (const img of images) {
+    content.push({
+      type: 'image',
+      source: { type: 'base64', media_type: img.mediaType, data: img.dataBase64 },
+    })
+  }
 
   return JSON.stringify({
     type: 'user',


### PR DESCRIPTION
## Summary
- Fixed multi-block message construction to put text first, then images
- Previous ordering (images → text) didn't match Claude API Messages convention
- Now builds content as `[{ type: 'text' }, ...images]` to align with standard Claude SDK usage

## Test plan
- [x] All 163 server tests pass (`bun test server/`)
- [x] Integration test confirms correct block order
- [x] Verified both flows: initial spawn with images + reply with images