### PR TITLE
feat(ui): replace mobile header icons with burger menu

### DIFF
--- a/e2e/tests/header-overflow.spec.ts
+++ b/e2e/tests/header-overflow.spec.ts
@@ -10,8 +10,11 @@ test.describe('header layout', () => {
     mock.setVersion({ features: ['messages'] })
     try {
       await connectToMinion(page, mock, 'My Minion')
-      await expect(page.getByTestId('header-refresh-btn')).toBeVisible()
-      await expect(page.getByTestId('header-clean-btn')).toBeVisible()
+
+      await expect(page.getByTestId('header-menu-btn')).toBeVisible()
+      await page.getByTestId('header-menu-btn').click()
+      await expect(page.getByTestId('menu-refresh')).toBeVisible()
+      await expect(page.getByTestId('menu-clean')).toBeVisible()
 
       const headerOverflow = await page
         .locator('header')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import type { ApiDagGraph } from './api/types'
 import { currentRoute } from './routing/current'
 import { VariantGroupView } from './groups/VariantGroupView'
 import type { ApiSession, AttentionReason, MinionCommand, QuickAction } from './api/types'
+import { HeaderMenu } from './components/HeaderMenu'
 
 export type ViewMode = 'list' | 'canvas' | 'ship'
 
@@ -749,45 +750,58 @@ function ActiveView() {
           <ResourceChip store={store} onOpen={() => { showRuntime.value = 'resources' }} />
         )}
         <RunningBadge store={store} onSelect={handleOpenChat} />
-        <div class="ml-auto flex items-center gap-1 sm:gap-1.5 shrink-0">
-          <ViewToggle mode={mode} onChange={(m) => { viewMode.value = m }} />
-          <ThemeToggle />
-          {hasFeature(store, 'runtime-config') && (
+        {isDesktop.value ? (
+          <div class="ml-auto flex items-center gap-1 sm:gap-1.5 shrink-0">
+            <ViewToggle mode={mode} onChange={(m) => { viewMode.value = m }} />
+            <ThemeToggle />
+            {hasFeature(store, 'runtime-config') && (
+              <button
+                type="button"
+                onClick={() => { showRuntime.value = 'config' }}
+                class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
+                title="Runtime config"
+                aria-label="Open runtime config"
+                data-testid="header-runtime-config-btn"
+              >
+                <span aria-hidden="true">⚙️</span>
+              </button>
+            )}
+            {hasFeature(store, 'messages') && (
+              <button
+                type="button"
+                onClick={() => void handleClean()}
+                disabled={cleaning}
+                class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                title={cleaning ? 'Cleaning…' : 'Clean unused worktrees, branches, and session state'}
+                aria-label={cleaning ? 'Cleaning…' : 'Clean unused worktrees, branches, and session state'}
+                data-testid="header-clean-btn"
+              >
+                <span aria-hidden="true">🧹</span>
+              </button>
+            )}
             <button
               type="button"
-              onClick={() => { showRuntime.value = 'config' }}
+              onClick={() => void store.refresh()}
               class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
-              title="Runtime config"
-              aria-label="Open runtime config"
-              data-testid="header-runtime-config-btn"
+              title="Refetch sessions and DAGs from the minion"
+              aria-label="Refetch sessions and DAGs from the minion"
+              data-testid="header-refresh-btn"
             >
-              <span aria-hidden="true">⚙️</span>
+              <span aria-hidden="true">🔄</span>
             </button>
-          )}
-          {hasFeature(store, 'messages') && (
-            <button
-              type="button"
-              onClick={() => void handleClean()}
-              disabled={cleaning}
-              class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
-              title={cleaning ? 'Cleaning…' : 'Clean unused worktrees, branches, and session state'}
-              aria-label={cleaning ? 'Cleaning…' : 'Clean unused worktrees, branches, and session state'}
-              data-testid="header-clean-btn"
-            >
-              <span aria-hidden="true">🧹</span>
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => void store.refresh()}
-            class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
-            title="Refetch sessions and DAGs from the minion"
-            aria-label="Refetch sessions and DAGs from the minion"
-            data-testid="header-refresh-btn"
-          >
-            <span aria-hidden="true">🔄</span>
-          </button>
-        </div>
+          </div>
+        ) : (
+          <div class="ml-auto">
+            <HeaderMenu
+              onRuntimeConfig={hasFeature(store, 'runtime-config') ? () => { showRuntime.value = 'config' } : undefined}
+              onClean={hasFeature(store, 'messages') ? handleClean : undefined}
+              onRefresh={() => void store.refresh()}
+              showRuntimeConfig={hasFeature(store, 'runtime-config')}
+              showClean={hasFeature(store, 'messages')}
+              cleaning={cleaning}
+            />
+          </div>
+        )}
       </header>
       {store.error.value && (
         <div class="flex items-center gap-3 px-4 py-2 bg-red-50 dark:bg-red-950 border-b border-red-200 dark:border-red-800 text-sm text-red-700 dark:text-red-300 shrink-0">

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -1,0 +1,155 @@
+import { signal } from '@preact/signals'
+import { useEffect, useRef } from 'preact/hooks'
+import { ThemeToggle } from '../chat/ThemeToggle'
+import type { ViewMode } from '../App'
+import { viewMode } from '../App'
+
+const menuOpen = signal(false)
+
+export { menuOpen }
+
+export function HeaderMenu({
+  onRuntimeConfig,
+  onClean,
+  onRefresh,
+  showRuntimeConfig,
+  showClean,
+  cleaning,
+}: {
+  onRuntimeConfig?: () => void
+  onClean?: () => void
+  onRefresh: () => void
+  showRuntimeConfig: boolean
+  showClean: boolean
+  cleaning: boolean
+}) {
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!menuOpen.value) return
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        menuOpen.value = false
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [menuOpen.value])
+
+  const closeMenu = () => {
+    menuOpen.value = false
+  }
+
+  const handleViewChange = (mode: ViewMode) => {
+    viewMode.value = mode
+    closeMenu()
+  }
+
+  return (
+    <div class="relative" ref={menuRef}>
+      <button
+        type="button"
+        onClick={() => { menuOpen.value = !menuOpen.value }}
+        class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-base hover:bg-slate-100 dark:hover:bg-slate-700"
+        title="Menu"
+        aria-label="Open menu"
+        data-testid="header-menu-btn"
+      >
+        <span aria-hidden="true">☰</span>
+      </button>
+      {menuOpen.value && (
+        <div
+          class="absolute right-0 top-full mt-1 w-56 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 shadow-lg z-50 py-1"
+          data-testid="header-menu-dropdown"
+        >
+          <div class="px-3 py-2 text-[10px] uppercase tracking-wider font-semibold text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
+            View
+          </div>
+          <button
+            type="button"
+            onClick={() => handleViewChange('list')}
+            class={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-slate-100 dark:hover:bg-slate-700 ${
+              viewMode.value === 'list' ? 'bg-indigo-50 dark:bg-indigo-950/30 text-indigo-700 dark:text-indigo-300 font-medium' : 'text-slate-700 dark:text-slate-200'
+            }`}
+            data-testid="menu-view-list"
+          >
+            <span aria-hidden="true">☰</span>
+            <span>List</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => handleViewChange('canvas')}
+            class={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-slate-100 dark:hover:bg-slate-700 ${
+              viewMode.value === 'canvas' ? 'bg-indigo-50 dark:bg-indigo-950/30 text-indigo-700 dark:text-indigo-300 font-medium' : 'text-slate-700 dark:text-slate-200'
+            }`}
+            data-testid="menu-view-canvas"
+          >
+            <span aria-hidden="true">◎</span>
+            <span>Canvas</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => handleViewChange('ship')}
+            class={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-slate-100 dark:hover:bg-slate-700 ${
+              viewMode.value === 'ship' ? 'bg-indigo-50 dark:bg-indigo-950/30 text-indigo-700 dark:text-indigo-300 font-medium' : 'text-slate-700 dark:text-slate-200'
+            }`}
+            data-testid="menu-view-ship"
+          >
+            <span aria-hidden="true">🚀</span>
+            <span>Ship</span>
+          </button>
+          <div class="border-t border-slate-200 dark:border-slate-700 my-1" />
+          <div class="px-3 py-2 flex items-center justify-between">
+            <span class="text-sm text-slate-700 dark:text-slate-200">Theme</span>
+            <ThemeToggle />
+          </div>
+          {showRuntimeConfig && onRuntimeConfig && (
+            <>
+              <div class="border-t border-slate-200 dark:border-slate-700 my-1" />
+              <button
+                type="button"
+                onClick={() => {
+                  onRuntimeConfig()
+                  closeMenu()
+                }}
+                class="w-full flex items-center gap-3 px-3 py-2 text-sm text-left text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+                data-testid="menu-runtime-config"
+              >
+                <span aria-hidden="true">⚙️</span>
+                <span>Runtime Config</span>
+              </button>
+            </>
+          )}
+          {showClean && onClean && (
+            <button
+              type="button"
+              onClick={() => {
+                void onClean()
+                closeMenu()
+              }}
+              disabled={cleaning}
+              class="w-full flex items-center gap-3 px-3 py-2 text-sm text-left text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid="menu-clean"
+            >
+              <span aria-hidden="true">🧹</span>
+              <span>{cleaning ? 'Cleaning…' : 'Clean'}</span>
+            </button>
+          )}
+          <div class="border-t border-slate-200 dark:border-slate-700 my-1" />
+          <button
+            type="button"
+            onClick={() => {
+              onRefresh()
+              closeMenu()
+            }}
+            class="w-full flex items-center gap-3 px-3 py-2 text-sm text-left text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+            data-testid="menu-refresh"
+          >
+            <span aria-hidden="true">🔄</span>
+            <span>Refresh</span>
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -209,7 +209,9 @@ describe('App', () => {
     const App = (await import('../src/App')).default
     render(<App />)
     await screen.findByText('My Minion')
-    expect(screen.queryByTestId('header-clean-btn')).toBeNull()
+    fireEvent.click(screen.getByTestId('header-menu-btn'))
+    await screen.findByTestId('header-menu-dropdown')
+    expect(screen.queryByTestId('menu-clean')).toBeNull()
   })
 
   it('clicking Clean sends /clean via /api/messages after confirmation', { timeout: 15000 }, async () => {
@@ -245,7 +247,8 @@ describe('App', () => {
     const App = (await import('../src/App')).default
     render(<App />)
 
-    const cleanBtn = await screen.findByTestId('header-clean-btn')
+    fireEvent.click(await screen.findByTestId('header-menu-btn'))
+    const cleanBtn = await screen.findByTestId('menu-clean')
     fireEvent.click(cleanBtn)
 
     const dialog = await screen.findByRole('dialog')

--- a/test/App.viewToggle.test.tsx
+++ b/test/App.viewToggle.test.tsx
@@ -248,7 +248,8 @@ describe('App view toggle', () => {
     const App = (await import('../src/App')).default
     render(<App />)
 
-    fireEvent.click(await screen.findByTestId('view-toggle-canvas'))
+    fireEvent.click(await screen.findByTestId('header-menu-btn'))
+    fireEvent.click(await screen.findByTestId('menu-view-canvas'))
 
     const modal = await screen.findByTestId('canvas-mobile-modal')
     expect(modal).toBeTruthy()
@@ -321,7 +322,8 @@ describe('App view toggle', () => {
     const App = (await import('../src/App')).default
     render(<App />)
 
-    fireEvent.click(await screen.findByTestId('view-toggle-ship'))
+    fireEvent.click(await screen.findByTestId('header-menu-btn'))
+    fireEvent.click(await screen.findByTestId('menu-view-ship'))
     const modal = await screen.findByTestId('ship-mobile-modal')
     expect(modal).toBeTruthy()
 


### PR DESCRIPTION
## Summary
- Replaced small icon buttons in mobile header with a consolidated burger menu
- Improved tap accuracy on mobile devices by providing a larger, single tap target
- Desktop layout unchanged — all buttons remain visible

## Changes
- Created `HeaderMenu.tsx` component with dropdown containing view toggle, theme, runtime config, clean, and refresh actions
- Updated `App.tsx` to conditionally render burger menu on mobile (`< 768px`) or individual buttons on desktop
- Updated tests to interact with the new menu structure on mobile

## Test plan
- [x] TypeScript compilation passes
- [x] Linter passes
- [x] Unit tests pass (App.test.tsx, App.viewToggle.test.tsx)
- [ ] Manual testing on mobile viewport
- [ ] Manual testing on desktop viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)