### PR TITLE
fix: enable Write/Edit tools when executing from readonly modes

### DIFF
--- a/server/commands/plan-actions.test.ts
+++ b/server/commands/plan-actions.test.ts
@@ -160,13 +160,23 @@ describe("plan-actions gating", () => {
       payload: { text: "Here is my analysis of the problem", final: true, blockId: "block-1" },
     })
     const stopCalls: string[] = []
-    const createCalls: Array<{ mode: string; prompt: string; parentId: string }> = []
+    const createCalls: Array<{ mode: string; prompt: string; parentId?: string }> = []
     const startedDagIds: string[] = []
-    const registry = {
+    const mockRuntime = {
+      running: false,
+      currentClaudeSessionId: undefined,
+      start: async () => {},
+      injectInput: async () => false,
+      stop: async () => {},
+    }
+    const registry: SessionRegistry = {
       ...makeRegistry(stopCalls),
-      create: async (opts: { mode: string; prompt: string; repo: string; parentId: string }) => {
+      create: async (opts) => {
         createCalls.push({ mode: opts.mode, prompt: opts.prompt, parentId: opts.parentId })
-        return { session: { id: "child-session-id" }, runtime: {} as any }
+        return {
+          session: { id: "child-session-id" } as any,
+          runtime: mockRuntime as any,
+        }
       },
     }
     const ctx: PlanActionCtx = {

--- a/server/commands/plan-actions.test.ts
+++ b/server/commands/plan-actions.test.ts
@@ -149,16 +149,24 @@ describe("plan-actions gating", () => {
     expect(result.reason).toBe("session not found")
   })
 
-  it("replies to the session (no kill, no DAG) for non-ship modes", async () => {
+  it("spawns a new child task session for think/plan/review modes", async () => {
     const sessionId = insertSession(db, { mode: "think" })
+    prepared.insertEvent(db, {
+      session_id: sessionId,
+      seq: 1,
+      turn: 1,
+      type: "assistant_text",
+      timestamp: Date.now(),
+      payload: { text: "Here is my analysis of the problem", final: true, blockId: "block-1" },
+    })
     const stopCalls: string[] = []
-    const replyCalls: Array<{ sessionId: string; text: string }> = []
+    const createCalls: Array<{ mode: string; prompt: string; parentId: string }> = []
     const startedDagIds: string[] = []
     const registry = {
       ...makeRegistry(stopCalls),
-      reply: async (sid: string, text: string) => {
-        replyCalls.push({ sessionId: sid, text })
-        return true
+      create: async (opts: { mode: string; prompt: string; repo: string; parentId: string }) => {
+        createCalls.push({ mode: opts.mode, prompt: opts.prompt, parentId: opts.parentId })
+        return { session: { id: "child-session-id" }, runtime: {} as any }
       },
     }
     const ctx: PlanActionCtx = {
@@ -170,20 +178,19 @@ describe("plan-actions gating", () => {
     const result = await handleExecute(sessionId, ctx)
 
     expect(result.ok).toBe(true)
-    expect(stopCalls).toHaveLength(0)
-    expect(startedDagIds).toHaveLength(0)
-    expect(replyCalls).toHaveLength(1)
-    expect(replyCalls[0]?.sessionId).toBe(sessionId)
-    expect(replyCalls[0]?.text).toMatch(/PR: <url>/)
-    expect(replyCalls[0]?.text).toMatch(/gh pr create/)
+    expect(result.dagId).toBe("child-session-id")
+    expect(stopCalls).toHaveLength(1)
+    expect(stopCalls[0]).toBe(sessionId)
+    expect(createCalls).toHaveLength(1)
+    expect(createCalls[0]?.mode).toBe("dag-task")
+    expect(createCalls[0]?.parentId).toBe(sessionId)
+    expect(createCalls[0]?.prompt).toContain("Here is my analysis of the problem")
+    expect(createCalls[0]?.prompt).toContain("gh pr create")
   })
 
-  it("returns ok:false when reply fails to inject", async () => {
+  it("returns ok:false when there is no plan to execute for think/plan/review modes", async () => {
     const sessionId = insertSession(db, { mode: "plan" })
-    const registry = {
-      ...makeRegistry([]),
-      reply: async () => false,
-    }
+    const registry = makeRegistry([])
     const ctx: PlanActionCtx = {
       db,
       registry,
@@ -192,6 +199,33 @@ describe("plan-actions gating", () => {
 
     const result = await handleExecute(sessionId, ctx)
     expect(result.ok).toBe(false)
+    expect(result.reason).toBe("no plan/analysis to execute")
+  })
+
+  it("replies to the session for task mode (no child session spawn)", async () => {
+    const sessionId = insertSession(db, { mode: "task" })
+    const replyCalls: Array<{ sessionId: string; text: string }> = []
+    const stopCalls: string[] = []
+    const registry = {
+      ...makeRegistry(stopCalls),
+      reply: async (sid: string, text: string) => {
+        replyCalls.push({ sessionId: sid, text })
+        return true
+      },
+    }
+    const ctx: PlanActionCtx = {
+      db,
+      registry,
+      scheduler: makeScheduler([]),
+    }
+
+    const result = await handleExecute(sessionId, ctx)
+
+    expect(result.ok).toBe(true)
+    expect(stopCalls).toHaveLength(0)
+    expect(replyCalls).toHaveLength(1)
+    expect(replyCalls[0]?.sessionId).toBe(sessionId)
+    expect(replyCalls[0]?.text).toContain("gh pr create")
   })
 })
 

--- a/server/commands/plan-actions.test.ts
+++ b/server/commands/plan-actions.test.ts
@@ -10,6 +10,8 @@ mock.module("node:child_process", () => ({
 import { handleExecute, handleSplit, handleStack, handleDag } from "./plan-actions"
 import type { PlanActionCtx } from "./plan-actions"
 import type { SessionRegistry } from "../session/registry"
+import type { SessionRuntime } from "../session/runtime"
+import type { ApiSession } from "../../shared/api-types"
 import type { SpawnedChild } from "../dag/claude-extract"
 import { spawn } from "node:child_process"
 
@@ -162,20 +164,23 @@ describe("plan-actions gating", () => {
     const stopCalls: string[] = []
     const createCalls: Array<{ mode: string; prompt: string; parentId?: string }> = []
     const startedDagIds: string[] = []
-    const mockRuntime = {
+    const mockRuntime: Partial<SessionRuntime> = {
       running: false,
       currentClaudeSessionId: undefined,
       start: async () => {},
       injectInput: async () => false,
       stop: async () => {},
     }
+    const mockSession: Partial<ApiSession> = {
+      id: "child-session-id",
+    }
     const registry: SessionRegistry = {
       ...makeRegistry(stopCalls),
       create: async (opts) => {
         createCalls.push({ mode: opts.mode, prompt: opts.prompt, parentId: opts.parentId })
         return {
-          session: { id: "child-session-id" } as any,
-          runtime: mockRuntime as any,
+          session: mockSession as ApiSession,
+          runtime: mockRuntime as SessionRuntime,
         }
       },
     }

--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -178,6 +178,33 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
     }
   }
 
+  if (mode === "think" || mode === "plan" || mode === "review") {
+    setPipelineAdvancing(ctx, sessionId, true)
+    try {
+      await killAndWait(sessionId, ctx)
+      const plan = getLastAssistantMessage(ctx.db, sessionId)
+      if (!plan) {
+        setPipelineAdvancing(ctx, sessionId, false)
+        return { ok: false, reason: "no plan/analysis to execute" }
+      }
+
+      const prompt = [plan, "", EXECUTE_DIRECTIVE].join("\n")
+
+      const { session } = await ctx.registry.create({
+        mode: "dag-task",
+        prompt,
+        repo: row?.repo ?? "",
+        parentId: sessionId,
+      })
+
+      setPipelineAdvancing(ctx, sessionId, false)
+      return { ok: true, dagId: session.id }
+    } catch (err) {
+      setPipelineAdvancing(ctx, sessionId, false)
+      throw err
+    }
+  }
+
   try {
     const ok = await ctx.registry.reply(sessionId, EXECUTE_DIRECTIVE)
     if (!ok) return { ok: false, reason: "could not inject execute directive into session" }


### PR DESCRIPTION
## Summary

Fixes `/execute` command to properly enable Write/Edit tools when called from THINK/PLAN/REVIEW sessions by spawning a new child task session instead of injecting into the readonly parent.

## Problem

When `/execute` was called from THINK/PLAN/REVIEW modes:
- The command injected an execution directive into the **same session**
- That session had `Write`, `Edit`, and `NotebookEdit` tools disabled (readonly mode design)
- Minions fell back to using Bash for file operations: `cat > file.ts`

## Solution

Modified `handleExecute()` to detect readonly modes (think/plan/review) and:
1. Stop the current session
2. Extract the plan/analysis from the last assistant message
3. Spawn a new **child session** in `dag-task` mode (full Write/Edit access)
4. Pass both the plan and execution directives to the child

This matches the existing pattern used for `ship-think` → `ship-plan` handoff.

## Test plan

- [x] All 636 server tests passing
- [x] Updated tests to verify child session creation for readonly modes
- [x] Added test to ensure task mode still uses in-session reply (no regression)
- [ ] Manual test: `/execute` from THINK mode spawns child with Write/Edit enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)