### PR TITLE
feat(ui): add pull-to-refresh for mobile PWA

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { ConfirmRoot } from './hooks/useConfirm'
 import { InstallPrompt } from './pwa/InstallPrompt'
 import { useOnlineStatus } from './pwa/useOnlineStatus'
 import { useMediaQuery } from './hooks/useMediaQuery'
+import { usePullToRefresh } from './hooks/usePullToRefresh'
 import { WorktreeHeader } from './components/WorktreeHeader'
 import { DagStatusPanel } from './chat/DagStatusPanel'
 import { ThemeToggle } from './chat/ThemeToggle'
@@ -712,6 +713,12 @@ function ActiveView() {
   const selected = sessionId ? sessions.find((s) => s.id === sessionId) ?? null : null
   const isGroupRoute = route.name === 'group'
 
+  const pullToRefresh = usePullToRefresh({
+    onRefresh: () => store.refresh(),
+    enabled: !isDesktop.value && mode === 'list' && !isGroupRoute,
+    threshold: 80,
+  })
+
   const handleAttentionSelect = (
     reason: AttentionReason | null,
     firstMatchId: string | null,
@@ -823,30 +830,57 @@ function ActiveView() {
           />
         )
       ) : (
-        <div class="flex flex-col flex-1 min-h-0">
-          <AttentionBar
-            sessions={sessions}
-            filter={attentionFilter}
-            onSelect={handleAttentionSelect}
-          />
-          <MobileSessionStrip
-            sessions={visibleSessions}
-            dags={store.dags.value}
-            activeSessionId={sessionId}
-            onSelect={setSessionId}
-          />
-          {selected ? (
-            <ChatPane
-              key={selected.id}
-              session={selected}
-              store={store}
-              onSend={handleSendMessage}
-              onCommand={handleCommand}
-              onNavigate={setSessionId}
-            />
-          ) : (
-            <EmptyPane />
+        <div class="flex flex-col flex-1 min-h-0 relative overflow-hidden">
+          {pullToRefresh.pullDistance > 0 && (
+            <div
+              class="absolute top-0 left-0 right-0 flex items-center justify-center transition-opacity z-10"
+              style={{
+                height: `${pullToRefresh.pullDistance}px`,
+                opacity: Math.min(pullToRefresh.pullDistance / 80, 1),
+              }}
+            >
+              <div class="flex items-center justify-center bg-white dark:bg-slate-800 rounded-full w-8 h-8 shadow-md">
+                <span
+                  class={`text-base ${pullToRefresh.isRefreshing ? 'animate-spin' : ''}`}
+                  aria-hidden="true"
+                >
+                  🔄
+                </span>
+              </div>
+            </div>
           )}
+          <div
+            {...pullToRefresh.containerProps}
+            class="flex flex-col flex-1 min-h-0 overflow-y-auto"
+            style={{
+              transform: pullToRefresh.pullDistance > 0 ? `translateY(${pullToRefresh.pullDistance}px)` : undefined,
+              transition: pullToRefresh.isRefreshing || pullToRefresh.pullDistance === 0 ? 'transform 0.2s ease-out' : 'none',
+            }}
+          >
+            <AttentionBar
+              sessions={sessions}
+              filter={attentionFilter}
+              onSelect={handleAttentionSelect}
+            />
+            <MobileSessionStrip
+              sessions={visibleSessions}
+              dags={store.dags.value}
+              activeSessionId={sessionId}
+              onSelect={setSessionId}
+            />
+            {selected ? (
+              <ChatPane
+                key={selected.id}
+                session={selected}
+                store={store}
+                onSend={handleSendMessage}
+                onCommand={handleCommand}
+                onNavigate={setSessionId}
+              />
+            ) : (
+              <EmptyPane />
+            )}
+          </div>
         </div>
       )}
       {!isDesktop.value && mode === 'canvas' && (

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from 'preact/hooks'
+
+interface PullToRefreshOptions {
+  onRefresh: () => void | Promise<void>
+  threshold?: number
+  resistance?: number
+  enabled?: boolean
+}
+
+interface PullToRefreshResult {
+  pullDistance: number
+  isRefreshing: boolean
+  containerProps: {
+    ref: (el: HTMLElement | null) => void
+    onTouchStart: (e: TouchEvent) => void
+    onTouchMove: (e: TouchEvent) => void
+    onTouchEnd: () => void
+  }
+}
+
+export function usePullToRefresh({
+  onRefresh,
+  threshold = 80,
+  resistance = 2.5,
+  enabled = true,
+}: PullToRefreshOptions): PullToRefreshResult {
+  const [pullDistance, setPullDistance] = useState(0)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const containerRef = useRef<HTMLElement | null>(null)
+  const touchStartY = useRef<number | null>(null)
+  const scrollTopAtStart = useRef<number>(0)
+
+  const handleTouchStart = (e: TouchEvent) => {
+    if (!enabled || isRefreshing) return
+    const container = containerRef.current
+    if (!container) return
+    scrollTopAtStart.current = container.scrollTop
+    if (scrollTopAtStart.current === 0) {
+      touchStartY.current = e.touches[0].clientY
+    }
+  }
+
+  const handleTouchMove = (e: TouchEvent) => {
+    if (!enabled || isRefreshing || touchStartY.current === null) return
+    const container = containerRef.current
+    if (!container || container.scrollTop > 0) {
+      touchStartY.current = null
+      setPullDistance(0)
+      return
+    }
+
+    const touchY = e.touches[0].clientY
+    const deltaY = touchY - touchStartY.current
+
+    if (deltaY > 0) {
+      const distance = Math.min(deltaY / resistance, threshold * 1.5)
+      setPullDistance(distance)
+      if (distance > 10) {
+        e.preventDefault()
+      }
+    }
+  }
+
+  const handleTouchEnd = () => {
+    if (!enabled || isRefreshing || touchStartY.current === null) {
+      touchStartY.current = null
+      setPullDistance(0)
+      return
+    }
+
+    touchStartY.current = null
+
+    if (pullDistance >= threshold) {
+      setIsRefreshing(true)
+      setPullDistance(threshold)
+      Promise.resolve(onRefresh()).finally(() => {
+        setIsRefreshing(false)
+        setPullDistance(0)
+      })
+    } else {
+      setPullDistance(0)
+    }
+  }
+
+  const setContainerRef = (el: HTMLElement | null) => {
+    containerRef.current = el
+  }
+
+  useEffect(() => {
+    if (!enabled) {
+      setPullDistance(0)
+      setIsRefreshing(false)
+      touchStartY.current = null
+    }
+  }, [enabled])
+
+  return {
+    pullDistance,
+    isRefreshing,
+    containerProps: {
+      ref: setContainerRef,
+      onTouchStart: handleTouchStart,
+      onTouchMove: handleTouchMove,
+      onTouchEnd: handleTouchEnd,
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- Add native pull-to-refresh gesture for mobile devices
- Pull down when at the top of the session list to trigger refresh
- Visual spinner indicator scales with pull distance
- Only enabled on mobile list view (disabled for desktop/canvas/ship)

## Implementation

- **New hook**: `usePullToRefresh` handles touch events, scroll detection, and refresh state
- **Visual feedback**: Animated refresh icon appears above content during pull
- **Smart triggering**: Only works when scrolled to top, with 80px threshold and resistance
- **Integration**: Applied to mobile view in `ActiveView` component

## Test plan

- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] All App component tests pass (19/19)
- [ ] Manual test on mobile device:
  - Pull down on session list when scrolled to top
  - Verify spinner appears and scales with pull distance
  - Release past threshold to trigger refresh
  - Verify sessions/DAGs reload
  - Check disabled when scrolled down or on desktop/canvas/ship views

🤖 Generated with [Claude Code](https://claude.com/claude-code)