### PR TITLE
feat: add images field to CreateSessionRequest

### DIFF
--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -211,6 +211,7 @@ export interface CreateSessionRequest {
   mode: CreateSessionMode
   repo?: string
   profileId?: string
+  images?: Array<{ mediaType: string; dataBase64: string }>
 }
 
 export interface CreateSessionVariantsRequest extends CreateSessionRequest {


### PR DESCRIPTION
## Summary
- Add optional `images?: Array<{ mediaType: string; dataBase64: string }>` to `CreateSessionRequest`
- `CreateSessionVariantsRequest` inherits this field automatically since it extends `CreateSessionRequest`

## Test plan
- [x] TypeScript compilation (pre-existing issues unrelated to this change)
- [x] Verified backward compatibility (optional field)
- [x] Existing tests pass (failures are pre-existing flaky timeout tests)