### PR TITLE
docs: make plan mode explicitly read-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,11 +12,11 @@ Always set the `model` parameter explicitly when spawning via the `Agent` tool.
 
 If an implementation agent encounters ambiguity, unresolved design questions, or an architectural decision — **stop implementing** and return to the planning loop with an opus-tier agent. Do not guess inline.
 
-## Plan mode is read-only
+## Plan/Think mode is read-only
 
-- Planning threads are strictly non-mutating: no file edits, no `apply_patch`, no write commands, no commits.
-- In plan mode, only gather context and produce a concrete step-by-step implementation plan.
-- If a plan thread accidentally starts making changes, stop immediately, discard that attempt, and restart in read-only planning.
+- `plan` and `think` threads are strictly non-mutating: no file edits, no `apply_patch`, no write commands, no commits.
+- In `plan`/`think` mode, only gather context and produce analysis plus a concrete step-by-step implementation plan.
+- If a `plan` or `think` thread accidentally starts making changes, stop immediately, discard that attempt, and restart in read-only planning.
 - Start implementation only after the user explicitly asks to execute the approved plan.
 
 ## Branch and PR workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,13 @@ Always set the `model` parameter explicitly when spawning via the `Agent` tool.
 
 If an implementation agent encounters ambiguity, unresolved design questions, or an architectural decision — **stop implementing** and return to the planning loop with an opus-tier agent. Do not guess inline.
 
+## Plan mode is read-only
+
+- Planning threads are strictly non-mutating: no file edits, no `apply_patch`, no write commands, no commits.
+- In plan mode, only gather context and produce a concrete step-by-step implementation plan.
+- If a plan thread accidentally starts making changes, stop immediately, discard that attempt, and restart in read-only planning.
+- Start implementation only after the user explicitly asks to execute the approved plan.
+
 ## Branch and PR workflow
 
 - Branch naming: `feat/<scope>`, `fix/<scope>`, `chore/<scope>`, `docs/<scope>`. Examples: `feat/install-prompt`, `fix/sse-reconnect-backoff`.


### PR DESCRIPTION
## What changed
- Added a new **Plan mode is read-only** section to `AGENTS.md`.
- Explicitly forbids file edits, write commands, and commits during planning threads.
- Requires explicit user approval before moving from plan to implementation.

## Why
A prior planning thread made code changes. This codifies planning as strictly non-mutating so planning stays safe and predictable.

## How to validate
1. Open `AGENTS.md` and confirm the `## Plan mode is read-only` section is present.
2. Verify it includes no-edit/no-write/no-commit constraints and explicit implementation handoff rule.