### PR TITLE
fix(dag): scheduler boot reconcile, PR URL parsing, parent nav

### DIFF
--- a/server/commands/force.test.ts
+++ b/server/commands/force.test.ts
@@ -12,6 +12,7 @@ function makeScheduler(shouldFail = false): DagScheduler {
     async forceNodeLanded(nodeId, dagId) {
       if (shouldFail) throw new Error(`cannot force ${nodeId} in ${dagId}`)
     },
+    async reconcileOnBoot() {},
   }
 }
 

--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -117,7 +117,7 @@ async function buildAndStartDag(
   const sessionRow = prepared.getSession(ctx.db, sessionId)
   const repo = sessionRow?.repo ?? ""
 
-  const graph = buildDag(dagId, items, 0, repo)
+  const graph = buildDag(dagId, items, sessionId, repo)
   saveDag(graph, ctx.db)
   await ctx.scheduler.start(dagId)
 

--- a/server/commands/retry.test.ts
+++ b/server/commands/retry.test.ts
@@ -12,6 +12,7 @@ function makeScheduler(shouldFail = false): DagScheduler {
       if (shouldFail) throw new Error(`cannot retry ${nodeId} in ${dagId}`)
     },
     async forceNodeLanded() {},
+    async reconcileOnBoot() {},
   }
 }
 

--- a/server/dag/dag.test.ts
+++ b/server/dag/dag.test.ts
@@ -31,7 +31,7 @@ describe("buildDag", () => {
       { id: "b", title: "Step B", description: "Second", dependsOn: ["a"] },
       { id: "c", title: "Step C", description: "Third", dependsOn: ["b"] },
     ]
-    const graph = buildDag("test-dag", items, 123, "myrepo")
+    const graph = buildDag("test-dag", items, "root-session", "myrepo")
 
     expect(graph.nodes).toHaveLength(3)
     expect(graph.nodes[0]!.status).toBe("ready")
@@ -46,7 +46,7 @@ describe("buildDag", () => {
       { id: "c", title: "Right", description: "Right branch", dependsOn: ["a"] },
       { id: "d", title: "Merge", description: "Merge point", dependsOn: ["b", "c"] },
     ]
-    const graph = buildDag("diamond", items, 1, "repo")
+    const graph = buildDag("diamond", items, "root-session", "repo")
 
     expect(graph.nodes[0]!.status).toBe("ready")
     expect(graph.nodes[1]!.status).toBe("pending")
@@ -60,7 +60,7 @@ describe("buildDag", () => {
       { id: "b", title: "B", description: "B", dependsOn: [] },
       { id: "c", title: "C", description: "C", dependsOn: [] },
     ]
-    const graph = buildDag("parallel", items, 1, "repo")
+    const graph = buildDag("parallel", items, "root-session", "repo")
 
     expect(graph.nodes.every((n) => n.status === "ready")).toBe(true)
   })
@@ -70,9 +70,9 @@ describe("buildDag", () => {
       { id: "a", title: "A", description: "A", dependsOn: ["nonexistent"] },
       { id: "b", title: "B", description: "B", dependsOn: [] },
     ]
-    expect(() => buildDag("bad", items, 1, "repo")).toThrow(UnknownNodeError)
+    expect(() => buildDag("bad", items, "root-session", "repo")).toThrow(UnknownNodeError)
     try {
-      buildDag("bad", items, 1, "repo")
+      buildDag("bad", items, "root-session", "repo")
     } catch (err) {
       expect(err).toBeInstanceOf(UnknownNodeError)
       expect((err as UnknownNodeError).nodeId).toBe("a")
@@ -86,9 +86,9 @@ describe("buildDag", () => {
     const items: DagInput[] = [
       { id: "a", title: "A", description: "A", dependsOn: ["a"] },
     ]
-    expect(() => buildDag("bad", items, 1, "repo")).toThrow(DagSelfDependencyError)
+    expect(() => buildDag("bad", items, "root-session", "repo")).toThrow(DagSelfDependencyError)
     try {
-      buildDag("bad", items, 1, "repo")
+      buildDag("bad", items, "root-session", "repo")
     } catch (err) {
       expect(err).toBeInstanceOf(DagSelfDependencyError)
       expect((err as DagSelfDependencyError).nodeId).toBe("a")
@@ -100,9 +100,9 @@ describe("buildDag", () => {
       { id: "a", title: "A", description: "A", dependsOn: ["b"] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
     ]
-    expect(() => buildDag("cycle", items, 1, "repo")).toThrow(DagCycleError)
+    expect(() => buildDag("cycle", items, "root-session", "repo")).toThrow(DagCycleError)
     try {
-      buildDag("cycle", items, 1, "repo")
+      buildDag("cycle", items, "root-session", "repo")
     } catch (err) {
       expect(err).toBeInstanceOf(DagCycleError)
       expect((err as DagCycleError).cycleNodes).toBeDefined()
@@ -117,9 +117,9 @@ describe("buildDag", () => {
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["b"] },
     ]
-    expect(() => buildDag("cycle", items, 1, "repo")).toThrow(DagCycleError)
+    expect(() => buildDag("cycle", items, "root-session", "repo")).toThrow(DagCycleError)
     try {
-      buildDag("cycle", items, 1, "repo")
+      buildDag("cycle", items, "root-session", "repo")
     } catch (err) {
       expect(err).toBeInstanceOf(DagCycleError)
       expect((err as DagCycleError).cycleNodes).toBeDefined()
@@ -135,7 +135,7 @@ describe("buildLinearDag", () => {
       { title: "Second", description: "Do second" },
       { title: "Third", description: "Do third" },
     ]
-    const graph = buildLinearDag("linear", items, 1, "repo")
+    const graph = buildLinearDag("linear", items, "root-session", "repo")
 
     expect(graph.nodes).toHaveLength(3)
     expect(graph.nodes[0]!.dependsOn).toEqual([])
@@ -153,7 +153,7 @@ describe("topologicalSort", () => {
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["b"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     expect(topologicalSort(graph)).toEqual(["a", "b", "c"])
   })
@@ -164,7 +164,7 @@ describe("topologicalSort", () => {
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["a"] },
       { id: "d", title: "D", description: "D", dependsOn: ["b", "c"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const sorted = topologicalSort(graph)
     expect(sorted).toHaveLength(4)
@@ -178,7 +178,7 @@ describe("topologicalSort", () => {
     const graph = buildDag("parallel", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const sorted = topologicalSort(graph)
     expect(sorted).toHaveLength(2)
@@ -192,7 +192,7 @@ describe("readyNodes", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const ready = readyNodes(graph)
     expect(ready).toHaveLength(1)
@@ -206,7 +206,7 @@ describe("advanceDag", () => {
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["b"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "done"
     const newlyReady = advanceDag(graph)
@@ -223,7 +223,7 @@ describe("advanceDag", () => {
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["a"] },
       { id: "d", title: "D", description: "D", dependsOn: ["b", "c"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "done"
     let ready = advanceDag(graph)
@@ -245,7 +245,7 @@ describe("advanceDag", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const ready = advanceDag(graph)
     expect(ready).toHaveLength(0)
@@ -255,7 +255,7 @@ describe("advanceDag", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "landed"
     const newlyReady = advanceDag(graph)
@@ -270,7 +270,7 @@ describe("advanceDag", () => {
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: [] },
       { id: "c", title: "C", description: "C", dependsOn: ["a", "b"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "landed"
     graph.nodes[1]!.status = "done"
@@ -287,7 +287,7 @@ describe("failNode", () => {
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["b"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const skipped = failNode(graph, "a")
     expect(graph.nodes[0]!.status).toBe("failed")
@@ -301,7 +301,7 @@ describe("failNode", () => {
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const skipped = failNode(graph, "a")
     expect(graph.nodes[0]!.status).toBe("failed")
@@ -315,7 +315,7 @@ describe("failNode", () => {
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[1]!.status = "done"
     const skipped = failNode(graph, "a")
@@ -329,7 +329,7 @@ describe("isDagComplete", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "done"
     graph.nodes[1]!.status = "done"
@@ -340,7 +340,7 @@ describe("isDagComplete", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "failed"
     graph.nodes[1]!.status = "skipped"
@@ -351,7 +351,7 @@ describe("isDagComplete", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "done"
     expect(isDagComplete(graph)).toBe(false)
@@ -361,7 +361,7 @@ describe("isDagComplete", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "landed"
     graph.nodes[1]!.status = "landed"
@@ -375,7 +375,7 @@ describe("getUpstreamBranches", () => {
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: [] },
       { id: "c", title: "C", description: "C", dependsOn: ["a", "b"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.branch = "minion/slug-a"
     graph.nodes[1]!.branch = "minion/slug-b"
@@ -388,7 +388,7 @@ describe("getUpstreamBranches", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const branches = getUpstreamBranches(graph, "b")
     expect(branches).toEqual([])
@@ -397,7 +397,7 @@ describe("getUpstreamBranches", () => {
   it("returns empty for root nodes", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     expect(getUpstreamBranches(graph, "a")).toEqual([])
   })
@@ -409,7 +409,7 @@ describe("getDownstreamNodes", () => {
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const downstream = getDownstreamNodes(graph, "a")
     expect(downstream.map((n) => n.id)).toEqual(["b"])
@@ -420,7 +420,7 @@ describe("getDownstreamNodes", () => {
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["b"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const downstream = getDownstreamNodes(graph, "a")
     expect(downstream.map((n) => n.id)).toEqual(["b", "c"])
@@ -430,7 +430,7 @@ describe("getDownstreamNodes", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     expect(getDownstreamNodes(graph, "b")).toEqual([])
   })
@@ -441,7 +441,7 @@ describe("getDownstreamNodes", () => {
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["a"] },
       { id: "d", title: "D", description: "D", dependsOn: ["b", "c"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const downstream = getDownstreamNodes(graph, "a")
     expect(downstream.map((n) => n.id).sort()).toEqual(["b", "c", "d"])
@@ -450,7 +450,7 @@ describe("getDownstreamNodes", () => {
   it("returns empty for unknown node", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     expect(getDownstreamNodes(graph, "nonexistent")).toEqual([])
   })
@@ -460,7 +460,7 @@ describe("mergeBase field", () => {
   it("is undefined by default when building a DAG", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     expect(graph.nodes[0]!.mergeBase).toBeUndefined()
   })
@@ -469,7 +469,7 @@ describe("mergeBase field", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.mergeBase = "abc123"
     graph.nodes[1]!.mergeBase = "def456"
@@ -483,7 +483,7 @@ describe("criticalPathLength", () => {
   it("returns 1 for a single node", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
     expect(criticalPathLength(graph)).toBe(1)
   })
 
@@ -492,7 +492,7 @@ describe("criticalPathLength", () => {
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["b"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
     expect(criticalPathLength(graph)).toBe(3)
   })
 
@@ -502,7 +502,7 @@ describe("criticalPathLength", () => {
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["a"] },
       { id: "d", title: "D", description: "D", dependsOn: ["b", "c"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
     expect(criticalPathLength(graph)).toBe(3)
   })
 })
@@ -514,7 +514,7 @@ describe("dagProgress", () => {
       { id: "b", title: "B", description: "B", dependsOn: [] },
       { id: "c", title: "C", description: "C", dependsOn: ["a"] },
       { id: "d", title: "D", description: "D", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "done"
     graph.nodes[1]!.status = "running"
@@ -534,7 +534,7 @@ describe("dagProgress", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "landed"
     graph.nodes[1]!.status = "done"
@@ -552,7 +552,7 @@ describe("transitiveReduction", () => {
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["a", "b"] },
     ]
-    const graph = buildDag("test", items, 1, "repo")
+    const graph = buildDag("test", items, "root-session", "repo")
 
     transitiveReduction(graph)
 
@@ -566,7 +566,7 @@ describe("transitiveReduction", () => {
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["a"] },
     ]
-    const graph = buildDag("test", items, 1, "repo")
+    const graph = buildDag("test", items, "root-session", "repo")
 
     transitiveReduction(graph)
 
@@ -580,7 +580,7 @@ describe("renderDagStatus", () => {
     const graph = buildDag("test", [
       { id: "a", title: "Schema", description: "DB schema", dependsOn: [] },
       { id: "b", title: "API", description: "API routes", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "done"
     graph.nodes[0]!.prUrl = "https://github.com/repo/pull/1"
@@ -597,7 +597,7 @@ describe("renderDagStatus", () => {
     const graph = buildDag("test", [
       { id: "a", title: "Done Task", description: "A", dependsOn: [] },
       { id: "b", title: "Skipped Task", description: "B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "done"
     graph.nodes[1]!.status = "skipped"
@@ -611,7 +611,7 @@ describe("renderDagStatus", () => {
     const graph = buildDag("test", [
       { id: "a", title: "Running Task", description: "A", dependsOn: [] },
       { id: "b", title: "Failed Task", description: "B", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "running"
     graph.nodes[1]!.status = "failed"
@@ -625,7 +625,7 @@ describe("renderDagStatus", () => {
     const graph = buildDag("test", [
       { id: "a", title: "Pending Task", description: "A", dependsOn: [] },
       { id: "b", title: "Ready Task", description: "B", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "pending"
     graph.nodes[1]!.status = "ready"
@@ -644,7 +644,7 @@ describe("renderDagForGitHub", () => {
   it("wraps output in HTML comment markers", () => {
     const graph = buildDag("test", [
       { id: "a", title: "Task A", description: "A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const result = renderDagForGitHub(graph)
     expect(result).toMatch(/^<!-- dag-status-start -->/)
@@ -655,7 +655,7 @@ describe("renderDagForGitHub", () => {
     const graph: DagGraph = {
       id: "empty",
       nodes: [],
-      parentThreadId: 1,
+      rootSessionId: "root-session",
       repo: "repo",
       createdAt: Date.now(),
     }
@@ -669,7 +669,7 @@ describe("renderDagForGitHub", () => {
   it("renders a single node", () => {
     const graph = buildDag("test", [
       { id: "a", title: "Only task", description: "Solo", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const result = renderDagForGitHub(graph)
     expect(result).toContain("```mermaid")
@@ -684,7 +684,7 @@ describe("renderDagForGitHub", () => {
       { title: "Schema migration", description: "DB" },
       { title: "API routes", description: "Routes" },
       { title: "Frontend UI", description: "UI" },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "done"
     graph.nodes[0]!.prUrl = "https://github.com/repo/pull/1"
@@ -713,7 +713,7 @@ describe("renderDagForGitHub", () => {
       { id: "b", title: "Left", description: "Left branch", dependsOn: ["a"] },
       { id: "c", title: "Right", description: "Right branch", dependsOn: ["a"] },
       { id: "d", title: "Merge", description: "Merge point", dependsOn: ["b", "c"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "done"
     graph.nodes[1]!.status = "running"
@@ -739,7 +739,7 @@ describe("renderDagForGitHub", () => {
       { id: "pending-node", title: "Pending", description: "P", dependsOn: ["done-node"] },
       { id: "failed-node", title: "Failed", description: "F", dependsOn: [] },
       { id: "skipped-node", title: "Skipped", description: "S", dependsOn: ["failed-node"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "done"
     graph.nodes[1]!.status = "running"
@@ -768,7 +768,7 @@ describe("renderDagForGitHub", () => {
   it("renders PR links as dash when absent", () => {
     const graph = buildDag("test", [
       { id: "a", title: "No PR", description: "A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const result = renderDagForGitHub(graph)
     expect(result).toContain("| — |")
@@ -777,7 +777,7 @@ describe("renderDagForGitHub", () => {
   it("handles special characters in titles", () => {
     const graph = buildDag("test", [
       { id: "a", title: 'Fix "quotes" & <tags>', description: "A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const result = renderDagForGitHub(graph)
     expect(result).toContain("'quotes'")
@@ -787,7 +787,7 @@ describe("renderDagForGitHub", () => {
   it("sanitizes node IDs for mermaid", () => {
     const graph = buildDag("test", [
       { id: "node.with.dots", title: "Dotty", description: "A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const result = renderDagForGitHub(graph)
     expect(result).toContain("node_with_dots")
@@ -797,7 +797,7 @@ describe("renderDagForGitHub", () => {
   it("does not apply current class when currentNodeId is not set", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     const result = renderDagForGitHub(graph)
     expect(result).not.toMatch(/class \w+ current/)
@@ -809,7 +809,7 @@ describe("renderDagForGitHub", () => {
       { id: "a", title: "A", description: "A", dependsOn: [] },
       { id: "b", title: "B", description: "B", dependsOn: ["a"] },
       { id: "c", title: "C", description: "C", dependsOn: ["b"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "failed"
     graph.nodes[1]!.status = "skipped"
@@ -864,7 +864,7 @@ describe("resetFailedNode", () => {
       { id: "a", title: "A", description: "", dependsOn: [] },
       { id: "b", title: "B", description: "", dependsOn: ["a"] },
       { id: "c", title: "C", description: "", dependsOn: ["b"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
   }
 
   it("resets a failed node to ready and un-skips dependents", () => {
@@ -906,7 +906,7 @@ describe("resetFailedNode", () => {
       { id: "b", title: "B", description: "", dependsOn: ["a"] },
       { id: "c", title: "C", description: "", dependsOn: ["a"] },
       { id: "d", title: "D", description: "", dependsOn: ["b", "c"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "done"
     graph.nodes[1]!.status = "failed"
@@ -927,7 +927,7 @@ describe("ci-pending and ci-failed statuses", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "", dependsOn: [] },
       { id: "b", title: "B", description: "", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "ci-failed"
     graph.nodes[1]!.status = "skipped"
@@ -939,7 +939,7 @@ describe("ci-pending and ci-failed statuses", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "", dependsOn: [] },
       { id: "b", title: "B", description: "", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "ci-pending"
     graph.nodes[1]!.status = "pending"
@@ -951,7 +951,7 @@ describe("ci-pending and ci-failed statuses", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "", dependsOn: [] },
       { id: "b", title: "B", description: "", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "ci-failed"
 
@@ -964,7 +964,7 @@ describe("ci-pending and ci-failed statuses", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "", dependsOn: [] },
       { id: "b", title: "B", description: "", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "ci-pending"
 
@@ -978,7 +978,7 @@ describe("ci-pending and ci-failed statuses", () => {
       { id: "a", title: "A", description: "", dependsOn: [] },
       { id: "b", title: "B", description: "", dependsOn: [] },
       { id: "c", title: "C", description: "", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "ci-pending"
     graph.nodes[1]!.status = "ci-failed"
@@ -995,7 +995,7 @@ describe("ci-pending and ci-failed statuses", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "", dependsOn: [] },
       { id: "b", title: "B", description: "", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "ci-failed"
     graph.nodes[0]!.error = "CI checks failed"
@@ -1012,7 +1012,7 @@ describe("ci-pending and ci-failed statuses", () => {
     const graph = buildDag("test", [
       { id: "a", title: "A", description: "", dependsOn: [] },
       { id: "b", title: "B", description: "", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     graph.nodes[0]!.status = "ci-pending"
     graph.nodes[1]!.status = "ci-failed"
@@ -1033,7 +1033,7 @@ describe("nodeIndex", () => {
       { id: "b", title: "B", description: "", dependsOn: ["a"] },
       { id: "c", title: "C", description: "", dependsOn: ["a"] },
     ]
-    const graph = buildDag("idx-test", items, 1, "repo")
+    const graph = buildDag("idx-test", items, "root-session", "repo")
     const idx = nodeIndex(graph)
 
     expect(idx.size).toBe(3)
@@ -1047,7 +1047,7 @@ describe("nodeIndex", () => {
     const items: DagInput[] = [
       { id: "x", title: "X", description: "", dependsOn: [] },
     ]
-    const graph = buildDag("mut-test", items, 1, "repo")
+    const graph = buildDag("mut-test", items, "root-session", "repo")
     const idx = nodeIndex(graph)
 
     idx.get("x")!.status = "running"

--- a/server/dag/dag.ts
+++ b/server/dag/dag.ts
@@ -44,7 +44,7 @@ export interface DagNode {
 export interface DagGraph {
   id: string
   nodes: DagNode[]
-  parentThreadId: number
+  rootSessionId: string
   repoUrl?: string
   repo: string
   createdAt: number
@@ -100,7 +100,7 @@ function findCycle(nodes: DagNode[] | DagInput[]): string[] {
 export function buildDag(
   dagId: string,
   items: DagInput[],
-  parentThreadId: number,
+  rootSessionId: string,
   repo: string,
   repoUrl?: string,
 ): DagGraph {
@@ -128,7 +128,7 @@ export function buildDag(
   const graph: DagGraph = {
     id: dagId,
     nodes,
-    parentThreadId,
+    rootSessionId,
     repo,
     repoUrl,
     createdAt: Date.now(),
@@ -152,7 +152,7 @@ export function buildDag(
 export function buildLinearDag(
   dagId: string,
   items: { title: string; description: string }[],
-  parentThreadId: number,
+  rootSessionId: string,
   repo: string,
   repoUrl?: string,
 ): DagGraph {
@@ -163,7 +163,7 @@ export function buildLinearDag(
     dependsOn: i > 0 ? [`step-${i - 1}`] : [],
   }))
 
-  return buildDag(dagId, dagItems, parentThreadId, repo, repoUrl)
+  return buildDag(dagId, dagItems, rootSessionId, repo, repoUrl)
 }
 
 export function topologicalSort(graph: DagGraph): string[] {

--- a/server/dag/landing.test.ts
+++ b/server/dag/landing.test.ts
@@ -21,7 +21,7 @@ function makeGraph() {
   const graph = buildDag("dag-1", [
     { id: "a", title: "Task A", description: "First task", dependsOn: [] },
     { id: "b", title: "Task B", description: "Second task", dependsOn: ["a"] },
-  ], 1, "https://github.com/org/repo")
+  ], "root-session", "https://github.com/org/repo")
   graph.nodes[0]!.prUrl = "https://github.com/org/repo/pull/1"
   graph.nodes[0]!.branch = "minion/slug-a"
   graph.nodes[0]!.status = "done"
@@ -49,7 +49,7 @@ describe("LandingManager.landNode", () => {
     const manager = createLandingManager({ bus, execFile: exec })
     const graph = buildDag("dag-1", [
       { id: "a", title: "Task A", description: "First task", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
     graph.nodes[0]!.status = "done"
 
     const result = await manager.landNode("a", graph)

--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -105,7 +105,7 @@ describe("DagScheduler", () => {
       { id: "a", title: "Task A", description: "A", dependsOn: [] },
       { id: "b", title: "Task B", description: "B", dependsOn: [] },
       { id: "c", title: "Task C", description: "C", dependsOn: ["a", "b"] },
-    ], 1, "https://github.com/org/repo")
+    ], "root-session", "https://github.com/org/repo")
     saveDag(graph, db)
 
     const created: string[] = []
@@ -125,7 +125,7 @@ describe("DagScheduler", () => {
     const repoUrl = "https://github.com/org/repo"
     const graph = buildDag("dag-repo", [
       { id: "a", title: "Task A", description: "A", dependsOn: [] },
-    ], 1, repoUrl)
+    ], "root-session", repoUrl)
     saveDag(graph, db)
 
     const repos: string[] = []
@@ -147,7 +147,7 @@ describe("DagScheduler", () => {
       description: `Task ${i} desc`,
       dependsOn: [] as string[],
     }))
-    const graph = buildDag("dag-big", nodes, 1, "https://github.com/org/repo")
+    const graph = buildDag("dag-big", nodes, "root-session", "https://github.com/org/repo")
     saveDag(graph, db)
 
     let concurrent = 0
@@ -171,7 +171,7 @@ describe("DagScheduler", () => {
     const graph = buildDag("dag-chain", [
       { id: "a", title: "Task A", description: "A", dependsOn: [] },
       { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
-    ], 1, "https://github.com/org/repo")
+    ], "root-session", "https://github.com/org/repo")
     saveDag(graph, db)
 
     const createdSessions: string[] = []
@@ -195,7 +195,7 @@ describe("DagScheduler", () => {
     const graph = buildDag("dag-fail", [
       { id: "a", title: "Task A", description: "A", dependsOn: [] },
       { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
-    ], 1, "https://github.com/org/repo")
+    ], "root-session", "https://github.com/org/repo")
     saveDag(graph, db)
 
     const createdSessions: string[] = []
@@ -222,7 +222,7 @@ describe("DagScheduler", () => {
   it("emits dag.node.started event when node spawns", async () => {
     const graph = buildDag("dag-events", [
       { id: "a", title: "Task A", description: "A", dependsOn: [] },
-    ], 1, "https://github.com/org/repo")
+    ], "root-session", "https://github.com/org/repo")
     saveDag(graph, db)
 
     const events: Array<{ kind: string; nodeId: string }> = []
@@ -239,7 +239,7 @@ describe("DagScheduler", () => {
   it("emits dag.node.completed event when session finishes", async () => {
     const graph = buildDag("dag-complete", [
       { id: "a", title: "Task A", description: "A", dependsOn: [] },
-    ], 1, "https://github.com/org/repo")
+    ], "root-session", "https://github.com/org/repo")
     saveDag(graph, db)
 
     const events: Array<{ kind: string; state: string }> = []
@@ -263,7 +263,7 @@ describe("DagScheduler", () => {
   it("cancel stops running sessions and marks them failed", async () => {
     const graph = buildDag("dag-cancel", [
       { id: "a", title: "Task A", description: "A", dependsOn: [] },
-    ], 1, "https://github.com/org/repo")
+    ], "root-session", "https://github.com/org/repo")
     saveDag(graph, db)
 
     const stopped: string[] = []
@@ -290,7 +290,7 @@ describe("DagScheduler", () => {
   it("retryNode resets a failed node and re-spawns it", async () => {
     const graph = buildDag("dag-retry", [
       { id: "a", title: "Task A", description: "A", dependsOn: [] },
-    ], 1, "https://github.com/org/repo")
+    ], "root-session", "https://github.com/org/repo")
     saveDag(graph, db)
 
     const sessions: string[] = []
@@ -319,7 +319,7 @@ describe("DagScheduler", () => {
     const graph = buildDag("dag-force", [
       { id: "a", title: "Task A", description: "A", dependsOn: [] },
       { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
-    ], 1, "https://github.com/org/repo")
+    ], "root-session", "https://github.com/org/repo")
     saveDag(graph, db)
 
     const sessions: string[] = []
@@ -352,7 +352,7 @@ describe("DagScheduler", () => {
   it("calls updateStackComment after each node state transition", async () => {
     const graph = buildDag("dag-comment", [
       { id: "a", title: "Task A", description: "A", dependsOn: [] },
-    ], 1, "https://github.com/org/repo")
+    ], "root-session", "https://github.com/org/repo")
     saveDag(graph, db)
 
     const sessions: string[] = []

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -1,12 +1,49 @@
 import type { Database } from "bun:sqlite"
 import { readyNodes, advanceDag, failNode, resetFailedNode, nodeIndex, getUpstreamBranches, isDagComplete } from "./dag"
 import type { DagGraph, DagNode } from "./dag"
-import { saveDag, loadDag } from "./store"
+import { saveDag, loadDag, listDags } from "./store"
 import { updateStackComment } from "./stack-comment"
 import type { SessionRegistry } from "../session/registry"
 import type { EngineEventBus } from "../events/bus"
 import type { SessionRunState } from "../events/types"
 import type { ApiDagNode, ApiDagGraph } from "../../shared/api-types"
+
+const PR_URL_REGEX = /https:\/\/github\.com\/[^\s)]+\/pull\/\d+/
+
+function readNodePrInfo(db: Database, sessionId: string): { prUrl?: string; branch?: string } {
+  const row = db
+    .query<{ branch: string | null }, [string]>("SELECT branch FROM sessions WHERE id = ?")
+    .get(sessionId)
+  const branch = row?.branch ?? undefined
+
+  const maxTurn = db
+    .query<{ m: number | null }, [string]>(
+      "SELECT MAX(turn) as m FROM session_events WHERE session_id = ? AND type = 'assistant_text'",
+    )
+    .get(sessionId)
+  if (!maxTurn || maxTurn.m === null) return { branch }
+
+  const rows = db
+    .query<{ payload: string }, [string, number]>(
+      "SELECT payload FROM session_events WHERE session_id = ? AND type = 'assistant_text' AND turn = ? ORDER BY seq ASC",
+    )
+    .all(sessionId, maxTurn.m)
+
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const row = rows[i]!
+    try {
+      const payload = JSON.parse(row.payload) as Record<string, unknown>
+      if (payload.final !== true) continue
+      const text = typeof payload.text === "string" ? payload.text : ""
+      const match = PR_URL_REGEX.exec(text)
+      if (match) return { prUrl: match[0], branch }
+    } catch {
+      continue
+    }
+  }
+
+  return { branch }
+}
 
 const MAX_DAG_CONCURRENCY = Number(process.env["MAX_DAG_CONCURRENCY"] ?? 4)
 
@@ -35,6 +72,7 @@ export interface DagScheduler {
   status(dagId: string): DagStatusSnapshot
   retryNode(nodeId: string, dagId: string): Promise<void>
   forceNodeLanded(nodeId: string, dagId: string): Promise<void>
+  reconcileOnBoot(): Promise<void>
 }
 
 export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
@@ -77,7 +115,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     }
     return {
       id: graph.id,
-      rootTaskId: String(graph.parentThreadId),
+      rootTaskId: graph.rootSessionId,
       nodes,
       status: "running",
       createdAt: new Date(graph.createdAt).toISOString(),
@@ -179,6 +217,9 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     nodeToGraph.delete(sessionId)
 
     if (state === "completed") {
+      const { prUrl, branch } = readNodePrInfo(db, sessionId)
+      if (branch) node.branch = branch
+      if (prUrl) node.prUrl = prUrl
       node.status = "done"
       advanceDag(graph)
 
@@ -262,6 +303,58 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     await tickGraph(graph)
   }
 
+  async function reconcileOnBoot(): Promise<void> {
+    const graphs = listDags(db)
+    for (const graph of graphs) {
+      const nonTerminal = graph.nodes.some((n) =>
+        n.status === "pending" || n.status === "ready" || n.status === "running"
+      )
+      if (!nonTerminal) continue
+
+      activeGraphs.set(graph.id, graph)
+
+      for (const node of graph.nodes) {
+        if (node.status !== "running") continue
+        if (!node.sessionId) {
+          node.status = "failed"
+          node.error = "session id missing after engine restart"
+          failNode(graph, node.id)
+          continue
+        }
+
+        const row = db
+          .query<{ status: string }, [string]>("SELECT status FROM sessions WHERE id = ?")
+          .get(node.sessionId)
+
+        if (!row) {
+          node.status = "failed"
+          node.error = "session row missing after engine restart"
+          failNode(graph, node.id)
+          continue
+        }
+
+        if (row.status === "completed") {
+          const { prUrl, branch } = readNodePrInfo(db, node.sessionId)
+          if (branch) node.branch = branch
+          if (prUrl) node.prUrl = prUrl
+          node.status = "done"
+          advanceDag(graph)
+        } else if (row.status === "failed") {
+          node.status = "failed"
+          node.error = "session ended (failed) while engine was down"
+          failNode(graph, node.id)
+        } else {
+          nodeToSession.set(node.id, node.sessionId)
+          nodeToGraph.set(node.sessionId, graph.id)
+        }
+      }
+
+      persist(graph)
+      await commentUpdater(graph).catch(() => {})
+      await tickGraph(graph)
+    }
+  }
+
   async function forceNodeLanded(nodeId: string, dagId: string): Promise<void> {
     let graph = activeGraphs.get(dagId)
     if (!graph) {
@@ -290,5 +383,5 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     await tickGraph(graph)
   }
 
-  return { start, onSessionCompleted, cancel, status, retryNode, forceNodeLanded }
+  return { start, onSessionCompleted, cancel, status, retryNode, forceNodeLanded, reconcileOnBoot }
 }

--- a/server/dag/stack-comment.test.ts
+++ b/server/dag/stack-comment.test.ts
@@ -21,7 +21,7 @@ describe("updateStackComment", () => {
     const { exec, calls } = makeSuccessExec()
     const graph = buildDag("test-dag", [
       { id: "a", title: "Task A", description: "Description A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
 
     await updateStackComment(graph, exec)
     expect(calls).toHaveLength(0)
@@ -31,7 +31,7 @@ describe("updateStackComment", () => {
     const { exec, calls } = makeSuccessExec()
     const graph = buildDag("test-dag", [
       { id: "a", title: "Task A", description: "Description A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
     graph.nodes[0]!.prUrl = "https://github.com/org/repo/pull/1"
     graph.nodes[0]!.status = "landed"
 
@@ -44,7 +44,7 @@ describe("updateStackComment", () => {
     const graph = buildDag("test-dag", [
       { id: "a", title: "Task A", description: "Description A", dependsOn: [] },
       { id: "b", title: "Task B", description: "Description B", dependsOn: ["a"] },
-    ], 1, "repo")
+    ], "root-session", "repo")
     graph.nodes[0]!.prUrl = "https://github.com/org/repo/pull/1"
     graph.nodes[0]!.status = "done"
     graph.nodes[1]!.prUrl = "https://github.com/org/repo/pull/2"
@@ -71,7 +71,7 @@ describe("updateStackComment", () => {
 
     const graph = buildDag("test-dag", [
       { id: "a", title: "Task A", description: "Description A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
     graph.nodes[0]!.prUrl = "https://github.com/org/repo/pull/1"
     graph.nodes[0]!.status = "running"
 
@@ -95,7 +95,7 @@ describe("updateStackComment", () => {
 
     const graph = buildDag("test-dag", [
       { id: "a", title: "Task A", description: "Description A", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
     graph.nodes[0]!.prUrl = "https://github.com/org/repo/pull/1"
     graph.nodes[0]!.status = "running"
 
@@ -122,7 +122,7 @@ describe("updateStackComment", () => {
     const graph = buildDag("test-dag", [
       { id: "a", title: "Task A", description: "Description A", dependsOn: [] },
       { id: "b", title: "Task B", description: "Description B", dependsOn: [] },
-    ], 1, "repo")
+    ], "root-session", "repo")
     graph.nodes[0]!.prUrl = "https://github.com/org/repo/pull/1"
     graph.nodes[0]!.status = "running"
     graph.nodes[1]!.prUrl = "https://github.com/org/repo/pull/2"

--- a/server/dag/store.ts
+++ b/server/dag/store.ts
@@ -7,7 +7,7 @@ function graphToRows(graph: DagGraph): { dagRow: Parameters<typeof prepared.inse
   const repo = graph.repoUrl ?? graph.repo ?? null
   const dagRow = {
     id: graph.id,
-    root_task_id: String(graph.parentThreadId),
+    root_task_id: graph.rootSessionId,
     status: "running" as const,
     repo: repo && repo.length > 0 ? repo : null,
     created_at: graph.createdAt,
@@ -118,7 +118,7 @@ export function loadDag(id: string, db?: Database): DagGraph | null {
   return {
     id: dagRow.id,
     nodes,
-    parentThreadId: Number(dagRow.root_task_id),
+    rootSessionId: dagRow.root_task_id,
     repo: dagRow.repo ?? "",
     createdAt: dagRow.created_at,
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -64,6 +64,7 @@ const reconciled = reconciledRows?.count ?? 0
 console.log(`[minion] engine on :${PORT}, ${reconciled} sessions resumed`)
 
 const scheduler = createDagScheduler({ registry, db, bus, workspace: WORKSPACE_ROOT })
+await scheduler.reconcileOnBoot()
 
 const loopScheduler = new LoopScheduler({
   db,

--- a/server/orchestration/split.ts
+++ b/server/orchestration/split.ts
@@ -12,7 +12,6 @@ export interface SplitOpts {
   db: Database
   scheduler: SplitScheduler
   repo?: string
-  parentThreadId?: number
 }
 
 export interface SplitResult {
@@ -25,14 +24,11 @@ export async function startSplit(
   opts: SplitOpts,
 ): Promise<SplitResult> {
   const dagId = randomUUID()
-  const parentThreadId = opts.parentThreadId ?? 0
   const repo = opts.repo ?? ""
 
   const parallelItems: DagInput[] = items.map((item) => ({ ...item, dependsOn: [] }))
 
-  const graph = buildDag(dagId, parallelItems, parentThreadId, repo)
-
-  void rootSessionId
+  const graph = buildDag(dagId, parallelItems, rootSessionId, repo)
 
   saveDag(graph, opts.db)
   await opts.scheduler.start(dagId)

--- a/server/orchestration/stack.ts
+++ b/server/orchestration/stack.ts
@@ -12,7 +12,6 @@ export interface StackOpts {
   db: Database
   scheduler: StackScheduler
   repo?: string
-  parentThreadId?: number
 }
 
 export interface StackResult {
@@ -25,7 +24,6 @@ export async function startStack(
   opts: StackOpts,
 ): Promise<StackResult> {
   const dagId = randomUUID()
-  const parentThreadId = opts.parentThreadId ?? 0
   const repo = opts.repo ?? ""
 
   const linearItems: DagInput[] = items.map((item, i) => ({
@@ -34,9 +32,7 @@ export async function startStack(
     dependsOn: i > 0 ? [items[i - 1]?.id ?? `step-${i - 1}`] : [],
   }))
 
-  const graph = buildDag(dagId, linearItems, parentThreadId, repo)
-
-  void rootSessionId
+  const graph = buildDag(dagId, linearItems, rootSessionId, repo)
 
   saveDag(graph, opts.db)
   await opts.scheduler.start(dagId)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -242,9 +242,34 @@ function ChatPane({
           ? 'text-green-700 dark:text-green-300'
           : 'text-slate-500 dark:text-slate-400'
 
+  const parentSession = useMemo(() => {
+    for (const dag of store.dags.value) {
+      for (const node of Object.values(dag.nodes)) {
+        if (node.session?.id === session.id) {
+          for (const s of store.sessions.value) {
+            if (s.id === dag.rootTaskId) return s
+          }
+          return null
+        }
+      }
+    }
+    return null
+  }, [session.id, store.dags.value, store.sessions.value])
+
   return (
     <div class={rootClass} data-testid="chat-pane" data-fullscreen={mobileFullscreen ? 'true' : 'false'}>
       <header class="flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-700 shrink-0">
+        {parentSession && onNavigate && (
+          <button
+            type="button"
+            onClick={() => onNavigate(parentSession.id)}
+            class="shrink-0 rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+            title={`Back to parent: ${parentSession.slug}`}
+            data-testid="chat-pane-parent-btn"
+          >
+            ↑ {parentSession.slug}
+          </button>
+        )}
         <span class={`inline-block h-2 w-2 rounded-full ${statusDot(session.status)}`} />
         <span class="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">{session.slug}</span>
         <span class={`text-xs ${statusTone}`} data-testid="chat-pane-status">{session.status}</span>

--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -21,14 +21,11 @@ interface DagStatusPanelProps {
 }
 
 // Finds the DAG for an active session. Either the active session IS the DAG
-// parent (match via threadId → `ApiDagGraph.rootTaskId`) or one of the DAG's
+// root (match via session.id → `ApiDagGraph.rootTaskId`) or one of the DAG's
 // child nodes wraps this session (match via `node.session.id`).
 function findDagForSession(dags: ApiDagGraph[], session: ApiSession): ApiDagGraph | null {
-  if (session.threadId !== undefined) {
-    const tidStr = String(session.threadId)
-    for (const g of dags) {
-      if (g.rootTaskId === tidStr) return g
-    }
+  for (const g of dags) {
+    if (g.rootTaskId === session.id) return g
   }
   for (const g of dags) {
     for (const n of Object.values(g.nodes)) {
@@ -40,7 +37,7 @@ function findDagForSession(dags: ApiDagGraph[], session: ApiSession): ApiDagGrap
 
 function findParentSession(sessions: ApiSession[], dag: ApiDagGraph): ApiSession | null {
   for (const s of sessions) {
-    if (s.threadId !== undefined && String(s.threadId) === dag.rootTaskId) return s
+    if (s.id === dag.rootTaskId) return s
   }
   return null
 }

--- a/src/state/hierarchy.ts
+++ b/src/state/hierarchy.ts
@@ -23,17 +23,15 @@ export type SessionGroup =
 // which wins over variant group which wins over standalone.
 export function buildSessionGroups(sessions: ApiSession[], dags: ApiDagGraph[]): SessionGroup[] {
   const byId = new Map<string, ApiSession>()
-  const byThreadId = new Map<string, ApiSession>()
   for (const s of sessions) {
     byId.set(s.id, s)
-    if (s.threadId !== undefined) byThreadId.set(String(s.threadId), s)
   }
 
   const consumed = new Set<string>()
   const groups: SessionGroup[] = []
 
   for (const dag of dags) {
-    const parent = byThreadId.get(dag.rootTaskId) ?? null
+    const parent = byId.get(dag.rootTaskId) ?? null
     const childIds = Object.values(dag.nodes)
       .map((n) => n.session?.id)
       .filter((id): id is string => typeof id === 'string')

--- a/test/state/hierarchy.test.ts
+++ b/test/state/hierarchy.test.ts
@@ -53,12 +53,12 @@ function makeDag(overrides: Partial<ApiDagGraph> & { id: string }): ApiDagGraph 
 
 describe('buildSessionGroups', () => {
   it('puts DAG parent + its children into one group', () => {
-    const parent = mkSession({ id: 'p', slug: 'parent', threadId: 1, childIds: ['c1', 'c2'] })
-    const c1 = mkSession({ id: 'c1', slug: 'child-1', parentId: 'p', threadId: 10 })
-    const c2 = mkSession({ id: 'c2', slug: 'child-2', parentId: 'p', threadId: 11 })
+    const parent = mkSession({ id: 'p', slug: 'parent', childIds: ['c1', 'c2'] })
+    const c1 = mkSession({ id: 'c1', slug: 'child-1', parentId: 'p' })
+    const c2 = mkSession({ id: 'c2', slug: 'child-2', parentId: 'p' })
     const dag: ApiDagGraph = {
       id: 'dag-parent',
-      rootTaskId: '1',
+      rootTaskId: 'p',
       status: 'running',
       createdAt: '',
       updatedAt: '',
@@ -105,11 +105,11 @@ describe('buildSessionGroups', () => {
   })
 
   it('does not double-count sessions across groups', () => {
-    const parent = mkSession({ id: 'p', childIds: ['c'], threadId: 1 })
-    const child = mkSession({ id: 'c', parentId: 'p', threadId: 10, variantGroupId: 'maybe' })
+    const parent = mkSession({ id: 'p', childIds: ['c'] })
+    const child = mkSession({ id: 'c', parentId: 'p', variantGroupId: 'maybe' })
     const dag: ApiDagGraph = {
       id: 'dag-p',
-      rootTaskId: '1',
+      rootTaskId: 'p',
       status: 'running',
       createdAt: '',
       updatedAt: '',


### PR DESCRIPTION
Three related rough edges from today's ship run.

## 1. Scheduler loses in-memory state on engine restart

If a DAG child session finished while the engine was rebooting, its \`session.completed\` event arrived at a scheduler whose \`activeGraphs\`/\`nodeToGraph\` maps were empty. The node stayed \`running\` forever and downstream nodes never dispatched.

- Add \`scheduler.reconcileOnBoot()\`: on startup, load every non-terminal DAG into \`activeGraphs\`, and for each \`running\` node cross-check the session row. If the session ended while the engine was down, mark the node \`done\` (populating \`prUrl\`+\`branch\` from its output) or \`failed\` and advance. Called once from \`server/index.ts\` right after the scheduler is constructed.

## 2. Node \`prUrl\` never populated

Children were producing \`github.com\` URLs in their final messages, but the scheduler never read them.

- Add \`readNodePrInfo()\`: pulls the last turn's \`final:true\` \`assistant_text\` events, regex-matches a github.com PR URL, and populates \`node.prUrl\`+\`node.branch\` (branch comes off the session row). Used by both \`onSessionCompleted\` and the new \`reconcileOnBoot\` path.

## 3. \"Open parent\" from a child was a dead button

\`buildDag\` hard-coded \`parentThreadId=0\` and nothing else populated it; the UI tried to match sessions by \`threadId\` but DAG children don't set one. Rename the field to \`rootSessionId\` (string, the session that triggered the DAG). Thread the actual session id through \`buildAndStartDag\`, \`startStack\`, \`startSplit\`. UI looks up the parent by id directly.

Also add a compact \`↑ <parent-slug>\` button to the chat pane header so the affordance works when the DAG panel is collapsed.

## Test plan

- [x] typecheck / lint / vitest / bun all green
- [ ] CI green
- [ ] On mini: fresh \`/ship\` → nodes get real \`prUrl\` values and \`↑ parent\` navigates correctly
- [ ] Restart engine mid-DAG → stuck \`running\` nodes get reconciled

## Follow-up

\`/land\` still isn't reachable from the UI. Next PR: wire a POST /api/dags/:id/nodes/:nodeId/land endpoint and add a \"Land\" button per node in \`DagStatusPanel\`.