### PR TITLE
fix: unbreak /land and clear stale ship-mode references

### DIFF
--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -182,19 +182,6 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
     }
   }
 
-  if (mode === "ship-plan") {
-    setPipelineAdvancing(ctx, sessionId, true)
-    try {
-      await killAndWait(sessionId, ctx)
-      const result = await handoffShipPhase(sessionId, "ship-verify", ctx)
-      if (!result.ok) setPipelineAdvancing(ctx, sessionId, false)
-      return result
-    } catch (err) {
-      setPipelineAdvancing(ctx, sessionId, false)
-      throw err
-    }
-  }
-
   if (mode === "think" || mode === "plan" || mode === "review") {
     setPipelineAdvancing(ctx, sessionId, true)
     try {

--- a/server/dag/landing.test.ts
+++ b/server/dag/landing.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+import os from "node:os"
 import { buildDag } from "./dag"
 import { EngineEventBus } from "../events/bus"
 import { createLandingManager } from "./landing"
@@ -31,11 +34,23 @@ function makeGraph() {
   return graph
 }
 
+let workspaceRoot: string
+
+beforeEach(() => {
+  workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "landing-test-"))
+  fs.mkdirSync(path.join(workspaceRoot, "slug-a"), { recursive: true })
+  fs.mkdirSync(path.join(workspaceRoot, "slug-b"), { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(workspaceRoot, { recursive: true, force: true })
+})
+
 describe("LandingManager.landNode", () => {
   it("returns error when node not found in graph", async () => {
     const { exec } = makeSuccessExec()
     const bus = makeBus()
-    const manager = createLandingManager({ bus, execFile: exec })
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
     const graph = makeGraph()
 
     const result = await manager.landNode("nonexistent", graph)
@@ -46,7 +61,7 @@ describe("LandingManager.landNode", () => {
   it("returns error when node has no PR URL", async () => {
     const { exec } = makeSuccessExec()
     const bus = makeBus()
-    const manager = createLandingManager({ bus, execFile: exec })
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
     const graph = buildDag("dag-1", [
       { id: "a", title: "Task A", description: "First task", dependsOn: [] },
     ], "root-session", "repo")
@@ -57,22 +72,26 @@ describe("LandingManager.landNode", () => {
     expect(result.error).toContain("no PR URL")
   })
 
-  it("retargets all stacked PRs to main before merging", async () => {
+  it("retargets all stacked PRs to main via gh api PATCH before merging", async () => {
     const { exec, calls } = makeSuccessExec()
     const bus = makeBus()
-    const manager = createLandingManager({ bus, execFile: exec })
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
     const graph = makeGraph()
 
     await manager.landNode("a", graph)
 
-    const retargetCalls = calls.filter((a) => a[0] === "pr" && a[1] === "edit" && a.includes("--base") && a.includes("main"))
+    const retargetCalls = calls.filter(
+      (a) => a[0] === "api" && a.includes("PATCH") && a.some((x) => x === "base=main"),
+    )
     expect(retargetCalls.length).toBeGreaterThanOrEqual(1)
+    const patchPath = retargetCalls[0]!.find((x) => x.startsWith("/repos/"))
+    expect(patchPath).toBe("/repos/org/repo/pulls/1")
   })
 
   it("calls gh pr merge with squash and delete-branch", async () => {
     const { exec, calls } = makeSuccessExec()
     const bus = makeBus()
-    const manager = createLandingManager({ bus, execFile: exec })
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
     const graph = makeGraph()
 
     const result = await manager.landNode("a", graph)
@@ -87,7 +106,7 @@ describe("LandingManager.landNode", () => {
   it("returns ok:true and sets node status to landed on success", async () => {
     const { exec } = makeSuccessExec()
     const bus = makeBus()
-    const manager = createLandingManager({ bus, execFile: exec })
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
     const graph = makeGraph()
 
     const result = await manager.landNode("a", graph)
@@ -99,10 +118,10 @@ describe("LandingManager.landNode", () => {
   it("returns ok:false with error when gh pr merge fails", async () => {
     const bus = makeBus()
     const exec: ExecFn = async ({ args }) => {
-      if (args[1] === "merge") throw new Error("PR is not mergeable")
+      if (args[0] === "pr" && args[1] === "merge") throw new Error("PR is not mergeable")
       return { stdout: "", stderr: "" }
     }
-    const manager = createLandingManager({ bus, execFile: exec })
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
     const graph = makeGraph()
 
     const result = await manager.landNode("a", graph)
@@ -113,7 +132,7 @@ describe("LandingManager.landNode", () => {
   it("emits dag.node.landed event on successful merge", async () => {
     const { exec } = makeSuccessExec()
     const bus = makeBus()
-    const manager = createLandingManager({ bus, execFile: exec })
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
     const graph = makeGraph()
 
     const emittedEvents: { kind: string; dagId: string; nodeId: string }[] = []
@@ -128,18 +147,42 @@ describe("LandingManager.landNode", () => {
     expect(emittedEvents[0]!.nodeId).toBe("a")
   })
 
-  it("rebases downstream nodes after successful merge", async () => {
-    const { exec, calls } = makeSuccessExec()
+  it("rebases downstream nodes in their worktree directory after successful merge", async () => {
+    const calls: { args: string[]; cwd: string | undefined }[] = []
+    const exec: ExecFn = async ({ args, opts }) => {
+      calls.push({ args: [...args], cwd: opts?.cwd as string | undefined })
+      return { stdout: "", stderr: "" }
+    }
     const bus = makeBus()
-    const manager = createLandingManager({ bus, execFile: exec })
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
     const graph = makeGraph()
 
     await manager.landNode("a", graph)
 
-    const fetchCalls = calls.filter((a) => a[0] === "fetch")
-    const rebaseCalls = calls.filter((a) => a[0] === "rebase")
+    const fetchCalls = calls.filter((c) => c.args[0] === "fetch")
+    const rebaseCalls = calls.filter((c) => c.args[0] === "rebase")
 
     expect(fetchCalls.length).toBeGreaterThan(0)
     expect(rebaseCalls.length).toBeGreaterThan(0)
+    expect(fetchCalls[0]!.cwd).toBe(path.join(workspaceRoot, "slug-b"))
+    expect(rebaseCalls[0]!.cwd).toBe(path.join(workspaceRoot, "slug-b"))
+  })
+
+  it("skips rebase when downstream worktree directory is missing", async () => {
+    const calls: { args: string[] }[] = []
+    const exec: ExecFn = async ({ args }) => {
+      calls.push({ args: [...args] })
+      return { stdout: "", stderr: "" }
+    }
+    fs.rmSync(path.join(workspaceRoot, "slug-b"), { recursive: true, force: true })
+
+    const bus = makeBus()
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
+    const graph = makeGraph()
+
+    const result = await manager.landNode("a", graph)
+    expect(result.ok).toBe(true)
+    const fetchCalls = calls.filter((c) => c.args[0] === "fetch")
+    expect(fetchCalls.length).toBe(0)
   })
 })

--- a/server/dag/landing.ts
+++ b/server/dag/landing.ts
@@ -1,5 +1,7 @@
 import { execFile as execFileCb } from "node:child_process"
 import { promisify } from "node:util"
+import path from "node:path"
+import fs from "node:fs"
 import { nodeIndex, getDownstreamNodes } from "./dag"
 import type { DagGraph } from "./dag"
 import type { EngineEventBus } from "../events/bus"
@@ -19,6 +21,7 @@ export interface LandNodeResult {
 
 export interface LandingManagerOpts {
   bus: EngineEventBus
+  workspaceRoot: string
   execFile?: ExecFn
 }
 
@@ -26,17 +29,46 @@ export interface LandingManager {
   landNode(nodeId: string, graph: DagGraph): Promise<LandNodeResult>
 }
 
+interface ParsedPrUrl {
+  owner: string
+  repo: string
+  number: string
+}
+
+function parsePrUrl(prUrl: string): ParsedPrUrl | null {
+  const m = prUrl.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/)
+  if (!m) return null
+  return { owner: m[1]!, repo: m[2]!, number: m[3]! }
+}
+
+function worktreeDir(workspaceRoot: string, branch: string): string {
+  const slug = branch.startsWith("minion/") ? branch.slice("minion/".length) : branch
+  return path.join(workspaceRoot, slug)
+}
+
 export function createLandingManager(opts: LandingManagerOpts): LandingManager {
-  const { bus } = opts
+  const { bus, workspaceRoot } = opts
   const run = opts.execFile ?? defaultExec
 
   async function retargetAllStackedPRs(graph: DagGraph): Promise<void> {
     const prNodes = graph.nodes.filter((n) => n.prUrl && n.status !== "landed")
     for (const node of prNodes) {
+      const parsed = parsePrUrl(node.prUrl!)
+      if (!parsed) {
+        console.error(`[landing] cannot parse PR URL ${node.prUrl}`)
+        continue
+      }
       try {
         await run({
           cmd: "gh",
-          args: ["pr", "edit", node.prUrl!, "--base", "main"],
+          args: [
+            "api",
+            "--method",
+            "PATCH",
+            `/repos/${parsed.owner}/${parsed.repo}/pulls/${parsed.number}`,
+            "-f",
+            "base=main",
+          ],
           opts: { timeout: 30_000, encoding: "utf-8" },
         })
       } catch (err) {
@@ -51,18 +83,25 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
     for (const node of downstream) {
       if (!node.branch || node.status === "landed") continue
 
+      const cwd = worktreeDir(workspaceRoot, node.branch)
+      if (!fs.existsSync(cwd)) {
+        console.error(`[landing] skip rebase for ${node.id}: worktree ${cwd} missing`)
+        continue
+      }
+
       try {
-        await run({ cmd: "git", args: ["fetch", "origin", "main"], opts: { timeout: 60_000, encoding: "utf-8" } })
+        await run({ cmd: "git", args: ["fetch", "origin", "main"], opts: { cwd, timeout: 60_000, encoding: "utf-8" } })
         await run({
           cmd: "git",
           args: ["rebase", "origin/main"],
           opts: {
+            cwd,
             timeout: 120_000,
             encoding: "utf-8",
             env: { ...process.env, GIT_SEQUENCE_EDITOR: "true" },
           },
         })
-        await run({ cmd: "git", args: ["push", "--force-with-lease"], opts: { timeout: 60_000, encoding: "utf-8" } })
+        await run({ cmd: "git", args: ["push", "--force-with-lease"], opts: { cwd, timeout: 60_000, encoding: "utf-8" } })
       } catch (err) {
         console.error(`[landing] rebase failed for node ${node.id} branch ${node.branch}:`, err)
       }

--- a/server/index.ts
+++ b/server/index.ts
@@ -166,7 +166,7 @@ try {
 
 startPushNotifier(bus)
 
-const landingManager = createLandingManager({ bus })
+const landingManager = createLandingManager({ bus, workspaceRoot: WORKSPACE_ROOT })
 registerApiRoutes(app, registry, () => db, scheduler, landingManager, {
   loopRuntime: loopScheduler,
   resourceMonitor,

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -52,7 +52,7 @@ export const NEW_TASK_MODES: ModeOption[] = [
   { value: 'task', label: 'Task', hint: 'Execute end-to-end' },
   { value: 'plan', label: 'Plan', hint: 'Produce a plan; no execution' },
   { value: 'think', label: 'Think', hint: 'Deliberate; no side effects' },
-  { value: 'ship-think', label: 'Ship', hint: 'Finish with a PR' },
+  { value: 'ship', label: 'Ship', hint: 'Finish with a PR' },
 ]
 
 export const VARIANT_COUNTS: ReadonlyArray<number> = [1, 2, 3, 4]

--- a/test/chat/NewTaskBar.test.tsx
+++ b/test/chat/NewTaskBar.test.tsx
@@ -124,7 +124,7 @@ describe('NewTaskBar', () => {
     expect(screen.getByTestId('mode-task')).toBeTruthy()
     expect(screen.getByTestId('mode-plan')).toBeTruthy()
     expect(screen.getByTestId('mode-think')).toBeTruthy()
-    expect(screen.getByTestId('mode-ship-think')).toBeTruthy()
+    expect(screen.getByTestId('mode-ship')).toBeTruthy()
     expect(screen.getByTestId('mode-task').getAttribute('aria-checked')).toBe('true')
   })
 


### PR DESCRIPTION
## Summary
- Restore main CI: `NewTaskBar` listed `ship-think` (removed by the ship-coordinator collapse) and `plan-actions.ts` had an unreachable second `ship-plan` branch calling the deleted `handoffShipPhase`.
- Fix `/land` for the rough-bay-1232 ship: docker logs showed `gh pr edit --base main` exiting non-zero on the GraphQL `Projects (classic)` deprecation warning, and `rebaseDownstream` running `git fetch/rebase/push` with no `cwd` so it always missed every worktree.
- Switch retargeting to `gh api PATCH /repos/.../pulls/N` (no project-card queries), and resolve the worktree dir from `node.branch` against `WORKSPACE_ROOT`; skip cleanly when the worktree has already been pruned.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (745 tests pass; new coverage in `server/dag/landing.test.ts` for retarget API call shape, downstream cwd, and missing-worktree skip)
- [x] `npm run build`