### PR TITLE
fix: wire images through /api/sessions + NewTaskBar

### DIFF
--- a/server/api/routes.inbound-images.test.ts
+++ b/server/api/routes.inbound-images.test.ts
@@ -101,7 +101,7 @@ afterEach(() => {
 })
 
 describe('POST /api/messages — inbound images', () => {
-  test('valid payload produces multi-block message with images then text', () => {
+  test('valid payload produces multi-block message with text then images', () => {
     const images = [
       { mediaType: 'image/png' as const, dataBase64: 'pngData123' },
       { mediaType: 'image/jpeg' as const, dataBase64: 'jpegData456' },
@@ -119,15 +119,15 @@ describe('POST /api/messages — inbound images', () => {
     const content = parsed.message.content
 
     expect(content).toHaveLength(3)
-    expect(content[0]?.type).toBe('image')
-    expect(content[0]?.source?.type).toBe('base64')
-    expect(content[0]?.source?.media_type).toBe('image/png')
-    expect(content[0]?.source?.data).toBe('pngData123')
+    expect(content[0]?.type).toBe('text')
+    expect(content[0]?.text).toBe('check these screenshots')
     expect(content[1]?.type).toBe('image')
-    expect(content[1]?.source?.media_type).toBe('image/jpeg')
-    expect(content[1]?.source?.data).toBe('jpegData456')
-    expect(content[2]?.type).toBe('text')
-    expect(content[2]?.text).toBe('check these screenshots')
+    expect(content[1]?.source?.type).toBe('base64')
+    expect(content[1]?.source?.media_type).toBe('image/png')
+    expect(content[1]?.source?.data).toBe('pngData123')
+    expect(content[2]?.type).toBe('image')
+    expect(content[2]?.source?.media_type).toBe('image/jpeg')
+    expect(content[2]?.source?.data).toBe('jpegData456')
   })
 
   test('rejects image exceeding 5 MB with 400', async () => {

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -62,11 +62,38 @@ const FEATURES = [
   'runtime-config',
 ]
 
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+const MAX_TOTAL_IMAGE_BYTES = 20 * 1024 * 1024
+
+const ImageSchema = z.object({
+  mediaType: z.enum(['image/png', 'image/jpeg', 'image/gif', 'image/webp']),
+  dataBase64: z.string().min(1),
+})
+
+function validateImagePayloads(
+  images: Array<{ dataBase64: string }> | undefined,
+): string | null {
+  if (!images) return null
+  let total = 0
+  for (const img of images) {
+    const bytes = Math.floor((img.dataBase64.length * 3) / 4)
+    if (bytes > MAX_IMAGE_BYTES) {
+      return `Image exceeds 5 MB limit (decoded ~${bytes} bytes)`
+    }
+    total += bytes
+  }
+  if (total > MAX_TOTAL_IMAGE_BYTES) {
+    return `Total image payload exceeds 20 MB (decoded ~${total} bytes)`
+  }
+  return null
+}
+
 const CreateSessionSchema = z.object({
   prompt: z.string().min(1),
   mode: z.enum(['task', 'plan', 'think', 'review', 'ship-think']),
   repo: z.string().min(1).optional(),
   profileId: z.string().optional(),
+  images: z.array(ImageSchema).optional(),
 })
 
 const CommandSchema = z.discriminatedUnion('action', [
@@ -76,14 +103,6 @@ const CommandSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('plan_action'), sessionId: z.string(), planAction: z.enum(['execute', 'split', 'stack', 'dag']), markdown: z.string().optional() }),
   z.object({ action: z.literal('land'), dagId: z.string(), nodeId: z.string() }),
 ])
-
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024
-const MAX_TOTAL_IMAGE_BYTES = 20 * 1024 * 1024
-
-const ImageSchema = z.object({
-  mediaType: z.enum(['image/png', 'image/jpeg', 'image/gif', 'image/webp']),
-  dataBase64: z.string().min(1),
-})
 
 const MessageSchema = z.object({
   text: z.string().min(1),
@@ -153,13 +172,20 @@ export function registerApiRoutes(
     if (!parsed.success) {
       return c.json({ error: formatZod(parsed.error.issues) }, 400)
     }
-    const { prompt, mode, repo } = parsed.data
+    const { prompt, mode, repo, images } = parsed.data
+    const imgErr = validateImagePayloads(images)
+    if (imgErr) return c.json({ error: imgErr }, 400)
     const resolvedRepo = repo ?? process.env['DEFAULT_REPO']
     if (!resolvedRepo) {
       return c.json({ error: 'repo is required (or set DEFAULT_REPO on the engine)' }, 400)
     }
     try {
-      const { session } = await registry.create({ mode, prompt, repo: resolvedRepo })
+      const { session } = await registry.create({
+        mode,
+        prompt,
+        repo: resolvedRepo,
+        initialImages: images,
+      })
       const body: ApiResponse<{ sessionId: string; slug: string }> = {
         data: { sessionId: session.id, slug: session.slug },
       }
@@ -617,6 +643,7 @@ export function registerApiRoutes(
     repo: z.string().min(1).optional(),
     profileId: z.string().optional(),
     count: z.number().int().min(2).max(10),
+    images: z.array(ImageSchema).optional(),
   })
 
   app.post('/api/sessions/variants', async (c) => {
@@ -625,14 +652,16 @@ export function registerApiRoutes(
     if (!parsed.success) {
       return c.json({ error: formatZod(parsed.error.issues) }, 400)
     }
-    const { prompt, mode, repo, count } = parsed.data
+    const { prompt, mode, repo, count, images } = parsed.data
+    const imgErr = validateImagePayloads(images)
+    if (imgErr) return c.json({ error: imgErr }, 400)
     const resolvedRepo = repo ?? process.env['DEFAULT_REPO']
     if (!resolvedRepo) {
       return c.json({ error: 'repo is required (or set DEFAULT_REPO on the engine)' }, 400)
     }
     try {
       const result = await createSessionVariants(
-        { prompt, mode, repo: resolvedRepo, count },
+        { prompt, mode, repo: resolvedRepo, count, initialImages: images },
         registry,
         resolveDb,
       )

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -176,12 +176,16 @@ export function NewTaskBar({
     error.value = null
     try {
       const selectedRepo = repo.value || undefined
+      const imagesPayload = attachments.length > 0
+        ? attachments.map((a) => ({ mediaType: a.mediaType, dataBase64: a.dataBase64 }))
+        : undefined
       if (wantVariants.value) {
         const out = await store.client.createSessionVariants({
           prompt: p,
           mode: mode.value,
           repo: selectedRepo,
           count: variantCount.value,
+          images: imagesPayload,
         })
         const slugs: string[] = []
         const errors: string[] = []
@@ -214,6 +218,7 @@ export function NewTaskBar({
           prompt: p,
           mode: mode.value,
           repo: selectedRepo,
+          images: imagesPayload,
         })
         store.applySessionCreated(created)
         prompt.value = ''


### PR DESCRIPTION
Creating a task with an image in the new-task bar silently dropped the attachment. Observed live in `loud-bay-6423`: user sent "What do you see" with an image, but the stored `user_message` event has `images=0` and the model had no image to describe.

Two gaps:

1. `POST /api/sessions`'s zod schema didn't include `images`, and the handler never forwarded them to `registry.create`. Same for `/api/sessions/variants`. Add `images?: Array<ImageSchema>` to both, run the same 5 MB / 20 MB total validator already used for `/api/messages`, pass through as `initialImages`.

2. `NewTaskBar` collected attachments for display but never sent them. Build an `imagesPayload` from `attachments` and include it in both `createSession` and `createSessionVariants` calls.

Also fix a stale assertion in `routes.inbound-images.test.ts` that still expected image-first ordering (serializer flipped to text-first by #94).

## Test plan

- [x] typecheck / lint / vitest / bun all green
- [ ] CI green
- [ ] Live on mini: new task with an image → model actually sees it
EOF
)