### PR TITLE
fix(dag): reset failed DAG node back to running on reply-resume

### DIFF
--- a/server/commands/force.test.ts
+++ b/server/commands/force.test.ts
@@ -6,6 +6,7 @@ function makeScheduler(shouldFail = false): DagScheduler {
   return {
     async start() {},
     async onSessionCompleted() {},
+    async onSessionResumed() {},
     async cancel() {},
     status() { return { dagId: '', nodes: [] } },
     async retryNode() {},

--- a/server/commands/retry.test.ts
+++ b/server/commands/retry.test.ts
@@ -6,6 +6,7 @@ function makeScheduler(shouldFail = false): DagScheduler {
   return {
     async start() {},
     async onSessionCompleted() {},
+    async onSessionResumed() {},
     async cancel() {},
     status() { return { dagId: '', nodes: [] } },
     async retryNode(nodeId, dagId) {

--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -368,4 +368,78 @@ describe("DagScheduler", () => {
 
     expect(stackCommentCallCount).toBeGreaterThan(0)
   })
+
+  it("onSessionResumed resets a failed DAG node back to running", async () => {
+    const graph = buildDag("dag-resume", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const id = `session-${sessions.length}`
+      const session = makeSession(id, db)
+      sessions.push(session.id)
+      prepared.updateSession(db, {
+        id: session.id,
+        updated_at: Date.now(),
+        metadata: { dagId: "dag-resume", dagNodeId: "a" },
+      })
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-resume")
+
+    const sessionId = sessions[0]!
+    await scheduler.onSessionCompleted(sessionId, "errored")
+
+    const afterFail = scheduler.status("dag-resume")
+    expect(afterFail.nodes.find((n) => n.id === "a")?.status).toBe("failed")
+    expect(afterFail.nodes.find((n) => n.id === "b")?.status).toBe("skipped")
+
+    await scheduler.onSessionResumed(sessionId)
+
+    const afterResume = scheduler.status("dag-resume")
+    expect(afterResume.nodes.find((n) => n.id === "a")?.status).toBe("running")
+    expect(afterResume.nodes.find((n) => n.id === "a")?.sessionId).toBe(sessionId)
+  })
+
+  it("onSessionResumed is a no-op when session is not part of a DAG", async () => {
+    const scheduler = makeScheduler(makeRegistry(db))
+    const session = makeSession("loner", db)
+    await expect(scheduler.onSessionResumed(session.id)).resolves.toBeUndefined()
+  })
+
+  it("onSessionResumed is a no-op when node is not in failed state", async () => {
+    const graph = buildDag("dag-resume-noop", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const id = `session-${sessions.length}`
+      const session = makeSession(id, db)
+      sessions.push(session.id)
+      prepared.updateSession(db, {
+        id: session.id,
+        updated_at: Date.now(),
+        metadata: { dagId: "dag-resume-noop", dagNodeId: "a" },
+      })
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-resume-noop")
+
+    const before = scheduler.status("dag-resume-noop")
+    expect(before.nodes[0]?.status).toBe("running")
+
+    await scheduler.onSessionResumed(sessions[0]!)
+
+    const after = scheduler.status("dag-resume-noop")
+    expect(after.nodes[0]?.status).toBe("running")
+  })
 })

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -2,6 +2,7 @@ import type { Database } from "bun:sqlite"
 import { readyNodes, advanceDag, failNode, resetFailedNode, nodeIndex, getUpstreamBranches, isDagComplete } from "./dag"
 import type { DagGraph, DagNode, DagInput } from "./dag"
 import { saveDag, loadDag, listDags } from "./store"
+import { prepared } from "../db/sqlite"
 import { updateStackComment } from "./stack-comment"
 import { buildDagChildPrompt } from "./dag-extract"
 import type { TopicMessage } from "./types"
@@ -105,6 +106,7 @@ export interface DagSchedulerOpts {
 export interface DagScheduler {
   start(dagId: string): Promise<void>
   onSessionCompleted(sessionId: string, state: SessionRunState): Promise<void>
+  onSessionResumed(sessionId: string): Promise<void>
   cancel(dagId: string): Promise<void>
   status(dagId: string): DagStatusSnapshot
   retryNode(nodeId: string, dagId: string): Promise<void>
@@ -341,6 +343,36 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     await tickGraph(graph)
   }
 
+  async function onSessionResumed(sessionId: string): Promise<void> {
+    const row = prepared.getSession(db, sessionId)
+    if (!row) return
+    const meta = row.metadata as { dagId?: string; dagNodeId?: string }
+    if (!meta.dagId || !meta.dagNodeId) return
+
+    let graph = activeGraphs.get(meta.dagId)
+    if (!graph) {
+      const stored = loadDag(meta.dagId, db)
+      if (!stored) return
+      graph = stored
+      activeGraphs.set(meta.dagId, graph)
+      cancelledDags.delete(meta.dagId)
+    }
+
+    const idx = nodeIndex(graph)
+    const node = idx.get(meta.dagNodeId)
+    if (!node) return
+    if (node.status !== "failed" && node.status !== "ci-failed") return
+
+    node.status = "running"
+    node.error = undefined
+    node.sessionId = sessionId
+    nodeToSession.set(node.id, sessionId)
+    nodeToGraph.set(sessionId, graph.id)
+
+    persist(graph)
+    await commentUpdater(graph).catch(() => {})
+  }
+
   async function reconcileOnBoot(): Promise<void> {
     const graphs = listDags(db)
     for (const graph of graphs) {
@@ -421,5 +453,5 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     await tickGraph(graph)
   }
 
-  return { start, onSessionCompleted, cancel, status, retryNode, forceNodeLanded, reconcileOnBoot }
+  return { start, onSessionCompleted, onSessionResumed, cancel, status, retryNode, forceNodeLanded, reconcileOnBoot }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -76,6 +76,9 @@ console.log(`[minion] engine on :${PORT}, ${reconciled} sessions resumed`)
 const scheduler = createDagScheduler({ registry, db, bus, workspace: WORKSPACE_ROOT })
 await scheduler.reconcileOnBoot()
 
+bus.onKind('session.resumed', (ev) => { void scheduler.onSessionResumed(ev.sessionId) })
+bus.onKind('session.reply_injected', (ev) => { void scheduler.onSessionResumed(ev.sessionId) })
+
 const loopScheduler = new LoopScheduler({
   db,
   registry,

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -273,6 +273,7 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
       runtime = await resumeRuntime(row, text, images)
       void runtime.start()
       prepared.updateSession(db(), { id: sessionId, status: 'running', updated_at: Date.now() })
+      bus.emit({ kind: 'session.resumed', sessionId, retryCount: 0 })
       emitSnapshot(sessionId)
       return true
     }


### PR DESCRIPTION
## Summary

When a DAG node's session failed (e.g. from a stream-idle error, recovered by the fix in #114) and the user sent a reply like "fix ci issues" to retry, the session correctly resumed but the DAG node stayed frozen visually as `failed`. The UI's node color is driven by `dagNode.status` (`src/components/universe-layout.ts:85`), which is wholly independent of the underlying session's status — so even though the session was running again, the node stayed red until the run fully completed.

Fix:

- `registry.reply()` now emits `session.resumed` in the cold-resume path (where the previous runtime had been torn down by `onClose`), alongside the existing DB status flip to `running`.
- `DagScheduler` gains `onSessionResumed(sessionId)`: reads the session's `metadata.dagId`/`dagNodeId`, and if the bound node is `failed` (or `ci-failed`), flips it back to `running`, clears `error`, re-registers the `nodeToSession`/`nodeToGraph` bindings that `onSessionCompleted` had cleared, and persists the new DAG snapshot.
- `server/index.ts` wires the scheduler to `session.resumed` and (as a safety net for live-runtime replies) `session.reply_injected`.

Why not reuse `retryNode`: `retryNode` calls `resetFailedNode` which sets the node to `ready` and then `tickGraph` spawns a fresh session — correct for the explicit retry menu, wrong for reply-resume where we already have an in-flight session and want status `running` with the existing `sessionId` preserved.

## Test plan

- [x] New tests in `server/dag/scheduler.test.ts` cover: failed node → reset to `running` on `onSessionResumed`; no-op for sessions without DAG metadata; no-op for nodes not in failed state.
- [x] `bun test server/dag/scheduler.test.ts` — 15 pass.
- [x] `bun test server/` — 641 pass, 0 fail, 1 skip.
- [x] `npm run test` — UI suite unchanged (same 8 pre-existing flakes as baseline, unrelated to this change).
- [x] `npm run typecheck` — no new errors (two pre-existing missing-type-library warnings unchanged).
- [ ] Manual: on a live engine, fail a DAG node via stream-idle, send a reply, observe node color returns to amber/running and then green/done.