### PR TITLE
chore(engine): install rg, fd, bat, jq, repomix in container

### DIFF
--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -25,14 +25,18 @@ FROM oven/bun:1.2-debian AS final
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git gh nodejs npm ca-certificates curl \
-    && rm -rf /var/lib/apt/lists/*
+    ripgrep fd-find bat jq \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/fdfind /usr/local/bin/fd \
+    && ln -s /usr/bin/batcat /usr/local/bin/bat
 
 RUN npm install -g \
       @anthropic-ai/claude-code \
       @openai/codex \
       @playwright/mcp \
       @upstash/context7-mcp \
-      github-mcp-server
+      github-mcp-server \
+      repomix
 
 COPY --from=devtools /opt/devtools /opt/devtools
 COPY --from=uv-base /opt/uv-python /opt/uv-python


### PR DESCRIPTION
Agent guidance asks agents to prefer `rg`/`fd`/`bat` over GNU grep/find/cat and to use `repomix` for context packaging. None were available in the engine image, so codex/claude sessions either fell back to GNU tools or had to install them mid-session. Apt-installs ripgrep/fd-find/bat/jq (with symlinks for the Debian-renamed binaries) and adds repomix to the global npm bundle.