### PR TITLE
fix(ui): open new thread after single-task launch

### DIFF
--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -224,6 +224,7 @@ export function NewTaskBar({
         prompt.value = ''
         for (const a of attachments) URL.revokeObjectURL(a.objectUrl)
         setAttachments([])
+        navigate(formatRoute({ name: 'session', sessionSlug: created.slug }))
       }
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Send failed'

--- a/test/chat/NewTaskBar.test.tsx
+++ b/test/chat/NewTaskBar.test.tsx
@@ -177,6 +177,21 @@ describe('NewTaskBar', () => {
     await waitFor(() => expect(store.applySessionCreated).toHaveBeenCalledWith(created))
   })
 
+  it('navigates to the new session route after single-task create resolves', async () => {
+    const created = makeSession({ id: 'created-2', slug: 'brave-fox' })
+    const { store } = makeStore({
+      features: ['sessions-create'],
+      createSessionImpl: async () => created,
+    })
+    const navigate = vi.fn<(hash: string) => void>()
+    render(<NewTaskBar store={store} navigate={navigate} />)
+    const textarea = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'open thread after launch' } })
+    fireEvent.click(screen.getByTestId('new-task-send'))
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('#/s/brave-fox'))
+  })
+
   it('omits repo field from payload when no repos are configured', async () => {
     const { store, client } = makeStore({ features: ['sessions-create'], repos: [] })
     render(<NewTaskBar store={store} />)


### PR DESCRIPTION
## Summary

When launching a single task via `NewTaskBar`, the session was created and added to the store but the hash route was never updated, so the chat pane stayed on the home/empty view. The user perceived the PWA as "frozen" after launch — pull-to-refresh is suppressed in the app, and the only way to reach the new thread was to close and reopen the PWA.

The variants path already called `navigate(formatRoute({ name: 'group', groupId }))`. This change brings the single-task path in line by navigating to `#/s/<slug>` after the session is created.

## Test plan

- [x] `npm run test -- test/chat/NewTaskBar.test.tsx` — 13/13 pass, including new assertion that `navigate` is called with `#/s/<slug>` after single-task create
- [x] `npm run lint` — clean
- [ ] Manually launch a single task in the PWA and confirm the thread opens without needing to reload
- [ ] Launch variants (×2+) and confirm group view still opens as before