### PR TITLE
fix(codex): translate v2 item/started + item/completed

### DIFF
--- a/server/session/providers/codex/stream-types.ts
+++ b/server/session/providers/codex/stream-types.ts
@@ -38,6 +38,54 @@ export interface CodexToolCall {
   params: CodexToolCallParams
 }
 
+export type ThreadItem =
+  | { type: 'agentMessage'; id: string; text: string }
+  | { type: 'reasoning'; id: string; content?: unknown[]; summary?: unknown[] }
+  | {
+      type: 'commandExecution'
+      id: string
+      command: string
+      cwd?: unknown
+      status: 'inProgress' | 'completed' | 'failed' | 'declined'
+      aggregatedOutput?: string | null
+      exitCode?: number | null
+    }
+  | {
+      type: 'fileChange'
+      id: string
+      changes: unknown[]
+      status: 'inProgress' | 'completed' | 'failed' | 'declined'
+    }
+  | { type: 'plan'; id: string; text: string }
+  | {
+      type: 'mcpToolCall'
+      id: string
+      server: string
+      tool: string
+      arguments: unknown
+      status: 'inProgress' | 'completed' | 'failed' | 'declined'
+      output?: unknown
+    }
+  | {
+      type: 'dynamicToolCall'
+      id: string
+      tool: string
+      arguments: unknown
+      status: 'inProgress' | 'completed' | 'failed' | 'declined'
+      output?: unknown
+    }
+  | { type: string; id: string; [key: string]: unknown }
+
+export interface CodexItemStarted {
+  method: 'item/started'
+  params: { item: ThreadItem; threadId: string; turnId: string }
+}
+
+export interface CodexItemCompleted {
+  method: 'item/completed'
+  params: { item: ThreadItem; threadId: string; turnId: string }
+}
+
 export interface CodexTurnCompleted {
   method: 'turn/completed'
   params: { turn: { id: string; status: 'completed' } }
@@ -56,6 +104,8 @@ export type CodexNotification =
   | CodexReasoningDelta
   | CodexReasoning
   | CodexToolCall
+  | CodexItemStarted
+  | CodexItemCompleted
   | CodexTurnCompleted
   | CodexTurnFailed
 

--- a/server/session/providers/codex/stream.test.ts
+++ b/server/session/providers/codex/stream.test.ts
@@ -306,14 +306,146 @@ describe('translateCodexLine — JSON-RPC error response', () => {
 // ---------------------------------------------------------------------------
 
 describe('translateCodexLine — unknown method', () => {
-  test('emits no events and warns', () => {
-    const warn = spyOn(console, 'warn').mockImplementation(() => {})
+  test('emits no events for non-actionable notifications', () => {
     const raw = parseCodexLine(
       JSON.stringify({ method: 'some/futureMethod', params: { foo: 'bar' } }),
     )!
     const { events } = translateCodexLine(raw)
     expect(events).toHaveLength(0)
-    expect(warn).toHaveBeenCalledWith('[codex-stream] Unknown notification method:', 'some/futureMethod')
-    warn.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateCodexLine — v2 item/started + item/completed
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — v2 item/* notifications', () => {
+  test('agentMessage on item/completed emits text_delta with full text', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/completed',
+        params: {
+          threadId: 't1',
+          turnId: 'r1',
+          item: { type: 'agentMessage', id: 'i1', text: 'Hello world' },
+        },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'text_delta', text: 'Hello world' }])
+  })
+
+  test('agentMessage on item/started emits no events', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/started',
+        params: {
+          threadId: 't1',
+          turnId: 'r1',
+          item: { type: 'agentMessage', id: 'i1', text: '' },
+        },
+      }),
+    )!
+    expect(translateCodexLine(raw).events).toHaveLength(0)
+  })
+
+  test('reasoning on item/completed emits thinking_block from summary', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/completed',
+        params: {
+          threadId: 't1',
+          turnId: 'r1',
+          item: {
+            type: 'reasoning',
+            id: 'i2',
+            summary: [{ text: 'Analyzed the request' }],
+          },
+        },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'thinking_block', text: 'Analyzed the request' }])
+  })
+
+  test('commandExecution on item/started emits tool_use shell', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/started',
+        params: {
+          threadId: 't1',
+          turnId: 'r1',
+          item: { type: 'commandExecution', id: 'cmd1', command: 'ls -la', status: 'inProgress' },
+        },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{ kind: 'tool_use', id: 'cmd1', name: 'shell', input: { command: 'ls -la' } }])
+  })
+
+  test('commandExecution on item/completed (status=completed) emits tool_result with stdout + exitCode', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/completed',
+        params: {
+          threadId: 't1',
+          turnId: 'r1',
+          item: {
+            type: 'commandExecution',
+            id: 'cmd1',
+            command: 'ls',
+            status: 'completed',
+            aggregatedOutput: 'README.md\npackage.json\n',
+            exitCode: 0,
+          },
+        },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{
+      kind: 'tool_result',
+      toolUseId: 'cmd1',
+      content: { stdout: 'README.md\npackage.json\n', exitCode: 0 },
+    }])
+  })
+
+  test('commandExecution failed emits tool_result error with aggregatedOutput', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/completed',
+        params: {
+          threadId: 't1',
+          turnId: 'r1',
+          item: {
+            type: 'commandExecution',
+            id: 'cmd2',
+            command: 'bad',
+            status: 'failed',
+            aggregatedOutput: 'bad: not found',
+            exitCode: 127,
+          },
+        },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{
+      kind: 'tool_result',
+      toolUseId: 'cmd2',
+      content: { error: 'bad: not found', exitCode: 127 },
+    }])
+  })
+
+  test('unknown item.type emits no events (forward-compatible)', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'item/completed',
+        params: {
+          threadId: 't1',
+          turnId: 'r1',
+          item: { type: 'imageGeneration', id: 'i9', status: 'completed' },
+        },
+      }),
+    )!
+    expect(translateCodexLine(raw).events).toHaveLength(0)
   })
 })

--- a/server/session/providers/codex/stream.ts
+++ b/server/session/providers/codex/stream.ts
@@ -1,5 +1,5 @@
 import type { ProviderEvent } from '../types.js'
-import type { CodexLine } from './stream-types.js'
+import type { CodexLine, ThreadItem } from './stream-types.js'
 
 export function parseCodexLine(raw: string): CodexLine | null {
   const trimmed = raw.trim()
@@ -93,6 +93,16 @@ export function translateCodexLine(
       break
     }
 
+    case 'item/started': {
+      events.push(...itemToProviderEvents(raw.params.item, 'started'))
+      break
+    }
+
+    case 'item/completed': {
+      events.push(...itemToProviderEvents(raw.params.item, 'completed'))
+      break
+    }
+
     case 'turn/completed':
       events.push({ kind: 'turn_complete', totalTokens: null, totalCostUsd: null, numTurns: null })
       break
@@ -105,10 +115,106 @@ export function translateCodexLine(
 
     default: {
       const method = (raw as unknown as { method: string }).method
-      console.warn('[codex-stream] Unknown notification method:', method)
+      // Many codex notifications are observability-only (configWarning, warning,
+      // thread/status/changed, mcpServer/startupStatus/updated, item/* progress
+      // for non-text items, etc.). Drop them silently rather than logging on
+      // every line.
+      void method
       break
     }
   }
 
   return { events, sessionId }
+}
+
+function itemToProviderEvents(item: ThreadItem, phase: 'started' | 'completed'): ProviderEvent[] {
+  if (item.type === 'agentMessage') {
+    if (phase !== 'completed') return []
+    const text = (item as { text?: unknown }).text
+    if (typeof text !== 'string' || text.length === 0) return []
+    return [{ kind: 'text_delta', text }]
+  }
+
+  if (item.type === 'reasoning') {
+    if (phase !== 'completed') return []
+    const text = stringifyReasoning(item as Record<string, unknown>)
+    if (text.length === 0) return []
+    return [{ kind: 'thinking_block', text }]
+  }
+
+  if (item.type === 'commandExecution') {
+    const cmd = item as {
+      id: string
+      command: string
+      status?: string
+      aggregatedOutput?: string | null
+      exitCode?: number | null
+    }
+    if (!cmd.id) return []
+    if (phase === 'started') {
+      return [{ kind: 'tool_use', id: cmd.id, name: 'shell', input: { command: cmd.command } }]
+    }
+    const okStatus = cmd.status === 'completed'
+    if (!okStatus) {
+      return [{
+        kind: 'tool_result',
+        toolUseId: cmd.id,
+        content: { error: cmd.aggregatedOutput ?? `command ${cmd.status ?? 'failed'}`, exitCode: cmd.exitCode ?? null },
+      }]
+    }
+    return [{
+      kind: 'tool_result',
+      toolUseId: cmd.id,
+      content: { stdout: cmd.aggregatedOutput ?? '', exitCode: cmd.exitCode ?? 0 },
+    }]
+  }
+
+  if (item.type === 'fileChange') {
+    const fc = item as { id: string; status?: string; changes?: unknown[] }
+    if (!fc.id) return []
+    if (phase === 'started') {
+      return [{ kind: 'tool_use', id: fc.id, name: 'fileChange', input: { changes: fc.changes ?? [] } }]
+    }
+    if (fc.status === 'completed') {
+      return [{ kind: 'tool_result', toolUseId: fc.id, content: { ok: true, changes: fc.changes ?? [] } }]
+    }
+    return [{
+      kind: 'tool_result',
+      toolUseId: fc.id,
+      content: { error: `fileChange ${fc.status ?? 'failed'}`, changes: fc.changes ?? [] },
+    }]
+  }
+
+  if (item.type === 'mcpToolCall' || item.type === 'dynamicToolCall') {
+    const tc = item as { id: string; tool?: string; arguments?: unknown; status?: string; output?: unknown }
+    if (!tc.id) return []
+    if (phase === 'started') {
+      return [{ kind: 'tool_use', id: tc.id, name: tc.tool ?? item.type, input: (tc.arguments as Record<string, unknown>) ?? {} }]
+    }
+    if (tc.status === 'completed') {
+      return [{ kind: 'tool_result', toolUseId: tc.id, content: tc.output ?? null }]
+    }
+    return [{ kind: 'tool_result', toolUseId: tc.id, content: { error: tc.output ?? `${item.type} ${tc.status ?? 'failed'}` } }]
+  }
+
+  return []
+}
+
+function stringifyReasoning(item: Record<string, unknown>): string {
+  if (typeof item['text'] === 'string') return item['text'] as string
+  const summary = item['summary']
+  if (Array.isArray(summary)) {
+    const parts = summary
+      .map((s) => (typeof s === 'string' ? s : typeof (s as { text?: unknown })?.text === 'string' ? (s as { text: string }).text : ''))
+      .filter((s) => s.length > 0)
+    if (parts.length > 0) return parts.join('\n\n')
+  }
+  const content = item['content']
+  if (Array.isArray(content)) {
+    const parts = content
+      .map((c) => (typeof c === 'string' ? c : typeof (c as { text?: unknown })?.text === 'string' ? (c as { text: string }).text : ''))
+      .filter((s) => s.length > 0)
+    if (parts.length > 0) return parts.join('\n\n')
+  }
+  return ''
 }


### PR DESCRIPTION
## Summary
- Live codex 0.125.0 emits \`item/started\` + \`item/completed\` (with a discriminated \`params.item.type\`) instead of the v1 \`item/agentMessage\`, \`item/reasoning\`, \`item/toolCall\` methods the provider watches.
- Net effect on the mini after #133: every codex turn finished cleanly, but \`turn_completed\` arrived with **no** \`assistant_text\` — agent reply, reasoning, and shell calls were all dropped before the engine could forward them.
- Add \`ThreadItem\` typings, translate \`agentMessage\` → \`text_delta\`, \`reasoning\` → \`thinking_block\` (with summary fallback), and \`commandExecution\` / \`fileChange\` / \`mcpToolCall\` / \`dynamicToolCall\` through \`tool_use\` + \`tool_result\`. Unknown item types no-op so we don't crash on future variants.
- Drop the unknown-method \`console.warn\` — codex emits a steady stream of observability-only notifications (\`configWarning\`, \`warning\`, \`thread/status/changed\`, \`mcpServer/startupStatus/updated\`, etc.) that aren't actionable.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test\` (768 vitest)
- [x] \`bun test server/session/providers/codex\` (32 stream + 37 provider tests)