### PR TITLE
Add images field to CreateSessionRequest

### DIFF
--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -211,6 +211,7 @@ export interface CreateSessionRequest {
   mode: CreateSessionMode
   repo?: string
   profileId?: string
+  images?: string[]
 }
 
 export interface CreateSessionVariantsRequest extends CreateSessionRequest {


### PR DESCRIPTION
## Summary

- Add optional `images?: string[]` field to `CreateSessionRequest` in `shared/api-types.ts`
- Mirrors the pattern used in `UserMessageEvent` and tool results for consistency
- Enables image attachments to be passed when creating sessions

## Test plan

- [x] ESLint passes
- [ ] Verify wire compatibility with `@tprei/telegram-minions` engine after S1 merges
- [ ] Type checking passes once environment dependencies are resolved