### PR TITLE
feat(ui): gate image attachments behind sessions-create-images flag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -353,7 +353,7 @@ function ChatPane({
             <div class="shrink-0 border-t border-slate-200 dark:border-slate-700">
               <QuickActionsBar actions={session.quickActions} onAction={handleQuickAction} />
               <SlashCommandMenu session={session} context={text} onCommand={handleSlashCommand} />
-              <MessageInput session={session} value={text} onValueChange={setText} onSend={handleSend} />
+              <MessageInput session={session} store={store} value={text} onValueChange={setText} onSend={handleSend} />
             </div>
           </>
         )}

--- a/src/chat/MessageInput.tsx
+++ b/src/chat/MessageInput.tsx
@@ -1,18 +1,22 @@
 import { useRef, useCallback, useState } from 'preact/hooks'
 import type { ApiSession } from '../api/types'
+import type { ConnectionStore } from '../state/types'
 import { useSpeechRecognition } from '../hooks/useSpeechRecognition'
 import { useImageAttachments, type ImageAttachment } from './ImageAttachments'
+import { hasFeature } from '../api/features'
 
 const PLACEHOLDER = 'Send instructions to the agent — Enter to send, Shift+Enter for newline'
 
 interface MessageInputProps {
   session: ApiSession
+  store: ConnectionStore
   value: string
   onValueChange: (text: string) => void
   onSend: (text: string, images?: Array<{ mediaType: string; dataBase64: string }>) => Promise<void>
 }
 
-export function MessageInput({ value, onValueChange, onSend }: MessageInputProps) {
+export function MessageInput({ store, value, onValueChange, onSend }: MessageInputProps) {
+  const imagesSupported = hasFeature(store, 'sessions-create-images')
   const [sending, setSending] = useState(false)
   const [errorText, setErrorText] = useState<string | null>(null)
   const pendingRef = useRef<{ text: string; images: ImageAttachment[] } | null>(null)
@@ -73,6 +77,10 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
     async (text: string, currentAttachments: ImageAttachment[]) => {
       const trimmed = text.trim()
       if (!trimmed || sending) return
+      if (currentAttachments.length > 0 && !imagesSupported) {
+        setErrorText('This engine does not advertise image support — needs sessions-create-images feature.')
+        return
+      }
       pendingRef.current = { text: trimmed, images: currentAttachments }
       setErrorText(null)
       setSending(true)
@@ -94,7 +102,7 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
         setSending(false)
       }
     },
-    [sending, onSend, onValueChange, clear],
+    [sending, onSend, onValueChange, clear, imagesSupported],
   )
 
   const handleKeyDown = useCallback(
@@ -165,15 +173,15 @@ export function MessageInput({ value, onValueChange, onSend }: MessageInputProps
         sending={sending}
         recording={recording}
       />
-      {attachmentsStrip}
+      {imagesSupported && attachmentsStrip}
       <div class="flex items-end gap-2">
-        {paperclipButton}
+        {imagesSupported && paperclipButton}
         <textarea
           ref={textareaRef}
           value={value}
           onInput={handleInput}
           onKeyDown={handleKeyDown}
-          onPaste={pasteHandler}
+          onPaste={imagesSupported ? pasteHandler : undefined}
           disabled={sending}
           placeholder={PLACEHOLDER}
           rows={1}

--- a/test/chat/MessageInput.test.tsx
+++ b/test/chat/MessageInput.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useState } from 'preact/hooks'
+import { signal } from '@preact/signals'
 import { MessageInput } from '../../src/chat/MessageInput'
 import type { ApiSession } from '../../src/api/types'
+import type { ConnectionStore } from '../../src/state/types'
 
 beforeEach(() => {
   if (!window.matchMedia) {
@@ -32,9 +34,13 @@ const session: ApiSession = {
   conversation: [],
 }
 
-function Controlled({ onSend }: { onSend: (text: string, images?: Array<{ mediaType: string; dataBase64: string }>) => Promise<void> }) {
+const mockStore = {
+  version: signal({ apiVersion: '2.0.0', libraryVersion: '0.1.0', features: ['sessions-create-images'] as string[] }),
+} as unknown as ConnectionStore
+
+function Controlled({ onSend, store = mockStore }: { onSend: (text: string, images?: Array<{ mediaType: string; dataBase64: string }>) => Promise<void>; store?: ConnectionStore }) {
   const [text, setText] = useState('')
-  return <MessageInput session={session} onSend={onSend} value={text} onValueChange={setText} />
+  return <MessageInput session={session} store={store} onSend={onSend} value={text} onValueChange={setText} />
 }
 
 function getTextarea() {


### PR DESCRIPTION
Supersedes #101 (conflicted with #99 after the MessageInput refactor landed).

- MessageInput reads `hasFeature(store, 'sessions-create-images')` and hides the paperclip, drops the paste handler, and rejects attachment-bearing submits when the engine doesn't advertise the capability.
- Thread `store` through `App.tsx → MessageInput`. Test harness gets a minimal mock store with the feature enabled.

Closes #101.