### PR TITLE
feat(ui): add stage-aware primary button in QuickActionsBar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,6 +176,9 @@ function ChatPane({
   }
   const handleSend = (t: string, images?: Array<{ mediaType: string; dataBase64: string }>) => onSend(t, session.id, images)
   const handleQuickAction = (action: QuickAction) => onSend(action.message, session.id)
+  const handleShipAdvance = async (to: import('./api/types').ShipStage) => {
+    await onCommand({ action: 'ship_advance', sessionId: session.id, to })
+  }
 
   const handlePrefillCommand = (fullText: string) => {
     setText(fullText)
@@ -336,7 +339,7 @@ function ChatPane({
               <TranscriptUpgradeNotice store={store} />
             )}
             <div class="shrink-0 border-t border-slate-200 dark:border-slate-700">
-              <QuickActionsBar actions={session.quickActions} onAction={handleQuickAction} />
+              <QuickActionsBar session={session} onAction={handleQuickAction} onShipAdvance={handleShipAdvance} />
               <SlashCommandMenu session={session} context={text} onPrefill={handlePrefillCommand} />
               <MessageInput session={session} store={store} value={text} onValueChange={setText} onSend={handleSend} />
             </div>

--- a/src/chat/QuickActionsBar.tsx
+++ b/src/chat/QuickActionsBar.tsx
@@ -1,16 +1,55 @@
-import type { QuickAction } from '../api/types'
+import type { QuickAction, ApiSession, ShipStage } from '../api/types'
 import { useTheme } from '../hooks/useTheme'
 
 interface QuickActionsBarProps {
-  actions: QuickAction[]
+  session: ApiSession
   onAction: (action: QuickAction) => Promise<void>
+  onShipAdvance?: (to: ShipStage) => Promise<void>
 }
 
-export function QuickActionsBar({ actions, onAction }: QuickActionsBarProps) {
+export function QuickActionsBar({ session, onAction, onShipAdvance }: QuickActionsBarProps) {
   const theme = useTheme()
   const isDark = theme.value === 'dark'
 
-  if (actions.length === 0) return null
+  if (session.mode === 'ship' && session.stage) {
+    if (session.stage === 'done') return null
+
+    const stageConfig = getShipStageConfig(session.stage, session.childIds.length)
+    if (!stageConfig) return null
+
+    const primaryClass = isDark
+      ? 'bg-indigo-600 hover:bg-indigo-700 text-white border-indigo-500'
+      : 'bg-indigo-600 hover:bg-indigo-700 text-white border-indigo-500'
+
+    const disabledClass = isDark
+      ? 'bg-gray-700 text-gray-400 border-gray-600 cursor-not-allowed'
+      : 'bg-gray-100 text-gray-400 border-gray-300 cursor-not-allowed'
+
+    const btnClass = stageConfig.disabled ? disabledClass : primaryClass
+
+    return (
+      <div
+        class="flex flex-wrap gap-2 px-4 py-2 border-t"
+        style={{ borderColor: isDark ? '#374151' : '#e5e7eb' }}
+        data-testid="quick-actions-bar"
+      >
+        <button
+          onClick={() => {
+            if (!stageConfig.disabled && stageConfig.advanceTo && onShipAdvance) {
+              void onShipAdvance(stageConfig.advanceTo)
+            }
+          }}
+          disabled={stageConfig.disabled}
+          class={`text-xs font-medium px-3 py-1.5 rounded-full border transition-colors ${btnClass}`}
+          data-testid="ship-advance-btn"
+        >
+          {stageConfig.label}
+        </button>
+      </div>
+    )
+  }
+
+  if (session.quickActions.length === 0) return null
 
   const btnClass = isDark
     ? 'bg-gray-700 hover:bg-gray-600 text-gray-200 border-gray-600'
@@ -22,7 +61,7 @@ export function QuickActionsBar({ actions, onAction }: QuickActionsBarProps) {
       style={{ borderColor: isDark ? '#374151' : '#e5e7eb' }}
       data-testid="quick-actions-bar"
     >
-      {actions.map((action) => (
+      {session.quickActions.map((action) => (
         <button
           key={action.type}
           onClick={() => void onAction(action)}
@@ -33,4 +72,27 @@ export function QuickActionsBar({ actions, onAction }: QuickActionsBarProps) {
       ))}
     </div>
   )
+}
+
+interface ShipStageConfig {
+  label: string
+  advanceTo?: ShipStage
+  disabled: boolean
+}
+
+function getShipStageConfig(stage: ShipStage, childCount: number): ShipStageConfig | null {
+  switch (stage) {
+    case 'think':
+      return { label: 'Move to plan', advanceTo: 'plan', disabled: false }
+    case 'plan':
+      return { label: 'Start DAG', advanceTo: 'dag', disabled: false }
+    case 'dag':
+      return { label: `Watching ${childCount} children`, disabled: true }
+    case 'verify':
+      return { label: 'Mark done', advanceTo: 'done', disabled: false }
+    case 'done':
+      return null
+    default:
+      return null
+  }
 }

--- a/test/chat/QuickActionsBar.test.tsx
+++ b/test/chat/QuickActionsBar.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QuickActionsBar } from '../../src/chat/QuickActionsBar'
-import type { QuickAction } from '../../src/api/types'
+import type { QuickAction, ApiSession } from '../../src/api/types'
 
 beforeEach(() => {
   if (!window.matchMedia) {
@@ -22,34 +22,190 @@ const actions: QuickAction[] = [
   { type: 'resume', label: 'Resume', message: '/resume' },
 ]
 
+function createSession(overrides: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 'sess-123',
+    slug: 'test-session',
+    status: 'running',
+    command: 'test task',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: actions,
+    mode: 'task',
+    conversation: [],
+    ...overrides,
+  }
+}
+
 describe('QuickActionsBar', () => {
-  it('renders N buttons for N actions', () => {
-    render(<QuickActionsBar actions={actions} onAction={vi.fn().mockResolvedValue(undefined)} />)
-    expect(screen.getByText('Make PR')).toBeTruthy()
-    expect(screen.getByText('Retry')).toBeTruthy()
-    expect(screen.getByText('Resume')).toBeTruthy()
+  describe('non-ship modes', () => {
+    it('renders N buttons for N actions', () => {
+      const session = createSession()
+      render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
+      expect(screen.getByText('Make PR')).toBeTruthy()
+      expect(screen.getByText('Retry')).toBeTruthy()
+      expect(screen.getByText('Resume')).toBeTruthy()
+    })
+
+    it('renders nothing when actions is empty', () => {
+      const session = createSession({ quickActions: [] })
+      const { container } = render(
+        <QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />
+      )
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('calls onAction with the matching QuickAction when button is clicked', async () => {
+      const session = createSession()
+      const onAction = vi.fn().mockResolvedValue(undefined)
+      render(<QuickActionsBar session={session} onAction={onAction} />)
+      fireEvent.click(screen.getByText('Make PR'))
+      expect(onAction).toHaveBeenCalledWith(actions[0])
+    })
+
+    it('calls onAction with the correct action for each button', async () => {
+      const session = createSession()
+      const onAction = vi.fn().mockResolvedValue(undefined)
+      render(<QuickActionsBar session={session} onAction={onAction} />)
+      fireEvent.click(screen.getByText('Retry'))
+      expect(onAction).toHaveBeenCalledWith(actions[1])
+      fireEvent.click(screen.getByText('Resume'))
+      expect(onAction).toHaveBeenCalledWith(actions[2])
+    })
   })
 
-  it('renders nothing when actions is empty', () => {
-    const { container } = render(
-      <QuickActionsBar actions={[]} onAction={vi.fn().mockResolvedValue(undefined)} />
-    )
-    expect(container.firstChild).toBeNull()
-  })
+  describe('ship mode', () => {
+    it('renders "Move to plan" button for think stage', () => {
+      const session = createSession({ mode: 'ship', stage: 'think' })
+      render(
+        <QuickActionsBar
+          session={session}
+          onAction={vi.fn().mockResolvedValue(undefined)}
+          onShipAdvance={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+      expect(screen.getByText('Move to plan')).toBeTruthy()
+    })
 
-  it('calls onAction with the matching QuickAction when button is clicked', async () => {
-    const onAction = vi.fn().mockResolvedValue(undefined)
-    render(<QuickActionsBar actions={actions} onAction={onAction} />)
-    fireEvent.click(screen.getByText('Make PR'))
-    expect(onAction).toHaveBeenCalledWith(actions[0])
-  })
+    it('calls onShipAdvance with "plan" when think stage button is clicked', async () => {
+      const session = createSession({ mode: 'ship', stage: 'think' })
+      const onShipAdvance = vi.fn().mockResolvedValue(undefined)
+      render(
+        <QuickActionsBar
+          session={session}
+          onAction={vi.fn().mockResolvedValue(undefined)}
+          onShipAdvance={onShipAdvance}
+        />
+      )
+      fireEvent.click(screen.getByTestId('ship-advance-btn'))
+      expect(onShipAdvance).toHaveBeenCalledWith('plan')
+    })
 
-  it('calls onAction with the correct action for each button', async () => {
-    const onAction = vi.fn().mockResolvedValue(undefined)
-    render(<QuickActionsBar actions={actions} onAction={onAction} />)
-    fireEvent.click(screen.getByText('Retry'))
-    expect(onAction).toHaveBeenCalledWith(actions[1])
-    fireEvent.click(screen.getByText('Resume'))
-    expect(onAction).toHaveBeenCalledWith(actions[2])
+    it('renders "Start DAG" button for plan stage', () => {
+      const session = createSession({ mode: 'ship', stage: 'plan' })
+      render(
+        <QuickActionsBar
+          session={session}
+          onAction={vi.fn().mockResolvedValue(undefined)}
+          onShipAdvance={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+      expect(screen.getByText('Start DAG')).toBeTruthy()
+    })
+
+    it('calls onShipAdvance with "dag" when plan stage button is clicked', async () => {
+      const session = createSession({ mode: 'ship', stage: 'plan' })
+      const onShipAdvance = vi.fn().mockResolvedValue(undefined)
+      render(
+        <QuickActionsBar
+          session={session}
+          onAction={vi.fn().mockResolvedValue(undefined)}
+          onShipAdvance={onShipAdvance}
+        />
+      )
+      fireEvent.click(screen.getByTestId('ship-advance-btn'))
+      expect(onShipAdvance).toHaveBeenCalledWith('dag')
+    })
+
+    it('renders disabled "Watching N children" button for dag stage', () => {
+      const session = createSession({ mode: 'ship', stage: 'dag', childIds: ['child-1', 'child-2', 'child-3'] })
+      render(
+        <QuickActionsBar
+          session={session}
+          onAction={vi.fn().mockResolvedValue(undefined)}
+          onShipAdvance={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+      const btn = screen.getByTestId('ship-advance-btn') as HTMLButtonElement
+      expect(btn.textContent).toBe('Watching 3 children')
+      expect(btn.disabled).toBe(true)
+    })
+
+    it('does not call onShipAdvance when dag stage button is clicked', async () => {
+      const session = createSession({ mode: 'ship', stage: 'dag', childIds: ['child-1'] })
+      const onShipAdvance = vi.fn().mockResolvedValue(undefined)
+      render(
+        <QuickActionsBar
+          session={session}
+          onAction={vi.fn().mockResolvedValue(undefined)}
+          onShipAdvance={onShipAdvance}
+        />
+      )
+      fireEvent.click(screen.getByTestId('ship-advance-btn'))
+      expect(onShipAdvance).not.toHaveBeenCalled()
+    })
+
+    it('renders "Mark done" button for verify stage', () => {
+      const session = createSession({ mode: 'ship', stage: 'verify' })
+      render(
+        <QuickActionsBar
+          session={session}
+          onAction={vi.fn().mockResolvedValue(undefined)}
+          onShipAdvance={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+      expect(screen.getByText('Mark done')).toBeTruthy()
+    })
+
+    it('calls onShipAdvance with "done" when verify stage button is clicked', async () => {
+      const session = createSession({ mode: 'ship', stage: 'verify' })
+      const onShipAdvance = vi.fn().mockResolvedValue(undefined)
+      render(
+        <QuickActionsBar
+          session={session}
+          onAction={vi.fn().mockResolvedValue(undefined)}
+          onShipAdvance={onShipAdvance}
+        />
+      )
+      fireEvent.click(screen.getByTestId('ship-advance-btn'))
+      expect(onShipAdvance).toHaveBeenCalledWith('done')
+    })
+
+    it('renders nothing for done stage', () => {
+      const session = createSession({ mode: 'ship', stage: 'done' })
+      const { container } = render(
+        <QuickActionsBar
+          session={session}
+          onAction={vi.fn().mockResolvedValue(undefined)}
+          onShipAdvance={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('renders nothing when ship mode has no stage and no quick actions', () => {
+      const session = createSession({ mode: 'ship', stage: undefined, quickActions: [] })
+      const { container } = render(
+        <QuickActionsBar
+          session={session}
+          onAction={vi.fn().mockResolvedValue(undefined)}
+          onShipAdvance={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+      expect(container.firstChild).toBeNull()
+    })
   })
 })


### PR DESCRIPTION
## Summary

Implements stage-aware ship coordinator controls in `QuickActionsBar`:
- When `session.mode === 'ship'`, renders a single primary button whose label and behavior depend on `session.stage`
- **think** → "Move to plan" (advances to 'plan')
- **plan** → "Start DAG" (advances to 'dag')  
- **dag** → disabled badge: "Watching N children"
- **verify** → "Mark done" (advances to 'done')
- **done** → hidden (returns null)

## Changes

- **QuickActionsBar.tsx**: Added `session` prop and `onShipAdvance` callback; ship mode renders stage-specific button instead of generic quick actions
- **App.tsx**: Added `handleShipAdvance` that sends `ship_advance` command; updated QuickActionsBar props
- **QuickActionsBar.test.tsx**: Added comprehensive tests for all ship stages and their click behaviors

## Test plan

- [x] Unit tests pass for all ship stages (think, plan, dag, verify, done)
- [x] Verify button labels match spec for each stage
- [x] Verify `onShipAdvance` called with correct target stage
- [x] Verify dag stage button is disabled
- [x] Verify done stage renders nothing
- [x] Verify non-ship modes still render quick actions as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)