### PR TITLE
feat(ui): gate image attachments behind sessions-create-images

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -317,7 +317,7 @@ function ChatPane({
             <div class="shrink-0 border-t border-slate-200 dark:border-slate-700">
               <QuickActionsBar actions={session.quickActions} onAction={handleQuickAction} />
               <SlashCommandMenu session={session} context={text} onCommand={handleSlashCommand} />
-              <MessageInput session={session} value={text} onValueChange={setText} onSend={handleSend} />
+              <MessageInput session={session} store={store} value={text} onValueChange={setText} onSend={handleSend} />
             </div>
           </>
         )}

--- a/src/api/features.ts
+++ b/src/api/features.ts
@@ -4,6 +4,7 @@ import type { VersionInfo } from './types'
 export type FeatureName =
   | 'messages'
   | 'sessions-create'
+  | 'sessions-create-images'
   | 'sessions-variants'
   | 'pr-preview'
   | 'diff-viewer'

--- a/src/chat/MessageInput.tsx
+++ b/src/chat/MessageInput.tsx
@@ -1,6 +1,8 @@
 import { useRef, useCallback, useState } from 'preact/hooks'
 import type { ApiSession } from '../api/types'
+import type { ConnectionStore } from '../state/types'
 import { useSpeechRecognition } from '../hooks/useSpeechRecognition'
+import { hasFeature } from '../api/features'
 
 const PLACEHOLDER = 'Send instructions to the agent — Enter to send, Shift+Enter for newline'
 
@@ -12,6 +14,7 @@ export interface ImageAttachment {
 
 interface MessageInputProps {
   session: ApiSession
+  store: ConnectionStore
   value: string
   onValueChange: (text: string) => void
   onSend: (text: string, images?: Array<{ mediaType: string; dataBase64: string }>) => Promise<void>
@@ -35,7 +38,7 @@ function readFileAsBase64(file: File): Promise<{ mediaType: string; dataBase64: 
   })
 }
 
-export function MessageInput({ value, onValueChange, onSend }: MessageInputProps) {
+export function MessageInput({ value, onValueChange, onSend, store }: MessageInputProps) {
   const [sending, setSending] = useState(false)
   const [errorText, setErrorText] = useState<string | null>(null)
   const [attachments, setAttachments] = useState<ImageAttachment[]>([])
@@ -150,6 +153,10 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
     async (text: string, currentAttachments: ImageAttachment[]) => {
       const trimmed = text.trim()
       if (!trimmed || sending) return
+      if (currentAttachments.length > 0 && !hasFeature(store, 'sessions-create-images')) {
+        setErrorText('Image attachments require library ≥ 1.120.0')
+        return
+      }
       pendingRef.current = { text: trimmed, images: currentAttachments }
       setErrorText(null)
       setSending(true)
@@ -172,7 +179,7 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
         setSending(false)
       }
     },
-    [sending, onSend, onValueChange],
+    [sending, onSend, onValueChange, store],
   )
 
   const handleKeyDown = useCallback(
@@ -269,26 +276,30 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
         </div>
       )}
       <div class="flex items-end gap-2">
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          multiple
-          class="hidden"
-          onChange={handleFileChange}
-          data-testid="file-input"
-        />
-        <button
-          type="button"
-          onClick={() => fileInputRef.current?.click()}
-          disabled={sending}
-          aria-label="Attach image"
-          title="Attach image"
-          class="shrink-0 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors border shadow-sm disabled:opacity-50 disabled:cursor-not-allowed bg-white dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600"
-          data-testid="attach-btn"
-        >
-          <PaperclipIcon />
-        </button>
+        {hasFeature(store, 'sessions-create-images') && (
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              class="hidden"
+              onChange={handleFileChange}
+              data-testid="file-input"
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={sending}
+              aria-label="Attach image"
+              title="Attach image"
+              class="shrink-0 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors border shadow-sm disabled:opacity-50 disabled:cursor-not-allowed bg-white dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600"
+              data-testid="attach-btn"
+            >
+              <PaperclipIcon />
+            </button>
+          </>
+        )}
         <textarea
           ref={textareaRef}
           value={value}

--- a/test/chat/MessageInput.test.tsx
+++ b/test/chat/MessageInput.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useState } from 'preact/hooks'
+import { signal } from '@preact/signals'
 import { MessageInput } from '../../src/chat/MessageInput'
-import type { ApiSession } from '../../src/api/types'
+import type { ApiSession, VersionInfo } from '../../src/api/types'
+import type { ConnectionStore } from '../../src/state/types'
 
 beforeEach(() => {
   if (!window.matchMedia) {
@@ -32,9 +34,14 @@ const session: ApiSession = {
   conversation: [],
 }
 
-function Controlled({ onSend }: { onSend: (text: string, images?: Array<{ mediaType: string; dataBase64: string }>) => Promise<void> }) {
+function makeStore(features: string[] = ['sessions-create-images']): ConnectionStore {
+  const version: VersionInfo = { apiVersion: '1', libraryVersion: '1.120.0', features }
+  return { version: signal(version) } as unknown as ConnectionStore
+}
+
+function Controlled({ onSend, store }: { onSend: (text: string, images?: Array<{ mediaType: string; dataBase64: string }>) => Promise<void>; store?: ConnectionStore }) {
   const [text, setText] = useState('')
-  return <MessageInput session={session} onSend={onSend} value={text} onValueChange={setText} />
+  return <MessageInput session={session} store={store ?? makeStore()} onSend={onSend} value={text} onValueChange={setText} />
 }
 
 function getTextarea() {
@@ -280,9 +287,54 @@ describe('MessageInput · image attachments', () => {
     vi.unstubAllGlobals()
   })
 
-  it('shows paperclip attach button', () => {
-    render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} />)
+  it('shows paperclip attach button when feature is available', () => {
+    const store = makeStore(['sessions-create-images'])
+    render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} store={store} />)
     expect(screen.getByTestId('attach-btn')).toBeTruthy()
+  })
+
+  it('hides paperclip attach button when feature is not available', () => {
+    const store = makeStore([])
+    render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} store={store} />)
+    expect(screen.queryByTestId('attach-btn')).toBeNull()
+  })
+
+  it('shows error when trying to send images without feature support', async () => {
+    const store = makeStore([])
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const fakeFile = new File([new Uint8Array([1, 2, 3])], 'img.png', { type: 'image/png' })
+
+    vi.stubGlobal('FileReader', class {
+      result: string | ArrayBuffer | null = null
+      onload: ((ev: ProgressEvent) => void) | null = null
+      onerror: ((ev: ProgressEvent) => void) | null = null
+      readAsDataURL = vi.fn().mockImplementation(function (this: { result: string | null; onload: ((ev: ProgressEvent) => void) | null }) {
+        Promise.resolve().then(() => {
+          this.result = 'data:image/png;base64,dGVzdA=='
+          this.onload?.call(this, new ProgressEvent('load'))
+        })
+      })
+    })
+
+    render(<Controlled onSend={onSend} store={store} />)
+
+    const dt = {
+      items: [
+        { kind: 'file', type: 'image/png', getAsFile: () => fakeFile },
+      ],
+    }
+    const textarea = screen.getByTestId('message-textarea')
+    fireEvent(textarea, Object.assign(new Event('paste', { bubbles: true }), { clipboardData: dt }))
+
+    await waitFor(() => expect(screen.getByTestId('attachment-strip')).toBeTruthy())
+
+    fireEvent.input(textarea, { target: { value: 'test message' } })
+    fireEvent.click(screen.getByTestId('send-btn'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Image attachments require library ≥ 1\.120\.0/)).toBeTruthy()
+    })
+    expect(onSend).not.toHaveBeenCalled()
   })
 
   it('paste event with image file queues attachment and shows thumbnail strip', async () => {


### PR DESCRIPTION
## Summary

- Adds `sessions-create-images` to FeatureName type
- Hides paperclip button in MessageInput when feature flag is absent
- Validates image attachments before send and displays upgrade notice ("require library ≥ 1.120.0") when backend lacks support
- Passes ConnectionStore to MessageInput for feature detection
- Adds test coverage for feature-gated behavior

## Test plan

- [x] MessageInput tests pass (19/19)
- [x] ESLint passes
- [x] Paperclip button hidden when feature flag missing
- [x] Error message shown when attempting to send images without support
- [ ] Verify with minion engine that advertises/omits the feature flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)