### PR TITLE
Add sessions-create-images feature flag

### DIFF
--- a/src/api/features.ts
+++ b/src/api/features.ts
@@ -4,6 +4,7 @@ import type { VersionInfo } from './types'
 export type FeatureName =
   | 'messages'
   | 'sessions-create'
+  | 'sessions-create-images'
   | 'sessions-variants'
   | 'pr-preview'
   | 'diff-viewer'


### PR DESCRIPTION
## Summary
- Adds `sessions-create-images` to the `FeatureName` enum in `src/api/features.ts`

Enables UI to detect when the connected minion engine supports image creation in sessions via `/api/version` feature detection.

## Test plan
- [x] ESLint passes
- [ ] Verify feature detection works when engine advertises `sessions-create-images` in version response