### PR TITLE
feat(session): share agent asset injection for Claude and Codex

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -117,6 +117,24 @@ Remove the `~/.claude` mount in `compose.dev.yaml` if you want full isolation pe
 
 - **Only option**: mount `~/.codex` — `compose.dev.yaml` and `compose.codex.yaml` both do this. Requires you've run `codex login` on the host. There is no API key fallback; Codex auth is tied to your ChatGPT coding plan.
 
+## Shared agent assets (`.agent-assets`)
+
+The engine now injects shared agent config into each session worktree on both create and resume.
+
+Resolution order:
+- `MINION_AGENT_ASSETS_DIR` (explicit override)
+- `<WORKSPACE_ROOT>/.agent-assets` (preferred shared location)
+- `<WORKSPACE_ROOT>/.claude-assets` (legacy fallback)
+
+Copy behavior:
+- Recursively copies all files and directories into the worktree
+- Never overwrites existing files in the worktree
+- Works for both provider trees (for example `.claude/*`, `.codex/*`, hooks, agents, skills)
+
+Instruction aliasing:
+- If `AGENT.md` exists in assets, it is copied to both `AGENTS.md` and `CLAUDE.md` when missing
+- If only one of `AGENTS.md` or `CLAUDE.md` exists in assets, it is mirrored to the other filename when missing
+
 ## Persistence
 
 Everything the engine persists (sessions, transcripts, DAGs, bare clones, node_modules caches) lives inside the `workspace` volume:

--- a/server/session/inject-assets.test.ts
+++ b/server/session/inject-assets.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
   }
 })
 
-function buildAssets(root: string): void {
+function buildLegacyAssets(root: string): void {
   fs.mkdirSync(path.join(root, '.claude', 'agents'), { recursive: true })
   fs.mkdirSync(path.join(root, '.claude', 'skills'), { recursive: true })
   fs.writeFileSync(path.join(root, 'CLAUDE.md'), '# CLAUDE')
@@ -30,56 +30,149 @@ function buildAssets(root: string): void {
 }
 
 describe('injectAgentFiles', () => {
-  test('copies CLAUDE.md and settings.json to cwd', () => {
+  test('copies entire asset tree recursively', () => {
     const assets = trackedDir()
     const cwd = trackedDir()
-    buildAssets(assets)
+    fs.mkdirSync(path.join(assets, '.codex', 'hooks'), { recursive: true })
+    fs.mkdirSync(path.join(assets, '.claude', 'agents'), { recursive: true })
+    fs.writeFileSync(path.join(assets, 'settings.json'), '{}')
+    fs.writeFileSync(path.join(assets, '.codex', 'hooks', 'pre-commit.sh'), 'echo ok')
+    fs.writeFileSync(path.join(assets, '.claude', 'agents', 'planner.md'), '# planner')
 
     injectAgentFiles(cwd, assets)
 
-    expect(fs.existsSync(path.join(cwd, 'CLAUDE.md'))).toBe(true)
     expect(fs.existsSync(path.join(cwd, 'settings.json'))).toBe(true)
-  })
-
-  test('copies .claude/agents and .claude/skills contents', () => {
-    const assets = trackedDir()
-    const cwd = trackedDir()
-    buildAssets(assets)
-
-    injectAgentFiles(cwd, assets)
-
-    expect(fs.existsSync(path.join(cwd, '.claude', 'agents', 'coding.md'))).toBe(true)
-    expect(fs.existsSync(path.join(cwd, '.claude', 'skills', 'deploy.md'))).toBe(true)
+    expect(fs.existsSync(path.join(cwd, '.codex', 'hooks', 'pre-commit.sh'))).toBe(true)
+    expect(fs.existsSync(path.join(cwd, '.claude', 'agents', 'planner.md'))).toBe(true)
   })
 
   test('does not overwrite existing files (no-overwrite policy)', () => {
     const assets = trackedDir()
     const cwd = trackedDir()
-    buildAssets(assets)
-
+    buildLegacyAssets(assets)
+    fs.mkdirSync(path.join(cwd, '.claude', 'agents'), { recursive: true })
     fs.writeFileSync(path.join(cwd, 'CLAUDE.md'), '# EXISTING')
+    fs.writeFileSync(path.join(cwd, '.claude', 'agents', 'coding.md'), '# EXISTING AGENT')
 
     injectAgentFiles(cwd, assets)
 
     expect(fs.readFileSync(path.join(cwd, 'CLAUDE.md'), 'utf8')).toBe('# EXISTING')
+    expect(fs.readFileSync(path.join(cwd, '.claude', 'agents', 'coding.md'), 'utf8')).toBe('# EXISTING AGENT')
   })
 
-  test('is a no-op when assets root does not exist', () => {
-    const cwd = trackedDir()
-    const nonExistent = path.join(TMPDIR, 'no-such-assets-dir')
-
-    expect(() => injectAgentFiles(cwd, nonExistent)).not.toThrow()
-    expect(fs.readdirSync(cwd)).toHaveLength(0)
-  })
-
-  test('skips non-existent optional assets gracefully', () => {
+  test('AGENT.md fans out to AGENTS.md and CLAUDE.md', () => {
     const assets = trackedDir()
     const cwd = trackedDir()
-    fs.writeFileSync(path.join(assets, 'CLAUDE.md'), '# only this')
+    fs.writeFileSync(path.join(assets, 'AGENT.md'), '# canonical')
 
     injectAgentFiles(cwd, assets)
 
-    expect(fs.existsSync(path.join(cwd, 'CLAUDE.md'))).toBe(true)
-    expect(fs.existsSync(path.join(cwd, 'settings.json'))).toBe(false)
+    expect(fs.readFileSync(path.join(cwd, 'AGENTS.md'), 'utf8')).toBe('# canonical')
+    expect(fs.readFileSync(path.join(cwd, 'CLAUDE.md'), 'utf8')).toBe('# canonical')
+  })
+
+  test('mirrors AGENTS.md to CLAUDE.md when only AGENTS.md exists', () => {
+    const assets = trackedDir()
+    const cwd = trackedDir()
+    fs.writeFileSync(path.join(assets, 'AGENTS.md'), '# shared')
+
+    injectAgentFiles(cwd, assets)
+
+    expect(fs.readFileSync(path.join(cwd, 'AGENTS.md'), 'utf8')).toBe('# shared')
+    expect(fs.readFileSync(path.join(cwd, 'CLAUDE.md'), 'utf8')).toBe('# shared')
+  })
+
+  test('mirrors CLAUDE.md to AGENTS.md when only CLAUDE.md exists', () => {
+    const assets = trackedDir()
+    const cwd = trackedDir()
+    fs.writeFileSync(path.join(assets, 'CLAUDE.md'), '# claude-only')
+
+    injectAgentFiles(cwd, assets)
+
+    expect(fs.readFileSync(path.join(cwd, 'CLAUDE.md'), 'utf8')).toBe('# claude-only')
+    expect(fs.readFileSync(path.join(cwd, 'AGENTS.md'), 'utf8')).toBe('# claude-only')
+  })
+
+  test('prefers .agent-assets over legacy .claude-assets', () => {
+    const workspaceRoot = trackedDir()
+    const cwd = trackedDir()
+    const shared = path.join(workspaceRoot, '.agent-assets')
+    const legacy = path.join(workspaceRoot, '.claude-assets')
+    fs.mkdirSync(shared, { recursive: true })
+    fs.mkdirSync(legacy, { recursive: true })
+    fs.writeFileSync(path.join(shared, 'CLAUDE.md'), '# shared')
+    fs.writeFileSync(path.join(legacy, 'CLAUDE.md'), '# legacy')
+    const prevWorkspaceRoot = process.env['WORKSPACE_ROOT']
+    delete process.env['MINION_AGENT_ASSETS_DIR']
+    process.env['WORKSPACE_ROOT'] = workspaceRoot
+
+    try {
+      injectAgentFiles(cwd)
+    } finally {
+      if (prevWorkspaceRoot === undefined) delete process.env['WORKSPACE_ROOT']
+      else process.env['WORKSPACE_ROOT'] = prevWorkspaceRoot
+    }
+
+    expect(fs.readFileSync(path.join(cwd, 'CLAUDE.md'), 'utf8')).toBe('# shared')
+  })
+
+  test('falls back to legacy .claude-assets when shared dir is absent', () => {
+    const workspaceRoot = trackedDir()
+    const cwd = trackedDir()
+    const legacy = path.join(workspaceRoot, '.claude-assets')
+    fs.mkdirSync(legacy, { recursive: true })
+    fs.writeFileSync(path.join(legacy, 'CLAUDE.md'), '# legacy')
+    const prevWorkspaceRoot = process.env['WORKSPACE_ROOT']
+    delete process.env['MINION_AGENT_ASSETS_DIR']
+    process.env['WORKSPACE_ROOT'] = workspaceRoot
+
+    try {
+      injectAgentFiles(cwd)
+    } finally {
+      if (prevWorkspaceRoot === undefined) delete process.env['WORKSPACE_ROOT']
+      else process.env['WORKSPACE_ROOT'] = prevWorkspaceRoot
+    }
+
+    expect(fs.readFileSync(path.join(cwd, 'CLAUDE.md'), 'utf8')).toBe('# legacy')
+  })
+
+  test('uses MINION_AGENT_ASSETS_DIR override when set', () => {
+    const workspaceRoot = trackedDir()
+    const explicitRoot = trackedDir()
+    const cwd = trackedDir()
+    fs.writeFileSync(path.join(explicitRoot, 'CLAUDE.md'), '# explicit')
+    fs.mkdirSync(path.join(workspaceRoot, '.agent-assets'), { recursive: true })
+    fs.writeFileSync(path.join(workspaceRoot, '.agent-assets', 'CLAUDE.md'), '# shared')
+    const prevWorkspaceRoot = process.env['WORKSPACE_ROOT']
+    const prevOverride = process.env['MINION_AGENT_ASSETS_DIR']
+    process.env['WORKSPACE_ROOT'] = workspaceRoot
+    process.env['MINION_AGENT_ASSETS_DIR'] = explicitRoot
+
+    try {
+      injectAgentFiles(cwd)
+    } finally {
+      if (prevWorkspaceRoot === undefined) delete process.env['WORKSPACE_ROOT']
+      else process.env['WORKSPACE_ROOT'] = prevWorkspaceRoot
+      if (prevOverride === undefined) delete process.env['MINION_AGENT_ASSETS_DIR']
+      else process.env['MINION_AGENT_ASSETS_DIR'] = prevOverride
+    }
+
+    expect(fs.readFileSync(path.join(cwd, 'CLAUDE.md'), 'utf8')).toBe('# explicit')
+  })
+
+  test('is a no-op when resolved assets root does not exist', () => {
+    const cwd = trackedDir()
+    const nonExistent = path.join(TMPDIR, 'no-such-assets-dir')
+    const prevOverride = process.env['MINION_AGENT_ASSETS_DIR']
+    process.env['MINION_AGENT_ASSETS_DIR'] = nonExistent
+
+    try {
+      expect(() => injectAgentFiles(cwd)).not.toThrow()
+    } finally {
+      if (prevOverride === undefined) delete process.env['MINION_AGENT_ASSETS_DIR']
+      else process.env['MINION_AGENT_ASSETS_DIR'] = prevOverride
+    }
+
+    expect(fs.readdirSync(cwd)).toHaveLength(0)
   })
 })

--- a/server/session/inject-assets.ts
+++ b/server/session/inject-assets.ts
@@ -1,9 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-const ASSET_FILES = ['CLAUDE.md', 'settings.json'] as const
-const AGENT_DIRS = ['.claude/agents', '.claude/skills'] as const
-
 function copyIfAbsent(src: string, dest: string): void {
   if (fs.existsSync(dest)) return
   const destDir = path.dirname(dest)
@@ -11,34 +8,78 @@ function copyIfAbsent(src: string, dest: string): void {
   fs.copyFileSync(src, dest)
 }
 
-function copyDirContentsIfAbsent(srcDir: string, destDir: string): void {
-  if (!fs.existsSync(srcDir)) return
-  let entries: fs.Dirent[]
+function copyPathIfAbsent(src: string, dest: string): void {
+  if (fs.existsSync(dest)) return
+  let stat: fs.Stats
   try {
-    entries = fs.readdirSync(srcDir, { withFileTypes: true })
+    stat = fs.statSync(src)
   } catch {
     return
   }
-  for (const entry of entries) {
-    if (!entry.isFile()) continue
-    const src = path.join(srcDir, entry.name)
-    const dest = path.join(destDir, entry.name)
+
+  if (stat.isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true })
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(src, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      copyPathIfAbsent(path.join(src, entry.name), path.join(dest, entry.name))
+    }
+    return
+  }
+
+  if (stat.isFile()) {
     copyIfAbsent(src, dest)
   }
 }
 
-export function injectAgentFiles(cwd: string, assetsRoot?: string): void {
-  const src = assetsRoot ?? path.join(process.env['WORKSPACE_ROOT'] ?? './.minion-data', '.claude-assets')
+function resolveAssetsRoot(assetsRoot?: string, workspaceRootOverride?: string): string | undefined {
+  if (assetsRoot) return assetsRoot
+  if (process.env['MINION_AGENT_ASSETS_DIR']) return process.env['MINION_AGENT_ASSETS_DIR']
 
-  if (!fs.existsSync(src)) return
+  const workspaceRoot = workspaceRootOverride ?? process.env['WORKSPACE_ROOT'] ?? './.minion-data'
+  const sharedPath = path.join(workspaceRoot, '.agent-assets')
+  if (fs.existsSync(sharedPath)) return sharedPath
 
-  for (const file of ASSET_FILES) {
-    const srcPath = path.join(src, file)
-    if (!fs.existsSync(srcPath)) continue
-    copyIfAbsent(srcPath, path.join(cwd, file))
+  const legacyPath = path.join(workspaceRoot, '.claude-assets')
+  if (fs.existsSync(legacyPath)) return legacyPath
+
+  return undefined
+}
+
+function mirrorInstructionFiles(cwd: string, src: string): void {
+  const agent = path.join(src, 'AGENT.md')
+  const agents = path.join(src, 'AGENTS.md')
+  const claude = path.join(src, 'CLAUDE.md')
+
+  if (fs.existsSync(agent)) {
+    copyIfAbsent(agent, path.join(cwd, 'AGENTS.md'))
+    copyIfAbsent(agent, path.join(cwd, 'CLAUDE.md'))
   }
 
-  for (const dir of AGENT_DIRS) {
-    copyDirContentsIfAbsent(path.join(src, dir), path.join(cwd, dir))
+  const hasAgents = fs.existsSync(agents)
+  const hasClaude = fs.existsSync(claude)
+  if (hasAgents && !hasClaude) copyIfAbsent(agents, path.join(cwd, 'CLAUDE.md'))
+  if (hasClaude && !hasAgents) copyIfAbsent(claude, path.join(cwd, 'AGENTS.md'))
+}
+
+export function injectAgentFiles(cwd: string, assetsRoot?: string, workspaceRootOverride?: string): void {
+  const src = resolveAssetsRoot(assetsRoot, workspaceRootOverride)
+  if (!src || !fs.existsSync(src)) return
+
+  let entries: fs.Dirent[]
+  try {
+    entries = fs.readdirSync(src, { withFileTypes: true })
+  } catch {
+    return
   }
+
+  for (const entry of entries) {
+    copyPathIfAbsent(path.join(src, entry.name), path.join(cwd, entry.name))
+  }
+
+  mirrorInstructionFiles(cwd, src)
 }

--- a/server/session/registry.test.ts
+++ b/server/session/registry.test.ts
@@ -170,6 +170,32 @@ describe('SessionRegistry', () => {
       expect(row?.bare_dir).toBeTruthy()
       expect(row?.bare_dir).toContain('.repos')
     }, 30_000)
+
+    test('injects shared agent assets into created worktree', async () => {
+      const bare = trackedDir('bare-assets')
+      const work = trackedDir('work-assets')
+      const workspaceRoot = trackedDir('ws-assets')
+      await initLocalBareRepo(bare, work)
+
+      const assetsRoot = path.join(workspaceRoot, '.agent-assets')
+      fs.mkdirSync(path.join(assetsRoot, '.codex', 'hooks'), { recursive: true })
+      fs.writeFileSync(path.join(assetsRoot, 'AGENT.md'), '# canonical agent')
+      fs.writeFileSync(path.join(assetsRoot, 'AGENT_RULES.txt'), 'shared rules')
+      fs.writeFileSync(path.join(assetsRoot, '.codex', 'hooks', 'pre.sh'), 'echo hook')
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn() })
+      const { session } = await registry.create({
+        mode: 'task',
+        prompt: 'inject assets',
+        repo: bare,
+        workspaceRoot,
+      })
+
+      const cwd = path.join(workspaceRoot, session.slug)
+      expect(fs.readFileSync(path.join(cwd, 'AGENT_RULES.txt'), 'utf8')).toBe('shared rules')
+      expect(fs.readFileSync(path.join(cwd, 'AGENT.md'), 'utf8')).toBe('# canonical agent')
+      expect(fs.readFileSync(path.join(cwd, '.codex', 'hooks', 'pre.sh'), 'utf8')).toBe('echo hook')
+    }, 30_000)
   })
 
   describe('list', () => {

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -8,6 +8,7 @@ import { buildMcpConfig, shouldAttachMcp } from '../mcp/config'
 import { getDb, prepared, type SessionRow } from '../db/sqlite'
 import { getEventBus } from '../events/bus'
 import type { Database } from 'bun:sqlite'
+import { injectAgentFiles } from './inject-assets'
 
 const ADJECTIVES = ['brisk','wide','quiet','loud','smart','bright','dim','warm','cool','fast','slow','neat','crisp','rough','sharp','soft']
 const NOUNS = ['ivy','oak','fern','river','meadow','peak','bay','cliff','dune','grove','lake','mesa','pond','reef','stream','wood']
@@ -133,6 +134,7 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
       workspaceRoot,
       startRef: createOpts.startRef,
     })
+    injectAgentFiles(handle.cwd, undefined, workspaceRoot)
 
     const now = Date.now()
     const row: SessionRow = {
@@ -261,6 +263,7 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
       const repoName = extractRepoName(row.repo)
       await rebootstrapIfMissing(cwd, repoName, row.workspace_root)
     }
+    injectAgentFiles(cwd, undefined, row.workspace_root)
 
     const runtime = makeRuntime({
       sessionId: row.id,


### PR DESCRIPTION
## Summary
- add provider-agnostic asset injection with shared root support via `.agent-assets` plus legacy `.claude-assets` fallback
- add `MINION_AGENT_ASSETS_DIR` override, recursive copy for provider trees, and no-overwrite behavior
- add canonical instruction aliasing (`AGENT.md` fan-out, `AGENTS.md`/`CLAUDE.md` mirroring)
- inject shared assets during both session create and resume paths
- expand tests for copy behavior, precedence/fallback, aliasing, and registry integration; document the contract in docker docs

## Test plan
- `AGENT_PROVIDER=claude bun test server/session/inject-assets.test.ts server/session/registry.test.ts`
- `npx eslint server/session/inject-assets.ts server/session/inject-assets.test.ts server/session/registry.ts server/session/registry.test.ts`
- `npm run lint`
- `npm run typecheck` *(fails in this environment with missing type definitions: `whatwg-mimetype`, `ws`)*
- `npm run test` *(existing unrelated baseline failures in `test/components/ContextMenu.test.tsx`, `test/components/PrPreviewCard.test.tsx`, `test/store.test.ts`, `test/state/store.test.ts`)*