### PR TITLE
fix(codex): use ChatGPT-supported default model + surface errors

### DIFF
--- a/server/session/prompts.test.ts
+++ b/server/session/prompts.test.ts
@@ -59,7 +59,7 @@ describe('getModeConfig', () => {
       expect(cfg.disallowedTools).toHaveLength(0)
     })
 
-    test('codex task model uses gpt-5.1-codex default', () => {
+    test('codex task model uses gpt-5.3-codex default', () => {
       const cfg = getModeConfig('codex', 'task')
       expect(cfg.model).toBe(CODEX_MODE_CONFIGS['task'].model)
     })

--- a/server/session/prompts.ts
+++ b/server/session/prompts.ts
@@ -74,19 +74,19 @@ const CODEX_REASONING_EFFORT = envReasoningEffort('CODEX_REASONING_EFFORT', 'hig
 export const CODEX_MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
   task: {
     systemPrompt: DEFAULT_TASK_PROMPT,
-    model: envModel('CODEX_TASK_MODEL', 'gpt-5.1-codex'),
+    model: envModel('CODEX_TASK_MODEL', 'gpt-5.3-codex'),
     disallowedTools: [],
     autoExitOnComplete: false,
   },
   'dag-task': {
     systemPrompt: DEFAULT_TASK_PROMPT,
-    model: envModel('CODEX_TASK_MODEL', 'gpt-5.1-codex'),
+    model: envModel('CODEX_TASK_MODEL', 'gpt-5.3-codex'),
     disallowedTools: [],
     autoExitOnComplete: true,
   },
   plan: {
     systemPrompt: DEFAULT_PLAN_PROMPT,
-    model: envModel('CODEX_PLAN_MODEL', 'gpt-5.1-codex'),
+    model: envModel('CODEX_PLAN_MODEL', 'gpt-5.3-codex'),
     disallowedTools: [],
     autoExitOnComplete: false,
     reasoningEffort: CODEX_REASONING_EFFORT,
@@ -94,7 +94,7 @@ export const CODEX_MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
   },
   think: {
     systemPrompt: DEFAULT_THINK_PROMPT,
-    model: envModel('CODEX_THINK_MODEL', 'gpt-5.1-codex'),
+    model: envModel('CODEX_THINK_MODEL', 'gpt-5.3-codex'),
     disallowedTools: [],
     autoExitOnComplete: false,
     reasoningEffort: CODEX_REASONING_EFFORT,
@@ -102,7 +102,7 @@ export const CODEX_MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
   },
   review: {
     systemPrompt: DEFAULT_REVIEW_PROMPT,
-    model: envModel('CODEX_REVIEW_MODEL', 'gpt-5.1-codex'),
+    model: envModel('CODEX_REVIEW_MODEL', 'gpt-5.3-codex'),
     disallowedTools: [],
     autoExitOnComplete: false,
     reasoningEffort: CODEX_REASONING_EFFORT,
@@ -110,14 +110,14 @@ export const CODEX_MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
   },
   ship: {
     systemPrompt: DEFAULT_SHIP_PROMPT,
-    model: envModel('CODEX_SHIP_MODEL', 'gpt-5.1-codex'),
+    model: envModel('CODEX_SHIP_MODEL', 'gpt-5.3-codex'),
     disallowedTools: [],
     autoExitOnComplete: false,
     reasoningEffort: CODEX_REASONING_EFFORT,
   },
   'ci-fix': {
     systemPrompt: DEFAULT_CI_FIX_PROMPT,
-    model: envModel('CODEX_CI_FIX_MODEL', 'gpt-5.1-codex'),
+    model: envModel('CODEX_CI_FIX_MODEL', 'gpt-5.3-codex'),
     disallowedTools: [],
     autoExitOnComplete: true,
   },

--- a/server/session/providers/codex/provider.test.ts
+++ b/server/session/providers/codex/provider.test.ts
@@ -16,7 +16,7 @@ function makeOpts(overrides?: Partial<SpawnArgsOpts>): SpawnArgsOpts {
     parentHome: PARENT_HOME,
     modeConfig: {
       systemPrompt: 'Be helpful',
-      model: 'gpt-5.1-codex',
+      model: 'gpt-5.3-codex',
       disallowedTools: [],
       autoExitOnComplete: false,
     },
@@ -106,7 +106,7 @@ describe('serializeInitialInput — fresh session', () => {
     const provider = makeCodexProvider()
     const raw = provider.serializeInitialInput('prompt', undefined, makeOpts())
     const params = splitFrames(raw)[1]!.params as { model: string; cwd: string; approvalPolicy: string }
-    expect(params.model).toBe('gpt-5.1-codex')
+    expect(params.model).toBe('gpt-5.3-codex')
     expect(params.cwd).toBe('/repo')
     expect(params.approvalPolicy).toBe('never')
   })
@@ -121,7 +121,7 @@ describe('serializeInitialInput — fresh session', () => {
   test('forwards read-only sandbox', () => {
     const provider = makeCodexProvider()
     const opts = makeOpts({
-      modeConfig: { systemPrompt: '', model: 'gpt-5.1-codex', disallowedTools: [], autoExitOnComplete: false, sandbox: 'read-only' },
+      modeConfig: { systemPrompt: '', model: 'gpt-5.3-codex', disallowedTools: [], autoExitOnComplete: false, sandbox: 'read-only' },
     })
     const raw = provider.serializeInitialInput('prompt', undefined, opts)
     const params = splitFrames(raw)[1]!.params as { sandbox: string }
@@ -131,7 +131,7 @@ describe('serializeInitialInput — fresh session', () => {
   test('includes reasoning effort in config when set', () => {
     const provider = makeCodexProvider()
     const opts = makeOpts({
-      modeConfig: { systemPrompt: '', model: 'gpt-5.1-codex', disallowedTools: [], autoExitOnComplete: false, reasoningEffort: 'high' },
+      modeConfig: { systemPrompt: '', model: 'gpt-5.3-codex', disallowedTools: [], autoExitOnComplete: false, reasoningEffort: 'high' },
     })
     const raw = provider.serializeInitialInput('prompt', undefined, opts)
     const params = splitFrames(raw)[1]!.params as { config?: { model_reasoning_effort: string } }

--- a/server/session/providers/codex/stream-types.ts
+++ b/server/session/providers/codex/stream-types.ts
@@ -88,12 +88,25 @@ export interface CodexItemCompleted {
 
 export interface CodexTurnCompleted {
   method: 'turn/completed'
-  params: { turn: { id: string; status: 'completed' } }
+  params: {
+    threadId?: string
+    turn: { id: string; status: 'completed' | 'failed'; error?: { message?: string } | null }
+  }
 }
 
 export interface CodexTurnFailed {
   method: 'turn/failed'
   params: { turn: { id: string; status: 'failed'; error?: { message: string } } }
+}
+
+export interface CodexError {
+  method: 'error'
+  params: {
+    threadId?: string
+    turnId?: string
+    willRetry?: boolean
+    error: { message?: string; codexErrorInfo?: string; additionalDetails?: unknown }
+  }
 }
 
 export type CodexNotification =
@@ -108,6 +121,7 @@ export type CodexNotification =
   | CodexItemCompleted
   | CodexTurnCompleted
   | CodexTurnFailed
+  | CodexError
 
 export interface CodexRpcResponse {
   id: number

--- a/server/session/providers/codex/stream.test.ts
+++ b/server/session/providers/codex/stream.test.ts
@@ -282,6 +282,79 @@ describe('translateCodexLine — turn/failed', () => {
 })
 
 // ---------------------------------------------------------------------------
+// translateCodexLine — error notifications and failed turns
+// ---------------------------------------------------------------------------
+
+describe('translateCodexLine — error and failed turn surfacing', () => {
+  test('error notification emits error event with inner backend message', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'error',
+        params: {
+          threadId: 'thr_1',
+          turnId: 'r1',
+          willRetry: false,
+          error: {
+            message: '{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The \'foo-codex\' model is not supported when using Codex with a ChatGPT account."}}',
+            codexErrorInfo: 'other',
+            additionalDetails: null,
+          },
+        },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([{
+      kind: 'error',
+      error: "The 'foo-codex' model is not supported when using Codex with a ChatGPT account.",
+    }])
+  })
+
+  test('error notification falls back to raw message when not JSON-wrapped', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'error',
+        params: { error: { message: 'plain error string' } },
+      }),
+    )!
+    expect(translateCodexLine(raw).events).toEqual([{ kind: 'error', error: 'plain error string' }])
+  })
+
+  test('turn/completed status=failed emits error then turn_complete', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'turn/completed',
+        params: {
+          threadId: 'thr_1',
+          turn: {
+            id: 'r1',
+            status: 'failed',
+            error: { message: 'something broke' },
+          },
+        },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([
+      { kind: 'error', error: 'something broke' },
+      { kind: 'turn_complete', totalTokens: null, totalCostUsd: null, numTurns: null },
+    ])
+  })
+
+  test('turn/completed status=completed emits only turn_complete', () => {
+    const raw = parseCodexLine(
+      JSON.stringify({
+        method: 'turn/completed',
+        params: { threadId: 'thr_1', turn: { id: 'r1', status: 'completed' } },
+      }),
+    )!
+    const { events } = translateCodexLine(raw)
+    expect(events).toEqual([
+      { kind: 'turn_complete', totalTokens: null, totalCostUsd: null, numTurns: null },
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
 // translateCodexLine — JSON-RPC error response
 // ---------------------------------------------------------------------------
 

--- a/server/session/providers/codex/stream.ts
+++ b/server/session/providers/codex/stream.ts
@@ -103,13 +103,24 @@ export function translateCodexLine(
       break
     }
 
-    case 'turn/completed':
+    case 'turn/completed': {
+      const turn = (raw.params as { turn?: { status?: string; error?: { message?: string } } }).turn
+      if (turn?.status === 'failed') {
+        events.push({ kind: 'error', error: extractCodexErrorMessage(turn.error?.message) ?? 'turn failed' })
+      }
       events.push({ kind: 'turn_complete', totalTokens: null, totalCostUsd: null, numTurns: null })
       break
+    }
 
     case 'turn/failed': {
       const turn = raw.params.turn
-      events.push({ kind: 'error', error: turn.error?.message ?? 'turn failed' })
+      events.push({ kind: 'error', error: extractCodexErrorMessage(turn.error?.message) ?? 'turn failed' })
+      break
+    }
+
+    case 'error': {
+      const params = raw.params as { error?: { message?: string } }
+      events.push({ kind: 'error', error: extractCodexErrorMessage(params.error?.message) ?? 'codex error' })
       break
     }
 
@@ -198,6 +209,21 @@ function itemToProviderEvents(item: ThreadItem, phase: 'started' | 'completed'):
   }
 
   return []
+}
+
+function extractCodexErrorMessage(raw: string | undefined): string | null {
+  if (!raw) return null
+  // Codex wraps backend HTTP errors as a JSON-encoded string with shape
+  // { type, status, error: { type, message } }. Pull the inner message when
+  // present so the user sees something readable instead of the raw envelope.
+  try {
+    const parsed = JSON.parse(raw) as { error?: { message?: string } }
+    const inner = parsed.error?.message
+    if (typeof inner === 'string' && inner.length > 0) return inner
+  } catch {
+    // not JSON; fall through
+  }
+  return raw
 }
 
 function stringifyReasoning(item: Record<string, unknown>): string {


### PR DESCRIPTION
## Summary
Tested a fresh codex session on the mini after #134 landed. Two follow-on bugs:

1. **Default model rejected by ChatGPT auth.** Codex returned HTTP 400 — \`The 'gpt-5.1-codex' model is not supported when using Codex with a ChatGPT account.\` That model is API-key only. The ChatGPT plan exposes \`gpt-5.5\`, \`gpt-5.4\`, \`gpt-5.4-mini\`, \`gpt-5.3-codex\`, \`gpt-5.2\`, \`codex-auto-review\` (per the model cache). Switch every \`CODEX_*_MODEL\` default to \`gpt-5.3-codex\` (coding-optimized).

2. **Backend errors silently dropped.** Codex emits failures as both an \`error\` notification and \`turn/completed\` with \`status: 'failed'\`. Provider knew about neither, so the user got \`turn_completed\` with no \`assistant_text\` and no clue what broke. Translate both, and unwrap codex's JSON-encoded backend error envelope so the inner message reaches the transcript.

## Test plan
- [x] \`npm run typecheck\` / \`npm run lint\` / \`npm run test\` (768 vitest)
- [x] \`bun test server/session/providers/codex\` (36 stream + 37 provider)
- [x] Reproduced the failure live on the mini; the new translator surfaces the inner backend message.