### PR TITLE
feat(runtime): populate Runtime sheet with live metrics and editable config

### DIFF
--- a/server/api/routes.metrics.test.ts
+++ b/server/api/routes.metrics.test.ts
@@ -6,6 +6,7 @@ import { createSessionRegistry } from '../session/registry'
 import { resetEventBus } from '../events/bus'
 import { runMigrations } from '../db/sqlite'
 import { registerApiRoutes } from './routes'
+import type { ResourceSnapshot } from '../../shared/api-types'
 
 function setupTestDb(): Database {
   const db = new Database(':memory:')
@@ -66,38 +67,27 @@ afterEach(() => {
 })
 
 describe('GET /api/metrics', () => {
-  test('returns metrics structure', async () => {
+  test('returns a ResourceSnapshot structure', async () => {
     const app = makeApp(testDb)
     const res = await app.fetch(new Request('http://localhost/api/metrics'))
     expect(res.status).toBe(200)
-    const body = await res.json() as { data: Record<string, unknown> }
+    const body = await res.json() as { data: ResourceSnapshot }
     expect(body.data).toBeDefined()
-    expect(typeof body.data['processMemBytes']).toBe('number')
-    expect(typeof body.data['processCpuPct']).toBe('number')
-    expect(typeof body.data['dbSizeBytes']).toBe('number')
-    expect(typeof body.data['activeSessions']).toBe('number')
-    expect(typeof body.data['activeDags']).toBe('number')
-    expect(typeof body.data['uptimeSec']).toBe('number')
+    expect(typeof body.data.ts).toBe('number')
+    expect(typeof body.data.cpu.usagePercent).toBe('number')
+    expect(typeof body.data.cpu.cpuCount).toBe('number')
+    expect(typeof body.data.memory.usedBytes).toBe('number')
+    expect(typeof body.data.memory.limitBytes).toBe('number')
+    expect(typeof body.data.memory.rssBytes).toBe('number')
+    expect(typeof body.data.disk.path).toBe('string')
+    expect(typeof body.data.eventLoopLagMs).toBe('number')
+    expect(typeof body.data.counts.activeSessions).toBe('number')
   })
 
-  test('processMemBytes is positive', async () => {
+  test('memory rssBytes is positive', async () => {
     const app = makeApp(testDb)
     const res = await app.fetch(new Request('http://localhost/api/metrics'))
-    const body = await res.json() as { data: { processMemBytes: number } }
-    expect(body.data.processMemBytes).toBeGreaterThan(0)
-  })
-
-  test('uptimeSec is non-negative', async () => {
-    const app = makeApp(testDb)
-    const res = await app.fetch(new Request('http://localhost/api/metrics'))
-    const body = await res.json() as { data: { uptimeSec: number } }
-    expect(body.data.uptimeSec).toBeGreaterThanOrEqual(0)
-  })
-
-  test('activeSessions is 0 with empty db', async () => {
-    const app = makeApp(testDb)
-    const res = await app.fetch(new Request('http://localhost/api/metrics'))
-    const body = await res.json() as { data: { activeSessions: number } }
-    expect(body.data.activeSessions).toBe(0)
+    const body = await res.json() as { data: ResourceSnapshot }
+    expect(body.data.memory.rssBytes).toBeGreaterThan(0)
   })
 })

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -9,6 +9,8 @@ import type {
   CommandResult,
   CreateSessionVariantsResult,
   MinionCommand,
+  OverrideField,
+  ResourceSnapshot,
   RuntimeConfigResponse,
   ScreenshotList,
   TranscriptSnapshot,
@@ -29,6 +31,8 @@ import { topologicalSort, nodeIndex } from '../dag/dag'
 import type { DagGraph } from '../dag/dag'
 import { loadOverrides, saveOverrides } from '../config/runtime-overrides'
 import { applyOverrides } from '../config/apply'
+import type { LoopRuntime } from '../config/apply'
+import type { ResourceMonitor } from '../metrics/resource'
 import { RuntimeOverridesSchema } from '../config/schema'
 import { DEFAULT_LOOPS } from '../loops/definitions'
 import { createSessionVariants } from '../session/variants'
@@ -61,7 +65,7 @@ const FEATURES = [
   'screenshots',
   'diff',
   'pr-preview',
-  'resource-tracking',
+  'resource-metrics',
   'runtime-config',
 ]
 
@@ -144,12 +148,34 @@ function formatZod(issues: Array<{ path: Array<string | number>; message: string
   return issues.map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`).join('; ')
 }
 
+export interface RuntimeBaseConfig {
+  maxConcurrentSessions: number
+  maxConcurrentLoops: number
+  reservedInteractiveSlots: number
+  retryMax: number
+  defaultSleepMs: number
+  mcp: {
+    browserEnabled: boolean
+    githubEnabled: boolean
+    context7Enabled: boolean
+    supabaseEnabled: boolean
+  }
+  loops: Array<{ id: string; enabled: boolean; intervalMs: number }>
+}
+
+export interface RuntimeContext {
+  loopRuntime?: LoopRuntime
+  resourceMonitor?: ResourceMonitor
+  getBaseConfig?: () => RuntimeBaseConfig
+}
+
 export function registerApiRoutes(
   app: Hono,
   registry: SessionRegistry,
   dbProvider?: () => Database,
   scheduler?: PlanScheduler,
   landingManager?: LandingManager,
+  runtimeCtx?: RuntimeContext,
 ): void {
   const resolveDb = dbProvider ?? getDb
 
@@ -534,20 +560,140 @@ export function registerApiRoutes(
   app.get('/api/config/runtime', (c) => {
     const overrides = loadOverrides()
     const applied = applyOverrides(overrides)
-    const schemaPayload: RuntimeConfigResponse['schema'] = {
-      fields: [],
-      loops: DEFAULT_LOOPS.map((l) => ({
+    const base = runtimeCtx?.getBaseConfig?.() ?? null
+    const fields: OverrideField[] = [
+      {
+        key: 'workspace.maxConcurrentSessions',
+        label: 'Max concurrent sessions',
+        type: 'number',
+        category: 'concurrency',
+        apply: 'live',
+        integer: true,
+        min: 1,
+        max: 256,
+        description: 'Total sessions the engine will run at once. Applied live to the scheduler.',
+      },
+      {
+        key: 'loopsConfig.maxConcurrentLoops',
+        label: 'Max concurrent loops',
+        type: 'number',
+        category: 'concurrency',
+        apply: 'restart',
+        integer: true,
+        min: 1,
+        max: 64,
+        description: 'Upper bound on autonomous loop sessions running in parallel.',
+      },
+      {
+        key: 'loopsConfig.reservedInteractiveSlots',
+        label: 'Reserved interactive slots',
+        type: 'number',
+        category: 'concurrency',
+        apply: 'restart',
+        integer: true,
+        min: 0,
+        max: 64,
+        description: 'Sessions held back from loops so interactive tasks can always start.',
+      },
+      {
+        key: 'quota.retryMax',
+        label: 'Quota retry max',
+        type: 'number',
+        category: 'concurrency',
+        apply: 'restart',
+        integer: true,
+        min: 0,
+        max: 32,
+        description: 'How many times the engine will resume a session after a quota sleep.',
+      },
+      {
+        key: 'quota.defaultSleepMs',
+        label: 'Default quota sleep (ms)',
+        type: 'number',
+        category: 'concurrency',
+        apply: 'restart',
+        integer: true,
+        min: 1000,
+        description: 'Fallback sleep when an Anthropic quota error omits a reset time.',
+      },
+      {
+        key: 'mcp.browserEnabled',
+        label: 'Browser MCP (Playwright)',
+        type: 'boolean',
+        category: 'features',
+        apply: 'restart',
+      },
+      {
+        key: 'mcp.githubEnabled',
+        label: 'GitHub MCP',
+        type: 'boolean',
+        category: 'features',
+        apply: 'restart',
+      },
+      {
+        key: 'mcp.context7Enabled',
+        label: 'Context7 MCP',
+        type: 'boolean',
+        category: 'features',
+        apply: 'restart',
+      },
+      {
+        key: 'mcp.supabaseEnabled',
+        label: 'Supabase MCP',
+        type: 'boolean',
+        category: 'features',
+        apply: 'restart',
+      },
+    ]
+    for (const l of DEFAULT_LOOPS) {
+      fields.push(
+        {
+          key: `loops.${l.id}.enabled`,
+          label: `${l.title} — enabled`,
+          type: 'boolean',
+          category: 'loops',
+          apply: 'live',
+        },
+        {
+          key: `loops.${l.id}.intervalMs`,
+          label: `${l.title} — interval (ms)`,
+          type: 'number',
+          category: 'loops',
+          apply: 'live',
+          integer: true,
+          min: 60_000,
+          description: l.description,
+        },
+      )
+    }
+    const loopMeta = DEFAULT_LOOPS.map((l) => {
+      const live = base?.loops.find((x) => x.id === l.id)
+      return {
         id: l.id,
         name: l.title,
-        defaultIntervalMs: l.intervalMs,
-        defaultEnabled: true,
-      })),
-    }
+        defaultIntervalMs: live?.intervalMs ?? l.intervalMs,
+        defaultEnabled: live?.enabled ?? true,
+      }
+    })
+    const baseDoc: Record<string, unknown> = base
+      ? {
+          workspace: { maxConcurrentSessions: base.maxConcurrentSessions },
+          loopsConfig: {
+            maxConcurrentLoops: base.maxConcurrentLoops,
+            reservedInteractiveSlots: base.reservedInteractiveSlots,
+          },
+          quota: { retryMax: base.retryMax, defaultSleepMs: base.defaultSleepMs },
+          mcp: { ...base.mcp },
+          loops: Object.fromEntries(
+            base.loops.map((l) => [l.id, { enabled: l.enabled, intervalMs: l.intervalMs }]),
+          ),
+        }
+      : {}
     const body: ApiResponse<RuntimeConfigResponse> = {
       data: {
-        base: {},
+        base: baseDoc,
         overrides,
-        schema: schemaPayload,
+        schema: { fields, loops: loopMeta },
         requiresRestart: applied.requiresRestart,
       },
     }
@@ -561,9 +707,14 @@ export function registerApiRoutes(
       return c.json({ error: formatZod(parsed.error.issues) }, 400)
     }
     const merged = saveOverrides(parsed.data)
-    const applied = applyOverrides(merged)
-    const body: ApiResponse<{ applied: true; requiresRestart: string[] }> = {
-      data: { applied: true, requiresRestart: applied.requiresRestart },
+    const applied = applyOverrides(merged, runtimeCtx?.loopRuntime)
+    const body: ApiResponse<RuntimeConfigResponse> = {
+      data: {
+        base: {},
+        overrides: merged,
+        schema: { fields: [], loops: [] },
+        requiresRestart: applied.requiresRestart,
+      },
     }
     return c.json(body)
   })
@@ -802,40 +953,28 @@ export function registerApiRoutes(
   })
 
   app.get('/api/metrics', (c) => {
-    const db = resolveDb()
-    const memUsage = process.memoryUsage()
-    const cpuUsage = process.cpuUsage()
-
-    interface ActiveRow { count: number }
-    const activeSessions = (db.query<ActiveRow, []>(
-      "SELECT COUNT(*) as count FROM sessions WHERE status IN ('running','waiting_input')",
-    ).get()?.count) ?? 0
-
-    const activeDags = (db.query<ActiveRow, []>(
-      "SELECT COUNT(*) as count FROM dags WHERE status IN ('pending','running')",
-    ).get()?.count) ?? 0
-
-    let dbSizeBytes = 0
-    const dbPath = process.env['MINION_DB_PATH'] ?? 'data/engine.db'
-    try {
-      dbSizeBytes = fs.statSync(dbPath).size
-    } catch {
-      // not critical
+    const monitor = runtimeCtx?.resourceMonitor
+    if (monitor) {
+      const snapshot: ResourceSnapshot = monitor.sample(Date.now())
+      const body: ApiResponse<ResourceSnapshot> = { data: snapshot }
+      return c.json(body)
     }
-
-    const uptimeSec = Math.floor(process.uptime())
-    const processCpuPct = Math.round((cpuUsage.user + cpuUsage.system) / 1e4) / 100
-
-    return c.json({
-      data: {
-        processMemBytes: memUsage.rss,
-        processCpuPct,
-        dbSizeBytes,
-        activeSessions,
-        activeDags,
-        uptimeSec,
+    const memUsage = process.memoryUsage()
+    const snapshot: ResourceSnapshot = {
+      ts: Date.now(),
+      cpu: { usagePercent: 0, cpuCount: 1, source: 'host' },
+      memory: {
+        usedBytes: memUsage.rss,
+        limitBytes: memUsage.rss,
+        rssBytes: memUsage.rss,
+        source: 'host',
       },
-    })
+      disk: { path: '/', usedBytes: 0, totalBytes: 0 },
+      eventLoopLagMs: 0,
+      counts: { activeSessions: 0, maxSessions: 0, activeLoops: 0, maxLoops: 0 },
+    }
+    const body: ApiResponse<ResourceSnapshot> = { data: snapshot }
+    return c.json(body)
   })
 
   app.get('/api/push/vapid-public-key', (c) => {

--- a/server/api/sse.ts
+++ b/server/api/sse.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import type { Hono } from 'hono'
 import type { Database } from 'bun:sqlite'
-import type { SseEvent, ResourceSnapshot } from '../../shared/api-types'
+import type { SseEvent } from '../../shared/api-types'
 import type { EngineEvent } from '../events/types'
 import { getEventBus } from '../events/bus'
 import { getDb, prepared } from '../db/sqlite'
@@ -127,20 +127,7 @@ function projectEvent(
   }
 
   if (event.kind === 'resource') {
-    const snapshot: ResourceSnapshot = {
-      ts: event.timestamp,
-      cpu: { usagePercent: event.cpuPct, cpuCount: 1, source: 'cgroup' },
-      memory: {
-        usedBytes: event.memBytes,
-        limitBytes: event.memMaxBytes,
-        rssBytes: event.memBytes,
-        source: 'cgroup',
-      },
-      disk: { path: '/', usedBytes: 0, totalBytes: 0 },
-      eventLoopLagMs: 0,
-      counts: { activeSessions: 0, maxSessions: 0, activeLoops: 0, maxLoops: 0 },
-    }
-    return { type: 'resource', snapshot }
+    return { type: 'resource', snapshot: event.snapshot }
   }
 
   return null

--- a/server/config/apply.test.ts
+++ b/server/config/apply.test.ts
@@ -73,10 +73,23 @@ describe('applyOverrides', () => {
   })
 })
 
+  test('calls setMaxConcurrentSessions live when runtime exposes it', () => {
+    const calls: Array<{ method: string; args: unknown[] }> = []
+    const runtime = {
+      setInterval(id: string, ms: number) { calls.push({ method: 'setInterval', args: [id, ms] }) },
+      enable(id: string) { calls.push({ method: 'enable', args: [id] }) },
+      disable(id: string) { calls.push({ method: 'disable', args: [id] }) },
+      setMaxConcurrentSessions(n: number) { calls.push({ method: 'setMaxConcurrentSessions', args: [n] }) },
+    }
+    const result = applyOverrides({ workspace: { maxConcurrentSessions: 5 } }, runtime)
+    expect(calls).toContainEqual({ method: 'setMaxConcurrentSessions', args: [5] })
+    expect(result.requiresRestart).not.toContain('workspace.maxConcurrentSessions')
+  })
+
 describe('requiresRestart', () => {
   test('returns only restart-flagged fields', () => {
-    const result = requiresRestart(['workspace', 'quota'])
-    expect(result).toContain('workspace')
+    const result = requiresRestart(['loopsConfig', 'quota'])
+    expect(result).toContain('loopsConfig')
     expect(result).not.toContain('quota')
   })
 

--- a/server/config/apply.ts
+++ b/server/config/apply.ts
@@ -4,6 +4,7 @@ export interface LoopRuntime {
   setInterval(id: string, ms: number): void
   enable(id: string): void
   disable(id: string): void
+  setMaxConcurrentSessions?(n: number): void
 }
 
 export interface AppliedResult {
@@ -11,7 +12,6 @@ export interface AppliedResult {
 }
 
 const RESTART_FIELDS: ReadonlyArray<keyof RuntimeOverrides> = [
-  'workspace',
   'loopsConfig',
 ]
 
@@ -39,11 +39,19 @@ export function applyOverrides(
   }
 
   if (overrides.workspace?.maxConcurrentSessions !== undefined) {
-    needsRestart.push('workspace.maxConcurrentSessions')
+    if (loopRuntime?.setMaxConcurrentSessions) {
+      loopRuntime.setMaxConcurrentSessions(overrides.workspace.maxConcurrentSessions)
+    } else {
+      needsRestart.push('workspace.maxConcurrentSessions')
+    }
   }
 
   if (overrides.loopsConfig?.maxConcurrentLoops !== undefined) {
     needsRestart.push('loopsConfig.maxConcurrentLoops')
+  }
+
+  if (overrides.loopsConfig?.reservedInteractiveSlots !== undefined) {
+    needsRestart.push('loopsConfig.reservedInteractiveSlots')
   }
 
   return { requiresRestart: needsRestart }

--- a/server/events/types.ts
+++ b/server/events/types.ts
@@ -1,4 +1,4 @@
-import type { TranscriptEvent, ApiSession, ApiDagGraph } from '../../shared/api-types'
+import type { TranscriptEvent, ApiSession, ApiDagGraph, ResourceSnapshot } from '../../shared/api-types'
 
 export type SessionRunState = 'completed' | 'errored' | 'quota_exhausted' | 'stream_stalled'
 
@@ -49,7 +49,7 @@ export type EngineEvent =
       allPassed: boolean
       results: Array<{ name: string; passed: boolean; output: string }>
     }
-  | { kind: 'resource'; cpuPct: number; memBytes: number; memMaxBytes: number; timestamp: number }
+  | { kind: 'resource'; snapshot: ResourceSnapshot }
 
 export type EngineEventKind = EngineEvent['kind']
 export type EngineEventOfKind<K extends EngineEventKind> = Extract<EngineEvent, { kind: K }>

--- a/server/index.ts
+++ b/server/index.ts
@@ -27,7 +27,11 @@ import {
 import { createDagScheduler } from './dag/scheduler'
 import { createLandingManager } from './dag/landing'
 import { LoopScheduler } from './loops/scheduler'
+import { DEFAULT_LOOPS } from './loops/definitions'
+import { listLoops } from './loops/store'
 import { ResourceMonitor } from './metrics/resource'
+import { loadOverrides } from './config/runtime-overrides'
+import { applyOverrides } from './config/apply'
 import { createDigestBuilder } from './digest/digest'
 import { ReplyQueue as DiskReplyQueue } from './session/reply-queue'
 import { startPushNotifier } from './push/notifier'
@@ -38,6 +42,11 @@ const PORT = Number(process.env['PORT'] ?? 8080)
 const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? '/tmp/minion-workspace'
 const DEFAULT_REPO = process.env['DEFAULT_REPO'] ?? ''
 const MAX_CONCURRENT_SESSIONS = Number(process.env['MAX_CONCURRENT_SESSIONS'] ?? 10)
+const MAX_CONCURRENT_LOOPS = Number(process.env['MAX_CONCURRENT_LOOPS'] ?? 3)
+const RESERVED_INTERACTIVE_SLOTS = Number(process.env['RESERVED_INTERACTIVE_SLOTS'] ?? 2)
+const QUOTA_RETRY_MAX = Number(process.env['QUOTA_RETRY_MAX'] ?? 3)
+const QUOTA_DEFAULT_SLEEP_MS = Number(process.env['QUOTA_DEFAULT_SLEEP_MS'] ?? 5 * 60 * 1000)
+const DISK_PATH = process.env['METRICS_DISK_PATH'] ?? WORKSPACE_ROOT
 
 const app = new Hono()
 app.use('*', corsMiddleware())
@@ -128,13 +137,63 @@ if (loopsEnabled) {
   console.log('[minion] loop scheduler disabled (set ENABLE_LOOPS=true to enable)')
 }
 
-const resourceMonitor = new ResourceMonitor(bus)
+const countsProvider = (): import('../shared/api-types').CountsSnapshot => {
+  const sessions = registry.list()
+  return {
+    activeSessions: sessions.length,
+    maxSessions: MAX_CONCURRENT_SESSIONS,
+    activeLoops: sessions.filter((s) => s.mode === 'loop').length,
+    maxLoops: MAX_CONCURRENT_LOOPS,
+  }
+}
+
+const resourceMonitor = new ResourceMonitor(bus, {
+  intervalMs: 2000,
+  diskPath: DISK_PATH,
+  countsProvider,
+})
 resourceMonitor.start()
+
+// Re-apply persisted overrides at boot so interval / enabled flags survive restart.
+try {
+  applyOverrides(loadOverrides(), loopScheduler)
+} catch (err) {
+  console.warn('[minion] applyOverrides on boot failed:', err)
+}
 
 startPushNotifier(bus)
 
 const landingManager = createLandingManager({ bus })
-registerApiRoutes(app, registry, () => db, scheduler, landingManager)
+registerApiRoutes(app, registry, () => db, scheduler, landingManager, {
+  loopRuntime: loopScheduler,
+  resourceMonitor,
+  getBaseConfig: () => {
+    const rows = listLoops(db)
+    const defaults = new Map(DEFAULT_LOOPS.map((l) => [l.id, l]))
+    return {
+      maxConcurrentSessions: MAX_CONCURRENT_SESSIONS,
+      maxConcurrentLoops: MAX_CONCURRENT_LOOPS,
+      reservedInteractiveSlots: RESERVED_INTERACTIVE_SLOTS,
+      retryMax: QUOTA_RETRY_MAX,
+      defaultSleepMs: QUOTA_DEFAULT_SLEEP_MS,
+      mcp: {
+        browserEnabled: process.env['ENABLE_BROWSER_MCP'] !== 'false',
+        githubEnabled:
+          process.env['ENABLE_GITHUB_MCP'] !== 'false' &&
+          Boolean(process.env['GITHUB_TOKEN'] ?? process.env['GITHUB_PERSONAL_ACCESS_TOKEN']),
+        context7Enabled: process.env['ENABLE_CONTEXT7_MCP'] !== 'false',
+        supabaseEnabled:
+          process.env['ENABLE_SUPABASE_MCP'] !== 'false' &&
+          Boolean(process.env['SUPABASE_ACCESS_TOKEN']),
+      },
+      loops: rows.map((r) => ({
+        id: r.id,
+        enabled: r.enabled,
+        intervalMs: r.interval_ms || (defaults.get(r.id)?.intervalMs ?? 60_000),
+      })),
+    }
+  },
+})
 registerSseRoute(app, () => db)
 
 export default { port: PORT, fetch: app.fetch, idleTimeout: 0 }

--- a/server/loops/scheduler.ts
+++ b/server/loops/scheduler.ts
@@ -24,7 +24,7 @@ export class LoopScheduler implements LoopSchedulerInterface {
   private readonly registry: SessionRegistry
   private readonly workspaceRoot: string
   private readonly repo: string
-  private readonly maxConcurrentSessions: number
+  private maxConcurrentSessions: number
   private readonly getInteractiveSessionCount: () => number
   private readonly definitions = new Map<string, LoopDefinition>()
   private timer: ReturnType<typeof setInterval> | null = null
@@ -163,6 +163,10 @@ export class LoopScheduler implements LoopSchedulerInterface {
 
   setInterval(id: string, ms: number): void {
     setLoopInterval(this.db, id, ms)
+  }
+
+  setMaxConcurrentSessions(n: number): void {
+    this.maxConcurrentSessions = n
   }
 
   private computeBackoff(consecutiveFailures: number): number {

--- a/server/metrics/resource.test.ts
+++ b/server/metrics/resource.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach } from 'bun:test'
 import { ResourceMonitor } from './resource'
 import { EngineEventBus } from '../events/bus'
+import type { ResourceSnapshot } from '../../shared/api-types'
 
 describe('ResourceMonitor', () => {
   let bus: EngineEventBus
@@ -9,40 +10,57 @@ describe('ResourceMonitor', () => {
     bus = new EngineEventBus()
   })
 
-  test('sample() returns valid metric shape', () => {
+  test('sample() returns a valid ResourceSnapshot', () => {
     const monitor = new ResourceMonitor(bus)
     const now = Date.now()
-    const metrics = monitor.sample(now)
-    expect(typeof metrics.cpuPct).toBe('number')
-    expect(metrics.cpuPct).toBeGreaterThanOrEqual(0)
-    expect(metrics.cpuPct).toBeLessThanOrEqual(100)
-    expect(typeof metrics.memBytes).toBe('number')
-    expect(typeof metrics.memMaxBytes).toBe('number')
-    expect(metrics.timestamp).toBe(now)
+    const snap = monitor.sample(now)
+    expect(snap.ts).toBe(now)
+    expect(typeof snap.cpu.usagePercent).toBe('number')
+    expect(snap.cpu.usagePercent).toBeGreaterThanOrEqual(0)
+    expect(snap.cpu.usagePercent).toBeLessThanOrEqual(100)
+    expect(typeof snap.cpu.cpuCount).toBe('number')
+    expect(typeof snap.memory.usedBytes).toBe('number')
+    expect(typeof snap.memory.limitBytes).toBe('number')
+    expect(typeof snap.memory.rssBytes).toBe('number')
+    expect(typeof snap.disk.path).toBe('string')
+    expect(typeof snap.eventLoopLagMs).toBe('number')
+    expect(snap.counts.activeSessions).toBe(0)
+    expect(snap.counts.maxSessions).toBe(0)
   })
 
-  test('start() emits resource events on tick', async () => {
-    const emitted: unknown[] = []
-    bus.onKind('resource', (e) => emitted.push(e))
+  test('sample() uses injected countsProvider', () => {
+    const monitor = new ResourceMonitor(bus, {
+      countsProvider: () => ({ activeSessions: 2, maxSessions: 10, activeLoops: 1, maxLoops: 3 }),
+    })
+    const snap = monitor.sample(Date.now())
+    expect(snap.counts.activeSessions).toBe(2)
+    expect(snap.counts.maxSessions).toBe(10)
+    expect(snap.counts.activeLoops).toBe(1)
+    expect(snap.counts.maxLoops).toBe(3)
+  })
 
-    const monitor = new ResourceMonitor(bus, 10)
+  test('start() emits resource events carrying snapshots', async () => {
+    const emitted: ResourceSnapshot[] = []
+    bus.onKind('resource', (e) => emitted.push(e.snapshot))
+
+    const monitor = new ResourceMonitor(bus, { intervalMs: 10 })
     monitor.start()
 
     await new Promise<void>((r) => setTimeout(r, 35))
     monitor.stop()
 
     expect(emitted.length).toBeGreaterThanOrEqual(2)
-    const first = emitted[0] as { kind: string; cpuPct: number; memBytes: number; timestamp: number }
-    expect(first.kind).toBe('resource')
-    expect(typeof first.cpuPct).toBe('number')
-    expect(typeof first.memBytes).toBe('number')
+    const first = emitted[0]!
+    expect(typeof first.ts).toBe('number')
+    expect(typeof first.cpu.usagePercent).toBe('number')
+    expect(typeof first.memory.usedBytes).toBe('number')
   })
 
   test('stop() prevents further ticks', async () => {
     const emitted: unknown[] = []
     bus.onKind('resource', (e) => emitted.push(e))
 
-    const monitor = new ResourceMonitor(bus, 10)
+    const monitor = new ResourceMonitor(bus, { intervalMs: 10 })
     monitor.start()
     await new Promise<void>((r) => setTimeout(r, 15))
     monitor.stop()
@@ -56,7 +74,7 @@ describe('ResourceMonitor', () => {
     const emitted: unknown[] = []
     bus.onKind('resource', (e) => emitted.push(e))
 
-    const monitor = new ResourceMonitor(bus, 10)
+    const monitor = new ResourceMonitor(bus, { intervalMs: 10 })
     monitor.start()
     monitor.start()
     await new Promise<void>((r) => setTimeout(r, 25))

--- a/server/metrics/resource.ts
+++ b/server/metrics/resource.ts
@@ -1,5 +1,7 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import type { EngineEventBus } from '../events/bus'
+import type { CountsSnapshot, ResourceSnapshot } from '../../shared/api-types'
 
 interface CpuStatCgroup {
   usageUsec: number
@@ -26,6 +28,20 @@ function readCgroupMemory(): { current: number; max: number } | null {
     const max = maxRaw === 'max' ? Number.MAX_SAFE_INTEGER : Number(maxRaw)
     if (!isFinite(current) || !isFinite(max)) return null
     return { current, max }
+  } catch {
+    return null
+  }
+}
+
+function readCgroupCpuMax(): number | null {
+  try {
+    const raw = fs.readFileSync('/sys/fs/cgroup/cpu.max', 'utf8').trim()
+    const [quota, period] = raw.split(/\s+/)
+    if (!quota || !period || quota === 'max') return null
+    const q = Number(quota)
+    const p = Number(period)
+    if (!isFinite(q) || !isFinite(p) || p <= 0) return null
+    return q / p
   } catch {
     return null
   }
@@ -71,28 +87,63 @@ function readProcMeminfo(): { used: number; total: number } | null {
   }
 }
 
-export interface ResourceMetrics {
-  kind: 'resource'
-  cpuPct: number
-  memBytes: number
-  memMaxBytes: number
-  timestamp: number
+function readDisk(p: string): { usedBytes: number; totalBytes: number } {
+  try {
+    const stats = fs.statfsSync(p)
+    const blockSize = Number(stats.bsize)
+    const total = Number(stats.blocks) * blockSize
+    const free = Number(stats.bavail) * blockSize
+    return { usedBytes: Math.max(0, total - free), totalBytes: total }
+  } catch {
+    return { usedBytes: 0, totalBytes: 0 }
+  }
+}
+
+export type CountsProvider = () => CountsSnapshot
+
+export interface ResourceMonitorOpts {
+  intervalMs?: number
+  diskPath?: string
+  countsProvider?: CountsProvider
+}
+
+const DEFAULT_COUNTS: CountsSnapshot = {
+  activeSessions: 0,
+  maxSessions: 0,
+  activeLoops: 0,
+  maxLoops: 0,
 }
 
 export class ResourceMonitor {
   private timer: ReturnType<typeof setInterval> | null = null
+  private lagTimer: ReturnType<typeof setInterval> | null = null
   private prevCgroupUsec: number | null = null
   private prevProcStat: ProcStatSnapshot | null = null
   private prevTs: number | null = null
+  private lastEventLoopLagMs = 0
+  private readonly intervalMs: number
+  private readonly diskPath: string
+  private readonly countsProvider: CountsProvider
 
   constructor(
     private readonly bus: EngineEventBus,
-    private readonly intervalMs = 1000,
-  ) {}
+    opts: number | ResourceMonitorOpts = {},
+  ) {
+    if (typeof opts === 'number') {
+      this.intervalMs = opts
+      this.diskPath = '/'
+      this.countsProvider = () => DEFAULT_COUNTS
+    } else {
+      this.intervalMs = opts.intervalMs ?? 1000
+      this.diskPath = opts.diskPath ?? '/'
+      this.countsProvider = opts.countsProvider ?? (() => DEFAULT_COUNTS)
+    }
+  }
 
   start(): void {
     if (this.timer !== null) return
     this.timer = setInterval(() => this.tick(), this.intervalMs)
+    this.lagTimer = setInterval(() => this.measureLag(), 500)
   }
 
   stop(): void {
@@ -100,37 +151,49 @@ export class ResourceMonitor {
       clearInterval(this.timer)
       this.timer = null
     }
+    if (this.lagTimer !== null) {
+      clearInterval(this.lagTimer)
+      this.lagTimer = null
+    }
   }
 
-  private tick(): void {
-    const now = Date.now()
-    const metrics = this.sample(now)
-    this.bus.emit({
-      kind: 'resource' as const,
-      ...metrics,
+  private measureLag(): void {
+    const start = process.hrtime.bigint()
+    setImmediate(() => {
+      const elapsedNs = Number(process.hrtime.bigint() - start)
+      this.lastEventLoopLagMs = elapsedNs / 1e6
     })
   }
 
-  sample(now: number): Omit<ResourceMetrics, 'kind'> {
+  private tick(): void {
+    const snapshot = this.sample(Date.now())
+    this.bus.emit({ kind: 'resource' as const, snapshot })
+  }
+
+  sample(now: number): ResourceSnapshot {
     const cgroupMem = readCgroupMemory()
     const cgroupCpu = readCgroupCpuStat()
 
     let cpuPct = 0
-    let memBytes = 0
-    let memMaxBytes = 0
+    let memUsed = 0
+    let memLimit = 0
+    let memSource: 'cgroup' | 'host' = 'host'
+    let cpuSource: 'cgroup' | 'host' = 'host'
 
     if (cgroupMem) {
-      memBytes = cgroupMem.current
-      memMaxBytes = cgroupMem.max
+      memUsed = cgroupMem.current
+      memLimit = cgroupMem.max
+      memSource = 'cgroup'
     } else {
       const proc = readProcMeminfo()
       if (proc) {
-        memBytes = proc.used
-        memMaxBytes = proc.total
+        memUsed = proc.used
+        memLimit = proc.total
       }
     }
 
     if (cgroupCpu) {
+      cpuSource = 'cgroup'
       if (this.prevCgroupUsec !== null && this.prevTs !== null) {
         const usecDelta = cgroupCpu.usageUsec - this.prevCgroupUsec
         const msDelta = now - this.prevTs
@@ -151,11 +214,27 @@ export class ResourceMonitor {
 
     this.prevTs = now
 
+    const cpuCount = readCgroupCpuMax() ?? os.cpus().length
+    const disk = readDisk(this.diskPath)
+    const counts = this.countsProvider()
+    const rssBytes = process.memoryUsage().rss
+
     return {
-      cpuPct: Math.max(0, Math.min(100, cpuPct)),
-      memBytes,
-      memMaxBytes,
-      timestamp: now,
+      ts: now,
+      cpu: {
+        usagePercent: Math.max(0, Math.min(100, cpuPct)),
+        cpuCount,
+        source: cpuSource,
+      },
+      memory: {
+        usedBytes: memUsed,
+        limitBytes: memLimit,
+        rssBytes,
+        source: memSource,
+      },
+      disk: { path: this.diskPath, ...disk },
+      eventLoopLagMs: this.lastEventLoopLagMs,
+      counts,
     }
   }
 }

--- a/server/test/e2e-ship.ts
+++ b/server/test/e2e-ship.ts
@@ -226,7 +226,7 @@ describe.skipIf(process.env['E2E'] !== '1')('e2e /ship pipeline', () => {
       expect(body.data.features).toContain('screenshots')
       expect(body.data.features).toContain('diff')
       expect(body.data.features).toContain('pr-preview')
-      expect(body.data.features).toContain('resource-tracking')
+      expect(body.data.features).toContain('resource-metrics')
       expect(body.data.features).toContain('runtime-config')
     } finally {
       stop()


### PR DESCRIPTION
## Summary
- **Resources tab**: `ResourceMonitor` now produces a full `ResourceSnapshot` (CPU %, memory used/limit/rss, disk usage via `statfsSync`, event-loop lag, session/loop counts). The snapshot is pushed on the SSE `resource` event and also served from `GET /api/metrics`. The advertised feature flag is renamed `resource-tracking` → `resource-metrics` so the UI stops gating the tab off.
- **Config tab**: `GET /api/config/runtime` now returns a populated `schema.fields` + `base` doc covering workspace max concurrency (live), per-loop `enabled`/`intervalMs` (live), plus loops config, quota, and MCP toggles (restart-flagged). `PATCH /api/config/runtime` applies overrides in-process where possible (via a new `LoopRuntime.setMaxConcurrentSessions`) and persists them to `.runtime-overrides.json`. At boot, `applyOverrides(loadOverrides(), loopScheduler)` replays persisted overrides so they survive restart.
- Wires `ResourceMonitor`, `LoopScheduler`, and a `getBaseConfig` closure through `server/index.ts` into the API routes.

## Test plan
- [x] `npm run typecheck` — 4 pre-existing `TS2688` errors for `whatwg-mimetype` / `ws` (identical on clean main, unrelated to this change)
- [x] `npm run lint` — clean
- [x] `npm run test` (vitest) — 710 pass; 8 pre-existing timer-based failures in ContextMenu/PrPreviewCard/store tests (identical set on clean main)
- [x] `bun test server/` — 635 pass, 1 skip, 0 fail
- [x] Targeted server tests (`resource.test.ts`, `routes.metrics.test.ts`, `apply.test.ts`) — 20 pass
- [ ] Manual: open the Runtime bottom sheet in the PWA, confirm Resources tab shows live CPU/memory/disk/counts and Config tab lists editable fields that persist after a server restart