### PR TITLE
feat(ship): resume coordinators on engine restart with extended idle timeout

### DIFF
--- a/server/session/registry.test.ts
+++ b/server/session/registry.test.ts
@@ -408,6 +408,71 @@ describe('SessionRegistry', () => {
       expect(row?.status).toBe('failed')
       expect(registry.get('recon-2')).toBeUndefined()
     })
+
+    test('resumes ship coordinator with claude_session_id on boot', async () => {
+      const bare = trackedDir('bare-ship-resume')
+      const work = trackedDir('work-ship-resume')
+      const workspaceRoot = trackedDir('ws-ship-resume')
+      await initLocalBareRepo(bare, work)
+
+      const repoName = path.basename(bare).replace(/\.git$/, '')
+      const bareDir = path.join(workspaceRoot, '.repos', `${repoName}.git`)
+
+      const handle = await import('../workspace/prepare').then((m) =>
+        m.prepareWorkspace({ slug: 'ship-resume-slug', repoUrl: bare, workspaceRoot, bootstrap: false }),
+      )
+
+      const now = Date.now()
+      db.run(
+        `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, bare_dir, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation, stage)
+         VALUES ('ship-coord', 'ship-resume-slug', 'running', 'ship the feature', 'ship', ?, ?, ?, null, null, null, 'claude-ship-123', ?, ?, ?, 0, '[]', '[]', '[]', 'dag')`,
+        [bare, handle.branch, bareDir, workspaceRoot, now, now],
+      )
+
+      let capturedArgs: string[] = []
+      const capturingSpawn: SpawnFn = (argv, opts) => {
+        capturedArgs = argv
+        return makeNoopSpawnFn()(argv, opts)
+      }
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: capturingSpawn })
+
+      // Check status before reconcile - should be 'running'
+      const beforeRow = db.query<{ status: string }, [string]>('SELECT status FROM sessions WHERE id = ?').get('ship-coord')
+      expect(beforeRow?.status).toBe('running')
+
+      await registry.reconcileOnBoot()
+
+      // Should have spawned with --resume
+      expect(capturedArgs).toContain('--resume')
+      const resumeIdx = capturedArgs.indexOf('--resume')
+      expect(capturedArgs[resumeIdx + 1]).toBe('claude-ship-123')
+
+      // The noop spawn completes immediately, so the status will be 'completed'
+      // What matters is that resumeRuntime was called and --resume flag was passed
+      await new Promise<void>((r) => setTimeout(r, 200))
+
+      // Status will be 'completed' after the noop process exits
+      const afterRow = db.query<{ status: string }, [string]>('SELECT status FROM sessions WHERE id = ?').get('ship-coord')
+      expect(afterRow?.status).toBe('completed')
+    }, 60_000)
+
+    test('marks ship coordinator as failed if resume throws', async () => {
+      const now = Date.now()
+      db.run(
+        `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, bare_dir, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation, stage)
+         VALUES ('ship-fail', 'ship-fail-slug', 'running', 'ship task', 'ship', null, 'minion/ship-fail-slug', null, null, null, null, 'claude-fail', null, ?, ?, 0, '[]', '[]', '[]', 'plan')`,
+        [now, now],
+      )
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn() })
+      await registry.reconcileOnBoot()
+
+      // Missing workspace should cause resume to fail
+      const row = db.query<{ status: string }, [string]>('SELECT status FROM sessions WHERE id = ?').get('ship-fail')
+      expect(row?.status).toBe('failed')
+      expect(registry.get('ship-fail')).toBeUndefined()
+    })
   })
 
   describe('session.snapshot events', () => {

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -313,6 +313,21 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
       const row = prepared.getSession(db(), id)
       if (!row) continue
 
+      // Ship coordinators: attempt to resume from stored claude_session_id
+      if (row.mode === 'ship' && row.claude_session_id) {
+        try {
+          const runtime = await resumeRuntime(row, row.command)
+          runtimes.set(id, runtime)
+          wireCompletionHandler(id)
+          void runtime.start()
+          console.log('[ship] reconcileOnBoot: resumed coordinator', id, 'stage', row.stage)
+          continue
+        } catch (err) {
+          console.warn('[ship] reconcileOnBoot: failed to resume coordinator', id, err)
+          // Fall through to mark failed
+        }
+      }
+
       const now = Date.now()
       const seq = prepared.nextSeq(db(), id)
       const turn = currentTurn(id)

--- a/server/session/runtime.test.ts
+++ b/server/session/runtime.test.ts
@@ -482,4 +482,61 @@ describe('SessionRuntime', () => {
       expect(completed).toHaveLength(1)
     })
   })
+
+  describe('ship coordinator inactivity timeout', () => {
+    test('uses 24h inactivity timeout for ship mode by default', async () => {
+      // Ship coordinator should get much longer timeout
+      currentProc = makeFakeProc([
+        JSON.stringify({ type: 'session_id', value: 'claude-123' }),
+        JSON.stringify({
+          type: 'turn_complete',
+          totalTokens: 100,
+          totalCostUsd: 0.01,
+        }),
+      ])
+
+      const rt = new SessionRuntime({
+        sessionId: SESS_ID,
+        mode: 'ship',
+        cwd: '/tmp/ship-cwd',
+        initialPrompt: 'ship the feature',
+        spawnFn: makeSpawnFn(currentProc),
+        getDb: () => db,
+      })
+
+      await rt.start()
+
+      // The timeout is set in startTimers, which is called in start()
+      // We can't easily test the actual timeout value without exposing internals,
+      // but we can verify that ship mode doesn't use the explicit override
+      // and would use the 24h default set in startTimers
+      expect(currentProc.killed).toBe(false)
+    })
+
+    test('respects explicit inactivityTimeoutMs override for ship mode', async () => {
+      currentProc = makeFakeProc([
+        JSON.stringify({ type: 'session_id', value: 'claude-123' }),
+        JSON.stringify({
+          type: 'turn_complete',
+          totalTokens: 100,
+          totalCostUsd: 0.01,
+        }),
+      ])
+
+      const rt = new SessionRuntime({
+        sessionId: SESS_ID,
+        mode: 'ship',
+        cwd: '/tmp/ship-cwd',
+        initialPrompt: 'ship the feature',
+        inactivityTimeoutMs: 1000, // 1 second
+        spawnFn: makeSpawnFn(currentProc),
+        getDb: () => db,
+      })
+
+      await rt.start()
+
+      // Even with explicit override, the runtime should start
+      expect(currentProc.killed).toBe(false)
+    })
+  })
 })

--- a/server/session/runtime.ts
+++ b/server/session/runtime.ts
@@ -351,7 +351,9 @@ export class SessionRuntime {
 
   private startTimers(): void {
     const sessionTimeoutMs = this.opts.sessionTimeoutMs ?? 60 * 60 * 1000
-    const inactivityTimeoutMs = this.opts.inactivityTimeoutMs ?? 15 * 60 * 1000
+    // Ship coordinators need much longer inactivity timeout since they may be idle during dag stage
+    const defaultInactivityMs = this.opts.mode === 'ship' ? 24 * 60 * 60 * 1000 : 15 * 60 * 1000
+    const inactivityTimeoutMs = this.opts.inactivityTimeoutMs ?? defaultInactivityMs
 
     this.hardTimer = setTimeout(() => {
       console.warn(`[runtime] hard session timeout for ${this.opts.sessionId}`)

--- a/server/ship/coordinator.test.ts
+++ b/server/ship/coordinator.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, mock } from 'bun:test'
+import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test'
 import type { Database } from 'bun:sqlite'
 import { openDatabase, prepared, runMigrations } from '../db/sqlite'
 import { advanceShip, DIRECTIVE_PLAN, DIRECTIVE_VERIFY } from './coordinator'
@@ -411,6 +411,48 @@ describe('advanceShip', () => {
       await advanceShip(sessionId, 'plan', ctx)
 
       expect(registry.reply).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('logging', () => {
+    test('logs stage transition to console', async () => {
+      const sessionId = 'session-22'
+      createSession(db, sessionId, 'ship', 'think')
+
+      const consoleLogSpy = spyOn(console, 'log')
+
+      await advanceShip(sessionId, undefined, ctx)
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('[ship]', sessionId, 'stage', 'think', '->', 'plan')
+
+      consoleLogSpy.mockRestore()
+    })
+
+    test('logs every stage transition', async () => {
+      const sessionId = 'session-23'
+      createSession(db, sessionId, 'ship', 'think')
+
+      const consoleLogSpy = spyOn(console, 'log')
+
+      // think → plan
+      await advanceShip(sessionId, undefined, ctx)
+      expect(consoleLogSpy).toHaveBeenCalledWith('[ship]', sessionId, 'stage', 'think', '->', 'plan')
+
+      // plan → dag
+      await advanceShip(sessionId, undefined, ctx)
+      expect(consoleLogSpy).toHaveBeenCalledWith('[ship]', sessionId, 'stage', 'plan', '->', 'dag')
+
+      // dag → verify
+      await advanceShip(sessionId, undefined, ctx)
+      expect(consoleLogSpy).toHaveBeenCalledWith('[ship]', sessionId, 'stage', 'dag', '->', 'verify')
+
+      // verify → done
+      await advanceShip(sessionId, undefined, ctx)
+      expect(consoleLogSpy).toHaveBeenCalledWith('[ship]', sessionId, 'stage', 'verify', '->', 'done')
+
+      expect(consoleLogSpy).toHaveBeenCalledTimes(4)
+
+      consoleLogSpy.mockRestore()
     })
   })
 })

--- a/server/ship/coordinator.ts
+++ b/server/ship/coordinator.ts
@@ -140,6 +140,8 @@ export async function advanceShip(
       [nextStage, now, sessionId],
     )
 
+    console.log('[ship]', sessionId, 'stage', currentStage, '->', nextStage)
+
     // Emit SSE event
     const updatedRow = prepared.getSession(ctx.db, sessionId)
     if (updatedRow) {


### PR DESCRIPTION
Re-opened from #124. Original PR auto-closed when its base branch (#123 head) was deleted on merge.