### PR TITLE
fix: /execute stays in-thread, /land works from chat, DAG children get proper prompts, slash menu prefills

### DIFF
--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -24,6 +24,9 @@ import { handleExecute, handleSplit, handleStack, handleDag } from '../commands/
 import type { PlanScheduler } from '../commands/plan-actions'
 import { handleLandCommand } from '../commands/land'
 import type { LandingManager } from '../dag/landing'
+import { listDags } from '../dag/store'
+import { topologicalSort, nodeIndex } from '../dag/dag'
+import type { DagGraph } from '../dag/dag'
 import { loadOverrides, saveOverrides } from '../config/runtime-overrides'
 import { applyOverrides } from '../config/apply'
 import { RuntimeOverridesSchema } from '../config/schema'
@@ -126,6 +129,15 @@ function resolveSessionBySlug(slug: string, registry: SessionRegistry, dbProvide
   const rows = prepared.listSessions(db)
   const row = rows.find((r) => r.slug === slug)
   return row ? sessionRowToApi(row) : null
+}
+
+function findDagForSession(db: Database, sessionId: string): DagGraph | null {
+  const graphs = listDags(db)
+  for (const g of graphs) {
+    if (g.rootSessionId === sessionId) return g
+    if (g.nodes.some((n) => n.sessionId === sessionId)) return g
+  }
+  return null
 }
 
 function formatZod(issues: Array<{ path: Array<string | number>; message: string }>): string {
@@ -437,6 +449,47 @@ export function registerApiRoutes(
       if (command === 'doctor') {
         const result = await handleDoctorCommand()
         return c.json({ data: result })
+      }
+
+      if (command === 'land') {
+        if (!sessionId) return c.json({ error: 'sessionId required for /land' }, 400)
+        if (!landingManager) return c.json({ error: 'landing is not configured on this engine' }, 503)
+        const db = resolveDb()
+        const graph = findDagForSession(db, sessionId)
+        if (!graph) return c.json({ error: 'no DAG associated with this session' }, 422)
+
+        const idx = nodeIndex(graph)
+        const order = topologicalSort(graph)
+        const landable = order
+          .map((id) => idx.get(id))
+          .filter((n): n is NonNullable<typeof n> => !!n && n.status === 'done' && !!n.prUrl)
+
+        if (landable.length === 0) {
+          return c.json({ error: 'no nodes with a PR URL are ready to land' }, 422)
+        }
+
+        const landed: Array<{ nodeId: string; prUrl?: string }> = []
+        const failed: Array<{ nodeId: string; error: string }> = []
+        for (const node of landable) {
+          const result = await landingManager.landNode(node.id, graph)
+          if (result.ok) {
+            landed.push({ nodeId: node.id, prUrl: result.prUrl })
+          } else {
+            failed.push({ nodeId: node.id, error: result.error ?? 'unknown error' })
+            break
+          }
+        }
+
+        return c.json({
+          data: {
+            ok: failed.length === 0,
+            sessionId,
+            dagId: graph.id,
+            landed: landed.length,
+            failed: failed.length,
+            details: { landed, failed },
+          },
+        })
       }
 
       const modeEntry = SLASH_MODES.get(command as Parameters<typeof SLASH_MODES.get>[0])

--- a/server/commands/plan-actions.test.ts
+++ b/server/commands/plan-actions.test.ts
@@ -149,100 +149,49 @@ describe("plan-actions gating", () => {
     expect(result.reason).toBe("session not found")
   })
 
-  it("calls registry.stop before extracting items", async () => {
-    const sessionId = insertSession(db)
+  it("replies to the session (no kill, no DAG) for non-ship modes", async () => {
+    const sessionId = insertSession(db, { mode: "think" })
     const stopCalls: string[] = []
+    const replyCalls: Array<{ sessionId: string; text: string }> = []
     const startedDagIds: string[] = []
+    const registry = {
+      ...makeRegistry(stopCalls),
+      reply: async (sid: string, text: string) => {
+        replyCalls.push({ sessionId: sid, text })
+        return true
+      },
+    }
     const ctx: PlanActionCtx = {
       db,
-      registry: makeRegistry(stopCalls),
+      registry,
       scheduler: makeScheduler(startedDagIds),
     }
-
-    await handleExecute(sessionId, ctx)
-
-    expect(stopCalls).toContain(sessionId)
-  })
-
-  it("returns ok:false with no items when extraction returns empty array", async () => {
-    const sessionId = insertSession(db)
-    const stopCalls: string[] = []
-    const startedDagIds: string[] = []
-    const ctx: PlanActionCtx = {
-      db,
-      registry: makeRegistry(stopCalls),
-      scheduler: makeScheduler(startedDagIds),
-    }
-
-    mockSpawn.mockImplementation(() => makeEmptyChild())
 
     const result = await handleExecute(sessionId, ctx)
 
-    expect(result.ok).toBe(false)
-    expect(result.reason).toBe("no items extracted")
+    expect(result.ok).toBe(true)
+    expect(stopCalls).toHaveLength(0)
     expect(startedDagIds).toHaveLength(0)
+    expect(replyCalls).toHaveLength(1)
+    expect(replyCalls[0]?.sessionId).toBe(sessionId)
+    expect(replyCalls[0]?.text).toMatch(/PR: <url>/)
+    expect(replyCalls[0]?.text).toMatch(/gh pr create/)
   })
 
-  it("includes assistant_text events (final:true) in the extraction conversation", async () => {
-    const sessionId = insertSession(db)
-    const now = Date.now()
-    prepared.insertEvent(db, {
-      session_id: sessionId,
-      seq: 1,
-      turn: 0,
-      type: "user_message",
-      timestamp: now,
-      payload: { text: "please plan the work" },
-    })
-    prepared.insertEvent(db, {
-      session_id: sessionId,
-      seq: 2,
-      turn: 1,
-      type: "assistant_text",
-      timestamp: now + 1,
-      payload: { text: "DELTA_CHUNK_do_not_include", final: false },
-    })
-    prepared.insertEvent(db, {
-      session_id: sessionId,
-      seq: 3,
-      turn: 1,
-      type: "assistant_text",
-      timestamp: now + 2,
-      payload: { text: "FINAL_PLAN_build_the_schema", final: true },
-    })
-
-    const stdinWrites: string[] = []
-    mockSpawn.mockImplementation(() => ({
-      stdout: {
-        on: vi.fn((event: string, cb: (data: Buffer) => void) => {
-          if (event === "data") cb(Buffer.from("[]"))
-        }),
-      },
-      stderr: { on: vi.fn() },
-      stdin: {
-        write: vi.fn((data: string) => { stdinWrites.push(data) }),
-        end: vi.fn(),
-      },
-      on: vi.fn((event: string, cb: (code: number) => void) => {
-        if (event === "close") cb(0)
-      }),
-      kill: vi.fn(),
-    }))
-
-    const stopCalls: string[] = []
-    const startedDagIds: string[] = []
+  it("returns ok:false when reply fails to inject", async () => {
+    const sessionId = insertSession(db, { mode: "plan" })
+    const registry = {
+      ...makeRegistry([]),
+      reply: async () => false,
+    }
     const ctx: PlanActionCtx = {
       db,
-      registry: makeRegistry(stopCalls),
-      scheduler: makeScheduler(startedDagIds),
+      registry,
+      scheduler: makeScheduler([]),
     }
 
-    await handleExecute(sessionId, ctx)
-
-    const combined = stdinWrites.join("")
-    expect(combined).toContain("please plan the work")
-    expect(combined).toContain("FINAL_PLAN_build_the_schema")
-    expect(combined).not.toContain("DELTA_CHUNK_do_not_include")
+    const result = await handleExecute(sessionId, ctx)
+    expect(result.ok).toBe(false)
   })
 })
 

--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -145,6 +145,19 @@ async function handoffShipPhase(
   return { ok: true, dagId: session.id }
 }
 
+const EXECUTE_DIRECTIVE = [
+  "Implement your plan now, in this session — do NOT wait for another turn.",
+  "",
+  "1. Write the code.",
+  "2. Run the unit/integration tests (NOT e2e or browser tests — too expensive).",
+  "3. `git add -A && git commit -m \"<descriptive message>\"`.",
+  "4. `git push -u origin HEAD`. Auth is preconfigured via GIT_ASKPASS.",
+  "5. `gh pr create` targeting `main` (no --draft, no --no-verify). Include a short summary and a test plan.",
+  "6. End your turn with a single trailing line: `PR: <url>` — so the orchestrator can link the PR.",
+  "",
+  "If blocked, end with `BLOCKED: <one-line reason>` instead of stopping silently.",
+].join("\n")
+
 export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Promise<PlanActionResult> {
   const rejection = await gate(sessionId, ctx)
   if (rejection) return { ok: false, reason: rejection }
@@ -152,35 +165,26 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
   const row = prepared.getSession(ctx.db, sessionId)
   const mode = row?.mode
 
-  setPipelineAdvancing(ctx, sessionId, true)
-
-  let result: PlanActionResult
-  try {
-    await killAndWait(sessionId, ctx)
-
-    if (mode === "ship-think") {
-      result = await handoffShipPhase(sessionId, "ship-plan", ctx)
-    } else {
-      const conversation = getConversationMessages(ctx.db, sessionId)
-      const typedConversation = conversation.map((m) => ({
-        role: m.role as "user" | "assistant",
-        text: m.text,
-      }))
-
-      const extraction = await extractDagItems(typedConversation)
-      if (extraction.error) {
-        result = { ok: false, reason: extraction.errorMessage ?? extraction.error }
-      } else {
-        result = await buildAndStartDag(extraction.items, sessionId, ctx)
-      }
+  if (mode === "ship-think") {
+    setPipelineAdvancing(ctx, sessionId, true)
+    try {
+      await killAndWait(sessionId, ctx)
+      const result = await handoffShipPhase(sessionId, "ship-plan", ctx)
+      if (!result.ok) setPipelineAdvancing(ctx, sessionId, false)
+      return result
+    } catch (err) {
+      setPipelineAdvancing(ctx, sessionId, false)
+      throw err
     }
-  } catch (err) {
-    setPipelineAdvancing(ctx, sessionId, false)
-    throw err
   }
 
-  if (!result.ok) setPipelineAdvancing(ctx, sessionId, false)
-  return result
+  try {
+    const ok = await ctx.registry.reply(sessionId, EXECUTE_DIRECTIVE)
+    if (!ok) return { ok: false, reason: "could not inject execute directive into session" }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  }
 }
 
 export async function handleSplit(sessionId: string, ctx: PlanActionCtx): Promise<PlanActionResult> {

--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -110,8 +110,8 @@ describe("DagScheduler", () => {
 
     const created: string[] = []
     const registry = makeRegistry(db, async (opts) => {
-      const session = makeSession(`session-${opts.prompt.split("\n")[0]}`, db)
-      created.push(opts.prompt.split("\n")[0]!)
+      const session = makeSession(`session-${created.length}`, db)
+      created.push(opts.prompt.slice(0, 40))
       return { session, runtime: {} as never }
     })
 

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -1,12 +1,49 @@
 import type { Database } from "bun:sqlite"
 import { readyNodes, advanceDag, failNode, resetFailedNode, nodeIndex, getUpstreamBranches, isDagComplete } from "./dag"
-import type { DagGraph, DagNode } from "./dag"
+import type { DagGraph, DagNode, DagInput } from "./dag"
 import { saveDag, loadDag, listDags } from "./store"
 import { updateStackComment } from "./stack-comment"
+import { buildDagChildPrompt } from "./dag-extract"
+import type { TopicMessage } from "./types"
 import type { SessionRegistry } from "../session/registry"
 import type { EngineEventBus } from "../events/bus"
 import type { SessionRunState } from "../events/types"
 import type { ApiDagNode, ApiDagGraph } from "../../shared/api-types"
+
+function fetchRootConversation(db: Database, rootSessionId: string): TopicMessage[] {
+  const rows = db
+    .query<{ type: string; payload: string }, [string]>(
+      "SELECT type, payload FROM session_events WHERE session_id = ? AND type IN ('user_message','assistant_text') ORDER BY seq ASC",
+    )
+    .all(rootSessionId)
+
+  const messages: TopicMessage[] = []
+  for (const row of rows) {
+    let payload: Record<string, unknown>
+    try {
+      payload = JSON.parse(row.payload) as Record<string, unknown>
+    } catch {
+      continue
+    }
+    const text = typeof payload.text === "string" ? payload.text : ""
+    if (!text) continue
+    if (row.type === "user_message") {
+      messages.push({ role: "user", text })
+    } else if (row.type === "assistant_text" && payload.final === true) {
+      messages.push({ role: "assistant", text })
+    }
+  }
+  return messages
+}
+
+function nodesToDagInputs(nodes: DagNode[]): DagInput[] {
+  return nodes.map((n) => ({
+    id: n.id,
+    title: n.title,
+    description: n.description,
+    dependsOn: n.dependsOn,
+  }))
+}
 
 const PR_URL_REGEX = /https:\/\/github\.com\/[^\s)]+\/pull\/\d+/
 
@@ -130,13 +167,14 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     node.status = "running"
 
     const upstreamBranches = getUpstreamBranches(graph, node.id)
-
-    let prompt = `${node.title}\n\n${node.description}`
-
-    if (upstreamBranches.length > 0) {
-      const cherryPickInfo = upstreamBranches.join(", ")
-      prompt = `${prompt}\n\nUpstream branches to incorporate: ${cherryPickInfo}`
-    }
+    const parentConversation = fetchRootConversation(db, graph.rootSessionId)
+    const prompt = buildDagChildPrompt(
+      parentConversation,
+      { id: node.id, title: node.title, description: node.description, dependsOn: node.dependsOn },
+      nodesToDagInputs(graph.nodes),
+      upstreamBranches,
+      false,
+    )
 
     try {
       const { session } = await registry.create({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { Transcript, TranscriptUpgradeNotice } from './chat/transcript'
 import { MessageInput } from './chat/MessageInput'
 import { NewTaskBar } from './chat/NewTaskBar'
 import { QuickActionsBar } from './chat/QuickActionsBar'
-import { SlashCommandMenu, type SlashCommand } from './chat/SlashCommandMenu'
+import { SlashCommandMenu } from './chat/SlashCommandMenu'
 import { SessionTabs, type SessionTabId } from './chat/SessionTabs'
 import { DiffTab } from './chat/DiffTab'
 import { ScreenshotsTab } from './chat/ScreenshotsTab'
@@ -176,26 +176,8 @@ function ChatPane({
   const handleSend = (t: string, images?: Array<{ mediaType: string; dataBase64: string }>) => onSend(t, session.id, images)
   const handleQuickAction = (action: QuickAction) => onSend(action.message, session.id)
 
-  const handleSlashCommand = async (fullText: string, cmd: SlashCommand) => {
-    if (cmd.destructive) {
-      const ok = await confirm({
-        title: `Run ${cmd.cmd}?`,
-        message: cmd.hint,
-        destructive: true,
-        confirmLabel: cmd.cmd,
-      })
-      if (!ok) return
-    }
-    try {
-      await onSend(fullText, session.id)
-      setText('')
-    } catch (e) {
-      await confirm({
-        title: `${cmd.cmd} failed`,
-        message: e instanceof Error ? e.message : String(e),
-        mode: 'alert',
-      })
-    }
+  const handlePrefillCommand = (fullText: string) => {
+    setText(fullText)
   }
 
   const handleStop = async () => {
@@ -354,7 +336,7 @@ function ChatPane({
             )}
             <div class="shrink-0 border-t border-slate-200 dark:border-slate-700">
               <QuickActionsBar actions={session.quickActions} onAction={handleQuickAction} />
-              <SlashCommandMenu session={session} context={text} onCommand={handleSlashCommand} />
+              <SlashCommandMenu session={session} context={text} onPrefill={handlePrefillCommand} />
               <MessageInput session={session} store={store} value={text} onValueChange={setText} onSend={handleSend} />
             </div>
           </>

--- a/src/chat/SlashCommandMenu.tsx
+++ b/src/chat/SlashCommandMenu.tsx
@@ -41,11 +41,11 @@ function commandsForMode(mode: string): SlashCommand[] {
 interface SlashCommandMenuProps {
   session: ApiSession
   context: string
-  onCommand: (fullText: string, command: SlashCommand) => void | Promise<void>
+  onPrefill: (fullText: string) => void
   disabled?: boolean
 }
 
-export function SlashCommandMenu({ session, context, onCommand, disabled }: SlashCommandMenuProps) {
+export function SlashCommandMenu({ session, context, onPrefill, disabled }: SlashCommandMenuProps) {
   const commands = commandsForMode(session.mode)
   const trimmed = context.trim()
   const hasContext = trimmed.length > 0
@@ -65,8 +65,8 @@ export function SlashCommandMenu({ session, context, onCommand, disabled }: Slas
             key={c.cmd}
             type="button"
             disabled={disabled}
-            onClick={() => void onCommand(full, c)}
-            title={hasContext ? `${full}` : `${c.cmd} — ${c.hint}`}
+            onClick={() => onPrefill(full)}
+            title={`${c.cmd} — ${c.hint} (prefills the chat; click Send to run)`}
             class={`rounded-full border px-3 py-1 text-xs font-mono transition-colors disabled:opacity-50 ${btnClass}`}
             data-testid={`slash-cmd-${c.cmd.replace('/', '')}`}
           >

--- a/test/chat/SlashCommandMenu.test.tsx
+++ b/test/chat/SlashCommandMenu.test.tsx
@@ -22,7 +22,7 @@ function makeSession(mode: string): ApiSession {
 
 describe('SlashCommandMenu', () => {
   it('shows plan-mode commands when session.mode is plan', () => {
-    render(<SlashCommandMenu session={makeSession('plan')} context="" onCommand={() => {}} />)
+    render(<SlashCommandMenu session={makeSession('plan')} context="" onPrefill={() => {}} />)
     expect(screen.getByTestId('slash-cmd-execute')).toBeTruthy()
     expect(screen.getByTestId('slash-cmd-split')).toBeTruthy()
     expect(screen.getByTestId('slash-cmd-stack')).toBeTruthy()
@@ -30,7 +30,7 @@ describe('SlashCommandMenu', () => {
   })
 
   it('shows task-mode commands when session.mode is task', () => {
-    render(<SlashCommandMenu session={makeSession('task')} context="" onCommand={() => {}} />)
+    render(<SlashCommandMenu session={makeSession('task')} context="" onPrefill={() => {}} />)
     expect(screen.getByTestId('slash-cmd-doctor')).toBeTruthy()
     expect(screen.getByTestId('slash-cmd-stop')).toBeTruthy()
     expect(screen.getByTestId('slash-cmd-close')).toBeTruthy()
@@ -38,7 +38,7 @@ describe('SlashCommandMenu', () => {
 
   it('sends the command alone when context is empty', async () => {
     const onCommand = vi.fn()
-    render(<SlashCommandMenu session={makeSession('plan')} context="" onCommand={onCommand} />)
+    render(<SlashCommandMenu session={makeSession('plan')} context="" onPrefill={onCommand} />)
     fireEvent.click(screen.getByTestId('slash-cmd-execute'))
     await waitFor(() => expect(onCommand).toHaveBeenCalled())
     expect(onCommand.mock.calls[0][0]).toBe('/execute')
@@ -46,7 +46,7 @@ describe('SlashCommandMenu', () => {
 
   it('appends context after the command when context is set', async () => {
     const onCommand = vi.fn()
-    render(<SlashCommandMenu session={makeSession('plan')} context="focus on auth" onCommand={onCommand} />)
+    render(<SlashCommandMenu session={makeSession('plan')} context="focus on auth" onPrefill={onCommand} />)
     fireEvent.click(screen.getByTestId('slash-cmd-execute'))
     await waitFor(() => expect(onCommand).toHaveBeenCalled())
     expect(onCommand.mock.calls[0][0]).toBe('/execute focus on auth')
@@ -54,14 +54,14 @@ describe('SlashCommandMenu', () => {
 
   it('trims whitespace from context', async () => {
     const onCommand = vi.fn()
-    render(<SlashCommandMenu session={makeSession('plan')} context="  pad  " onCommand={onCommand} />)
+    render(<SlashCommandMenu session={makeSession('plan')} context="  pad  " onPrefill={onCommand} />)
     fireEvent.click(screen.getByTestId('slash-cmd-execute'))
     await waitFor(() => expect(onCommand).toHaveBeenCalled())
     expect(onCommand.mock.calls[0][0]).toBe('/execute pad')
   })
 
   it('marks destructive buttons with different styling', () => {
-    render(<SlashCommandMenu session={makeSession('task')} context="" onCommand={() => {}} />)
+    render(<SlashCommandMenu session={makeSession('task')} context="" onPrefill={() => {}} />)
     const stop = screen.getByTestId('slash-cmd-stop')
     expect(stop.className).toContain('text-red-700')
   })


### PR DESCRIPTION
Four related issues from today's /execute → DAG run:

## 1. DAG children had stub prompts

`scheduler.spawnNode` was handing each child just ```${node.title}\n\n${node.description}``` and ignoring the well-built `buildDagChildPrompt` helper. Children had no original request, no planning thread, no deliverable checklist, no `PR: <url>` trailer instruction — so they stopped at code+report and skipped commit/push/`gh pr create`. That's why `node.prUrl` was always null and `/land` said 'no nodes with a PR URL are ready to land'.

Wire `spawnNode` through `buildDagChildPrompt` with the parent conversation fetched from the root session's events.

## 2. /execute ran a DAG instead of staying in-thread

`handleExecute` on non-ship modes killed the session and extracted a DAG. User expectation: `/execute` stays in-thread and tells the session to implement its own plan; `/dag`, `/split`, `/stack` are the commands that fan out into children.

Rework: for `ship-think` it still hands off to `ship-plan`; for every other mode it replies to the same session with a 6-step directive (write code, run tests, commit, push, open PR, end with `PR: <url>`). No kill, no DAG, no `pipeline_advancing` flag.

## 3. /land from chat returned 'unknown command'

`/api/messages` had no handler for `/land`. Add one: look up the DAG by session id (root or child), collect completed nodes with a `prUrl`, iterate in topological order calling `landingManager.landNode`. Stop on first failure, return a `{landed, failed}` summary.

## 4. Slash menu dispatched immediately

Clicking a command sent it straight to the server. Switch to prefill: `SlashCommandMenu` pushes `/execute …` into the chat textarea so you can tweak and hit Send yourself. The existing destructive-confirm dialog in `handleSlashCommand` went away; the per-button Stop / Close actions already have their own confirms.

## Test plan

- [x] typecheck / lint / vitest / bun all green
- [ ] CI green
- [ ] Live on mini: fresh `/execute` → session replies in-thread with PR; `/dag` still spawns children; children's PRs populate `node.prUrl`; `/land` in a parent chat lands them in order