### PR TITLE
fix(codex): default sandbox to danger-full-access

### DIFF
--- a/server/session/providers/codex/provider.test.ts
+++ b/server/session/providers/codex/provider.test.ts
@@ -111,14 +111,16 @@ describe('serializeInitialInput — fresh session', () => {
     expect(params.approvalPolicy).toBe('never')
   })
 
-  test('defaults sandbox to workspace-write when not set', () => {
+  test('defaults sandbox to danger-full-access when no env override and no mode hint', () => {
+    delete process.env['CODEX_SANDBOX_MODE']
     const provider = makeCodexProvider()
     const raw = provider.serializeInitialInput('prompt', undefined, makeOpts())
     const params = splitFrames(raw)[1]!.params as { sandbox: string }
-    expect(params.sandbox).toBe('workspace-write')
+    expect(params.sandbox).toBe('danger-full-access')
   })
 
-  test('forwards read-only sandbox', () => {
+  test('forwards read-only sandbox when mode hint asks for it', () => {
+    delete process.env['CODEX_SANDBOX_MODE']
     const provider = makeCodexProvider()
     const opts = makeOpts({
       modeConfig: { systemPrompt: '', model: 'gpt-5.3-codex', disallowedTools: [], autoExitOnComplete: false, sandbox: 'read-only' },
@@ -126,6 +128,33 @@ describe('serializeInitialInput — fresh session', () => {
     const raw = provider.serializeInitialInput('prompt', undefined, opts)
     const params = splitFrames(raw)[1]!.params as { sandbox: string }
     expect(params.sandbox).toBe('read-only')
+  })
+
+  test('CODEX_SANDBOX_MODE env overrides everything', () => {
+    process.env['CODEX_SANDBOX_MODE'] = 'workspace-write'
+    try {
+      const provider = makeCodexProvider()
+      const opts = makeOpts({
+        modeConfig: { systemPrompt: '', model: 'gpt-5.3-codex', disallowedTools: [], autoExitOnComplete: false, sandbox: 'read-only' },
+      })
+      const raw = provider.serializeInitialInput('prompt', undefined, opts)
+      const params = splitFrames(raw)[1]!.params as { sandbox: string }
+      expect(params.sandbox).toBe('workspace-write')
+    } finally {
+      delete process.env['CODEX_SANDBOX_MODE']
+    }
+  })
+
+  test('CODEX_SANDBOX_MODE env ignores invalid values and falls back to default', () => {
+    process.env['CODEX_SANDBOX_MODE'] = 'totally-bogus'
+    try {
+      const provider = makeCodexProvider()
+      const raw = provider.serializeInitialInput('prompt', undefined, makeOpts())
+      const params = splitFrames(raw)[1]!.params as { sandbox: string }
+      expect(params.sandbox).toBe('danger-full-access')
+    } finally {
+      delete process.env['CODEX_SANDBOX_MODE']
+    }
   })
 
   test('includes reasoning effort in config when set', () => {

--- a/server/session/providers/codex/provider.ts
+++ b/server/session/providers/codex/provider.ts
@@ -14,6 +14,25 @@ const MEDIA_EXT: Record<Image['mediaType'], string> = {
 
 type CodexInput = { type: 'text'; text: string } | { type: 'localImage'; path: string }
 
+type CodexSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access'
+
+function resolveSandbox(modeHint: string | undefined): CodexSandboxMode {
+  // Codex enforces 'read-only' and 'workspace-write' via bubblewrap, which needs
+  // unprivileged user namespaces. That doesn't work in many container setups
+  // (the engine container fails with `bwrap: No permissions to create a new
+  // namespace`). The container itself is the trust boundary, so default to
+  // 'danger-full-access'. Operators with bwrap-capable hosts can opt back in
+  // via CODEX_SANDBOX_MODE=workspace-write|read-only.
+  const env = process.env['CODEX_SANDBOX_MODE']
+  if (env === 'read-only' || env === 'workspace-write' || env === 'danger-full-access') {
+    return env
+  }
+  if (modeHint === 'read-only' || modeHint === 'workspace-write' || modeHint === 'danger-full-access') {
+    return modeHint as CodexSandboxMode
+  }
+  return 'danger-full-access'
+}
+
 export function makeCodexProvider(): AgentProvider {
   let idCounter = 0
   let imageSeq = 0
@@ -75,7 +94,7 @@ export function makeCodexProvider(): AgentProvider {
 
       pendingInitialInput = { prompt, images }
 
-      const sandbox = opts.modeConfig.sandbox === 'read-only' ? 'read-only' : 'workspace-write'
+      const sandbox = resolveSandbox(opts.modeConfig.sandbox)
       const params: Record<string, unknown> = {
         model: opts.modeConfig.model,
         cwd: opts.cwd,


### PR DESCRIPTION
## Summary
Codex shell tool calls fail in the engine container with \`bwrap: No permissions to create a new namespace\` because the container doesn't have unprivileged-userns. Codex's read-only and workspace-write modes both rely on bubblewrap; only \`danger-full-access\` skips it. The container is already the trust boundary, so default to \`danger-full-access\`. Add \`CODEX_SANDBOX_MODE\` env override for operators on bwrap-capable hosts who want a tighter mode.

## Test plan
- [x] \`npm run typecheck\` / \`lint\` / \`test\` (768 vitest)
- [x] \`bun test\` codex provider (39 tests)
- [x] Reproduced live: codex agent answered \"list files in repo\" but every shell command bounced off bwrap; reasoning included the bwrap error verbatim.