### PR TITLE
fix(ship-plan): prevent fallthrough to EXECUTE_DIRECTIVE injection

### DIFF
--- a/server/commands/plan-actions.test.ts
+++ b/server/commands/plan-actions.test.ts
@@ -242,6 +242,127 @@ describe("plan-actions gating", () => {
     expect(replyCalls[0]?.sessionId).toBe(sessionId)
     expect(replyCalls[0]?.text).toContain("gh pr create")
   })
+
+  it("ship-plan with valid DAG JSON triggers buildAndStartDag, not registry.reply", async () => {
+    const sessionId = insertSession(db, { mode: "ship-plan" })
+    const dagJson = JSON.stringify([
+      { id: "task-a", title: "Task A", description: "Do task A", dependsOn: [] },
+      { id: "task-b", title: "Task B", description: "Do task B", dependsOn: ["task-a"] },
+    ])
+    prepared.insertEvent(db, {
+      session_id: sessionId,
+      seq: 1,
+      turn: 1,
+      type: "assistant_text",
+      timestamp: Date.now(),
+      payload: { text: `Here is the DAG:\n\n\`\`\`json\n${dagJson}\n\`\`\``, final: true, blockId: "block-1" },
+    })
+
+    const stopCalls: string[] = []
+    const replyCalls: Array<{ sessionId: string; text: string }> = []
+    const startedDagIds: string[] = []
+    const registry = {
+      ...makeRegistry(stopCalls),
+      reply: async (sid: string, text: string) => {
+        replyCalls.push({ sessionId: sid, text })
+        return true
+      },
+    }
+    const ctx: PlanActionCtx = {
+      db,
+      registry,
+      scheduler: makeScheduler(startedDagIds),
+    }
+
+    const result = await handleExecute(sessionId, ctx)
+
+    expect(result.ok).toBe(true)
+    expect(result.dagId).toBeTruthy()
+    expect(stopCalls).toHaveLength(1)
+    expect(stopCalls[0]).toBe(sessionId)
+    expect(startedDagIds).toHaveLength(1)
+    expect(replyCalls).toHaveLength(0)
+  })
+
+  it("ship-plan with no DAG output returns error", async () => {
+    const sessionId = insertSession(db, { mode: "ship-plan" })
+    const stopCalls: string[] = []
+    const startedDagIds: string[] = []
+    const ctx: PlanActionCtx = {
+      db,
+      registry: makeRegistry(stopCalls),
+      scheduler: makeScheduler(startedDagIds),
+    }
+
+    const result = await handleExecute(sessionId, ctx)
+
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe("no DAG output from ship-plan to parse")
+    expect(startedDagIds).toHaveLength(0)
+  })
+
+  it("ship-plan falls back to extractDagItems when parseDagItems fails", async () => {
+    mockSpawn.mockImplementation(() => makeDagItemsChild([
+      { id: "task-1", title: "Task 1", description: "Do task 1", dependsOn: [] },
+    ]))
+
+    const sessionId = insertSession(db, { mode: "ship-plan" })
+    prepared.insertEvent(db, {
+      session_id: sessionId,
+      seq: 1,
+      turn: 1,
+      type: "user_message",
+      timestamp: Date.now(),
+      payload: { text: "Plan a feature" },
+    })
+    prepared.insertEvent(db, {
+      session_id: sessionId,
+      seq: 2,
+      turn: 1,
+      type: "assistant_text",
+      timestamp: Date.now(),
+      payload: { text: "Not valid JSON format but conversation contains plan", final: true, blockId: "block-1" },
+    })
+
+    const stopCalls: string[] = []
+    const startedDagIds: string[] = []
+    const ctx: PlanActionCtx = {
+      db,
+      registry: makeRegistry(stopCalls),
+      scheduler: makeScheduler(startedDagIds),
+    }
+
+    const result = await handleExecute(sessionId, ctx)
+
+    expect(result.ok).toBe(true)
+    expect(result.dagId).toBeTruthy()
+    expect(startedDagIds).toHaveLength(1)
+  })
+
+  it("rejects unknown modes with helpful error message", async () => {
+    const sessionId = insertSession(db, { mode: "unknown-mode" })
+    const stopCalls: string[] = []
+    const replyCalls: Array<{ sessionId: string; text: string }> = []
+    const registry = {
+      ...makeRegistry(stopCalls),
+      reply: async (sid: string, text: string) => {
+        replyCalls.push({ sessionId: sid, text })
+        return true
+      },
+    }
+    const ctx: PlanActionCtx = {
+      db,
+      registry,
+      scheduler: makeScheduler([]),
+    }
+
+    const result = await handleExecute(sessionId, ctx)
+
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain("execute not supported")
+    expect(result.reason).toContain("unknown-mode")
+    expect(replyCalls).toHaveLength(0)
+  })
 })
 
 describe("handleSplit", () => {

--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -178,6 +178,42 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
     }
   }
 
+  if (mode === "ship-plan") {
+    setPipelineAdvancing(ctx, sessionId, true)
+    try {
+      await killAndWait(sessionId, ctx)
+      const lastMsg = getLastAssistantMessage(ctx.db, sessionId)
+      if (!lastMsg) {
+        setPipelineAdvancing(ctx, sessionId, false)
+        return { ok: false, reason: "no DAG output from ship-plan to parse" }
+      }
+
+      let items: DagInput[]
+      try {
+        items = parseDagItems(lastMsg)
+      } catch {
+        const conversation = getConversationMessages(ctx.db, sessionId)
+        const typedConversation = conversation.map((m) => ({
+          role: m.role as "user" | "assistant",
+          text: m.text,
+        }))
+        const result = await extractDagItems(typedConversation)
+        if (result.error || result.items.length === 0) {
+          setPipelineAdvancing(ctx, sessionId, false)
+          return { ok: false, reason: result.errorMessage ?? "failed to extract DAG items" }
+        }
+        items = result.items
+      }
+
+      const dagResult = await buildAndStartDag(items, sessionId, ctx)
+      if (!dagResult.ok) setPipelineAdvancing(ctx, sessionId, false)
+      return dagResult
+    } catch (err) {
+      setPipelineAdvancing(ctx, sessionId, false)
+      throw err
+    }
+  }
+
   if (mode === "think" || mode === "plan" || mode === "review") {
     setPipelineAdvancing(ctx, sessionId, true)
     try {
@@ -205,13 +241,17 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
     }
   }
 
-  try {
-    const ok = await ctx.registry.reply(sessionId, EXECUTE_DIRECTIVE)
-    if (!ok) return { ok: false, reason: "could not inject execute directive into session" }
-    return { ok: true }
-  } catch (err) {
-    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  if (mode === "task" || mode === "dag-task" || mode === "ship-verify") {
+    try {
+      const ok = await ctx.registry.reply(sessionId, EXECUTE_DIRECTIVE)
+      if (!ok) return { ok: false, reason: "could not inject execute directive into session" }
+      return { ok: true }
+    } catch (err) {
+      return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+    }
   }
+
+  return { ok: false, reason: `execute not supported for mode ${mode ?? "unknown"}` }
 }
 
 export async function handleSplit(sessionId: string, ctx: PlanActionCtx): Promise<PlanActionResult> {


### PR DESCRIPTION
## Summary

- Add dedicated `ship-plan` branch in `handleExecute` that parses DAG output from the last assistant message
- Falls back to `extractDagItems` over full conversation if `parseDagItems` fails
- Calls `buildAndStartDag` to spawn child dag-task sessions
- Never falls through to `registry.reply(EXECUTE_DIRECTIVE)` for ship-plan sessions
- Change final fallthrough to explicitly whitelist `task`, `dag-task`, and `ship-verify` modes for EXECUTE_DIRECTIVE injection
- Reject unknown modes with descriptive error message instead of silently injecting directives

Fixes the bug where ship-plan sessions (which are read-only planners) would fall through to the execute directive injection, causing them to git-commit and push arbitrary scratch state since Bash is still enabled.

## Test plan

- ✅ Unit tests pass: `bun test plan-actions.test.ts` (14/14)
- ✅ All server tests pass: `bun test` (643/644, 1 skip)
- ✅ Lint passes: `npm run lint`
- New test coverage:
  - ship-plan with valid DAG JSON triggers buildAndStartDag, not registry.reply
  - ship-plan with no DAG output returns error
  - ship-plan falls back to extractDagItems when parseDagItems fails
  - Unknown modes rejected with helpful error message
  - task mode still gets registry.reply as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)