### PR TITLE
fix(codex): drop read-only sandbox hint from plan/think/review

### DIFF
--- a/server/session/prompts.test.ts
+++ b/server/session/prompts.test.ts
@@ -34,9 +34,9 @@ describe('getModeConfig', () => {
       expect(cfg.reasoningEffort).toBe('high')
     })
 
-    test('plan mode has sandbox read-only', () => {
+    test('plan mode leaves sandbox unset (provider resolves to env/default)', () => {
       const cfg = getModeConfig('codex', 'plan')
-      expect(cfg.sandbox).toBe('read-only')
+      expect(cfg.sandbox).toBeUndefined()
     })
 
     test('task mode has no reasoningEffort', () => {

--- a/server/session/prompts.ts
+++ b/server/session/prompts.ts
@@ -90,7 +90,6 @@ export const CODEX_MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
     disallowedTools: [],
     autoExitOnComplete: false,
     reasoningEffort: CODEX_REASONING_EFFORT,
-    sandbox: 'read-only',
   },
   think: {
     systemPrompt: DEFAULT_THINK_PROMPT,
@@ -98,7 +97,6 @@ export const CODEX_MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
     disallowedTools: [],
     autoExitOnComplete: false,
     reasoningEffort: CODEX_REASONING_EFFORT,
-    sandbox: 'read-only',
   },
   review: {
     systemPrompt: DEFAULT_REVIEW_PROMPT,
@@ -106,7 +104,6 @@ export const CODEX_MODE_CONFIGS: Record<AllSessionMode, ModeConfig> = {
     disallowedTools: [],
     autoExitOnComplete: false,
     reasoningEffort: CODEX_REASONING_EFFORT,
-    sandbox: 'read-only',
   },
   ship: {
     systemPrompt: DEFAULT_SHIP_PROMPT,


### PR DESCRIPTION
Follow-up to #136. Codex plan/think/review sessions still hit bwrap because their mode configs hardcoded `sandbox: 'read-only'`, which the resolver honored as a downgrade. Drop the hint so they fall through to the env-controlled default (`danger-full-access`).