### PR TITLE
fix(ui): prevent pull-to-refresh when scrolling chat

### DIFF
--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,5 +1,18 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
 
+function findScrollableParent(element: HTMLElement, stopAt: HTMLElement): HTMLElement | null {
+  let current: HTMLElement | null = element
+  while (current && current !== stopAt) {
+    const overflowY = window.getComputedStyle(current).overflowY
+    const isScrollable = overflowY === 'auto' || overflowY === 'scroll'
+    if (isScrollable && current.scrollHeight > current.clientHeight) {
+      return current
+    }
+    current = current.parentElement
+  }
+  return null
+}
+
 interface PullToRefreshOptions {
   onRefresh: () => void | Promise<void>
   threshold?: number
@@ -34,6 +47,13 @@ export function usePullToRefresh({
     if (!enabled || isRefreshing) return
     const container = containerRef.current
     if (!container) return
+
+    const target = e.target as HTMLElement
+    const scrollableParent = findScrollableParent(target, container)
+    if (scrollableParent && scrollableParent !== container) {
+      return
+    }
+
     scrollTopAtStart.current = container.scrollTop
     if (scrollTopAtStart.current === 0) {
       touchStartY.current = e.touches[0].clientY
@@ -44,6 +64,14 @@ export function usePullToRefresh({
     if (!enabled || isRefreshing || touchStartY.current === null) return
     const container = containerRef.current
     if (!container || container.scrollTop > 0) {
+      touchStartY.current = null
+      setPullDistance(0)
+      return
+    }
+
+    const target = e.target as HTMLElement
+    const scrollableParent = findScrollableParent(target, container)
+    if (scrollableParent && scrollableParent !== container) {
       touchStartY.current = null
       setPullDistance(0)
       return


### PR DESCRIPTION
## Summary
- Fixed pull-to-refresh triggering when scrolling inside the chat transcript
- Added scrollable child element detection to the pull-to-refresh hook

## Details
The pull-to-refresh gesture was interfering with normal scrolling in the chat transcript. When users tried to scroll through messages, the gesture would trigger if they started scrolling near the top of the chat.

The fix adds a `findScrollableParent()` helper that detects when touch events originate from within a scrollable child element (like the chat transcript's `overflow-y-auto` container). When detected, the pull-to-refresh gesture is skipped, allowing normal scrolling behavior.

## Test plan
- [ ] Test scrolling in chat transcript on mobile - should not trigger refresh
- [ ] Test pull-to-refresh on the outer container - should still work
- [ ] Verify chat scrolling feels natural and responsive
- [ ] Test on both empty and long chat transcripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)