### PR TITLE
feat(server): Codex CLI provider — AGENT_PROVIDER=codex

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,6 +1,12 @@
 # Required
 MINION_API_TOKEN=change-me-generate-a-random-token
+
+# claude | codex — picks the coding agent backend
+AGENT_PROVIDER=claude
+
+# Optional if ~/.claude is mounted (dev compose does this)
 ANTHROPIC_API_KEY=sk-ant-...
+# Codex uses ChatGPT coding plan auth; no API key needed — mount ~/.codex via compose.codex.yaml after running 'codex login' on the host.
 
 # For github PR/commit operations
 GITHUB_TOKEN=ghp_...

--- a/docker/README.md
+++ b/docker/README.md
@@ -80,6 +80,22 @@ The engine will:
 
 The PWA renders the transcript as it arrives.
 
+## Run with Codex
+
+Prereq: run `codex login` on the host once. This stores credentials in `~/.codex`.
+
+```sh
+docker compose -f docker/compose.yaml -f docker/compose.codex.yaml up
+```
+
+The override sets `AGENT_PROVIDER=codex` and mounts `~/.codex` into the container. Same PWA, same API — no other changes. No API key required; Codex authenticates via your ChatGPT coding plan.
+
+Build the image first if you haven't:
+
+```sh
+docker build -f docker/engine.Dockerfile -t minions-engine:local .
+```
+
 ## Run with cloudflared tunnel
 
 Add a `CLOUDFLARE_TUNNEL_TOKEN` to `.env`, then:
@@ -88,14 +104,18 @@ Add a `CLOUDFLARE_TUNNEL_TOKEN` to `.env`, then:
 docker compose --profile tunnel up
 ```
 
-## Claude auth in the container
+## Agent auth in the container
 
-Two options:
+### Claude
 
 - **Preferred (dev)**: mount `~/.claude` — `compose.dev.yaml` already does this. Requires you've done `claude auth login` on the host.
 - **Headless**: set `ANTHROPIC_API_KEY` in `docker/.env`. The CLI picks it up without a login.
 
 Remove the `~/.claude` mount in `compose.dev.yaml` if you want full isolation per container.
+
+### Codex
+
+- **Only option**: mount `~/.codex` — `compose.dev.yaml` and `compose.codex.yaml` both do this. Requires you've run `codex login` on the host. There is no API key fallback; Codex auth is tied to your ChatGPT coding plan.
 
 ## Persistence
 

--- a/docker/compose.codex.yaml
+++ b/docker/compose.codex.yaml
@@ -1,0 +1,6 @@
+services:
+  engine:
+    environment:
+      AGENT_PROVIDER: codex
+    volumes:
+      - ${HOME}/.codex:/workspace/home/.codex

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -4,5 +4,6 @@ services:
     volumes:
       - /home/prei/minions/minions-ui:/hostrepo:ro
       - ${HOME}/.claude:/workspace/home/.claude
+      - ${HOME}/.codex:/workspace/home/.codex
     environment:
       DEFAULT_REPO: file:///hostrepo

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -23,6 +23,7 @@ services:
       ENABLE_CONTEXT7_MCP: ${ENABLE_CONTEXT7_MCP:-true}
       ENABLE_SUPABASE_MCP: ${ENABLE_SUPABASE_MCP:-false}
       ENABLE_LOOPS: ${ENABLE_LOOPS:-false}
+      AGENT_PROVIDER: ${AGENT_PROVIDER:-claude}
     volumes:
       - workspace:/workspace
 

--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN npm install -g \
       @anthropic-ai/claude-code \
+      @openai/codex \
       @playwright/mcp \
       @upstash/context7-mcp \
       github-mcp-server

--- a/server/api/routes.inbound-images.test.ts
+++ b/server/api/routes.inbound-images.test.ts
@@ -7,7 +7,7 @@ import { resetEventBus } from '../events/bus'
 import { runMigrations } from '../db/sqlite'
 import { registerApiRoutes } from './routes'
 import type { SpawnFn, SubprocessHandle } from '../session/runtime'
-import { serializeUserMessage } from '../session/stream-json'
+import { serializeUserMessage } from '../session/providers/claude/stream'
 
 function setupTestDb(): Database {
   const db = new Database(':memory:')

--- a/server/api/routes.test.ts
+++ b/server/api/routes.test.ts
@@ -98,7 +98,7 @@ describe('GET /api/version', () => {
     const app = makeApp(testDb)
     const res = await app.fetch(new Request('http://localhost/api/version'))
     expect(res.status).toBe(200)
-    const body = await json<{ data: { apiVersion: string; libraryVersion: string; features: string[] } }>(res)
+    const body = await json<{ data: { apiVersion: string; libraryVersion: string; features: string[]; provider: string } }>(res)
     expect(body.data.apiVersion).toBeTruthy()
     expect(body.data.libraryVersion).toBeTruthy()
     const features = body.data.features
@@ -107,6 +107,7 @@ describe('GET /api/version', () => {
     expect(features).toContain('transcript')
     expect(features).toContain('auth')
     expect(features).toContain('cors-allowlist')
+    expect(body.data.provider).toBe('claude')
   })
 })
 

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -48,6 +48,7 @@ import { handleConfigCommand } from '../commands/config'
 import { handleLoopsCommand } from '../commands/loops'
 import { handleDoneCommand } from '../commands/done'
 import { handleDoctorCommand } from '../commands/doctor'
+import { getProvider } from '../session/providers/index'
 
 const API_VERSION = '2.0.0'
 const LIBRARY_VERSION = '0.1.0'
@@ -185,7 +186,7 @@ export function registerApiRoutes(
 
   app.get('/api/version', (c) => {
     const body: ApiResponse<VersionInfo> = {
-      data: { apiVersion: API_VERSION, libraryVersion: LIBRARY_VERSION, features: FEATURES },
+      data: { apiVersion: API_VERSION, libraryVersion: LIBRARY_VERSION, features: FEATURES, provider: getProvider().name },
     }
     return c.json(body)
   })

--- a/server/cli/doctor.test.ts
+++ b/server/cli/doctor.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { formatDoctorReport } from './doctor'
 import type { DoctorReport } from './doctor'
+import type { AgentProvider } from '../session/providers/types'
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `doctor-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
@@ -89,9 +90,9 @@ describe('runDoctor', () => {
     rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  test('returns a DoctorReport with all expected check names', async () => {
+  test('returns a DoctorReport with all expected check names (claude provider)', async () => {
     const { runDoctor } = await import('./doctor')
-    const report = await runDoctor()
+    const report = await runDoctor({ name: 'claude' } as AgentProvider)
     const names = report.checks.map((c) => c.name)
     expect(names.some((n) => n.includes('Node'))).toBe(true)
     expect(names.some((n) => n.includes('WORKSPACE_ROOT'))).toBe(true)
@@ -99,6 +100,22 @@ describe('runDoctor', () => {
     expect(names.some((n) => n.includes('MINION_API_TOKEN'))).toBe(true)
     expect(names.some((n) => n.includes('GITHUB_TOKEN'))).toBe(true)
     expect(names.some((n) => n.includes('claude'))).toBe(true)
+  })
+
+  test('codex provider includes codex CLI and auth checks instead of claude', async () => {
+    const { runDoctor } = await import('./doctor')
+    const report = await runDoctor({ name: 'codex' } as AgentProvider)
+    const names = report.checks.map((c) => c.name)
+    expect(names.some((n) => n.includes('codex'))).toBe(true)
+    expect(names.every((n) => !n.includes('claude'))).toBe(true)
+  })
+
+  test('codex provider includes both binary and auth checks', async () => {
+    const { runDoctor } = await import('./doctor')
+    const report = await runDoctor({ name: 'codex' } as AgentProvider)
+    const names = report.checks.map((c) => c.name)
+    expect(names.some((n) => n === 'codex CLI')).toBe(true)
+    expect(names.some((n) => n === 'codex auth')).toBe(true)
   })
 
   test('WORKSPACE_ROOT writable check passes for writable dir', async () => {

--- a/server/cli/doctor.ts
+++ b/server/cli/doctor.ts
@@ -1,6 +1,10 @@
 import { execFile as execFileCb } from 'node:child_process'
 import { access, constants } from 'node:fs/promises'
 import { createServer } from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import { getProvider } from '../session/providers/index.js'
+import type { AgentProvider } from '../session/providers/types.js'
 
 export interface DoctorCheck {
   name: string
@@ -80,7 +84,7 @@ async function checkGithubToken(): Promise<DoctorCheck> {
   return { name: 'GITHUB_TOKEN', status: 'warn', detail: 'not set and gh auth token failed' }
 }
 
-async function checkClaudeAuth(): Promise<DoctorCheck> {
+async function checkClaude(): Promise<DoctorCheck> {
   const result = await execAsync('claude', ['--version'], 5000).catch(() => null)
   if (result !== null) {
     return { name: 'claude CLI', status: 'ok', detail: result.stdout.split('\n')[0] ?? result.stdout }
@@ -88,14 +92,53 @@ async function checkClaudeAuth(): Promise<DoctorCheck> {
   return { name: 'claude CLI', status: 'fail', detail: 'claude --version failed — is claude CLI installed and on PATH?' }
 }
 
-export async function runDoctor(): Promise<DoctorReport> {
+async function checkCodexBinary(): Promise<DoctorCheck> {
+  const result = await execAsync('codex', ['--version'], 5000).catch(() => null)
+  if (result !== null) {
+    return { name: 'codex CLI', status: 'ok', detail: result.stdout.split('\n')[0] ?? result.stdout }
+  }
+  return { name: 'codex CLI', status: 'fail', detail: 'codex --version failed — is @openai/codex installed and on PATH?' }
+}
+
+async function checkCodexAuth(): Promise<DoctorCheck> {
+  const codexHome = process.env['CODEX_HOME'] ?? path.join(os.homedir(), '.codex')
+  const authPath = path.join(codexHome, 'auth.json')
+  const hasAuth = await access(authPath, constants.R_OK).then(() => true).catch(() => false)
+
+  if (hasAuth) {
+    return { name: 'codex auth', status: 'ok', detail: authPath }
+  }
+
+  if (process.env['OPENAI_API_KEY']) {
+    return {
+      name: 'codex auth',
+      status: 'warn',
+      detail: `${authPath} not found but OPENAI_API_KEY is set — Codex will use PAYG API, not ChatGPT plan auth. Run \`codex login\` on the host.`,
+    }
+  }
+
+  return {
+    name: 'codex auth',
+    status: 'fail',
+    detail: `${authPath} not found — run \`codex login\` on the host then redeploy`,
+  }
+}
+
+export async function runDoctor(provider?: AgentProvider): Promise<DoctorReport> {
+  const activeProvider = provider ?? getProvider()
+
+  const providerChecks: Promise<DoctorCheck>[] =
+    activeProvider.name === 'claude'
+      ? [checkClaude()]
+      : [checkCodexBinary(), checkCodexAuth()]
+
   const checks = await Promise.all([
     checkNodeVersion(),
     checkWorkspaceWritable(),
     checkPortFreeCheck(),
     checkApiToken(),
     checkGithubToken(),
-    checkClaudeAuth(),
+    ...providerChecks,
   ])
 
   return { checks }

--- a/server/commands/plan-actions.test.ts
+++ b/server/commands/plan-actions.test.ts
@@ -168,7 +168,7 @@ describe("plan-actions gating", () => {
     const startedDagIds: string[] = []
     const mockRuntime: Partial<SessionRuntime> = {
       running: false,
-      currentClaudeSessionId: undefined,
+      currentProviderSessionId: undefined,
       start: async () => {},
       injectInput: async () => false,
       stop: async () => {},

--- a/server/session/env.ts
+++ b/server/session/env.ts
@@ -3,10 +3,8 @@ import path from 'node:path'
 
 export function buildIsolatedEnv({
   workspaceHome,
-  parentHome,
 }: {
   workspaceHome: string
-  parentHome: string
 }): NodeJS.ProcessEnv {
   for (const subdir of [
     '.claude',
@@ -20,12 +18,6 @@ export function buildIsolatedEnv({
     fs.mkdirSync(path.join(workspaceHome, subdir), { recursive: true })
   }
 
-  const srcSettings = path.join(parentHome, '.claude', 'settings.json')
-  const dstSettings = path.join(workspaceHome, '.claude', 'settings.json')
-  if (fs.existsSync(srcSettings) && !fs.existsSync(dstSettings)) {
-    fs.copyFileSync(srcSettings, dstSettings)
-  }
-
   const env: NodeJS.ProcessEnv = { ...process.env }
 
   env['HOME'] = workspaceHome
@@ -34,9 +26,7 @@ export function buildIsolatedEnv({
   env['XDG_CACHE_HOME'] = path.join(workspaceHome, '.cache')
   env['XDG_DATA_HOME'] = path.join(workspaceHome, '.local', 'share')
   env['XDG_STATE_HOME'] = path.join(workspaceHome, '.local', 'state')
-  env['CLAUDE_CONFIG_DIR'] = path.join(parentHome, '.claude')
   env['PLAYWRIGHT_BROWSERS_PATH'] = process.env['PLAYWRIGHT_BROWSERS_PATH'] ?? '/opt/pw-browsers'
-  env['CLAUDE_CODE_STREAM_CLOSE_TIMEOUT'] = '30000'
 
   for (const key of ['GITHUB_TOKEN', 'GITHUB_PERSONAL_ACCESS_TOKEN', 'SUPABASE_ACCESS_TOKEN'] as const) {
     if (process.env[key] !== undefined) {

--- a/server/session/prompts.test.ts
+++ b/server/session/prompts.test.ts
@@ -88,7 +88,7 @@ describe('getModeConfig', () => {
   })
 
   describe('autoExitOnComplete parity', () => {
-    const modes = ['task', 'dag-task', 'plan', 'think', 'review', 'ship-think', 'ship-plan', 'ship-verify', 'ci-fix'] as const
+    const modes = ['task', 'dag-task', 'plan', 'think', 'review', 'ship', 'ci-fix'] as const
 
     for (const mode of modes) {
       test(`${mode}: claude and codex have same autoExitOnComplete`, () => {

--- a/server/session/prompts.test.ts
+++ b/server/session/prompts.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { getModeConfig, CLAUDE_MODE_CONFIGS, CODEX_MODE_CONFIGS } from './prompts'
+
+describe('getModeConfig', () => {
+  describe('claude provider', () => {
+    test('plan mode uses Claude default model', () => {
+      const cfg = getModeConfig('claude', 'plan')
+      expect(cfg.model).toBe(CLAUDE_MODE_CONFIGS['plan'].model)
+      expect(cfg.model).toContain('claude')
+    })
+
+    test('task mode has no reasoningEffort', () => {
+      const cfg = getModeConfig('claude', 'task')
+      expect(cfg.reasoningEffort).toBeUndefined()
+    })
+
+    test('plan mode has disallowedTools for readonly enforcement', () => {
+      const cfg = getModeConfig('claude', 'plan')
+      expect(cfg.disallowedTools).toContain('Edit')
+      expect(cfg.disallowedTools).toContain('Write')
+    })
+
+    test('CLAUDE_TASK_MODEL env override is respected', () => {
+      // CLAUDE_MODE_CONFIGS is built at module load time, so we test the
+      // exported object directly (env vars are captured at import time in tests)
+      expect(typeof CLAUDE_MODE_CONFIGS['task'].model).toBe('string')
+      expect(CLAUDE_MODE_CONFIGS['task'].model.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('codex provider', () => {
+    test('plan mode has reasoningEffort high by default', () => {
+      const cfg = getModeConfig('codex', 'plan')
+      expect(cfg.reasoningEffort).toBe('high')
+    })
+
+    test('plan mode has sandbox read-only', () => {
+      const cfg = getModeConfig('codex', 'plan')
+      expect(cfg.sandbox).toBe('read-only')
+    })
+
+    test('task mode has no reasoningEffort', () => {
+      const cfg = getModeConfig('codex', 'task')
+      expect(cfg.reasoningEffort).toBeUndefined()
+    })
+
+    test('task mode has no sandbox', () => {
+      const cfg = getModeConfig('codex', 'task')
+      expect(cfg.sandbox).toBeUndefined()
+    })
+
+    test('task mode disallowedTools is empty (sandbox enforces readonly)', () => {
+      const cfg = getModeConfig('codex', 'task')
+      expect(cfg.disallowedTools).toHaveLength(0)
+    })
+
+    test('plan mode disallowedTools is empty (sandbox enforces readonly)', () => {
+      const cfg = getModeConfig('codex', 'plan')
+      expect(cfg.disallowedTools).toHaveLength(0)
+    })
+
+    test('codex task model uses gpt-5.1-codex default', () => {
+      const cfg = getModeConfig('codex', 'task')
+      expect(cfg.model).toBe(CODEX_MODE_CONFIGS['task'].model)
+    })
+  })
+
+  describe('CODEX_TASK_MODEL env override', () => {
+    let originalVal: string | undefined
+
+    beforeEach(() => {
+      originalVal = process.env['CODEX_TASK_MODEL']
+    })
+
+    afterEach(() => {
+      if (originalVal === undefined) {
+        delete process.env['CODEX_TASK_MODEL']
+      } else {
+        process.env['CODEX_TASK_MODEL'] = originalVal
+      }
+    })
+
+    test('CODEX_MODE_CONFIGS task model reflects env at module load time', () => {
+      // The config is evaluated at module import, so we just assert the type here.
+      // Real env-override behaviour is covered by the integration/e2e layer.
+      expect(typeof CODEX_MODE_CONFIGS['task'].model).toBe('string')
+    })
+  })
+
+  describe('autoExitOnComplete parity', () => {
+    const modes = ['task', 'dag-task', 'plan', 'think', 'review', 'ship-think', 'ship-plan', 'ship-verify', 'ci-fix'] as const
+
+    for (const mode of modes) {
+      test(`${mode}: claude and codex have same autoExitOnComplete`, () => {
+        expect(getModeConfig('claude', mode).autoExitOnComplete).toBe(getModeConfig('codex', mode).autoExitOnComplete)
+      })
+    }
+  })
+})

--- a/server/session/prompts.ts
+++ b/server/session/prompts.ts
@@ -1,4 +1,7 @@
 import type { CreateSessionMode } from '../../shared/api-types'
+import type { ModeConfig } from './providers/types'
+
+export type { ModeConfig }
 
 export const DEFAULT_TASK_PROMPT = 'You are executing a coding task. Work autonomously and conclude with a clear summary.'
 export const DEFAULT_PLAN_PROMPT = 'You produce a detailed implementation plan without modifying files.'
@@ -11,19 +14,17 @@ const READONLY_DISALLOWED_TOOLS = ['Edit', 'Write', 'NotebookEdit'] as const
 
 export type AllSessionMode = CreateSessionMode | 'ci-fix'
 
-export interface ModeConfig {
-  systemPrompt: string
-  model: string
-  disallowedTools: string[]
-  autoExitOnComplete: boolean
-}
-
-// Per-mode env overrides: e.g. CLAUDE_TASK_MODEL, CLAUDE_PLAN_MODEL, etc.
 function envModel(key: string, fallback: string): string {
   return process.env[key] ?? fallback
 }
 
-export const MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
+function envReasoningEffort(key: string, fallback: ModeConfig['reasoningEffort']): ModeConfig['reasoningEffort'] {
+  const val = process.env[key]
+  if (val === 'minimal' || val === 'low' || val === 'medium' || val === 'high') return val
+  return fallback
+}
+
+export const CLAUDE_MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
   task: {
     systemPrompt: DEFAULT_TASK_PROMPT,
     model: envModel('CLAUDE_TASK_MODEL', 'claude-sonnet-4-5-20250929'),
@@ -66,4 +67,82 @@ export const MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
     disallowedTools: [],
     autoExitOnComplete: true,
   },
+}
+
+const CODEX_REASONING_EFFORT = envReasoningEffort('CODEX_REASONING_EFFORT', 'high')
+
+export const CODEX_MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
+  task: {
+    systemPrompt: DEFAULT_TASK_PROMPT,
+    model: envModel('CODEX_TASK_MODEL', 'gpt-5.1-codex'),
+    disallowedTools: [],
+    autoExitOnComplete: false,
+  },
+  'dag-task': {
+    systemPrompt: DEFAULT_TASK_PROMPT,
+    model: envModel('CODEX_TASK_MODEL', 'gpt-5.1-codex'),
+    disallowedTools: [],
+    autoExitOnComplete: true,
+  },
+  plan: {
+    systemPrompt: DEFAULT_PLAN_PROMPT,
+    model: envModel('CODEX_PLAN_MODEL', 'gpt-5.1-codex'),
+    disallowedTools: [],
+    autoExitOnComplete: false,
+    reasoningEffort: CODEX_REASONING_EFFORT,
+    sandbox: 'read-only',
+  },
+  think: {
+    systemPrompt: DEFAULT_THINK_PROMPT,
+    model: envModel('CODEX_THINK_MODEL', 'gpt-5.1-codex'),
+    disallowedTools: [],
+    autoExitOnComplete: false,
+    reasoningEffort: CODEX_REASONING_EFFORT,
+    sandbox: 'read-only',
+  },
+  review: {
+    systemPrompt: DEFAULT_REVIEW_PROMPT,
+    model: envModel('CODEX_REVIEW_MODEL', 'gpt-5.1-codex'),
+    disallowedTools: [],
+    autoExitOnComplete: false,
+    reasoningEffort: CODEX_REASONING_EFFORT,
+    sandbox: 'read-only',
+  },
+  'ship-think': {
+    systemPrompt: DEFAULT_SHIP_THINK_PROMPT,
+    model: envModel('CODEX_SHIP_THINK_MODEL', 'gpt-5.1-codex'),
+    disallowedTools: [],
+    autoExitOnComplete: true,
+    reasoningEffort: CODEX_REASONING_EFFORT,
+    sandbox: 'read-only',
+  },
+  'ship-plan': {
+    systemPrompt: DEFAULT_SHIP_PLAN_PROMPT,
+    model: envModel('CODEX_SHIP_PLAN_MODEL', 'gpt-5.1-codex'),
+    disallowedTools: [],
+    autoExitOnComplete: true,
+    reasoningEffort: CODEX_REASONING_EFFORT,
+    sandbox: 'read-only',
+  },
+  'ship-verify': {
+    systemPrompt: DEFAULT_SHIP_VERIFY_PROMPT,
+    model: envModel('CODEX_SHIP_VERIFY_MODEL', 'gpt-5.1-codex'),
+    disallowedTools: [],
+    autoExitOnComplete: true,
+  },
+  'ci-fix': {
+    systemPrompt: DEFAULT_CI_FIX_PROMPT,
+    model: envModel('CODEX_CI_FIX_MODEL', 'gpt-5.1-codex'),
+    disallowedTools: [],
+    autoExitOnComplete: true,
+  },
+}
+
+const MODE_CONFIG_MAP: Record<'claude' | 'codex', Record<AllSessionMode, ModeConfig>> = {
+  claude: CLAUDE_MODE_CONFIGS,
+  codex: CODEX_MODE_CONFIGS,
+}
+
+export function getModeConfig(provider: 'claude' | 'codex', mode: AllSessionMode): ModeConfig {
+  return MODE_CONFIG_MAP[provider][mode]
 }

--- a/server/session/prompts.ts
+++ b/server/session/prompts.ts
@@ -108,27 +108,12 @@ export const CODEX_MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
     reasoningEffort: CODEX_REASONING_EFFORT,
     sandbox: 'read-only',
   },
-  'ship-think': {
-    systemPrompt: DEFAULT_SHIP_THINK_PROMPT,
-    model: envModel('CODEX_SHIP_THINK_MODEL', 'gpt-5.1-codex'),
+  ship: {
+    systemPrompt: DEFAULT_SHIP_PROMPT,
+    model: envModel('CODEX_SHIP_MODEL', 'gpt-5.1-codex'),
     disallowedTools: [],
-    autoExitOnComplete: true,
+    autoExitOnComplete: false,
     reasoningEffort: CODEX_REASONING_EFFORT,
-    sandbox: 'read-only',
-  },
-  'ship-plan': {
-    systemPrompt: DEFAULT_SHIP_PLAN_PROMPT,
-    model: envModel('CODEX_SHIP_PLAN_MODEL', 'gpt-5.1-codex'),
-    disallowedTools: [],
-    autoExitOnComplete: true,
-    reasoningEffort: CODEX_REASONING_EFFORT,
-    sandbox: 'read-only',
-  },
-  'ship-verify': {
-    systemPrompt: DEFAULT_SHIP_VERIFY_PROMPT,
-    model: envModel('CODEX_SHIP_VERIFY_MODEL', 'gpt-5.1-codex'),
-    disallowedTools: [],
-    autoExitOnComplete: true,
   },
   'ci-fix': {
     systemPrompt: DEFAULT_CI_FIX_PROMPT,

--- a/server/session/providers/claude/env.ts
+++ b/server/session/providers/claude/env.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export function applyClaudeEnv(
+  env: NodeJS.ProcessEnv,
+  opts: { workspaceHome: string; parentHome: string },
+): void {
+  const { workspaceHome, parentHome } = opts
+
+  const srcSettings = path.join(parentHome, '.claude', 'settings.json')
+  const dstSettings = path.join(workspaceHome, '.claude', 'settings.json')
+  if (fs.existsSync(srcSettings) && !fs.existsSync(dstSettings)) {
+    fs.copyFileSync(srcSettings, dstSettings)
+  }
+
+  env['CLAUDE_CONFIG_DIR'] = path.join(parentHome, '.claude')
+  env['CLAUDE_CODE_STREAM_CLOSE_TIMEOUT'] = '30000'
+}

--- a/server/session/providers/claude/provider.ts
+++ b/server/session/providers/claude/provider.ts
@@ -1,0 +1,56 @@
+import { buildIsolatedEnv } from '../../env.js'
+import { applyClaudeEnv } from './env.js'
+import { isQuotaError } from '../../quota-detection.js'
+import { parseClaudeLine, translateLine, serializeUserMessage } from './stream.js'
+import type { AgentProvider, Image, ParserState, ProviderEvent, SpawnArgsOpts } from '../types.js'
+
+interface ClaudeParserState {
+  providerSessionId: string | undefined
+}
+
+export const claudeProvider: AgentProvider = {
+  name: 'claude',
+
+  buildSpawnArgs(opts: SpawnArgsOpts): { argv: string[]; env: NodeJS.ProcessEnv } {
+    const argv: string[] = [
+      'claude',
+      '--print',
+      '--output-format', 'stream-json',
+      '--input-format', 'stream-json',
+      '--verbose',
+      '--include-partial-messages',
+      '--dangerously-skip-permissions',
+      ...(opts.modeConfig.disallowedTools.length
+        ? ['--disallowed-tools', ...opts.modeConfig.disallowedTools]
+        : []),
+      ...(opts.mcpConfig && Object.keys(opts.mcpConfig.mcpServers).length
+        ? ['--mcp-config', JSON.stringify(opts.mcpConfig)]
+        : []),
+      '--append-system-prompt', opts.modeConfig.systemPrompt,
+      '--model', opts.modeConfig.model,
+      ...(opts.resumeSessionId ? ['--resume', opts.resumeSessionId] : []),
+    ]
+    const env = buildIsolatedEnv({ workspaceHome: opts.workspaceHome })
+    applyClaudeEnv(env, { workspaceHome: opts.workspaceHome, parentHome: opts.parentHome })
+    return { argv, env }
+  },
+
+  serializeInitialInput: (prompt: string, images: Image[] | undefined): string =>
+    serializeUserMessage(prompt, images),
+
+  serializeUserReply: (prompt: string, images: Image[] | undefined): string =>
+    serializeUserMessage(prompt, images),
+
+  parseLine(line: string, state: ParserState): { events: ProviderEvent[]; sessionId?: string } {
+    const claudeState = state as unknown as ClaudeParserState
+    const raw = parseClaudeLine(line)
+    if (!raw) return { events: [] }
+    const { events, sessionId } = translateLine(raw, claudeState.providerSessionId)
+    claudeState.providerSessionId = sessionId
+    return { events, sessionId }
+  },
+
+  resumeArgs: (sessionId: string): string[] => ['--resume', sessionId],
+
+  isQuotaError: (stderr: string): boolean => isQuotaError(stderr),
+}

--- a/server/session/providers/claude/stream-types.ts
+++ b/server/session/providers/claude/stream-types.ts
@@ -34,12 +34,3 @@ export type ClaudeStreamLine =
   | { type: 'user'; parent_tool_use_id?: string | null; message: ClaudeMessage; session_id?: string }
   | { type: 'result'; subtype?: string; result?: string; is_error?: boolean; total_cost_usd?: number; num_turns?: number; usage?: ClaudeUsage; session_id?: string }
   | { type: 'system'; session_id?: string; [k: string]: unknown }
-
-export type ParsedStreamEvent =
-  | { kind: 'text_delta'; text: string; parentToolUseId?: string | null }
-  | { kind: 'thinking_block'; text: string; signature?: string; parentToolUseId?: string | null }
-  | { kind: 'tool_use'; id: string; name: string; input: Record<string, unknown>; parentToolUseId?: string | null; stopReason?: string | null }
-  | { kind: 'tool_result'; toolUseId: string; content: unknown; parentToolUseId?: string | null }
-  | { kind: 'turn_complete'; totalTokens: number | null; totalCostUsd: number | null; numTurns: number | null }
-  | { kind: 'error'; error: string }
-  | { kind: 'session_id'; sessionId: string }

--- a/server/session/providers/claude/stream.test.ts
+++ b/server/session/providers/claude/stream.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, spyOn } from 'bun:test'
-import { parseClaudeLine, translateLine, serializeUserMessage, makeLineReader } from './stream-json.js'
-import type { ClaudeStreamLine } from './stream-json-types.js'
+import { parseClaudeLine, translateLine, serializeUserMessage, makeLineReader } from './stream.js'
+import type { ClaudeStreamLine } from './stream-types.js'
 
 // ---------------------------------------------------------------------------
 // parseClaudeLine

--- a/server/session/providers/claude/stream.ts
+++ b/server/session/providers/claude/stream.ts
@@ -1,6 +1,7 @@
-import type { ClaudeStreamLine, ParsedStreamEvent } from './stream-json-types.js'
+import type { ClaudeStreamLine } from './stream-types.js'
+import type { ProviderEvent } from '../types.js'
 
-export type { ClaudeStreamLine, ParsedStreamEvent } from './stream-json-types.js'
+export type { ClaudeStreamLine } from './stream-types.js'
 
 export function parseClaudeLine(raw: string): ClaudeStreamLine | null {
   const trimmed = raw.trim()
@@ -16,8 +17,8 @@ export function parseClaudeLine(raw: string): ClaudeStreamLine | null {
 export function translateLine(
   raw: ClaudeStreamLine,
   prevSessionId: string | undefined,
-): { events: ParsedStreamEvent[]; sessionId: string | undefined } {
-  const events: ParsedStreamEvent[] = []
+): { events: ProviderEvent[]; sessionId: string | undefined } {
+  const events: ProviderEvent[] = []
   let sessionId = prevSessionId
 
   const incomingSessionId = 'session_id' in raw ? (raw.session_id as string | undefined) : undefined
@@ -48,7 +49,7 @@ export function translateLine(
       const parentToolUseId = raw.parent_tool_use_id
       const stopReason = msg.stop_reason ?? null
 
-      const toolUseEvents: Array<ParsedStreamEvent & { kind: 'tool_use' }> = []
+      const toolUseEvents: Array<ProviderEvent & { kind: 'tool_use' }> = []
 
       for (const block of msg.content) {
         if (block.type === 'thinking') {

--- a/server/session/providers/codex/env.ts
+++ b/server/session/providers/codex/env.ts
@@ -1,0 +1,11 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export function applyCodexEnv(
+  env: NodeJS.ProcessEnv,
+  opts: { workspaceHome: string; parentHome: string },
+): void {
+  const { workspaceHome, parentHome } = opts
+  fs.mkdirSync(path.join(workspaceHome, '.codex'), { recursive: true })
+  env['CODEX_HOME'] = path.join(parentHome, '.codex')
+}

--- a/server/session/providers/codex/provider.test.ts
+++ b/server/session/providers/codex/provider.test.ts
@@ -1,0 +1,374 @@
+import { describe, test, expect, spyOn, beforeEach, afterEach } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { makeCodexProvider } from './provider.js'
+import type { SpawnArgsOpts, Image } from '../types.js'
+
+const WORKSPACE = '/test/workspace'
+const PARENT_HOME = '/test/home'
+
+function makeOpts(overrides?: Partial<SpawnArgsOpts>): SpawnArgsOpts {
+  return {
+    sessionId: 'sess-1',
+    mode: 'task',
+    cwd: '/repo',
+    workspaceHome: WORKSPACE,
+    parentHome: PARENT_HOME,
+    modeConfig: {
+      systemPrompt: 'Be helpful',
+      model: 'gpt-5.1-codex',
+      disallowedTools: [],
+      autoExitOnComplete: false,
+    },
+    ...overrides,
+  }
+}
+
+const PNG_IMG: Image = {
+  mediaType: 'image/png',
+  dataBase64: 'iVBORw0KGgo=',
+}
+
+// ---------------------------------------------------------------------------
+// buildSpawnArgs
+// ---------------------------------------------------------------------------
+
+describe('buildSpawnArgs', () => {
+  let mkdirSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    mkdirSpy = spyOn(fs, 'mkdirSync').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    mkdirSpy.mockRestore()
+  })
+
+  test('returns correct argv', () => {
+    const provider = makeCodexProvider()
+    const { argv } = provider.buildSpawnArgs(makeOpts())
+    expect(argv).toEqual(['codex', 'app-server', '--listen', 'stdio://'])
+  })
+
+  test('sets CODEX_HOME to parentHome/.codex', () => {
+    const provider = makeCodexProvider()
+    const { env } = provider.buildSpawnArgs(makeOpts())
+    expect(env['CODEX_HOME']).toBe(path.join(PARENT_HOME, '.codex'))
+  })
+
+  test('sets HOME to workspaceHome', () => {
+    const provider = makeCodexProvider()
+    const { env } = provider.buildSpawnArgs(makeOpts())
+    expect(env['HOME']).toBe(WORKSPACE)
+  })
+
+  test('creates .codex subdir in workspace', () => {
+    const provider = makeCodexProvider()
+    provider.buildSpawnArgs(makeOpts())
+    const dirs = (mkdirSpy.mock.calls as unknown[][]).map((args) => args[0] as string)
+    expect(dirs.some((p) => p === path.join(WORKSPACE, '.codex'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// serializeInitialInput — fresh session
+// ---------------------------------------------------------------------------
+
+describe('serializeInitialInput — fresh session', () => {
+  test('emits a single thread/start frame', () => {
+    const provider = makeCodexProvider()
+    const raw = provider.serializeInitialInput('do the thing', undefined, makeOpts())
+    const parsed = JSON.parse(raw) as { method: string; jsonrpc: string; id: number }
+    expect(parsed.method).toBe('thread/start')
+    expect(parsed.jsonrpc).toBe('2.0')
+    expect(parsed.id).toBeGreaterThan(0)
+  })
+
+  test('thread/start params include model, cwd, and approvalPolicy', () => {
+    const provider = makeCodexProvider()
+    const raw = provider.serializeInitialInput('prompt', undefined, makeOpts())
+    const parsed = JSON.parse(raw) as { params: { model: string; cwd: string; approvalPolicy: string } }
+    expect(parsed.params.model).toBe('gpt-5.1-codex')
+    expect(parsed.params.cwd).toBe('/repo')
+    expect(parsed.params.approvalPolicy).toBe('never')
+  })
+
+  test('defaults sandbox to workspace-write when not set', () => {
+    const provider = makeCodexProvider()
+    const raw = provider.serializeInitialInput('prompt', undefined, makeOpts())
+    const parsed = JSON.parse(raw) as { params: { sandbox: string } }
+    expect(parsed.params.sandbox).toBe('workspace-write')
+  })
+
+  test('forwards read-only sandbox', () => {
+    const provider = makeCodexProvider()
+    const opts = makeOpts({
+      modeConfig: { systemPrompt: '', model: 'gpt-5.1-codex', disallowedTools: [], autoExitOnComplete: false, sandbox: 'read-only' },
+    })
+    const raw = provider.serializeInitialInput('prompt', undefined, opts)
+    const parsed = JSON.parse(raw) as { params: { sandbox: string } }
+    expect(parsed.params.sandbox).toBe('read-only')
+  })
+
+  test('includes reasoning effort in config when set', () => {
+    const provider = makeCodexProvider()
+    const opts = makeOpts({
+      modeConfig: { systemPrompt: '', model: 'gpt-5.1-codex', disallowedTools: [], autoExitOnComplete: false, reasoningEffort: 'high' },
+    })
+    const raw = provider.serializeInitialInput('prompt', undefined, opts)
+    const parsed = JSON.parse(raw) as { params: { config?: { model_reasoning_effort: string } } }
+    expect(parsed.params.config).toEqual({ model_reasoning_effort: 'high' })
+  })
+
+  test('omits config when reasoningEffort not set', () => {
+    const provider = makeCodexProvider()
+    const raw = provider.serializeInitialInput('prompt', undefined, makeOpts())
+    const parsed = JSON.parse(raw) as { params: { config?: unknown } }
+    expect(parsed.params.config).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// onProviderEvent — deferred turn/start
+// ---------------------------------------------------------------------------
+
+describe('onProviderEvent — session_id', () => {
+  test('returns turn/start frame on session_id event', () => {
+    const provider = makeCodexProvider()
+    provider.serializeInitialInput('do the thing', undefined, makeOpts())
+
+    const result = provider.onProviderEvent!(
+      { kind: 'session_id', sessionId: 'thr_abc' },
+      { providerSessionId: 'thr_abc' },
+    )
+
+    expect(result).not.toBeNull()
+    const frame = JSON.parse(result![0]!) as { method: string; params: { threadId: string; input: Array<{ type: string; text?: string }> } }
+    expect(frame.method).toBe('turn/start')
+    expect(frame.params.threadId).toBe('thr_abc')
+    expect(frame.params.input[0]).toEqual({ type: 'text', text: 'do the thing' })
+  })
+
+  test('clears pendingInitialInput so second session_id returns null', () => {
+    const provider = makeCodexProvider()
+    provider.serializeInitialInput('prompt', undefined, makeOpts())
+
+    provider.onProviderEvent!({ kind: 'session_id', sessionId: 'thr_abc' }, { providerSessionId: 'thr_abc' })
+    const second = provider.onProviderEvent!({ kind: 'session_id', sessionId: 'thr_abc' }, { providerSessionId: 'thr_abc' })
+    expect(second).toBeNull()
+  })
+
+  test('returns null for non-session_id events', () => {
+    const provider = makeCodexProvider()
+    const result = provider.onProviderEvent!(
+      { kind: 'text_delta', text: 'hello' },
+      { providerSessionId: 'thr_abc' },
+    )
+    expect(result).toBeNull()
+  })
+
+  test('returns null when providerSessionId is missing', () => {
+    const provider = makeCodexProvider()
+    provider.serializeInitialInput('prompt', undefined, makeOpts())
+    const result = provider.onProviderEvent!(
+      { kind: 'session_id', sessionId: 'thr_abc' },
+      { providerSessionId: undefined },
+    )
+    expect(result).toBeNull()
+  })
+
+  test('turn/start frame ends with newline for runtime stdin', () => {
+    const provider = makeCodexProvider()
+    provider.serializeInitialInput('prompt', undefined, makeOpts())
+    const result = provider.onProviderEvent!(
+      { kind: 'session_id', sessionId: 'thr_abc' },
+      { providerSessionId: 'thr_abc' },
+    )!
+    expect(result[0]!.endsWith('\n')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// serializeInitialInput — resume
+// ---------------------------------------------------------------------------
+
+describe('serializeInitialInput — resume', () => {
+  test('emits thread/resume then turn/start joined by newline', () => {
+    const provider = makeCodexProvider()
+    const raw = provider.serializeInitialInput('continue', undefined, makeOpts({ resumeSessionId: 'thr_existing' }))
+    const lines = raw.split('\n')
+    const resume = JSON.parse(lines[0]!) as { method: string; params: { threadId: string } }
+    const turn = JSON.parse(lines[1]!) as { method: string; params: { threadId: string; input: unknown[] } }
+
+    expect(resume.method).toBe('thread/resume')
+    expect(resume.params.threadId).toBe('thr_existing')
+    expect(turn.method).toBe('turn/start')
+    expect(turn.params.threadId).toBe('thr_existing')
+    expect(turn.params.input[0]!).toEqual({ type: 'text', text: 'continue' })
+  })
+
+  test('does not defer turn/start — onProviderEvent returns null', () => {
+    const provider = makeCodexProvider()
+    provider.serializeInitialInput('continue', undefined, makeOpts({ resumeSessionId: 'thr_existing' }))
+    const result = provider.onProviderEvent!(
+      { kind: 'session_id', sessionId: 'thr_existing' },
+      { providerSessionId: 'thr_existing' },
+    )
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// serializeUserReply
+// ---------------------------------------------------------------------------
+
+describe('serializeUserReply', () => {
+  test('emits turn/start with correct threadId', () => {
+    const provider = makeCodexProvider()
+    provider.serializeInitialInput('init', undefined, makeOpts())
+
+    const raw = provider.serializeUserReply('follow-up', undefined, { providerSessionId: 'thr_abc' })
+    const parsed = JSON.parse(raw) as { method: string; params: { threadId: string; input: Array<{ type: string; text: string }> } }
+
+    expect(parsed.method).toBe('turn/start')
+    expect(parsed.params.threadId).toBe('thr_abc')
+    expect(parsed.params.input[0]!).toEqual({ type: 'text', text: 'follow-up' })
+  })
+
+  test('throws when providerSessionId is missing', () => {
+    const provider = makeCodexProvider()
+    expect(() =>
+      provider.serializeUserReply('reply', undefined, { providerSessionId: undefined }),
+    ).toThrow()
+  })
+
+  test('id increments monotonically across calls', () => {
+    const provider = makeCodexProvider()
+    provider.serializeInitialInput('init', undefined, makeOpts())
+    provider.onProviderEvent!({ kind: 'session_id', sessionId: 'thr_1' }, { providerSessionId: 'thr_1' })
+
+    const r1 = JSON.parse(provider.serializeUserReply('msg1', undefined, { providerSessionId: 'thr_1' })) as { id: number }
+    const r2 = JSON.parse(provider.serializeUserReply('msg2', undefined, { providerSessionId: 'thr_1' })) as { id: number }
+
+    expect(r2.id).toBeGreaterThan(r1.id)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Image staging
+// ---------------------------------------------------------------------------
+
+describe('image staging', () => {
+  let writeSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    writeSpy = spyOn(fs, 'writeFileSync').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    writeSpy.mockRestore()
+  })
+
+  test('stages image to tmp dir and emits localImage ref in turn/start', () => {
+    const provider = makeCodexProvider()
+    provider.serializeInitialInput('prompt', [PNG_IMG], makeOpts())
+
+    const mkdirSpy = spyOn(fs, 'mkdirSync').mockImplementation(() => undefined)
+    const result = provider.onProviderEvent!(
+      { kind: 'session_id', sessionId: 'thr_abc' },
+      { providerSessionId: 'thr_abc' },
+    )!
+    mkdirSpy.mockRestore()
+
+    const frame = JSON.parse(result[0]!) as { params: { input: Array<{ type: string; path?: string }> } }
+    const localImage = frame.params.input.find((i) => i.type === 'localImage')
+
+    expect(localImage).toBeDefined()
+    expect(localImage!.path).toContain(path.join(WORKSPACE, 'tmp'))
+    expect(localImage!.path).toMatch(/\.png$/)
+  })
+
+  test('writeFileSync called with base64-decoded Buffer', () => {
+    const provider = makeCodexProvider()
+    provider.serializeInitialInput('prompt', [PNG_IMG], makeOpts())
+
+    spyOn(fs, 'mkdirSync').mockImplementation(() => undefined)
+    provider.onProviderEvent!(
+      { kind: 'session_id', sessionId: 'thr_abc' },
+      { providerSessionId: 'thr_abc' },
+    )
+
+    expect(writeSpy).toHaveBeenCalledTimes(1)
+    const [, data] = writeSpy.mock.calls[0]! as [string, Buffer]
+    expect(data).toBeInstanceOf(Buffer)
+  })
+
+  test('jpeg image gets .jpg extension', () => {
+    const jpegImg: Image = { mediaType: 'image/jpeg', dataBase64: '/9j/4AAQ' }
+    const provider = makeCodexProvider()
+    provider.serializeInitialInput('prompt', [jpegImg], makeOpts())
+
+    spyOn(fs, 'mkdirSync').mockImplementation(() => undefined)
+    const result = provider.onProviderEvent!(
+      { kind: 'session_id', sessionId: 'thr_abc' },
+      { providerSessionId: 'thr_abc' },
+    )!
+
+    const frame = JSON.parse(result[0]!) as { params: { input: Array<{ type: string; path?: string }> } }
+    const localImage = frame.params.input.find((i) => i.type === 'localImage')
+    expect(localImage!.path).toMatch(/\.jpg$/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseLine
+// ---------------------------------------------------------------------------
+
+describe('parseLine', () => {
+  test('thread/started notification emits session_id event', () => {
+    const provider = makeCodexProvider()
+    const line = JSON.stringify({ method: 'thread/started', params: { thread: { id: 'thr_xyz' } } })
+    const { events, sessionId } = provider.parseLine(line, {})
+    expect(events).toEqual([{ kind: 'session_id', sessionId: 'thr_xyz' }])
+    expect(sessionId).toBe('thr_xyz')
+  })
+
+  test('empty line returns no events', () => {
+    const provider = makeCodexProvider()
+    const { events } = provider.parseLine('', {})
+    expect(events).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resumeArgs
+// ---------------------------------------------------------------------------
+
+describe('resumeArgs', () => {
+  test('returns empty array (Codex resumes via RPC, not argv)', () => {
+    const provider = makeCodexProvider()
+    expect(provider.resumeArgs('any-id')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isQuotaError
+// ---------------------------------------------------------------------------
+
+describe('isQuotaError', () => {
+  test.each([
+    ['plan limit reached', true],
+    ['quota exceeded', true],
+    ['rate limit exceeded', true],
+    ['rate-limit exceeded', true],
+    ['too many requests', true],
+    ['exhausted your credits', true],
+    ['plan_limit_reached', true],
+    ['normal stderr output', false],
+    ['error: file not found', false],
+    ['', false],
+  ] as const)('isQuotaError(%s) === %s', (input, expected) => {
+    const provider = makeCodexProvider()
+    expect(provider.isQuotaError(input)).toBe(expected)
+  })
+})

--- a/server/session/providers/codex/provider.ts
+++ b/server/session/providers/codex/provider.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { buildIsolatedEnv } from '../../env.js'
+import { applyCodexEnv } from './env.js'
+import { parseCodexLine, translateCodexLine } from './stream.js'
+import type { AgentProvider, Image, ProviderEvent, SpawnArgsOpts } from '../types.js'
+
+const MEDIA_EXT: Record<Image['mediaType'], string> = {
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+}
+
+type CodexInput = { type: 'text'; text: string } | { type: 'localImage'; path: string }
+
+export function makeCodexProvider(): AgentProvider {
+  let idCounter = 0
+  let imageSeq = 0
+  let workspaceHome = ''
+  let pendingInitialInput: { prompt: string; images: Image[] | undefined } | null = null
+
+  function nextId(): number {
+    return ++idCounter
+  }
+
+  function stageImages(images: Image[], wHome: string): { type: 'localImage'; path: string }[] {
+    const tmpDir = path.join(wHome, 'tmp')
+    return images.map((img) => {
+      imageSeq++
+      const ext = MEDIA_EXT[img.mediaType]
+      const filePath = path.join(tmpDir, `codex-${imageSeq}${ext}`)
+      fs.writeFileSync(filePath, Buffer.from(img.dataBase64, 'base64'))
+      return { type: 'localImage' as const, path: filePath }
+    })
+  }
+
+  function buildInput(prompt: string, images: Image[] | undefined, wHome: string): CodexInput[] {
+    const input: CodexInput[] = [{ type: 'text', text: prompt }]
+    if (images && images.length > 0) {
+      input.push(...stageImages(images, wHome))
+    }
+    return input
+  }
+
+  function rpcFrame(method: string, params: Record<string, unknown>): string {
+    return JSON.stringify({ jsonrpc: '2.0', id: nextId(), method, params })
+  }
+
+  return {
+    name: 'codex',
+
+    buildSpawnArgs(opts: SpawnArgsOpts): { argv: string[]; env: NodeJS.ProcessEnv } {
+      workspaceHome = opts.workspaceHome
+      const argv = ['codex', 'app-server', '--listen', 'stdio://']
+      const env = buildIsolatedEnv({ workspaceHome: opts.workspaceHome })
+      applyCodexEnv(env, { workspaceHome: opts.workspaceHome, parentHome: opts.parentHome })
+      return { argv, env }
+    },
+
+    serializeInitialInput(prompt: string, images: Image[] | undefined, opts: SpawnArgsOpts): string {
+      workspaceHome = opts.workspaceHome
+
+      if (opts.resumeSessionId) {
+        const threadId = opts.resumeSessionId
+        const resumeFrame = rpcFrame('thread/resume', { threadId })
+        const input = buildInput(prompt, images, opts.workspaceHome)
+        const turnFrame = rpcFrame('turn/start', { threadId, input })
+        return [resumeFrame, turnFrame].join('\n')
+      }
+
+      pendingInitialInput = { prompt, images }
+
+      const sandbox = opts.modeConfig.sandbox === 'read-only' ? 'read-only' : 'workspace-write'
+      const params: Record<string, unknown> = {
+        model: opts.modeConfig.model,
+        cwd: opts.cwd,
+        approvalPolicy: 'never',
+        sandbox,
+      }
+      if (opts.modeConfig.reasoningEffort) {
+        params['config'] = { model_reasoning_effort: opts.modeConfig.reasoningEffort }
+      }
+      return rpcFrame('thread/start', params)
+    },
+
+    serializeUserReply(
+      prompt: string,
+      images: Image[] | undefined,
+      ctx: { providerSessionId: string | undefined },
+    ): string {
+      const threadId = ctx.providerSessionId
+      if (!threadId) {
+        throw new Error('[codex-provider] serializeUserReply called before thread/started')
+      }
+      const input = buildInput(prompt, images, workspaceHome)
+      return rpcFrame('turn/start', { threadId, input })
+    },
+
+    parseLine(line: string): { events: ProviderEvent[]; sessionId?: string } {
+      const raw = parseCodexLine(line)
+      if (!raw) return { events: [] }
+      return translateCodexLine(raw)
+    },
+
+    onProviderEvent(
+      event: ProviderEvent,
+      ctx: { providerSessionId: string | undefined },
+    ): string[] | null {
+      if (event.kind !== 'session_id') return null
+      const threadId = ctx.providerSessionId
+      if (!threadId || !pendingInitialInput) return null
+      const { prompt, images } = pendingInitialInput
+      pendingInitialInput = null
+      const input = buildInput(prompt, images, workspaceHome)
+      return [rpcFrame('turn/start', { threadId, input }) + '\n']
+    },
+
+    resumeArgs(): string[] {
+      return []
+    },
+
+    isQuotaError(stderr: string): boolean {
+      // Codex quota strings not yet observed in production; tune after real events.
+      return /(plan|quota|rate[- ]?limit|exhausted|exceeded|too many requests)/i.test(stderr)
+    },
+  }
+}

--- a/server/session/providers/codex/stream-types.ts
+++ b/server/session/providers/codex/stream-types.ts
@@ -1,0 +1,68 @@
+export interface CodexThreadStarted {
+  method: 'thread/started'
+  params: { thread: { id: string } }
+}
+
+export interface CodexTurnStarted {
+  method: 'turn/started'
+  params: { threadId: string; turnId: string }
+}
+
+export interface CodexAgentMessageDelta {
+  method: 'item/agentMessage/delta'
+  params: { turnId: string; delta: string }
+}
+
+export interface CodexAgentMessage {
+  method: 'item/agentMessage'
+  params: { turnId: string; text: string }
+}
+
+export interface CodexReasoningDelta {
+  method: 'item/reasoning/delta'
+  params: { turnId: string; delta: string }
+}
+
+export interface CodexReasoning {
+  method: 'item/reasoning'
+  params: { turnId: string; text: string }
+}
+
+export type CodexToolCallParams =
+  | { turnId: string; id: string; name: string; input: Record<string, unknown>; status: 'inProgress' }
+  | { turnId: string; id: string; name: string; input: Record<string, unknown>; status: 'completed'; output?: string }
+  | { turnId: string; id: string; name: string; input: Record<string, unknown>; status: 'failed'; output?: string }
+
+export interface CodexToolCall {
+  method: 'item/toolCall'
+  params: CodexToolCallParams
+}
+
+export interface CodexTurnCompleted {
+  method: 'turn/completed'
+  params: { turn: { id: string; status: 'completed' } }
+}
+
+export interface CodexTurnFailed {
+  method: 'turn/failed'
+  params: { turn: { id: string; status: 'failed'; error?: { message: string } } }
+}
+
+export type CodexNotification =
+  | CodexThreadStarted
+  | CodexTurnStarted
+  | CodexAgentMessageDelta
+  | CodexAgentMessage
+  | CodexReasoningDelta
+  | CodexReasoning
+  | CodexToolCall
+  | CodexTurnCompleted
+  | CodexTurnFailed
+
+export interface CodexRpcResponse {
+  id: number
+  result?: unknown
+  error?: { code: number; message: string }
+}
+
+export type CodexLine = CodexRpcResponse | CodexNotification

--- a/server/session/providers/codex/stream.test.ts
+++ b/server/session/providers/codex/stream.test.ts
@@ -1,0 +1,319 @@
+import { describe, test, expect, spyOn } from 'bun:test'
+import { parseCodexLine, translateCodexLine } from './stream.js'
+
+// ---------------------------------------------------------------------------
+// parseCodexLine
+// ---------------------------------------------------------------------------
+
+describe('parseCodexLine', () => {
+  test('returns null on empty string', () => {
+    expect(parseCodexLine('')).toBeNull()
+  })
+
+  test('returns null on whitespace-only string', () => {
+    expect(parseCodexLine('   ')).toBeNull()
+  })
+
+  test('returns null on invalid JSON and warns', () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {})
+    expect(parseCodexLine('not json')).toBeNull()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  test('parses valid JSON object', () => {
+    const line = JSON.stringify({ method: 'turn/started', params: { threadId: 't1', turnId: 'r1' } })
+    expect(parseCodexLine(line)).toEqual({ method: 'turn/started', params: { threadId: 't1', turnId: 'r1' } })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — thread/started
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — thread/started', () => {
+  test('emits session_id event and returns sessionId', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'thread/started', params: { thread: { id: 'thr_123' } } }),
+    )!
+    const { events, sessionId } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'session_id', sessionId: 'thr_123' }])
+    expect(sessionId).toBe('thr_123')
+  })
+
+  test('emits error when thread.id is missing', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'thread/started', params: { thread: {} } }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ kind: 'error' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — turn/started
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — turn/started', () => {
+  test('emits no events', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'turn/started', params: { threadId: 'thr_123', turnId: 'turn_456' } }),
+    )!
+    const { events, sessionId } = translateCodexLine(raw)
+    expect(events).toHaveLength(0)
+    expect(sessionId).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — item/agentMessage/delta
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — item/agentMessage/delta', () => {
+  test('emits text_delta', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'item/agentMessage/delta', params: { turnId: 'turn_456', delta: 'Hello ' } }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'text_delta', text: 'Hello ' }])
+  })
+
+  test('emits error when delta is missing', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'item/agentMessage/delta', params: { turnId: 'turn_456' } }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ kind: 'error' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — item/agentMessage (final)
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — item/agentMessage', () => {
+  test('emits no events (deltas already carried content)', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'item/agentMessage', params: { turnId: 'turn_456', text: 'Hello world' } }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — item/reasoning/delta
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — item/reasoning/delta', () => {
+  test('emits no events (discarded; final item/reasoning carries full text)', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'item/reasoning/delta', params: { turnId: 'turn_456', delta: 'thinking...' } }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — item/reasoning (final)
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — item/reasoning', () => {
+  test('emits thinking_block with full text', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'item/reasoning', params: { turnId: 'turn_456', text: 'I should consider...' } }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'thinking_block', text: 'I should consider...' }])
+  })
+
+  test('emits error when text is missing', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'item/reasoning', params: { turnId: 'turn_456' } }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ kind: 'error' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — item/toolCall (inProgress)
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — item/toolCall status=inProgress', () => {
+  test('emits tool_use', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/toolCall',
+        params: { turnId: 'turn_456', id: 'call_abc', name: 'shell', input: { cmd: 'ls' }, status: 'inProgress' },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'tool_use', id: 'call_abc', name: 'shell', input: { cmd: 'ls' } }])
+  })
+
+  test('emits error when id is missing', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/toolCall',
+        params: { turnId: 'turn_456', name: 'shell', input: {}, status: 'inProgress' },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events[0]).toMatchObject({ kind: 'error' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — item/toolCall (completed)
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — item/toolCall status=completed', () => {
+  test('emits tool_result with output', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/toolCall',
+        params: {
+          turnId: 'turn_456',
+          id: 'call_abc',
+          name: 'shell',
+          input: {},
+          status: 'completed',
+          output: 'file.txt',
+        },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'tool_result', toolUseId: 'call_abc', content: 'file.txt' }])
+  })
+
+  test('emits tool_result with null content when output absent', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/toolCall',
+        params: { turnId: 'turn_456', id: 'call_abc', name: 'shell', input: {}, status: 'completed' },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'tool_result', toolUseId: 'call_abc', content: null }])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — item/toolCall (failed)
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — item/toolCall status=failed', () => {
+  test('emits tool_result with error object containing output', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/toolCall',
+        params: {
+          turnId: 'turn_456',
+          id: 'call_abc',
+          name: 'shell',
+          input: {},
+          status: 'failed',
+          output: 'permission denied',
+        },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([
+      { kind: 'tool_result', toolUseId: 'call_abc', content: { error: 'permission denied' } },
+    ])
+  })
+
+  test('emits tool_result with default error message when output absent', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/toolCall',
+        params: { turnId: 'turn_456', id: 'call_abc', name: 'shell', input: {}, status: 'failed' },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([
+      { kind: 'tool_result', toolUseId: 'call_abc', content: { error: 'tool failed' } },
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — turn/completed
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — turn/completed', () => {
+  test('emits turn_complete with null cost fields', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'turn/completed', params: { turn: { id: 'turn_456', status: 'completed' } } }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'turn_complete', totalTokens: null, totalCostUsd: null, numTurns: null }])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — turn/failed
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — turn/failed', () => {
+  test('emits error with turn error message', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'turn/failed',
+        params: { turn: { id: 'turn_456', status: 'failed', error: { message: 'context limit exceeded' } } },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'error', error: 'context limit exceeded' }])
+  })
+
+  test('emits fallback error message when error object absent', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'turn/failed', params: { turn: { id: 'turn_456', status: 'failed' } } }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'error', error: 'turn failed' }])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — JSON-RPC error response
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — JSON-RPC error response', () => {
+  test('emits error from JSON-RPC error field', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({ id: 1, error: { code: -32000, message: 'rate limit exceeded' } }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'error', error: 'rate limit exceeded' }])
+  })
+
+  test('emits no events for successful JSON-RPC response', () => {
+    const raw = parseCodexLine(JSON.stringify({ id: 1, result: { ok: true } }))!
+    const { events } = translateCodexLine(raw)
+    expect(events).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — unknown method
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — unknown method', () => {
+  test('emits no events and warns', () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {})
+    const raw = parseCodexLine(
+      JSON.stringify({ method: 'some/futureMethod', params: { foo: 'bar' } }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toHaveLength(0)
+    expect(warn).toHaveBeenCalledWith('[codex-stream] Unknown notification method:', 'some/futureMethod')
+    warn.mockRestore()
+  })
+})

--- a/server/session/providers/codex/stream.ts
+++ b/server/session/providers/codex/stream.ts
@@ -1,0 +1,114 @@
+import type { ProviderEvent } from '../types.js'
+import type { CodexLine } from './stream-types.js'
+
+export function parseCodexLine(raw: string): CodexLine | null {
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  try {
+    return JSON.parse(trimmed) as CodexLine
+  } catch {
+    console.warn('[codex-stream] Failed to parse line:', trimmed.slice(0, 200))
+    return null
+  }
+}
+
+export function translateCodexLine(
+  raw: CodexLine,
+): { events: ProviderEvent[]; sessionId?: string } {
+  const events: ProviderEvent[] = []
+  let sessionId: string | undefined
+
+  if ('id' in raw) {
+    if (raw.error) {
+      events.push({ kind: 'error', error: raw.error.message })
+    }
+    return { events, sessionId }
+  }
+
+  switch (raw.method) {
+    case 'thread/started': {
+      const threadId = raw.params.thread.id
+      if (!threadId) {
+        events.push({ kind: 'error', error: 'thread/started: missing thread.id' })
+        break
+      }
+      events.push({ kind: 'session_id', sessionId: threadId })
+      sessionId = threadId
+      break
+    }
+
+    case 'turn/started':
+      break
+
+    case 'item/agentMessage/delta': {
+      const delta = raw.params.delta
+      if (!delta) {
+        events.push({ kind: 'error', error: 'item/agentMessage/delta: missing delta field' })
+        break
+      }
+      events.push({ kind: 'text_delta', text: delta })
+      break
+    }
+
+    case 'item/agentMessage':
+      break
+
+    case 'item/reasoning/delta':
+      // Reasoning deltas are discarded; the final item/reasoning carries the full text.
+      // TranscriptTranslator.handleThinkingBlock emits final:true on every call and does
+      // not accumulate, so streaming deltas would produce fragmented thinking blocks.
+      break
+
+    case 'item/reasoning': {
+      const text = raw.params.text
+      if (!text) {
+        events.push({ kind: 'error', error: 'item/reasoning: missing text field' })
+        break
+      }
+      events.push({ kind: 'thinking_block', text })
+      break
+    }
+
+    case 'item/toolCall': {
+      const p = raw.params
+      if (p.status === 'inProgress') {
+        if (!p.id || !p.name || p.input === undefined) {
+          events.push({ kind: 'error', error: 'item/toolCall inProgress: missing required field (id, name, or input)' })
+          break
+        }
+        events.push({ kind: 'tool_use', id: p.id, name: p.name, input: p.input })
+      } else if (p.status === 'completed') {
+        if (!p.id) {
+          events.push({ kind: 'error', error: 'item/toolCall completed: missing id' })
+          break
+        }
+        events.push({ kind: 'tool_result', toolUseId: p.id, content: p.output ?? null })
+      } else if (p.status === 'failed') {
+        if (!p.id) {
+          events.push({ kind: 'error', error: 'item/toolCall failed: missing id' })
+          break
+        }
+        events.push({ kind: 'tool_result', toolUseId: p.id, content: { error: p.output ?? 'tool failed' } })
+      }
+      break
+    }
+
+    case 'turn/completed':
+      events.push({ kind: 'turn_complete', totalTokens: null, totalCostUsd: null, numTurns: null })
+      break
+
+    case 'turn/failed': {
+      const turn = raw.params.turn
+      events.push({ kind: 'error', error: turn.error?.message ?? 'turn failed' })
+      break
+    }
+
+    default: {
+      const method = (raw as unknown as { method: string }).method
+      console.warn('[codex-stream] Unknown notification method:', method)
+      break
+    }
+  }
+
+  return { events, sessionId }
+}

--- a/server/session/providers/index.ts
+++ b/server/session/providers/index.ts
@@ -1,0 +1,10 @@
+import { claudeProvider } from './claude/provider.js'
+import { makeCodexProvider } from './codex/provider.js'
+import type { AgentProvider } from './types.js'
+
+export function getProvider(name?: string): AgentProvider {
+  const resolved = name ?? process.env['AGENT_PROVIDER'] ?? 'claude'
+  if (resolved === 'claude') return claudeProvider
+  if (resolved === 'codex') return makeCodexProvider()
+  throw new Error(`Unknown AGENT_PROVIDER: ${resolved}`)
+}

--- a/server/session/providers/types.test.ts
+++ b/server/session/providers/types.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expectTypeOf } from 'vitest'
+import type { AgentProvider, ParserState, ProviderEvent, SpawnArgsOpts, Image } from './types.js'
+
+describe('AgentProvider interface', () => {
+  it('is satisfied by a conforming object', () => {
+    const provider = {
+      name: 'claude' as const,
+      buildSpawnArgs: (): { argv: string[]; env: NodeJS.ProcessEnv } => ({ argv: [], env: {} }),
+      serializeInitialInput: (): string => '',
+      serializeUserReply: (): string => '',
+      parseLine: (): { events: ProviderEvent[] } => ({ events: [] }),
+      resumeArgs: (): string[] => [],
+      isQuotaError: (): boolean => false,
+    } satisfies AgentProvider
+
+    expectTypeOf(provider).toMatchTypeOf<AgentProvider>()
+    expectTypeOf(provider.name).toMatchTypeOf<'claude' | 'codex'>()
+  })
+
+  it('ProviderEvent union covers all kinds', () => {
+    const event: ProviderEvent = { kind: 'session_id', sessionId: 'sid' }
+    expectTypeOf(event).toMatchTypeOf<ProviderEvent>()
+  })
+
+  it('SpawnArgsOpts and Image are structurally sound', () => {
+    expectTypeOf<SpawnArgsOpts['modeConfig']['disallowedTools']>().toEqualTypeOf<string[]>()
+    expectTypeOf<Image['mediaType']>().toEqualTypeOf<'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'>()
+  })
+
+  it('ParserState accepts any object', () => {
+    const state: ParserState = { providerSessionId: undefined }
+    expectTypeOf(state).toMatchTypeOf<ParserState>()
+  })
+})

--- a/server/session/providers/types.ts
+++ b/server/session/providers/types.ts
@@ -1,0 +1,47 @@
+export type ProviderEvent =
+  | { kind: 'text_delta'; text: string; parentToolUseId?: string | null }
+  | { kind: 'thinking_block'; text: string; signature?: string; parentToolUseId?: string | null }
+  | { kind: 'tool_use'; id: string; name: string; input: Record<string, unknown>; parentToolUseId?: string | null; stopReason?: string | null }
+  | { kind: 'tool_result'; toolUseId: string; content: unknown; parentToolUseId?: string | null }
+  | { kind: 'turn_complete'; totalTokens: number | null; totalCostUsd: number | null; numTurns: number | null }
+  | { kind: 'error'; error: string }
+  | { kind: 'session_id'; sessionId: string }
+
+export interface Image {
+  mediaType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'
+  dataBase64: string
+}
+
+export interface ModeConfig {
+  systemPrompt: string
+  model: string
+  disallowedTools: string[]
+  autoExitOnComplete: boolean
+  reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high'
+  sandbox?: 'read-only' | 'workspace-write'
+}
+
+export interface SpawnArgsOpts {
+  sessionId: string
+  mode: string
+  cwd: string
+  workspaceHome: string
+  parentHome: string
+  modeConfig: ModeConfig
+  resumeSessionId?: string
+  mcpConfig?: { mcpServers: Record<string, unknown> }
+}
+
+// Mutable cursor each provider owns. Extend this with provider-specific fields.
+export type ParserState = object
+
+export interface AgentProvider {
+  readonly name: 'claude' | 'codex'
+  buildSpawnArgs(opts: SpawnArgsOpts): { argv: string[]; env: NodeJS.ProcessEnv }
+  serializeInitialInput(prompt: string, images: Image[] | undefined, opts: SpawnArgsOpts): string
+  serializeUserReply(prompt: string, images: Image[] | undefined, ctx: { providerSessionId: string | undefined }): string
+  parseLine(line: string, state: ParserState): { events: ProviderEvent[]; sessionId?: string }
+  resumeArgs(sessionId: string): string[]
+  isQuotaError(stderr: string): boolean
+  onProviderEvent?(event: ProviderEvent, ctx: { providerSessionId: string | undefined }): string[] | null
+}

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -268,7 +268,7 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
       cwd,
       initialPrompt,
       initialImages,
-      resumeClaudeSessionId: row.claude_session_id,
+      resumeSessionId: row.claude_session_id,
     })
 
     handles.set(row.id, handle)

--- a/server/session/runtime.test.ts
+++ b/server/session/runtime.test.ts
@@ -6,6 +6,7 @@ import { SessionRuntime, type SubprocessHandle, type SpawnFn, type StartOpts } f
 import { runMigrations } from '../db/sqlite'
 import type { EngineEvent } from '../events/types'
 import type { TranscriptEvent } from '../../shared/api-types'
+import type { AgentProvider, SpawnArgsOpts } from './providers/types'
 
 // ---------------------------------------------------------------------------
 // In-memory DB helpers
@@ -325,10 +326,10 @@ describe('SessionRuntime', () => {
   })
 
   describe('resume path', () => {
-    test('argv includes --resume <id> when resumeClaudeSessionId is set', async () => {
+    test('argv includes --resume <id> when resumeSessionId is set', async () => {
       currentProc = makeFakeProc([])
       const rt = new SessionRuntime(
-        makeOpts(currentProc, { resumeClaudeSessionId: 'resume-session-xyz' }),
+        makeOpts(currentProc, { resumeSessionId: 'resume-session-xyz' }),
       )
       await rt.start()
 
@@ -337,21 +338,21 @@ describe('SessionRuntime', () => {
       expect(capturedArgs[resumeIdx + 1]).toBe('resume-session-xyz')
     })
 
-    test('argv does NOT include --resume when resumeClaudeSessionId is absent', async () => {
+    test('argv does NOT include --resume when resumeSessionId is absent', async () => {
       currentProc = makeFakeProc([])
       const rt = new SessionRuntime(makeOpts(currentProc))
       await rt.start()
       expect(capturedArgs).not.toContain('--resume')
     })
 
-    test('turn trigger is "resume" when resumeClaudeSessionId is set', async () => {
+    test('turn trigger is "resume" when resumeSessionId is set', async () => {
       const bus = getEventBus()
       const streamEvents: TranscriptEvent[] = []
       bus.onKind('session.stream', (e) => { streamEvents.push(e.event) })
 
       currentProc = makeFakeProc([])
       const rt = new SessionRuntime(
-        makeOpts(currentProc, { resumeClaudeSessionId: 'old-session-id' }),
+        makeOpts(currentProc, { resumeSessionId: 'old-session-id' }),
       )
       await rt.start()
 
@@ -485,7 +486,6 @@ describe('SessionRuntime', () => {
 
   describe('ship coordinator inactivity timeout', () => {
     test('uses 24h inactivity timeout for ship mode by default', async () => {
-      // Ship coordinator should get much longer timeout
       currentProc = makeFakeProc([
         JSON.stringify({ type: 'session_id', value: 'claude-123' }),
         JSON.stringify({
@@ -506,10 +506,6 @@ describe('SessionRuntime', () => {
 
       await rt.start()
 
-      // The timeout is set in startTimers, which is called in start()
-      // We can't easily test the actual timeout value without exposing internals,
-      // but we can verify that ship mode doesn't use the explicit override
-      // and would use the 24h default set in startTimers
       expect(currentProc.killed).toBe(false)
     })
 
@@ -528,15 +524,64 @@ describe('SessionRuntime', () => {
         mode: 'ship',
         cwd: '/tmp/ship-cwd',
         initialPrompt: 'ship the feature',
-        inactivityTimeoutMs: 1000, // 1 second
+        inactivityTimeoutMs: 1000,
         spawnFn: makeSpawnFn(currentProc),
         getDb: () => db,
       })
 
       await rt.start()
 
-      // Even with explicit override, the runtime should start
       expect(currentProc.killed).toBe(false)
+    })
+  })
+
+  describe('custom provider injection', () => {
+    test('runtime delegates spawn args, serialization, and parsing to injected provider', async () => {
+      const calls: string[] = []
+
+      const fakeProvider: AgentProvider = {
+        name: 'claude',
+        buildSpawnArgs(opts: SpawnArgsOpts) {
+          calls.push('buildSpawnArgs')
+          return {
+            argv: ['claude', '--print', '--output-format', 'stream-json', '--input-format', 'stream-json',
+              '--verbose', '--include-partial-messages', '--dangerously-skip-permissions',
+              '--append-system-prompt', opts.modeConfig.systemPrompt, '--model', opts.modeConfig.model],
+            env: {},
+          }
+        },
+        serializeInitialInput(prompt: string) {
+          calls.push('serializeInitialInput')
+          return JSON.stringify({ type: 'user', session_id: '', message: { role: 'user', content: prompt }, parent_tool_use_id: null })
+        },
+        serializeUserReply(prompt: string) {
+          calls.push('serializeUserReply')
+          return JSON.stringify({ type: 'user', session_id: '', message: { role: 'user', content: prompt }, parent_tool_use_id: null })
+        },
+        parseLine(line: string) {
+          calls.push('parseLine')
+          try {
+            const raw = JSON.parse(line) as { type?: string; is_error?: boolean }
+            if (raw.type === 'result' && !raw.is_error) {
+              return { events: [{ kind: 'turn_complete', totalTokens: null, totalCostUsd: null, numTurns: null }] }
+            }
+          } catch { /* ignore */ }
+          return { events: [] }
+        },
+        resumeArgs: () => [],
+        isQuotaError: () => false,
+      }
+
+      currentProc = makeFakeProc([JSON.stringify({ type: 'result' })])
+      const rt = new SessionRuntime({
+        ...makeOpts(currentProc),
+        provider: fakeProvider,
+      })
+      await rt.start()
+
+      expect(calls).toContain('buildSpawnArgs')
+      expect(calls).toContain('serializeInitialInput')
+      expect(calls).toContain('parseLine')
     })
   })
 })

--- a/server/session/runtime.ts
+++ b/server/session/runtime.ts
@@ -5,10 +5,9 @@ import { getEventBus } from '../events/bus'
 import { getDb as defaultGetDb, prepared } from '../db/sqlite'
 import type { Database } from 'bun:sqlite'
 import { TranscriptTranslator } from './transcript'
-import { parseClaudeLine, translateLine, serializeUserMessage } from './stream-json'
-import { MODE_CONFIGS, type AllSessionMode } from './prompts'
-import { buildIsolatedEnv } from './env'
-import { isQuotaError } from './quota-detection'
+import { getModeConfig, type AllSessionMode } from './prompts'
+import { getProvider } from './providers/index'
+import type { AgentProvider, ParserState, SpawnArgsOpts } from './providers/types'
 
 export interface SubprocessHandle {
   pid: number
@@ -44,12 +43,13 @@ export interface StartOpts {
   cwd: string
   initialPrompt: string
   initialImages?: Array<{ mediaType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'; dataBase64: string }>
-  resumeClaudeSessionId?: string
+  resumeSessionId?: string
   mcpConfig?: { mcpServers: Record<string, unknown> }
   sessionTimeoutMs?: number
   inactivityTimeoutMs?: number
   spawnFn?: SpawnFn
   getDb?: () => Database
+  provider?: AgentProvider
 }
 
 type RuntimeState = 'starting' | 'working' | 'idle' | 'stopping' | 'done'
@@ -57,7 +57,9 @@ type RuntimeState = 'starting' | 'working' | 'idle' | 'stopping' | 'done'
 export class SessionRuntime {
   private proc: SubprocessHandle | null = null
   private translator: TranscriptTranslator
-  private claudeSessionId: string | undefined
+  private providerSessionId: string | undefined
+  private readonly provider: AgentProvider
+  private readonly parserState: ParserState
   private readonly bus = getEventBus()
   private state: RuntimeState = 'starting'
   private readonly startedAt = Date.now()
@@ -73,6 +75,8 @@ export class SessionRuntime {
 
   constructor(private readonly opts: StartOpts) {
     this.getDb = opts.getDb ?? defaultGetDb
+    this.provider = opts.provider ?? getProvider()
+    this.parserState = {}
     const db = this.getDb()
     const startingSeq = prepared.nextSeq(db, opts.sessionId)
     this.translator = new TranscriptTranslator({ sessionId: opts.sessionId, startingSeq })
@@ -83,37 +87,33 @@ export class SessionRuntime {
     return this.proc !== null && !this.proc.killed
   }
 
-  get currentClaudeSessionId(): string | undefined {
-    return this.claudeSessionId
+  get currentProviderSessionId(): string | undefined {
+    return this.providerSessionId
   }
 
   async start(): Promise<void> {
-    const { sessionId, mode, cwd, initialPrompt, resumeClaudeSessionId, mcpConfig } = this.opts
-    const cfg = MODE_CONFIGS[mode as AllSessionMode]
+    const { sessionId, mode, cwd, initialPrompt, resumeSessionId, mcpConfig } = this.opts
+    const cfg = getModeConfig(this.provider.name, mode as AllSessionMode)
 
     this.bus.emit({ kind: 'session.spawning', sessionId, mode, cwd })
 
-    const args: string[] = [
-      '--print',
-      '--output-format', 'stream-json',
-      '--input-format', 'stream-json',
-      '--verbose',
-      '--include-partial-messages',
-      '--dangerously-skip-permissions',
-      ...(cfg.disallowedTools.length ? ['--disallowed-tools', ...cfg.disallowedTools] : []),
-      ...(mcpConfig && Object.keys(mcpConfig.mcpServers).length
-        ? ['--mcp-config', JSON.stringify(mcpConfig)]
-        : []),
-      '--append-system-prompt', cfg.systemPrompt,
-      '--model', cfg.model,
-      ...(resumeClaudeSessionId ? ['--resume', resumeClaudeSessionId] : []),
-    ]
-
     const parentHome = process.env['HOME'] ?? os.homedir()
     const workspaceHome = path.join(cwd, '.home')
-    const env = buildIsolatedEnv({ workspaceHome, parentHome })
 
-    this.proc = this.spawnFn(['claude', ...args], {
+    const spawnOpts: SpawnArgsOpts = {
+      sessionId,
+      mode,
+      cwd,
+      workspaceHome,
+      parentHome,
+      modeConfig: cfg,
+      resumeSessionId,
+      mcpConfig,
+    }
+
+    const { argv, env } = this.provider.buildSpawnArgs(spawnOpts)
+
+    this.proc = this.spawnFn(argv, {
       cwd,
       env,
       stdin: 'pipe',
@@ -125,7 +125,7 @@ export class SessionRuntime {
 
     this.startTimers()
 
-    const turnStartedEvt = this.translator.startTurn(resumeClaudeSessionId ? 'resume' : 'user_message')
+    const turnStartedEvt = this.translator.startTurn(resumeSessionId ? 'resume' : 'user_message')
     if (turnStartedEvt) {
       this.persistAndEmit(turnStartedEvt)
     }
@@ -133,7 +133,7 @@ export class SessionRuntime {
     const userMsgEvt = this.translator.userMessage(initialPrompt, this.opts.initialImages?.map((img) => img.dataBase64))
     this.persistAndEmit(userMsgEvt)
 
-    const initialLine = serializeUserMessage(initialPrompt, this.opts.initialImages)
+    const initialLine = this.provider.serializeInitialInput(initialPrompt, this.opts.initialImages, spawnOpts)
     await this.proc.stdin.write(initialLine + '\n')
     this.proc.stdin.flush()
 
@@ -164,7 +164,7 @@ export class SessionRuntime {
     const userMsgEvt = this.translator.userMessage(text, images?.map((img) => img.dataBase64))
     this.persistAndEmit(userMsgEvt)
 
-    const line = serializeUserMessage(text, images)
+    const line = this.provider.serializeUserReply(text, images, { providerSessionId: this.providerSessionId })
     await this.proc.stdin.write(line + '\n')
     this.proc.stdin.flush()
 
@@ -229,19 +229,20 @@ export class SessionRuntime {
   }
 
   private processLine(line: string): void {
-    const raw = parseClaudeLine(line)
-    if (!raw) return
+    const { events, sessionId: nextSid } = this.provider.parseLine(line, this.parserState)
 
-    const { events, sessionId: nextSid } = translateLine(raw, this.claudeSessionId)
-    if (nextSid && nextSid !== this.claudeSessionId) {
-      this.claudeSessionId = nextSid
+    if (nextSid && nextSid !== this.providerSessionId) {
+      this.providerSessionId = nextSid
       const db = this.getDb()
       prepared.updateSession(db, {
         id: this.opts.sessionId,
+        // legacy column name; carries provider session id regardless of backend
         claude_session_id: nextSid,
         updated_at: Date.now(),
       })
     }
+
+    const followUpQueue: string[] = []
 
     const db = this.getDb()
     db.transaction(() => {
@@ -250,6 +251,9 @@ export class SessionRuntime {
         for (const te of transcriptEvents) {
           this.persistAndEmit(te)
         }
+
+        const followUp = this.provider.onProviderEvent?.(event, { providerSessionId: this.providerSessionId })
+        if (followUp) followUpQueue.push(...followUp)
 
         if (event.kind === 'turn_complete') {
           if (event.totalTokens !== null) this.totalTokens = event.totalTokens
@@ -260,7 +264,7 @@ export class SessionRuntime {
             this.bus.emit({ kind: 'session.idle', sessionId: this.opts.sessionId })
           }
 
-          const cfg = MODE_CONFIGS[this.opts.mode as AllSessionMode]
+          const cfg = getModeConfig(this.provider.name, this.opts.mode as AllSessionMode)
           if (cfg.autoExitOnComplete && this.state !== 'done') {
             void this.stop('auto_exit')
           }
@@ -273,6 +277,15 @@ export class SessionRuntime {
         }
       }
     })()
+
+    if (followUpQueue.length > 0 && this.proc?.stdin) {
+      void (async () => {
+        for (const frame of followUpQueue) {
+          await this.proc!.stdin.write(frame)
+          this.proc!.stdin.flush()
+        }
+      })()
+    }
   }
 
   private pipeStderr(): void {
@@ -310,7 +323,7 @@ export class SessionRuntime {
       runState = 'stream_stalled'
     } else if (exitCode === 0) {
       runState = 'completed'
-    } else if (isQuotaError(stderrText)) {
+    } else if (this.provider.isQuotaError(stderrText)) {
       runState = 'quota_exhausted'
     } else {
       runState = 'errored'

--- a/server/session/stream-observer.test.ts
+++ b/server/session/stream-observer.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import crypto from 'node:crypto'
 import { SessionStreamObserver } from './stream-observer'
 import { EngineEventBus } from '../events/bus'
-import type { ParsedStreamEvent } from './stream-json-types'
+import type { ProviderEvent } from './providers/types'
 import type { EngineEvent } from '../events/types'
 
 const TMPDIR = Bun.env['TMPDIR'] ?? '/tmp'
@@ -29,7 +29,7 @@ describe('SessionStreamObserver', () => {
     const events = collectEvents(bus)
     const observer = new SessionStreamObserver('sess-1', bus)
 
-    const toolUseEvent: ParsedStreamEvent = {
+    const toolUseEvent: ProviderEvent = {
       kind: 'tool_use',
       id: 'tool-abc',
       name: 'bash',
@@ -52,7 +52,7 @@ describe('SessionStreamObserver', () => {
     const events = collectEvents(bus)
     const observer = new SessionStreamObserver('sess-2', bus)
 
-    const textDelta: ParsedStreamEvent = { kind: 'text_delta', text: 'hello' }
+    const textDelta: ProviderEvent = { kind: 'text_delta', text: 'hello' }
     observer.onEvent(textDelta)
 
     expect(events.filter((e) => e.kind === 'session.assistant_activity')).toHaveLength(0)

--- a/server/session/stream-observer.ts
+++ b/server/session/stream-observer.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import type { ParsedStreamEvent } from './stream-json-types'
+import type { ProviderEvent } from './providers/types'
 import type { EngineEventBus } from '../events/bus'
 
 export class SessionStreamObserver {
@@ -11,7 +11,7 @@ export class SessionStreamObserver {
     private readonly bus: EngineEventBus,
   ) {}
 
-  onEvent(event: ParsedStreamEvent): void {
+  onEvent(event: ProviderEvent): void {
     if (event.kind === 'tool_use') {
       this.bus.emit({
         kind: 'session.assistant_activity',

--- a/server/session/transcript.test.ts
+++ b/server/session/transcript.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test'
 import { TranscriptTranslator } from './transcript'
-import type { ParsedStreamEvent } from './stream-json-types'
+import type { ProviderEvent } from './providers/types'
 import type { AssistantTextEvent, TurnCompletedEvent, ToolCallEvent, ToolResultEvent, StatusEvent } from '../../shared/api-types'
 
 function makeTranslator(startingSeq = 0, startingTurn = 0) {
@@ -120,7 +120,7 @@ describe('TranscriptTranslator', () => {
         id: 'tool-1',
         name: 'Bash',
         input: { command: 'echo hello' },
-      } satisfies ParsedStreamEvent)
+      } satisfies ProviderEvent)
 
       const toolCall = callEvents.find((e) => e.type === 'tool_call') as ToolCallEvent | undefined
       expect(toolCall).toBeDefined()
@@ -132,7 +132,7 @@ describe('TranscriptTranslator', () => {
         kind: 'tool_result',
         toolUseId: 'tool-1',
         content: 'hello\n',
-      } satisfies ParsedStreamEvent)
+      } satisfies ProviderEvent)
 
       const toolResult = resultEvents.find((e) => e.type === 'tool_result') as ToolResultEvent | undefined
       expect(toolResult).toBeDefined()
@@ -149,7 +149,7 @@ describe('TranscriptTranslator', () => {
         kind: 'tool_result',
         toolUseId: 'nonexistent-id',
         content: 'some output',
-      } satisfies ParsedStreamEvent)
+      } satisfies ProviderEvent)
 
       const toolResult = resultEvents.find((e) => e.type === 'tool_result') as ToolResultEvent | undefined
       expect(toolResult).toBeDefined()
@@ -160,7 +160,7 @@ describe('TranscriptTranslator', () => {
   describe('error event', () => {
     it('emits status with severity error and kind session_error when no turn is open', () => {
       const t = makeTranslator()
-      const events = t.handle({ kind: 'error', error: 'Something went wrong' } satisfies ParsedStreamEvent)
+      const events = t.handle({ kind: 'error', error: 'Something went wrong' } satisfies ProviderEvent)
 
       expect(events).toHaveLength(1)
       const status = events[0] as StatusEvent
@@ -219,13 +219,13 @@ describe('TranscriptTranslator', () => {
 
       const large = 'A'.repeat(100 * 1024)
 
-      t.handle({ kind: 'tool_use', id: 'bash-1', name: 'Bash', input: { command: 'cat big' } } satisfies ParsedStreamEvent)
+      t.handle({ kind: 'tool_use', id: 'bash-1', name: 'Bash', input: { command: 'cat big' } } satisfies ProviderEvent)
 
       const resultEvents = t.handle({
         kind: 'tool_result',
         toolUseId: 'bash-1',
         content: large,
-      } satisfies ParsedStreamEvent)
+      } satisfies ProviderEvent)
 
       const toolResult = resultEvents.find((e) => e.type === 'tool_result') as ToolResultEvent | undefined
       expect(toolResult).toBeDefined()
@@ -240,13 +240,13 @@ describe('TranscriptTranslator', () => {
 
       const large = 'B'.repeat(100 * 1024)
 
-      t.handle({ kind: 'tool_use', id: 'read-1', name: 'Read', input: { file_path: '/tmp/big' } } satisfies ParsedStreamEvent)
+      t.handle({ kind: 'tool_use', id: 'read-1', name: 'Read', input: { file_path: '/tmp/big' } } satisfies ProviderEvent)
 
       const resultEvents = t.handle({
         kind: 'tool_result',
         toolUseId: 'read-1',
         content: large,
-      } satisfies ParsedStreamEvent)
+      } satisfies ProviderEvent)
 
       const toolResult = resultEvents.find((e) => e.type === 'tool_result') as ToolResultEvent | undefined
       expect(toolResult?.result.truncated).toBe(true)
@@ -258,7 +258,7 @@ describe('TranscriptTranslator', () => {
   describe('session_id event', () => {
     it('produces no transcript events', () => {
       const t = makeTranslator()
-      const events = t.handle({ kind: 'session_id', sessionId: 'claude-abc-123' } satisfies ParsedStreamEvent)
+      const events = t.handle({ kind: 'session_id', sessionId: 'claude-abc-123' } satisfies ProviderEvent)
       expect(events).toHaveLength(0)
     })
   })
@@ -272,7 +272,7 @@ describe('TranscriptTranslator', () => {
         kind: 'thinking_block',
         text: 'Let me think...',
         signature: 'sig-abc',
-      } satisfies ParsedStreamEvent)
+      } satisfies ProviderEvent)
 
       expect(events).toHaveLength(1)
       const thinking = events[0]

--- a/server/session/transcript.test.ts
+++ b/server/session/transcript.test.ts
@@ -179,7 +179,7 @@ describe('TranscriptTranslator', () => {
       const events = t.handle({
         kind: 'error',
         error: 'API Error: Stream idle timeout - partial response received',
-      } satisfies ParsedStreamEvent)
+      } satisfies ProviderEvent)
 
       const flushed = events.find((e) => e.type === 'assistant_text') as AssistantTextEvent | undefined
       expect(flushed?.final).toBe(true)

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto'
 import type { TranscriptEvent, TranscriptEventBase, TurnTrigger, StatusSeverity } from '../../shared/api-types'
-import type { ParsedStreamEvent } from './stream-json-types'
+import type { ProviderEvent } from './providers/types'
 import { buildToolCallSummary, buildToolResultPayload, classifyTool } from './tool-classifier'
 
 export interface TranscriptTranslatorOpts {
@@ -54,7 +54,7 @@ export class TranscriptTranslator {
     return { ...this.base(), type: 'turn_started', trigger }
   }
 
-  handle(event: ParsedStreamEvent): TranscriptEvent[] {
+  handle(event: ProviderEvent): TranscriptEvent[] {
     switch (event.kind) {
       case 'text_delta':
         return this.handleTextDelta(event.text, event.parentToolUseId ?? null)

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -198,6 +198,7 @@ export interface VersionInfo {
   apiVersion: string
   libraryVersion: string
   features: string[]
+  provider?: 'claude' | 'codex'
   repos?: RepoEntry[]
 }
 

--- a/src/connections/ConnectionSettings.tsx
+++ b/src/connections/ConnectionSettings.tsx
@@ -24,6 +24,7 @@ export function ConnectionSettings({ onClose, existing, embedded }: Props) {
   const err = useSignal<string | null>(null)
   const loading = useSignal(false)
   const features = useSignal<string[]>([])
+  const serverProvider = useSignal<'claude' | 'codex' | null>(null)
 
   const showPushPanel = Boolean(existing) && isPushFlagEnabled()
   const editClient = useMemo(
@@ -56,6 +57,25 @@ export function ConnectionSettings({ onClose, existing, embedded }: Props) {
       cancelled = true
     }
   }, [editClient])
+
+  useEffect(() => {
+    if (!existing) return
+    let cancelled = false
+    serverProvider.value = null
+    const client = createApiClient({ baseUrl: existing.baseUrl, token: existing.token })
+    void client
+      .getVersion()
+      .then((info) => {
+        if (cancelled) return
+        serverProvider.value = info.provider ?? null
+      })
+      .catch(() => {
+        // best-effort; badge omitted on network error
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [existing?.id, existing?.baseUrl, existing?.token])
 
   async function submit(e: Event) {
     e.preventDefault()
@@ -199,6 +219,14 @@ export function ConnectionSettings({ onClose, existing, embedded }: Props) {
                 {f}
               </span>
             ))}
+          </div>
+        )}
+        {serverProvider.value && (
+          <div class="flex items-center gap-1.5" data-testid="backend-badge">
+            <span class="text-xs text-slate-500 dark:text-slate-400">Backend:</span>
+            <span class="rounded-full bg-slate-100 dark:bg-slate-700 px-2 py-0.5 text-xs font-medium text-slate-600 dark:text-slate-300">
+              {serverProvider.value === 'claude' ? 'Claude' : 'Codex'}
+            </span>
           </div>
         )}
         {showPushPanel && editClient && (

--- a/test/connections/ConnectionSettings.test.tsx
+++ b/test/connections/ConnectionSettings.test.tsx
@@ -160,4 +160,32 @@ describe('ConnectionSettings', () => {
     expect(screen.queryByTestId('push-section')).toBeNull()
     vi.unstubAllEnvs()
   })
+
+  it('shows backend badge when server returns a provider for existing connection', async () => {
+    const { createApiClient } = await import('../../src/api/client')
+    vi.mocked(createApiClient).mockReturnValueOnce({
+      getVersion: vi.fn().mockResolvedValue({
+        apiVersion: '1',
+        libraryVersion: '0.1.0',
+        features: [],
+        provider: 'codex',
+      }),
+    } as unknown as ReturnType<typeof createApiClient>)
+
+    await renderSettings({
+      existing: { id: 'e1', label: 'Old', baseUrl: 'https://old.example.com', token: 'tok', color: '#10b981' },
+    })
+
+    await waitFor(() => expect(screen.queryByTestId('backend-badge')).not.toBeNull())
+    expect(screen.getByTestId('backend-badge').textContent).toContain('Codex')
+  })
+
+  it('omits backend badge when server does not return a provider', async () => {
+    await renderSettings({
+      existing: { id: 'e1', label: 'Old', baseUrl: 'https://old.example.com', token: 'tok', color: '#10b981' },
+    })
+    // mock returns no provider — badge must not appear
+    await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+    expect(screen.queryByTestId('backend-badge')).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary

- Introduces an `AgentProvider` interface so `SessionRuntime` is fully provider-agnostic
- Adds a Codex provider that drives `codex app-server --listen stdio://` via JSON-RPC
- One image, both CLIs; `AGENT_PROVIDER=claude|codex` (env) picks the backend — no rebuild
- `compose.codex.yaml` override uses ChatGPT coding plan auth (`~/.codex` mount); no PAYG API key
- `/api/version` now exposes active provider; doctor CLI and ConnectionSettings surface it

## How to validate

**Claude (unchanged):**
```sh
docker compose -f docker/compose.yaml -f docker/compose.dev.yaml up
```

**Codex (after `codex login` on host):**
```sh
docker compose -f docker/compose.yaml -f docker/compose.codex.yaml up
```

Then open the PWA, run a `/task` and confirm stream delivery and transcript persistence.

## Test plan

- [ ] `npm run typecheck && npm run lint && npm run test` — 721 tests pass
- [ ] Doctor output shows correct provider checks for claude and codex branches
- [ ] ConnectionSettings badge renders "Backend: Claude" with default compose
- [ ] (CI) Full test matrix passes on push