### PR TITLE
refactor: extract image attachment logic into useImageAttachments hook

### DIFF
--- a/src/chat/MessageInput.tsx
+++ b/src/chat/MessageInput.tsx
@@ -1,14 +1,9 @@
 import { useRef, useCallback, useState } from 'preact/hooks'
 import type { ApiSession } from '../api/types'
 import { useSpeechRecognition } from '../hooks/useSpeechRecognition'
+import { useImageAttachments, type ImageAttachment } from '../hooks/useImageAttachments'
 
 const PLACEHOLDER = 'Send instructions to the agent — Enter to send, Shift+Enter for newline'
-
-export interface ImageAttachment {
-  mediaType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'
-  dataBase64: string
-  objectUrl: string
-}
 
 interface MessageInputProps {
   session: ApiSession
@@ -17,34 +12,18 @@ interface MessageInputProps {
   onSend: (text: string, images?: Array<{ mediaType: string; dataBase64: string }>) => Promise<void>
 }
 
-const VALID_IMAGE_TYPES = new Set<string>(['image/png', 'image/jpeg', 'image/gif', 'image/webp'])
-
-function readFileAsBase64(file: File): Promise<{ mediaType: string; dataBase64: string; objectUrl: string }> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      const result = reader.result as string
-      const comma = result.indexOf(',')
-      if (comma === -1) { reject(new Error('Invalid data URL')); return }
-      const dataBase64 = result.slice(comma + 1)
-      const objectUrl = URL.createObjectURL(file)
-      resolve({ mediaType: file.type, dataBase64, objectUrl })
-    }
-    reader.onerror = () => reject(reader.error ?? new Error('FileReader error'))
-    reader.readAsDataURL(file)
-  })
-}
-
 export function MessageInput({ value, onValueChange, onSend }: MessageInputProps) {
   const [sending, setSending] = useState(false)
   const [errorText, setErrorText] = useState<string | null>(null)
-  const [attachments, setAttachments] = useState<ImageAttachment[]>([])
   const pendingRef = useRef<{ text: string; images: ImageAttachment[] } | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const baseTextRef = useRef('')
   const valueRef = useRef(value)
   valueRef.current = value
+
+  const { attachments, handlePaste, handleFileChange, removeAttachment, clearAttachments } =
+    useImageAttachments()
 
   const adjustHeight = useCallback(() => {
     const el = textareaRef.current
@@ -92,59 +71,6 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
     onError: handleVoiceError,
   })
 
-  const addFiles = useCallback(async (files: File[]) => {
-    const valid = files.filter((f) => VALID_IMAGE_TYPES.has(f.type))
-    if (valid.length === 0) return
-    const results = await Promise.all(valid.map(readFileAsBase64))
-    setAttachments((prev) => [
-      ...prev,
-      ...results.map((r) => ({
-        mediaType: r.mediaType as ImageAttachment['mediaType'],
-        dataBase64: r.dataBase64,
-        objectUrl: r.objectUrl,
-      })),
-    ])
-  }, [])
-
-  const handlePaste = useCallback(
-    (e: ClipboardEvent) => {
-      const items = e.clipboardData?.items
-      if (!items) return
-      const imageItems: File[] = []
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i]
-        if (!item) continue
-        if (item.kind === 'file' && VALID_IMAGE_TYPES.has(item.type)) {
-          const file = item.getAsFile()
-          if (file) imageItems.push(file)
-        }
-      }
-      if (imageItems.length > 0) {
-        e.preventDefault()
-        void addFiles(imageItems)
-      }
-    },
-    [addFiles],
-  )
-
-  const handleFileChange = useCallback(
-    (e: Event) => {
-      const input = e.target as HTMLInputElement
-      if (!input.files) return
-      void addFiles(Array.from(input.files))
-      input.value = ''
-    },
-    [addFiles],
-  )
-
-  const removeAttachment = useCallback((idx: number) => {
-    setAttachments((prev) => {
-      const next = [...prev]
-      const removed = next.splice(idx, 1)
-      for (const r of removed) URL.revokeObjectURL(r.objectUrl)
-      return next
-    })
-  }, [])
 
   const submit = useCallback(
     async (text: string, currentAttachments: ImageAttachment[]) => {
@@ -160,8 +86,7 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
             : undefined
         await onSend(trimmed, images)
         onValueChange('')
-        for (const a of currentAttachments) URL.revokeObjectURL(a.objectUrl)
-        setAttachments([])
+        clearAttachments()
         pendingRef.current = null
         if (textareaRef.current) {
           textareaRef.current.style.height = 'auto'
@@ -172,7 +97,7 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
         setSending(false)
       }
     },
-    [sending, onSend, onValueChange],
+    [sending, onSend, onValueChange, clearAttachments],
   )
 
   const handleKeyDown = useCallback(

--- a/src/hooks/useImageAttachments.ts
+++ b/src/hooks/useImageAttachments.ts
@@ -1,0 +1,99 @@
+import { useState, useCallback } from 'preact/hooks'
+
+export interface ImageAttachment {
+  mediaType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'
+  dataBase64: string
+  objectUrl: string
+}
+
+const VALID_IMAGE_TYPES = new Set<string>(['image/png', 'image/jpeg', 'image/gif', 'image/webp'])
+
+function readFileAsBase64(file: File): Promise<{ mediaType: string; dataBase64: string; objectUrl: string }> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      const comma = result.indexOf(',')
+      if (comma === -1) { reject(new Error('Invalid data URL')); return }
+      const dataBase64 = result.slice(comma + 1)
+      const objectUrl = URL.createObjectURL(file)
+      resolve({ mediaType: file.type, dataBase64, objectUrl })
+    }
+    reader.onerror = () => reject(reader.error ?? new Error('FileReader error'))
+    reader.readAsDataURL(file)
+  })
+}
+
+export function useImageAttachments() {
+  const [attachments, setAttachments] = useState<ImageAttachment[]>([])
+
+  const addFiles = useCallback(async (files: File[]) => {
+    const valid = files.filter((f) => VALID_IMAGE_TYPES.has(f.type))
+    if (valid.length === 0) return
+    const results = await Promise.all(valid.map(readFileAsBase64))
+    setAttachments((prev) => [
+      ...prev,
+      ...results.map((r) => ({
+        mediaType: r.mediaType as ImageAttachment['mediaType'],
+        dataBase64: r.dataBase64,
+        objectUrl: r.objectUrl,
+      })),
+    ])
+  }, [])
+
+  const handlePaste = useCallback(
+    (e: ClipboardEvent) => {
+      const items = e.clipboardData?.items
+      if (!items) return
+      const imageItems: File[] = []
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i]
+        if (!item) continue
+        if (item.kind === 'file' && VALID_IMAGE_TYPES.has(item.type)) {
+          const file = item.getAsFile()
+          if (file) imageItems.push(file)
+        }
+      }
+      if (imageItems.length > 0) {
+        e.preventDefault()
+        void addFiles(imageItems)
+      }
+    },
+    [addFiles],
+  )
+
+  const handleFileChange = useCallback(
+    (e: Event) => {
+      const input = e.target as HTMLInputElement
+      if (!input.files) return
+      void addFiles(Array.from(input.files))
+      input.value = ''
+    },
+    [addFiles],
+  )
+
+  const removeAttachment = useCallback((idx: number) => {
+    setAttachments((prev) => {
+      const next = [...prev]
+      const removed = next.splice(idx, 1)
+      for (const r of removed) URL.revokeObjectURL(r.objectUrl)
+      return next
+    })
+  }, [])
+
+  const clearAttachments = useCallback(() => {
+    setAttachments((prev) => {
+      for (const a of prev) URL.revokeObjectURL(a.objectUrl)
+      return []
+    })
+  }, [])
+
+  return {
+    attachments,
+    addFiles,
+    handlePaste,
+    handleFileChange,
+    removeAttachment,
+    clearAttachments,
+  }
+}


### PR DESCRIPTION
## Summary
- Extract image attachment state and handlers from `MessageInput` into `useImageAttachments` hook
- Move `ImageAttachment` type, validation constants, and file reading logic to the hook
- Add `clearAttachments()` helper for cleanup
- Update `MessageInput` to consume the hook

## Test plan
- [x] All `MessageInput` tests pass
- [x] Linting passes
- [x] No behavior change — attachment UI works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)