### PR TITLE
feat: land DAG nodes from the UI

### DIFF
--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -22,6 +22,8 @@ import { fetchPrPreview } from '../github/pr-preview'
 import { computeWorkspaceDiff } from '../workspace/diff'
 import { handleExecute, handleSplit, handleStack, handleDag } from '../commands/plan-actions'
 import type { PlanScheduler } from '../commands/plan-actions'
+import { handleLandCommand } from '../commands/land'
+import type { LandingManager } from '../dag/landing'
 import { loadOverrides, saveOverrides } from '../config/runtime-overrides'
 import { applyOverrides } from '../config/apply'
 import { RuntimeOverridesSchema } from '../config/schema'
@@ -71,6 +73,7 @@ const CommandSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('stop'), sessionId: z.string() }),
   z.object({ action: z.literal('close'), sessionId: z.string() }),
   z.object({ action: z.literal('plan_action'), sessionId: z.string(), planAction: z.enum(['execute', 'split', 'stack', 'dag']), markdown: z.string().optional() }),
+  z.object({ action: z.literal('land'), dagId: z.string(), nodeId: z.string() }),
 ])
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
@@ -113,6 +116,7 @@ export function registerApiRoutes(
   registry: SessionRegistry,
   dbProvider?: () => Database,
   scheduler?: PlanScheduler,
+  landingManager?: LandingManager,
 ): void {
   const resolveDb = dbProvider ?? getDb
 
@@ -243,6 +247,27 @@ export function registerApiRoutes(
           data: result.ok
             ? { success: true, dagId: result.dagId }
             : { success: false, error: result.reason ?? 'plan_action failed' },
+        }
+        return c.json(body)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return c.json({ data: { success: false, error: message } } satisfies ApiResponse<CommandResult>)
+      }
+    }
+
+    if (command.action === 'land') {
+      if (!landingManager) {
+        return c.json({
+          data: { success: false, error: 'landing is not configured on this engine' },
+        } satisfies ApiResponse<CommandResult>)
+      }
+      try {
+        const result = await handleLandCommand(command.nodeId, command.dagId, {
+          landingManager,
+          db: resolveDb(),
+        })
+        const body: ApiResponse<CommandResult> = {
+          data: result.ok ? { success: true } : { success: false, error: result.error ?? 'land failed' },
         }
         return c.json(body)
       } catch (err) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,6 +25,7 @@ import {
   createDefaultConfig,
 } from './handlers/stubs'
 import { createDagScheduler } from './dag/scheduler'
+import { createLandingManager } from './dag/landing'
 import { LoopScheduler } from './loops/scheduler'
 import { ResourceMonitor } from './metrics/resource'
 import { createDigestBuilder } from './digest/digest'
@@ -132,7 +133,8 @@ resourceMonitor.start()
 
 startPushNotifier(bus)
 
-registerApiRoutes(app, registry, () => db, scheduler)
+const landingManager = createLandingManager({ bus })
+registerApiRoutes(app, registry, () => db, scheduler, landingManager)
 registerSseRoute(app, () => db)
 
 export default { port: PORT, fetch: app.fetch, idleTimeout: 0 }

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -184,6 +184,7 @@ export type MinionCommand =
   | { action: 'stop'; sessionId: string }
   | { action: 'close'; sessionId: string }
   | { action: 'plan_action'; sessionId: string; planAction: PlanActionType; markdown?: string }
+  | { action: 'land'; dagId: string; nodeId: string }
 
 export interface RepoEntry {
   alias: string

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -212,6 +212,10 @@ function ChatPane({
     }
   }
 
+  const handleLand = async (dagId: string, nodeId: string): Promise<void> => {
+    await onCommand({ action: 'land', dagId, nodeId })
+  }
+
   const handleClose = async () => {
     const ok = await confirm({
       title: `Close ${session.slug}?`,
@@ -322,7 +326,7 @@ function ChatPane({
         </div>
       </header>
       <WorktreeHeader session={session} store={store} />
-      <DagStatusPanel session={session} store={store} onSelect={onNavigate} />
+      <DagStatusPanel session={session} store={store} onSelect={onNavigate} onLand={handleLand} />
       <SessionTabs
         tabs={[
           { id: 'chat', label: 'Chat', available: true },

--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -18,6 +18,7 @@ interface DagStatusPanelProps {
   session: ApiSession
   store: ConnectionStore
   onSelect?: (sessionId: string) => void
+  onLand?: (dagId: string, nodeId: string) => Promise<void>
 }
 
 // Finds the DAG for an active session. Either the active session IS the DAG
@@ -82,7 +83,7 @@ const DAG_NODE_LABELS: Record<ApiDagNode['status'], string> = {
   skipped: 'skipped',
 }
 
-export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps) {
+export function DagStatusPanel({ session, store, onSelect, onLand }: DagStatusPanelProps) {
   const isDesktop = useMediaQuery('(min-width: 768px)')
   const collapsed = useSignal(readInitialCollapsed(isDesktop.value))
 
@@ -218,8 +219,10 @@ export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps
             <DagNodeRow
               key={node.id}
               node={node}
+              dagId={graph.id}
               isActive={!!node.session && node.session.id === session.id}
               onSelect={onSelect}
+              onLand={onLand}
             />
           ))}
         </ul>
@@ -230,18 +233,24 @@ export function DagStatusPanel({ session, store, onSelect }: DagStatusPanelProps
 
 function DagNodeRow({
   node,
+  dagId,
   isActive,
   onSelect,
+  onLand,
 }: {
   node: ApiDagNode
+  dagId: string
   isActive: boolean
   onSelect?: (sessionId: string) => void
+  onLand?: (dagId: string, nodeId: string) => Promise<void>
 }) {
+  const landing = useSignal(false)
   const dot = DAG_NODE_COLORS[node.status]
   const label = DAG_NODE_LABELS[node.status]
   const sess = node.session
   const prUrl = sess?.prUrl
   const deps = node.dependencies
+  const canLand = !!onLand && node.status === 'completed' && !!prUrl
   const tone =
     node.status === 'failed' || node.status === 'ci-failed'
       ? 'bg-red-50/60 dark:bg-red-950/30'
@@ -300,6 +309,32 @@ function DagNodeRow({
         >
           PR ↗
         </a>
+      )}
+      {canLand && (
+        <button
+          type="button"
+          disabled={landing.value}
+          onClick={async (e) => {
+            e.stopPropagation()
+            if (landing.value) return
+            landing.value = true
+            try {
+              await onLand!(dagId, node.id)
+            } finally {
+              landing.value = false
+            }
+          }}
+          class="rounded-md border border-emerald-300 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/40 px-2 py-0.5 text-[10px] font-medium text-emerald-800 dark:text-emerald-200 hover:bg-emerald-100 dark:hover:bg-emerald-900/50 disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+          data-testid={`dag-status-land-${node.id}`}
+          title="Merge this node's PR"
+        >
+          {landing.value ? 'Landing…' : 'Land'}
+        </button>
+      )}
+      {node.status === 'landed' && (
+        <span class="text-[10px] uppercase tracking-wide font-semibold text-emerald-700 dark:text-emerald-400 shrink-0">
+          landed
+        </span>
       )}
     </li>
   )


### PR DESCRIPTION
## Summary

Adds a per-node **Land** button in the DAG status panel that merges the node's PR without needing to drop into a chat slash-command. Wires \`MinionCommand.action='land' { dagId, nodeId }\` through \`POST /api/commands\` to \`handleLandCommand\`, and finally instantiates \`LandingManager\` in \`server/index.ts\` (previously unused outside the dead ship pipeline).

- New \`land\` variant in \`MinionCommand\` / \`CommandSchema\`.
- \`registerApiRoutes\` takes an optional \`landingManager\`; \`server/index.ts\` passes \`createLandingManager({ bus })\`.
- \`DagStatusPanel\`: per-node Land button rendered when \`status === 'completed' && prUrl\`. Disables mid-flight. Flips to a \`landed\` badge once the backend persists \`node.status = 'landed'\`.
- \`ChatPane.handleLand\` sends the command.

## Test plan

- [x] typecheck / lint / vitest / bun all green
- [ ] CI green
- [ ] On mini with a fresh DAG: click Land on a completed node → PR merges, badge flips to 'landed'

## Follow-ups (not in this PR)

- A 'Land all ready nodes' button at the DAG panel top — useful once trust is established.
- The deduplication / planning issues from today's ship (#88 telegram-minions, duplicate PRs) are a planner problem, separate.