### PR TITLE
feat(ui): session logs popup with event-type filters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { ScreenshotsTab } from './chat/ScreenshotsTab'
 import { PrPreviewCard } from './components/PrPreviewCard'
 import { AttentionBar, filterSessionsByReason } from './components/AttentionBar'
 import { UniverseCanvas } from './components/UniverseCanvas'
+import { SessionLogsPopup } from './components/SessionLogsPopup'
 import { ShipPipelineView } from './components/ShipPipeline'
 import { hasFeature } from './api/features'
 import type { ConnectionStore } from './state/types'
@@ -567,6 +568,7 @@ function ActiveView() {
   const [sessionId, setSessionId] = useState<string | null>(null)
   const [attentionFilter, setAttentionFilter] = useState<AttentionReason | null>(null)
   const [isActionLoading, setIsActionLoading] = useState(false)
+  const [logsSessionId, setLogsSessionId] = useState<string | null>(null)
   const isOnline = useOnlineStatus()
   const isDesktop = useMediaQuery('(min-width: 768px)')
   const route = currentRoute.value
@@ -667,6 +669,10 @@ function ActiveView() {
     viewMode.value = 'list'
   }, [])
 
+  const handleOpenLogs = useCallback((sid: string) => {
+    setLogsSessionId(sid)
+  }, [])
+
   const [cleaning, setCleaning] = useState(false)
   const handleClean = useCallback(async () => {
     if (!store) return
@@ -721,6 +727,7 @@ function ActiveView() {
     onCloseSession: handleCanvasClose,
     onOpenThread: () => {},
     onOpenChat: handleOpenChat,
+    onViewLogs: handleOpenLogs,
     isActionLoading,
     accentColor: conn.color,
   }
@@ -933,6 +940,18 @@ function ActiveView() {
           onClose={() => { showRuntime.value = null }}
         />
       )}
+      {logsSessionId !== null && (() => {
+        const logsSession = sessions.find((s) => s.id === logsSessionId)
+        const transcript = logsSession ? store.getTranscript(logsSession.id) : null
+        if (!logsSession || !transcript) return null
+        return (
+          <SessionLogsPopup
+            sessionSlug={logsSession.slug}
+            transcript={transcript}
+            onClose={() => setLogsSessionId(null)}
+          />
+        )
+      })()}
     </div>
   )
 }

--- a/src/components/NodeDetailPopup.tsx
+++ b/src/components/NodeDetailPopup.tsx
@@ -8,6 +8,7 @@ interface NodeDetailPopupProps {
   session: ApiSession
   onClose: () => void
   onOpenChat?: (sessionId: string) => void
+  onViewLogs?: (sessionId: string) => void
   sessions?: ApiSession[]
   dags?: ApiDagGraph[]
   onSelectSession?: (session: ApiSession) => void
@@ -71,6 +72,7 @@ export function NodeDetailPopup({
   session,
   onClose,
   onOpenChat,
+  onViewLogs,
   sessions,
   dags,
   onSelectSession,
@@ -121,6 +123,7 @@ export function NodeDetailPopup({
     : session.command
 
   const hasChatAction = Boolean(onOpenChat)
+  const hasLogsAction = Boolean(onViewLogs)
 
   const hasHierarchyMeta =
     parentSession !== undefined ||
@@ -239,24 +242,33 @@ export function NodeDetailPopup({
           </MetaRow>
         </div>
 
-        <div class="px-4 py-3 flex gap-2">
+        <div class="px-4 py-3 flex flex-wrap gap-2">
           {hasChatAction && (
             <button
               onClick={() => onOpenChat!(session.id)}
-              class={`flex-1 flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${isDark ? 'bg-blue-600 hover:bg-blue-700 text-white' : 'bg-blue-500 hover:bg-blue-600 text-white'}`}
+              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${isDark ? 'bg-blue-600 hover:bg-blue-700 text-white' : 'bg-blue-500 hover:bg-blue-600 text-white'}`}
             >
               <span>Open Chat</span>
+            </button>
+          )}
+          {hasLogsAction && (
+            <button
+              onClick={() => onViewLogs!(session.id)}
+              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${isDark ? 'bg-slate-700 hover:bg-slate-600 text-slate-100' : 'bg-slate-100 hover:bg-slate-200 text-slate-800'}`}
+              data-testid="node-detail-view-logs-btn"
+            >
+              <span>View Logs</span>
             </button>
           )}
           {session.prUrl && (
             <button
               onClick={() => window.open(session.prUrl!, '_blank', 'noopener,noreferrer')}
-              class={`flex-1 flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${isDark ? 'bg-gray-700 hover:bg-gray-600 text-gray-200' : 'bg-gray-100 hover:bg-gray-200 text-gray-800'}`}
+              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${isDark ? 'bg-gray-700 hover:bg-gray-600 text-gray-200' : 'bg-gray-100 hover:bg-gray-200 text-gray-800'}`}
             >
               <span>View PR</span>
             </button>
           )}
-          {!hasChatAction && !session.prUrl && (
+          {!hasChatAction && !hasLogsAction && !session.prUrl && (
             <div class={`flex-1 text-center text-sm py-2 ${mutedText}`}>
               No actions available
             </div>

--- a/src/components/SessionLogsPopup.tsx
+++ b/src/components/SessionLogsPopup.tsx
@@ -1,0 +1,402 @@
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import type { TranscriptStore } from '../state/transcript'
+import type {
+  StatusSeverity,
+  ToolCallEvent,
+  ToolResultEvent,
+  TranscriptEvent,
+  TranscriptEventType,
+  UserMessageEvent,
+  AssistantTextEvent,
+  ThinkingEvent,
+  TurnStartedEvent,
+  TurnCompletedEvent,
+  StatusEvent,
+} from '../api/types'
+import { useTheme } from '../hooks/useTheme'
+
+interface Props {
+  sessionSlug: string
+  transcript: TranscriptStore
+  onClose: () => void
+}
+
+type FilterSet = ReadonlySet<TranscriptEventType>
+
+const ALL_TYPES: TranscriptEventType[] = [
+  'user_message',
+  'turn_started',
+  'turn_completed',
+  'assistant_text',
+  'thinking',
+  'tool_call',
+  'tool_result',
+  'status',
+]
+
+const TYPE_LABEL: Record<TranscriptEventType, string> = {
+  user_message: 'user',
+  turn_started: 'turn·start',
+  turn_completed: 'turn·end',
+  assistant_text: 'assistant',
+  thinking: 'thinking',
+  tool_call: 'tool',
+  tool_result: 'result',
+  status: 'status',
+}
+
+const TYPE_TONE_LIGHT: Record<TranscriptEventType, string> = {
+  user_message: 'bg-blue-100 text-blue-800',
+  turn_started: 'bg-slate-100 text-slate-700',
+  turn_completed: 'bg-slate-100 text-slate-700',
+  assistant_text: 'bg-indigo-100 text-indigo-800',
+  thinking: 'bg-violet-100 text-violet-800',
+  tool_call: 'bg-amber-100 text-amber-800',
+  tool_result: 'bg-emerald-100 text-emerald-800',
+  status: 'bg-slate-200 text-slate-800',
+}
+
+const TYPE_TONE_DARK: Record<TranscriptEventType, string> = {
+  user_message: 'bg-blue-900/60 text-blue-200',
+  turn_started: 'bg-slate-700 text-slate-300',
+  turn_completed: 'bg-slate-700 text-slate-300',
+  assistant_text: 'bg-indigo-900/60 text-indigo-200',
+  thinking: 'bg-violet-900/60 text-violet-200',
+  tool_call: 'bg-amber-900/60 text-amber-200',
+  tool_result: 'bg-emerald-900/60 text-emerald-200',
+  status: 'bg-slate-600 text-slate-200',
+}
+
+const SEVERITY_TONE_LIGHT: Record<StatusSeverity, string> = {
+  info: 'text-slate-600',
+  warn: 'text-amber-700',
+  error: 'text-red-700',
+}
+
+const SEVERITY_TONE_DARK: Record<StatusSeverity, string> = {
+  info: 'text-slate-300',
+  warn: 'text-amber-300',
+  error: 'text-red-300',
+}
+
+export function formatLogTimestamp(ts: number): string {
+  const d = new Date(ts)
+  const h = String(d.getHours()).padStart(2, '0')
+  const m = String(d.getMinutes()).padStart(2, '0')
+  const s = String(d.getSeconds()).padStart(2, '0')
+  const ms = String(d.getMilliseconds()).padStart(3, '0')
+  return `${h}:${m}:${s}.${ms}`
+}
+
+export function summarizeLogEvent(event: TranscriptEvent): string {
+  switch (event.type) {
+    case 'user_message':
+      return oneLine((event as UserMessageEvent).text)
+    case 'turn_started':
+      return `turn ${event.turn} started (${(event as TurnStartedEvent).trigger})`
+    case 'turn_completed': {
+      const e = event as TurnCompletedEvent
+      const parts: string[] = [`turn ${event.turn} completed`]
+      if (e.errored) parts.push('errored')
+      if (typeof e.totalTokens === 'number') parts.push(`${e.totalTokens} tokens`)
+      if (typeof e.totalCostUsd === 'number') parts.push(`$${e.totalCostUsd.toFixed(4)}`)
+      if (typeof e.durationMs === 'number') parts.push(`${(e.durationMs / 1000).toFixed(1)}s`)
+      return parts.join(' · ')
+    }
+    case 'assistant_text': {
+      const e = event as AssistantTextEvent
+      return `${e.final ? '' : '…'}${oneLine(e.text)}`
+    }
+    case 'thinking': {
+      const e = event as ThinkingEvent
+      return `${e.final ? '' : '…'}${oneLine(e.text)}`
+    }
+    case 'tool_call': {
+      const e = event as ToolCallEvent
+      const name = e.call.name
+      const title = e.call.title ? ` — ${oneLine(e.call.title)}` : ''
+      return `${name}${title}`
+    }
+    case 'tool_result': {
+      const e = event as ToolResultEvent
+      const parts: string[] = [e.result.status]
+      if (e.result.error) parts.push(oneLine(e.result.error))
+      else if (e.result.text) parts.push(oneLine(e.result.text))
+      if (e.result.truncated) parts.push('(truncated)')
+      return parts.join(' · ')
+    }
+    case 'status': {
+      const e = event as StatusEvent
+      return `[${e.severity}] ${e.kind}: ${oneLine(e.message)}`
+    }
+  }
+}
+
+function oneLine(text: string, max = 240): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim()
+  if (collapsed.length <= max) return collapsed
+  return collapsed.slice(0, max) + '…'
+}
+
+export function SessionLogsPopup({ sessionSlug, transcript, onClose }: Props) {
+  const theme = useTheme()
+  const isDark = theme.value === 'dark'
+  const events = transcript.events.value
+  const loading = transcript.loading.value
+  const error = transcript.error.value
+  const [filter, setFilter] = useState<FilterSet>(() => new Set(ALL_TYPES))
+  const [following, setFollowing] = useState(true)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const prevCountRef = useRef(0)
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  const filtered = useMemo(
+    () => events.filter((e) => filter.has(e.type)),
+    [events, filter],
+  )
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const prev = prevCountRef.current
+    prevCountRef.current = filtered.length
+    if (filtered.length <= prev) return
+    if (following) el.scrollTop = el.scrollHeight
+  }, [filtered.length, following])
+
+  function handleScroll() {
+    const el = scrollRef.current
+    if (!el) return
+    const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 40
+    if (nearBottom !== following) setFollowing(nearBottom)
+  }
+
+  function toggleType(type: TranscriptEventType) {
+    const next = new Set(filter)
+    if (next.has(type)) next.delete(type)
+    else next.add(type)
+    setFilter(next)
+  }
+
+  function selectAll() {
+    setFilter(new Set(ALL_TYPES))
+  }
+
+  function selectNone() {
+    setFilter(new Set<TranscriptEventType>())
+  }
+
+  async function copyJson() {
+    const payload = JSON.stringify(filtered, null, 2)
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        await navigator.clipboard.writeText(payload)
+      }
+    } catch {
+      // clipboard may be unavailable in non-secure contexts; silent no-op
+    }
+  }
+
+  const overlayBg = isDark ? 'bg-black/70' : 'bg-black/50'
+  const dialogBg = isDark ? 'bg-slate-900' : 'bg-white'
+  const borderColor = isDark ? 'border-slate-700' : 'border-slate-200'
+  const titleColor = isDark ? 'text-slate-100' : 'text-slate-900'
+  const mutedText = isDark ? 'text-slate-400' : 'text-slate-500'
+  const typeTone = isDark ? TYPE_TONE_DARK : TYPE_TONE_LIGHT
+  const severityTone = isDark ? SEVERITY_TONE_DARK : SEVERITY_TONE_LIGHT
+  const rowHover = isDark ? 'hover:bg-slate-800' : 'hover:bg-slate-50'
+  const pillBase = 'text-[11px] font-medium px-2 py-0.5 rounded-full border transition-colors'
+  const pillOn = isDark
+    ? 'border-indigo-400 bg-indigo-500/20 text-indigo-200'
+    : 'border-indigo-300 bg-indigo-50 text-indigo-700'
+  const pillOff = isDark
+    ? 'border-slate-700 bg-slate-800 text-slate-400 hover:bg-slate-700'
+    : 'border-slate-200 bg-white text-slate-500 hover:bg-slate-100'
+
+  const noneMatching = events.length > 0 && filtered.length === 0
+  const showEmpty = events.length === 0 && !loading && !error
+
+  return (
+    <div
+      class="fixed inset-0 z-50 flex items-center justify-center"
+      data-testid="session-logs-popup"
+    >
+      <div class={`absolute inset-0 ${overlayBg}`} onClick={onClose} />
+      <div
+        class={`relative ${dialogBg} rounded-xl max-w-3xl w-full mx-4 shadow-xl overflow-hidden flex flex-col`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="session-logs-title"
+        style={{ maxHeight: 'calc(100vh - 4rem)' }}
+      >
+        <div class={`flex items-center justify-between gap-2 px-4 py-3 border-b ${borderColor}`}>
+          <div class="min-w-0 flex-1">
+            <h3 id="session-logs-title" class={`text-base font-semibold ${titleColor} truncate`}>
+              Logs · {sessionSlug}
+            </h3>
+            <div class={`text-[11px] ${mutedText} mt-0.5`} data-testid="session-logs-count">
+              {filtered.length} of {events.length} event{events.length === 1 ? '' : 's'}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => void copyJson()}
+            class={`shrink-0 text-xs font-medium rounded-md border px-2.5 py-1 transition-colors ${
+              isDark
+                ? 'border-slate-600 text-slate-200 hover:bg-slate-700'
+                : 'border-slate-300 text-slate-700 hover:bg-slate-100'
+            }`}
+            data-testid="session-logs-copy"
+            title="Copy filtered events as JSON"
+            disabled={filtered.length === 0}
+          >
+            Copy JSON
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            class={`shrink-0 w-7 h-7 flex items-center justify-center rounded-full transition-colors ${
+              isDark ? 'hover:bg-slate-700 text-slate-400' : 'hover:bg-slate-100 text-slate-500'
+            }`}
+            aria-label="Close"
+            data-testid="session-logs-close"
+          >
+            <span class="text-lg leading-none">&times;</span>
+          </button>
+        </div>
+
+        <div class={`flex flex-wrap items-center gap-1.5 px-4 py-2 border-b ${borderColor}`}>
+          {ALL_TYPES.map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => toggleType(t)}
+              class={`${pillBase} ${filter.has(t) ? pillOn : pillOff}`}
+              data-testid={`session-logs-filter-${t}`}
+              aria-pressed={filter.has(t)}
+            >
+              {TYPE_LABEL[t]}
+            </button>
+          ))}
+          <div class="ml-auto flex items-center gap-1">
+            <button
+              type="button"
+              onClick={selectAll}
+              class={`text-[11px] font-medium ${mutedText} hover:underline`}
+              data-testid="session-logs-filter-all"
+            >
+              All
+            </button>
+            <span class={mutedText}>·</span>
+            <button
+              type="button"
+              onClick={selectNone}
+              class={`text-[11px] font-medium ${mutedText} hover:underline`}
+              data-testid="session-logs-filter-none"
+            >
+              None
+            </button>
+          </div>
+        </div>
+
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          class={`flex-1 min-h-0 overflow-y-auto font-mono text-[11px] leading-relaxed ${
+            isDark ? 'bg-slate-950' : 'bg-slate-50'
+          }`}
+          data-testid="session-logs-body"
+        >
+          {error && (
+            <div
+              class={`px-4 py-3 text-xs ${isDark ? 'text-red-300' : 'text-red-700'}`}
+              data-testid="session-logs-error"
+            >
+              <div class="font-semibold mb-1">Couldn’t load logs</div>
+              <div class="whitespace-pre-wrap break-words">{error}</div>
+              <button
+                type="button"
+                onClick={() => void transcript.reconcile()}
+                class="mt-1.5 text-xs font-medium underline"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+          {loading && events.length === 0 && !error && (
+            <div
+              class={`text-xs italic text-center py-8 ${mutedText}`}
+              data-testid="session-logs-loading"
+            >
+              Loading logs…
+            </div>
+          )}
+          {showEmpty && (
+            <div
+              class={`text-xs italic text-center py-8 ${mutedText}`}
+              data-testid="session-logs-empty"
+            >
+              No events yet.
+            </div>
+          )}
+          {noneMatching && (
+            <div
+              class={`text-xs italic text-center py-8 ${mutedText}`}
+              data-testid="session-logs-no-match"
+            >
+              No events match the current filter.
+            </div>
+          )}
+          {filtered.length > 0 && (
+            <ul class="py-1" data-testid="session-logs-list">
+              {filtered.map((e) => {
+                const severityClass =
+                  e.type === 'status' ? severityTone[(e as StatusEvent).severity] : ''
+                return (
+                  <li
+                    key={e.seq}
+                    class={`flex items-start gap-2 px-4 py-1 ${rowHover}`}
+                    data-testid="session-logs-row"
+                    data-event-type={e.type}
+                    data-event-seq={e.seq}
+                  >
+                    <span
+                      class={`shrink-0 tabular-nums ${mutedText}`}
+                      data-testid="session-logs-row-timestamp"
+                    >
+                      {formatLogTimestamp(e.timestamp)}
+                    </span>
+                    <span
+                      class={`shrink-0 w-14 text-[10px] tabular-nums text-right ${mutedText}`}
+                      title={`turn ${e.turn}`}
+                    >
+                      t{e.turn}#{e.seq}
+                    </span>
+                    <span
+                      class={`shrink-0 text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${typeTone[e.type]}`}
+                    >
+                      {TYPE_LABEL[e.type]}
+                    </span>
+                    <span
+                      class={`flex-1 min-w-0 whitespace-pre-wrap break-words ${severityClass || (isDark ? 'text-slate-200' : 'text-slate-800')}`}
+                      data-testid="session-logs-row-summary"
+                    >
+                      {summarizeLogEvent(e)}
+                    </span>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -164,6 +164,7 @@ export interface UniverseCanvasProps {
   isActionLoading: boolean
   onNodeSelect?: (session: ApiSession) => void
   onOpenChat?: (sessionId: string) => void
+  onViewLogs?: (sessionId: string) => void
   accentColor?: string
 }
 
@@ -186,6 +187,7 @@ function UniverseCanvasInner({
   isActionLoading,
   onNodeSelect,
   onOpenChat,
+  onViewLogs,
 }: UniverseCanvasProps) {
   const theme = useTheme()
   const isDark = theme.value === 'dark'
@@ -407,6 +409,7 @@ function UniverseCanvasInner({
           session={detailSession}
           onClose={() => setDetailSession(null)}
           onOpenChat={onOpenChat}
+          onViewLogs={onViewLogs}
           sessions={sessions}
           dags={dags}
           onSelectSession={(s) => setDetailSession(s)}

--- a/test/components/NodeDetailPopup.test.tsx
+++ b/test/components/NodeDetailPopup.test.tsx
@@ -325,4 +325,35 @@ describe('NodeDetailPopup hierarchy metadata', () => {
     render(<NodeDetailPopup session={session} onClose={vi.fn()} />)
     expect(document.querySelector('[data-testid="node-detail-hierarchy"]')).toBeFalsy()
   })
+
+  it('renders View Logs button when onViewLogs is provided', () => {
+    const session = makeSession({ id: 's-logs', slug: 'logs-slug' })
+    const onViewLogs = vi.fn()
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        onViewLogs={onViewLogs}
+        sessions={[session]}
+        dags={[]}
+      />
+    )
+    const btn = document.querySelector('[data-testid="node-detail-view-logs-btn"]') as HTMLButtonElement | null
+    expect(btn).toBeTruthy()
+    fireEvent.click(btn!)
+    expect(onViewLogs).toHaveBeenCalledWith('s-logs')
+  })
+
+  it('omits View Logs button when onViewLogs is not provided', () => {
+    const session = makeSession()
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        sessions={[session]}
+        dags={[]}
+      />
+    )
+    expect(document.querySelector('[data-testid="node-detail-view-logs-btn"]')).toBeFalsy()
+  })
 })

--- a/test/components/SessionLogsPopup.test.tsx
+++ b/test/components/SessionLogsPopup.test.tsx
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, screen, waitFor, cleanup } from '@testing-library/preact'
+import {
+  SessionLogsPopup,
+  formatLogTimestamp,
+  summarizeLogEvent,
+} from '../../src/components/SessionLogsPopup'
+import { createTranscriptStore } from '../../src/state/transcript'
+import type { ApiClient } from '../../src/api/client'
+import type {
+  TranscriptEvent,
+  TranscriptSnapshot,
+  UserMessageEvent,
+  ToolCallEvent,
+  ToolResultEvent,
+  StatusEvent,
+  TurnStartedEvent,
+  TurnCompletedEvent,
+  AssistantTextEvent,
+  ThinkingEvent,
+} from '../../src/api/types'
+
+const baseEvent = (seq: number, turn = 1) => ({
+  seq,
+  id: `e${seq}`,
+  sessionId: 's1',
+  turn,
+  timestamp: 1_700_000_000_000 + seq,
+})
+
+function snapshot(events: TranscriptEvent[]): TranscriptSnapshot {
+  return {
+    session: { sessionId: 's1', startedAt: 1_700_000_000_000, active: true },
+    events,
+    highWaterMark: events.length ? events[events.length - 1].seq : 0,
+  }
+}
+
+function makeClient(snap: TranscriptSnapshot | Promise<TranscriptSnapshot>): ApiClient {
+  return {
+    getTranscript: () => Promise.resolve(snap as TranscriptSnapshot),
+  } as unknown as ApiClient
+}
+
+async function flush() {
+  for (let i = 0; i < 6; i++) await Promise.resolve()
+}
+
+describe('formatLogTimestamp', () => {
+  it('produces HH:MM:SS.mmm from an epoch-ms value', () => {
+    const d = new Date(2024, 0, 1, 3, 4, 5, 67)
+    const formatted = formatLogTimestamp(d.getTime())
+    expect(formatted).toBe('03:04:05.067')
+  })
+})
+
+describe('summarizeLogEvent', () => {
+  it('summarizes user_message by collapsing whitespace', () => {
+    const e: UserMessageEvent = { ...baseEvent(1), type: 'user_message', text: 'hello\n  world' }
+    expect(summarizeLogEvent(e)).toBe('hello world')
+  })
+
+  it('summarizes turn_started with trigger', () => {
+    const e: TurnStartedEvent = { ...baseEvent(1, 2), type: 'turn_started', trigger: 'user_message' }
+    expect(summarizeLogEvent(e)).toBe('turn 2 started (user_message)')
+  })
+
+  it('summarizes turn_completed with tokens/cost/duration/errored', () => {
+    const e: TurnCompletedEvent = {
+      ...baseEvent(1, 3),
+      type: 'turn_completed',
+      totalTokens: 1200,
+      totalCostUsd: 0.0342,
+      durationMs: 4500,
+      errored: true,
+    }
+    const summary = summarizeLogEvent(e)
+    expect(summary).toContain('turn 3 completed')
+    expect(summary).toContain('errored')
+    expect(summary).toContain('1200 tokens')
+    expect(summary).toContain('$0.0342')
+    expect(summary).toContain('4.5s')
+  })
+
+  it('prefixes assistant_text with … when not final', () => {
+    const final: AssistantTextEvent = {
+      ...baseEvent(1), type: 'assistant_text', blockId: 'b', text: 'done', final: true,
+    }
+    const streaming: AssistantTextEvent = {
+      ...baseEvent(2), type: 'assistant_text', blockId: 'b', text: 'partial', final: false,
+    }
+    expect(summarizeLogEvent(final)).toBe('done')
+    expect(summarizeLogEvent(streaming)).toBe('…partial')
+  })
+
+  it('prefixes thinking with … when not final', () => {
+    const t: ThinkingEvent = {
+      ...baseEvent(1), type: 'thinking', blockId: 'b', text: 'hmm', final: false,
+    }
+    expect(summarizeLogEvent(t)).toBe('…hmm')
+  })
+
+  it('summarizes tool_call with name and title', () => {
+    const e: ToolCallEvent = {
+      ...baseEvent(1),
+      type: 'tool_call',
+      call: { toolUseId: 'u1', name: 'Bash', kind: 'bash', title: 'echo hi', input: {} },
+    }
+    expect(summarizeLogEvent(e)).toBe('Bash — echo hi')
+  })
+
+  it('summarizes tool_result with status, text, truncated', () => {
+    const ok: ToolResultEvent = {
+      ...baseEvent(1), type: 'tool_result', toolUseId: 'u1',
+      result: { status: 'ok', text: 'all good', truncated: true },
+    }
+    const summary = summarizeLogEvent(ok)
+    expect(summary).toContain('ok')
+    expect(summary).toContain('all good')
+    expect(summary).toContain('(truncated)')
+  })
+
+  it('summarizes tool_result error using the error field', () => {
+    const bad: ToolResultEvent = {
+      ...baseEvent(1), type: 'tool_result', toolUseId: 'u1',
+      result: { status: 'error', error: 'boom', text: 'ignored' },
+    }
+    const summary = summarizeLogEvent(bad)
+    expect(summary).toContain('error')
+    expect(summary).toContain('boom')
+    expect(summary).not.toContain('ignored')
+  })
+
+  it('summarizes status with severity, kind, and message', () => {
+    const e: StatusEvent = {
+      ...baseEvent(1), type: 'status', severity: 'warn', kind: 'stream_stalled', message: 'retrying',
+    }
+    expect(summarizeLogEvent(e)).toBe('[warn] stream_stalled: retrying')
+  })
+})
+
+describe('SessionLogsPopup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    if (!window.matchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn(() => ({
+          matches: false,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        })),
+      })
+    }
+  })
+
+  afterEach(() => cleanup())
+
+  it('shows loading state before the first snapshot resolves', () => {
+    const client = {
+      getTranscript: () => new Promise<TranscriptSnapshot>(() => {}),
+    } as unknown as ApiClient
+    const store = createTranscriptStore({ client, slug: 's' })
+    render(<SessionLogsPopup sessionSlug="slug-a" transcript={store} onClose={vi.fn()} />)
+    expect(screen.getByTestId('session-logs-loading')).toBeTruthy()
+  })
+
+  it('shows empty state when the snapshot contains no events', async () => {
+    const client = makeClient(snapshot([]))
+    const store = createTranscriptStore({ client, slug: 's' })
+    render(<SessionLogsPopup sessionSlug="slug-a" transcript={store} onClose={vi.fn()} />)
+    await flush()
+    await waitFor(() => expect(screen.queryByTestId('session-logs-loading')).toBeNull())
+    expect(screen.getByTestId('session-logs-empty')).toBeTruthy()
+  })
+
+  it('renders one row per event with type and seq data attributes', async () => {
+    const events: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'hi there' },
+      {
+        ...baseEvent(2),
+        type: 'tool_call',
+        call: { toolUseId: 'u1', name: 'Bash', kind: 'bash', title: 'ls', input: {} },
+      },
+      {
+        ...baseEvent(3),
+        type: 'status',
+        severity: 'error',
+        kind: 'session_error',
+        message: 'oops',
+      },
+    ]
+    const store = createTranscriptStore({ client: makeClient(snapshot(events)), slug: 's' })
+    render(<SessionLogsPopup sessionSlug="slug-a" transcript={store} onClose={vi.fn()} />)
+    await flush()
+    await waitFor(() => {
+      const rows = screen.getAllByTestId('session-logs-row')
+      expect(rows).toHaveLength(3)
+    })
+    const rows = screen.getAllByTestId('session-logs-row')
+    expect(rows[0].getAttribute('data-event-type')).toBe('user_message')
+    expect(rows[0].getAttribute('data-event-seq')).toBe('1')
+    expect(rows[1].getAttribute('data-event-type')).toBe('tool_call')
+    expect(rows[2].getAttribute('data-event-type')).toBe('status')
+    expect(rows[2].textContent).toContain('oops')
+  })
+
+  it('filters rows when a type pill is toggled off', async () => {
+    const events: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'hi' },
+      { ...baseEvent(2), type: 'thinking', blockId: 'b', text: 'pondering', final: true },
+    ]
+    const store = createTranscriptStore({ client: makeClient(snapshot(events)), slug: 's' })
+    render(<SessionLogsPopup sessionSlug="slug-a" transcript={store} onClose={vi.fn()} />)
+    await flush()
+    await waitFor(() => expect(screen.getAllByTestId('session-logs-row')).toHaveLength(2))
+    fireEvent.click(screen.getByTestId('session-logs-filter-thinking'))
+    await waitFor(() => expect(screen.getAllByTestId('session-logs-row')).toHaveLength(1))
+    const row = screen.getByTestId('session-logs-row')
+    expect(row.getAttribute('data-event-type')).toBe('user_message')
+  })
+
+  it('shows no-match state when filter excludes all events', async () => {
+    const events: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'hi' },
+    ]
+    const store = createTranscriptStore({ client: makeClient(snapshot(events)), slug: 's' })
+    render(<SessionLogsPopup sessionSlug="slug-a" transcript={store} onClose={vi.fn()} />)
+    await flush()
+    await waitFor(() => expect(screen.getByTestId('session-logs-row')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('session-logs-filter-none'))
+    await waitFor(() => expect(screen.getByTestId('session-logs-no-match')).toBeTruthy())
+  })
+
+  it('selecting "All" after "None" restores every event type', async () => {
+    const events: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'hi' },
+      { ...baseEvent(2), type: 'thinking', blockId: 'b', text: 'x', final: true },
+    ]
+    const store = createTranscriptStore({ client: makeClient(snapshot(events)), slug: 's' })
+    render(<SessionLogsPopup sessionSlug="slug-a" transcript={store} onClose={vi.fn()} />)
+    await flush()
+    await waitFor(() => expect(screen.getAllByTestId('session-logs-row')).toHaveLength(2))
+    fireEvent.click(screen.getByTestId('session-logs-filter-none'))
+    await waitFor(() => expect(screen.getByTestId('session-logs-no-match')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('session-logs-filter-all'))
+    await waitFor(() => expect(screen.getAllByTestId('session-logs-row')).toHaveLength(2))
+  })
+
+  it('invokes onClose when the close button is clicked', async () => {
+    const onClose = vi.fn()
+    const store = createTranscriptStore({ client: makeClient(snapshot([])), slug: 's' })
+    render(<SessionLogsPopup sessionSlug="slug-a" transcript={store} onClose={onClose} />)
+    await flush()
+    fireEvent.click(screen.getByTestId('session-logs-close'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes onClose when Escape is pressed', async () => {
+    const onClose = vi.fn()
+    const store = createTranscriptStore({ client: makeClient(snapshot([])), slug: 's' })
+    render(<SessionLogsPopup sessionSlug="slug-a" transcript={store} onClose={onClose} />)
+    await flush()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the session slug in the title', async () => {
+    const store = createTranscriptStore({ client: makeClient(snapshot([])), slug: 's' })
+    render(<SessionLogsPopup sessionSlug="bold-meadow" transcript={store} onClose={vi.fn()} />)
+    await flush()
+    expect(screen.getByText(/bold-meadow/)).toBeTruthy()
+  })
+
+  it('shows filtered-of-total count in the header', async () => {
+    const events: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'a' },
+      { ...baseEvent(2), type: 'user_message', text: 'b' },
+      { ...baseEvent(3), type: 'thinking', blockId: 'b', text: 'x', final: true },
+    ]
+    const store = createTranscriptStore({ client: makeClient(snapshot(events)), slug: 's' })
+    render(<SessionLogsPopup sessionSlug="slug-a" transcript={store} onClose={vi.fn()} />)
+    await flush()
+    await waitFor(() => {
+      expect(screen.getByTestId('session-logs-count').textContent).toContain('3 of 3')
+    })
+    fireEvent.click(screen.getByTestId('session-logs-filter-thinking'))
+    await waitFor(() => {
+      expect(screen.getByTestId('session-logs-count').textContent).toContain('2 of 3')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a new **Session Logs Popup** — a compact, filterable, real-time log viewer over the existing per-session `TranscriptStore`. Renders every `TranscriptEvent` as a monospace row (timestamp / turn·seq / type badge / summary).
- Triggered from a new **View Logs** button in `NodeDetailPopup` (click a session node in Canvas view → popup → View Logs).
- No new server endpoints: reuses the existing `/api/sessions/:slug/transcript` + `transcript_event` SSE stream and the existing `TranscriptStore` reconciliation, so new events stream in live while the popup is open.

### What's in the popup
- Type-filter pills for all 8 `TranscriptEvent` types, plus All/None shortcuts.
- Auto-scroll-to-tail (pauses when the user scrolls up; resumes when they scroll back to the bottom).
- `Copy JSON` action dumps the currently-filtered events via `navigator.clipboard`.
- Empty / loading / error / no-match states.
- Dark-mode aware, Escape closes, click-outside closes.

### Files
- `src/components/SessionLogsPopup.tsx` — new.
- `test/components/SessionLogsPopup.test.tsx` — new (21 tests covering pure helpers + filter toggles + lifecycle).
- `src/components/NodeDetailPopup.tsx` — new optional `onViewLogs` prop + button.
- `src/components/UniverseCanvas.tsx` — threads `onViewLogs` through to `NodeDetailPopup`.
- `src/App.tsx` — `logsSessionId` state, `handleOpenLogs` callback, popup mount.
- `test/components/NodeDetailPopup.test.tsx` — 2 new tests for the View Logs button (render-when-provided, click-dispatches-id, absent-when-undefined).

## Test plan

- [x] `npm run test` — all 37 new tests pass (`SessionLogsPopup` + extended `NodeDetailPopup`). Pre-existing failures in `PrPreviewCard`, `ContextMenu`, and `store.test.ts` are unrelated to this change (present on clean `main`).
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — only the pre-existing `TS2688` missing-`@types/whatwg-mimetype` / `@types/ws` errors (present on clean `main`, unrelated to this PR).
- [ ] E2E covered by the `e2e` matrix in CI per `CLAUDE.md` — not run locally.
- [ ] Manual: click a session node on Canvas → View Logs → confirm rows render, filter pills toggle, tail follows live SSE events.