### PR TITLE
fix(engine): ship-plan sessions now hand off to ship-verify

### DIFF
--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -178,6 +178,19 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
     }
   }
 
+  if (mode === "ship-plan") {
+    setPipelineAdvancing(ctx, sessionId, true)
+    try {
+      await killAndWait(sessionId, ctx)
+      const result = await handoffShipPhase(sessionId, "ship-verify", ctx)
+      if (!result.ok) setPipelineAdvancing(ctx, sessionId, false)
+      return result
+    } catch (err) {
+      setPipelineAdvancing(ctx, sessionId, false)
+      throw err
+    }
+  }
+
   if (mode === "think" || mode === "plan" || mode === "review") {
     setPipelineAdvancing(ctx, sessionId, true)
     try {

--- a/server/handlers/ship-advance-handler.test.ts
+++ b/server/handlers/ship-advance-handler.test.ts
@@ -199,4 +199,22 @@ describe('shipAdvanceHandler', () => {
     expect(registryCalls.create).toHaveLength(0)
     expect(schedulerCalls.start).toHaveLength(0)
   })
+
+  test('spawns ship-verify session when ship-plan completes', async () => {
+    seedSession(db, 'sess-plan', 'ship-plan')
+    seedAssistantMessage(db, 'sess-plan', 'DAG of tasks: 1. implement auth, 2. add tests, 3. deploy')
+
+    const registryCalls = { stop: [] as string[], create: [] as Array<{ mode: string; prompt: string; parentId?: string }> }
+    const schedulerCalls = { start: [] as string[], onSessionCompleted: [] as string[] }
+    const ctx = makeCtx(db, registryCalls, schedulerCalls)
+
+    const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-plan', state: 'completed', durationMs: 0 }
+    await shipAdvanceHandler.handle(ev, ctx)
+
+    expect(registryCalls.create).toHaveLength(1)
+    expect(registryCalls.create[0]?.mode).toBe('ship-verify')
+    expect(registryCalls.create[0]?.prompt).toContain('DAG of tasks')
+    expect(registryCalls.create[0]?.parentId).toBe('sess-plan')
+    expect(schedulerCalls.start).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
## Summary

- Fixed ship-plan sessions to properly hand off to ship-verify instead of falling through to the default EXECUTE_DIRECTIVE case
- Prevents contradictory "Implement your plan now" messages appearing in readonly plan mode
- Added test coverage for ship-plan → ship-verify handoff

## Background

Previously, when a ship-plan session completed, it fell through to the catch-all case in `handleExecute` which injected the EXECUTE_DIRECTIVE ("Implement your plan now, in this session — do NOT wait for another turn."). This was contradictory because:

1. ship-plan is a readonly mode meant to produce a DAG of tasks, not execute code
2. The directive instructed the agent to write code, commit, push, and create PRs - contradicting the readonly nature
3. This caused "edits in plan mode" as reported

## Changes

- `server/commands/plan-actions.ts`: Added ship-plan → ship-verify handoff case (lines 181-192)
- `server/handlers/ship-advance-handler.test.ts`: Added test for ship-plan completion behavior

The ship pipeline now flows correctly:
- ship-think (design) → ship-plan (DAG creation) → ship-verify (verification)

## Test plan

- [x] All ship-advance-handler tests pass (7 pass)
- [x] All plan-actions tests pass (10 pass)
- [x] All server tests pass (640 pass)
- [x] Lint and typecheck pass