### PR TITLE
fix(engine): recover from stream idle errors; accept id-or-slug on session routes

### DIFF
--- a/server/api/routes.test.ts
+++ b/server/api/routes.test.ts
@@ -307,6 +307,24 @@ describe('Deferred routes return 501', () => {
     expect(res.status).toBe(404)
   })
 
+  test('session-scoped routes accept either id or slug', async () => {
+    const app = makeApp(testDb)
+    const now = Date.now()
+    testDb.run(
+      `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation, quota_sleep_until, quota_retry_count, metadata, pipeline_advancing)
+       VALUES ('sess-uuid-aaa', 'nice-slug-0001', 'running', 'hi', 'task', null, null, null, null, null, null, null, ${now}, ${now}, 0, '[]', '[]', '[]', null, 0, '{}', 0)`,
+    )
+
+    const bySlug = await app.fetch(new Request('http://localhost/api/sessions/nice-slug-0001/transcript'))
+    expect(bySlug.status).toBe(200)
+
+    const byId = await app.fetch(new Request('http://localhost/api/sessions/sess-uuid-aaa/transcript'))
+    expect(byId.status).toBe(200)
+
+    const missing = await app.fetch(new Request('http://localhost/api/sessions/not-a-thing/transcript'))
+    expect(missing.status).toBe(404)
+  })
+
   test('POST /api/sessions/variants with no body → 400', async () => {
     const app = makeApp(testDb)
     const res = await app.fetch(

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -128,10 +128,13 @@ const SLASH_MODES = new Map([
 
 type SlashMode = 'task' | 'plan' | 'think' | 'review' | 'ship-think'
 
-function resolveSessionBySlug(slug: string, registry: SessionRegistry, dbProvider: () => Database): ApiSession | null {
-  const db = dbProvider()
+function findSessionRow(key: string, db: Database) {
   const rows = prepared.listSessions(db)
-  const row = rows.find((r) => r.slug === slug)
+  return rows.find((r) => r.slug === key || r.id === key)
+}
+
+function resolveSessionBySlug(slug: string, dbProvider: () => Database): ApiSession | null {
+  const row = findSessionRow(slug, dbProvider())
   return row ? sessionRowToApi(row) : null
 }
 
@@ -198,7 +201,7 @@ export function registerApiRoutes(
 
   app.get('/api/sessions/:slug', (c) => {
     const { slug } = c.req.param()
-    const session = resolveSessionBySlug(slug, registry, resolveDb)
+    const session = resolveSessionBySlug(slug, resolveDb)
     if (!session) return c.json({ data: null, error: 'Session not found' }, 404)
     const body: ApiResponse<ApiSession> = { data: session }
     return c.json(body)
@@ -247,8 +250,7 @@ export function registerApiRoutes(
     }
 
     const db = resolveDb()
-    const rows = prepared.listSessions(db)
-    const row = rows.find((r) => r.slug === slug)
+    const row = findSessionRow(slug, db)
     if (!row) return c.json({ data: null, error: 'Session not found' }, 404)
 
     const eventRows = prepared.listEvents(db, row.id, afterSeq)
@@ -551,7 +553,7 @@ export function registerApiRoutes(
 
   app.delete('/api/sessions/:slug', async (c) => {
     const { slug } = c.req.param()
-    const session = resolveSessionBySlug(slug, registry, resolveDb)
+    const session = resolveSessionBySlug(slug, resolveDb)
     if (!session) return c.json({ data: null, error: 'Session not found' }, 404)
     await registry.close(session.id)
     return c.json({ data: { ok: true } })
@@ -722,8 +724,7 @@ export function registerApiRoutes(
   app.get('/api/sessions/:slug/diff', async (c) => {
     const { slug } = c.req.param()
     const db = resolveDb()
-    const rows = prepared.listSessions(db)
-    const row = rows.find((r) => r.slug === slug)
+    const row = findSessionRow(slug, db)
     if (!row) return c.json({ data: null, error: 'Session not found' }, 404)
     if (!row.workspace_root) return c.json({ error: 'Session has no workspace' }, 422)
     const cwd = `${row.workspace_root}/${row.slug}`
@@ -739,11 +740,10 @@ export function registerApiRoutes(
   app.get('/api/sessions/:slug/screenshots', (c) => {
     const { slug } = c.req.param()
     const db = resolveDb()
-    const rows = prepared.listSessions(db)
-    const row = rows.find((r) => r.slug === slug)
+    const row = findSessionRow(slug, db)
     if (!row) return c.json({ data: null, error: 'Session not found' }, 404)
     const workspaceRoot = row.workspace_root ?? process.env['WORKSPACE_ROOT'] ?? './.minion-data'
-    const screenshotDir = path.join(workspaceRoot, slug, '.screenshots')
+    const screenshotDir = path.join(workspaceRoot, row.slug, '.screenshots')
 
     let entries: fs.Dirent[]
     try {
@@ -768,7 +768,7 @@ export function registerApiRoutes(
         }
         return {
           file: e.name,
-          url: `/api/sessions/${encodeURIComponent(slug)}/screenshots/${encodeURIComponent(e.name)}`,
+          url: `/api/sessions/${encodeURIComponent(row.slug)}/screenshots/${encodeURIComponent(e.name)}`,
           capturedAt: new Date().toISOString(),
           size,
         }
@@ -783,8 +783,7 @@ export function registerApiRoutes(
   app.get('/api/sessions/:slug/screenshots/:filename', async (c) => {
     const { slug, filename } = c.req.param()
     const db = resolveDb()
-    const rows = prepared.listSessions(db)
-    const row = rows.find((r) => r.slug === slug)
+    const row = findSessionRow(slug, db)
     if (!row) return c.json({ data: null, error: 'Session not found' }, 404)
 
     if (filename.includes('/') || filename.includes('..')) {
@@ -792,7 +791,7 @@ export function registerApiRoutes(
     }
 
     const workspaceRoot = row.workspace_root ?? process.env['WORKSPACE_ROOT'] ?? './.minion-data'
-    const screenshotDir = path.join(workspaceRoot, slug, '.screenshots')
+    const screenshotDir = path.join(workspaceRoot, row.slug, '.screenshots')
 
     let dirEntries: fs.Dirent[]
     try {
@@ -828,8 +827,7 @@ export function registerApiRoutes(
   app.get('/api/sessions/:slug/pr', async (c) => {
     const { slug } = c.req.param()
     const db = resolveDb()
-    const rows = prepared.listSessions(db)
-    const row = rows.find((r) => r.slug === slug)
+    const row = findSessionRow(slug, db)
     if (!row) return c.json({ data: null, error: 'Session not found' }, 404)
     if (!row.pr_url) return c.json({ error: 'Session has no PR' }, 422)
     try {

--- a/server/session/runtime.test.ts
+++ b/server/session/runtime.test.ts
@@ -412,4 +412,74 @@ describe('SessionRuntime', () => {
       expect(completed[0]?.state).toBe('stream_stalled')
     }, 5000)
   })
+
+  describe('error event recovery', () => {
+    test('result{is_error:true} closes the open turn and stops the subprocess', async () => {
+      const bus = getEventBus()
+      const streamEvents: TranscriptEvent[] = []
+      bus.onKind('session.stream', (e) => { streamEvents.push(e.event) })
+      const completed: Array<Extract<EngineEvent, { kind: 'session.completed' }>> = []
+      bus.onKind('session.completed', (e) => { completed.push(e) })
+
+      let stdoutCtrl!: ReadableStreamDefaultController<Uint8Array>
+      let stderrCtrl!: ReadableStreamDefaultController<Uint8Array>
+      let resolveExit!: (code: number) => void
+      const exitedPromise = new Promise<number>((r) => { resolveExit = r })
+
+      const errorProc: SubprocessHandle = {
+        pid: 777,
+        killed: false,
+        stdin: {
+          async write(d: string) { void d },
+          flush() {},
+        },
+        stdout: new ReadableStream<Uint8Array>({ start(c) { stdoutCtrl = c } }),
+        stderr: new ReadableStream<Uint8Array>({ start(c) { stderrCtrl = c } }),
+        exited: exitedPromise,
+        kill() {
+          this.killed = true
+          stderrCtrl.close()
+          stdoutCtrl.close()
+          resolveExit(1)
+        },
+      }
+
+      const errorLine = JSON.stringify({
+        type: 'result',
+        is_error: true,
+        result: 'API Error: Stream idle timeout - partial response received',
+      }) + '\n'
+
+      void (async () => {
+        await new Promise<void>((r) => setTimeout(r, 5))
+        stdoutCtrl.enqueue(new TextEncoder().encode(errorLine))
+      })()
+
+      const rt = new SessionRuntime({
+        sessionId: SESS_ID,
+        mode: 'task',
+        cwd: '/tmp/test-cwd',
+        initialPrompt: 'hi',
+        inactivityTimeoutMs: 60_000,
+        sessionTimeoutMs: 120_000,
+        spawnFn: () => errorProc,
+        getDb: () => db,
+      })
+
+      await rt.start()
+
+      const errorStatus = streamEvents.find(
+        (e) => e.type === 'status' && e.kind === 'session_error',
+      )
+      expect(errorStatus).toBeDefined()
+
+      const errorTurnClose = streamEvents.find(
+        (e) => e.type === 'turn_completed' && (e as { errored?: boolean }).errored === true,
+      )
+      expect(errorTurnClose).toBeDefined()
+
+      expect(errorProc.killed).toBe(true)
+      expect(completed).toHaveLength(1)
+    })
+  })
 })

--- a/server/session/runtime.ts
+++ b/server/session/runtime.ts
@@ -268,7 +268,7 @@ export class SessionRuntime {
 
         if (event.kind === 'error') {
           if (this.state !== 'stopping' && this.state !== 'done') {
-            this.state = 'idle'
+            void this.stop('session_error')
           }
         }
       }

--- a/server/session/transcript.test.ts
+++ b/server/session/transcript.test.ts
@@ -158,7 +158,7 @@ describe('TranscriptTranslator', () => {
   })
 
   describe('error event', () => {
-    it('emits status with severity error and kind session_error', () => {
+    it('emits status with severity error and kind session_error when no turn is open', () => {
       const t = makeTranslator()
       const events = t.handle({ kind: 'error', error: 'Something went wrong' } satisfies ParsedStreamEvent)
 
@@ -168,6 +168,30 @@ describe('TranscriptTranslator', () => {
       expect(status.severity).toBe('error')
       expect(status.kind).toBe('session_error')
       expect(status.message).toBe('Something went wrong')
+    })
+
+    it('closes the open turn with errored:true and flushes buffered text', () => {
+      const t = makeTranslator()
+      t.startTurn('user_message')
+      t.handle({ kind: 'text_delta', text: 'partial ' })
+      t.handle({ kind: 'text_delta', text: 'response' })
+
+      const events = t.handle({
+        kind: 'error',
+        error: 'API Error: Stream idle timeout - partial response received',
+      } satisfies ParsedStreamEvent)
+
+      const flushed = events.find((e) => e.type === 'assistant_text') as AssistantTextEvent | undefined
+      expect(flushed?.final).toBe(true)
+      expect(flushed?.text).toBe('partial response')
+
+      const status = events.find((e) => e.type === 'status') as StatusEvent | undefined
+      expect(status?.severity).toBe('error')
+      expect(status?.kind).toBe('session_error')
+
+      const closed = events.find((e) => e.type === 'turn_completed') as TurnCompletedEvent | undefined
+      expect(closed).toBeDefined()
+      expect(closed?.errored).toBe(true)
     })
   })
 

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -96,8 +96,13 @@ export class TranscriptTranslator {
         return out
       }
 
-      case 'error':
-        return [this.status('session_error', event.error, { severity: 'error' })]
+      case 'error': {
+        const out: TranscriptEvent[] = [...this.flushAllBuffers()]
+        out.push(this.status('session_error', event.error, { severity: 'error' }))
+        const closed = this.closeTurn(undefined, undefined, true)
+        if (closed) out.push(closed)
+        return out
+      }
 
       case 'session_id':
         return []


### PR DESCRIPTION
## Summary

- When the Claude CLI emitted \`{type:'result', is_error:true, result:'API Error: Stream idle timeout - partial response received'}\`, the runtime left the subprocess running with an open turn. Later stream output got appended to a zombie turn and the DB status stayed 'running', so the UI looked alive but was stuck. The translator now closes the open turn with \`errored:true\` on error events, and the runtime tears the subprocess down via \`stop('session_error')\` so the next reply lands in \`resumeRuntime()\` with \`--resume\` for a clean recovery.
- \`/api/sessions/:slug/{transcript,diff,screenshots,pr}\` only matched by slug, but the UI passes \`session.id\` (UUID) on the diff and screenshots tabs — hence the "Session not found" banner. Lookup now accepts either slug or id. Screenshot paths and generated URLs use \`row.slug\` so the filesystem location is stable no matter which key the caller sent.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test\` (vitest, 719 pass)
- [x] \`bun test server/\` (638 pass, 1 skip)
- [x] New test: transcript translator closes the open turn on error and flushes partial text
- [x] New test: runtime \`result{is_error:true}\` kills the subprocess and emits \`session.completed\`
- [x] New test: session-scoped routes resolve by either id or slug