### PR TITLE
feat(ui): render child_completed status events in transcript

### DIFF
--- a/src/chat/transcript/StatusBanner.tsx
+++ b/src/chat/transcript/StatusBanner.tsx
@@ -1,4 +1,5 @@
 import type { StatusEvent } from '../../api/types'
+import { PrLink } from '../../components/PrLink'
 import { StatusIcon } from './icons'
 
 interface Props {
@@ -18,6 +19,7 @@ const KIND_LABELS: Record<string, string> = {
   session_resumed: 'Session resumed',
   quota_exhausted: 'Quota exhausted',
   stream_stalled: 'Stream stalled',
+  child_completed: 'Child task',
 }
 
 function formatKind(kind: string): string {
@@ -28,7 +30,60 @@ function formatKind(kind: string): string {
     .join(' ')
 }
 
+interface ChildCompletedData {
+  slug?: string
+  status?: 'completed' | 'failed'
+  prUrl?: string
+}
+
+function isChildCompletedData(data: unknown): data is ChildCompletedData {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    ('slug' in data || 'status' in data || 'prUrl' in data)
+  )
+}
+
+function ChildCompletedCard({ data }: { data: ChildCompletedData }) {
+  const status = data.status ?? 'completed'
+  const isSuccess = status === 'completed'
+  const chipBg = isSuccess
+    ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300'
+    : 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'
+
+  return (
+    <div class="flex items-center gap-2 flex-wrap">
+      <span class="font-mono text-xs text-slate-700 dark:text-slate-200">
+        {data.slug ?? 'child'}
+      </span>
+      <span
+        class={`text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded ${chipBg}`}
+        data-testid="child-status-chip"
+      >
+        {status}
+      </span>
+      {data.prUrl && <PrLink prUrl={data.prUrl} compact />}
+    </div>
+  )
+}
+
 export function StatusBanner({ event }: Props) {
+  if (event.kind === 'child_completed' && isChildCompletedData(event.data)) {
+    return (
+      <div
+        class="flex items-start gap-2 rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/40 px-3 py-1.5 text-xs"
+        data-testid="transcript-status"
+        data-severity={event.severity}
+        data-kind={event.kind}
+      >
+        <StatusIcon severity={event.severity} class="w-3.5 h-3.5 mt-0.5 shrink-0" />
+        <div class="flex-1 min-w-0">
+          <ChildCompletedCard data={event.data} />
+        </div>
+      </div>
+    )
+  }
+
   const tone = TONE[event.severity]
   return (
     <div

--- a/test/chat/transcript/components.test.tsx
+++ b/test/chat/transcript/components.test.tsx
@@ -407,6 +407,107 @@ describe('StatusBanner', () => {
     const banner = screen.getByTestId('transcript-status')
     expect(banner.textContent).toContain('Session interrupted')
   })
+
+  it('renders child_completed status with slug and status chip', () => {
+    const event: StatusEvent = {
+      ...baseEvent(1),
+      type: 'status',
+      severity: 'info',
+      kind: 'child_completed',
+      message: '',
+      data: {
+        slug: 'fix-login-bug',
+        status: 'completed',
+      },
+    }
+    render(<StatusBanner event={event} />)
+    const banner = screen.getByTestId('transcript-status')
+    expect(banner.getAttribute('data-kind')).toBe('child_completed')
+    expect(banner.textContent).toContain('fix-login-bug')
+    const chip = screen.getByTestId('child-status-chip')
+    expect(chip.textContent).toBe('completed')
+  })
+
+  it('renders child_completed with failed status', () => {
+    const event: StatusEvent = {
+      ...baseEvent(1),
+      type: 'status',
+      severity: 'info',
+      kind: 'child_completed',
+      message: '',
+      data: {
+        slug: 'refactor-database',
+        status: 'failed',
+      },
+    }
+    render(<StatusBanner event={event} />)
+    expect(screen.getByText('refactor-database')).toBeTruthy()
+    const chip = screen.getByTestId('child-status-chip')
+    expect(chip.textContent).toBe('failed')
+  })
+
+  it('renders child_completed with prUrl', () => {
+    const event: StatusEvent = {
+      ...baseEvent(1),
+      type: 'status',
+      severity: 'info',
+      kind: 'child_completed',
+      message: '',
+      data: {
+        slug: 'add-feature-x',
+        status: 'completed',
+        prUrl: 'https://github.com/owner/repo/pull/42',
+      },
+    }
+    render(<StatusBanner event={event} />)
+    expect(screen.getByText('add-feature-x')).toBeTruthy()
+    expect(screen.getByText('#42')).toBeTruthy()
+  })
+
+  it('defaults to completed status when not provided', () => {
+    const event: StatusEvent = {
+      ...baseEvent(1),
+      type: 'status',
+      severity: 'info',
+      kind: 'child_completed',
+      message: '',
+      data: {
+        slug: 'task-without-status',
+      },
+    }
+    render(<StatusBanner event={event} />)
+    const chip = screen.getByTestId('child-status-chip')
+    expect(chip.textContent).toBe('completed')
+  })
+
+  it('defaults to "child" slug when not provided', () => {
+    const event: StatusEvent = {
+      ...baseEvent(1),
+      type: 'status',
+      severity: 'info',
+      kind: 'child_completed',
+      message: '',
+      data: {
+        status: 'completed',
+      },
+    }
+    render(<StatusBanner event={event} />)
+    expect(screen.getByText('child')).toBeTruthy()
+  })
+
+  it('falls back to generic rendering when data is missing for child_completed', () => {
+    const event: StatusEvent = {
+      ...baseEvent(1),
+      type: 'status',
+      severity: 'info',
+      kind: 'child_completed',
+      message: 'Child completed',
+    }
+    render(<StatusBanner event={event} />)
+    const banner = screen.getByTestId('transcript-status')
+    expect(banner.textContent).toContain('Child task')
+    expect(banner.textContent).toContain('Child completed')
+  })
 })
 
 describe('TurnSeparator', () => {


### PR DESCRIPTION
## Summary

Adds special rendering for `child_completed` status events in the transcript StatusBanner component. When a coordinator session receives a child completion notification, the UI now displays:

- Child session slug
- Status chip (completed/failed) with appropriate color coding
- PR link (when available)

Falls back to generic status rendering when the expected data structure is missing.

## Changes

- `src/chat/transcript/StatusBanner.tsx`: Add child_completed case with dedicated card component
- `test/chat/transcript/components.test.tsx`: Add comprehensive test coverage for all child_completed scenarios

## Test plan

- [x] Unit tests pass for all child_completed scenarios (completed, failed, with/without PR, missing data)
- [x] All transcript component tests pass
- [x] Lint passes
- [ ] Visual verification in browser (coordinator flow not yet fully wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)