### PR TITLE
fix: keep thread navigation in sync with route hash

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import { useResizable } from './hooks/useResizable'
 import { SessionList, statusDot } from './components/SessionList'
 import type { ApiDagGraph } from './api/types'
 import { currentRoute } from './routing/current'
+import { formatRoute } from './routing/route'
 import { VariantGroupView } from './groups/VariantGroupView'
 import type { ApiSession, AttentionReason, MinionCommand, QuickAction } from './api/types'
 import { HeaderMenu } from './components/HeaderMenu'
@@ -567,6 +568,8 @@ function MobileSessionStrip({
 function ActiveView() {
   const id = activeId.value
   const store = id ? getActiveStore() : null
+  const sessions = store?.sessions.value ?? []
+  const dags = store?.dags.value ?? []
   const conn = connections.value.find((c) => c.id === id)
   const [sessionId, setSessionId] = useState<string | null>(null)
   const [attentionFilter, setAttentionFilter] = useState<AttentionReason | null>(null)
@@ -593,19 +596,31 @@ function ActiveView() {
 
   useEffect(() => {
     if (route.name !== 'session') return
-    const match = store?.sessions.value.find((s) => s.slug === route.sessionSlug)
-    if (match && match.id !== sessionId) setSessionId(match.id)
-  }, [route, store, sessionId])
+    const match = sessions.find((s) => s.slug === route.sessionSlug)
+    if (!match) return
+    setSessionId((prev) => (prev === match.id ? prev : match.id))
+  }, [route, sessions])
 
   useEffect(() => {
     setAttentionFilter(null)
   }, [id])
 
-  const sessions = store?.sessions.value ?? []
-  const dags = store?.dags.value ?? []
   const visibleSessions = useMemo(
     () => filterSessionsByReason(sessions, attentionFilter),
     [sessions, attentionFilter],
+  )
+
+  const selectSession = useCallback(
+    (sid: string) => {
+      setSessionId(sid)
+      const session = sessions.find((s) => s.id === sid)
+      if (!session || typeof window === 'undefined') return
+      const nextHash = formatRoute({ name: 'session', sessionSlug: session.slug })
+      if (window.location.hash !== nextHash) {
+        window.location.hash = nextHash
+      }
+    },
+    [sessions],
   )
 
   const handleSendMessage = useCallback(
@@ -668,9 +683,9 @@ function ActiveView() {
   )
 
   const handleOpenChat = useCallback((sid: string) => {
-    setSessionId(sid)
+    selectSession(sid)
     viewMode.value = 'list'
-  }, [])
+  }, [selectSession])
 
   const handleOpenLogs = useCallback((sid: string) => {
     setLogsSessionId(sid)
@@ -716,7 +731,7 @@ function ActiveView() {
     firstMatchId: string | null,
   ) => {
     setAttentionFilter(reason)
-    if (firstMatchId !== null) setSessionId(firstMatchId)
+    if (firstMatchId !== null) selectSession(firstMatchId)
   }
 
 
@@ -826,7 +841,7 @@ function ActiveView() {
             visibleSessions={visibleSessions}
             dags={store.dags.value}
             sessionId={sessionId}
-            setSessionId={setSessionId}
+            setSessionId={selectSession}
             selected={selected}
             store={store}
             onSend={handleSendMessage}
@@ -872,7 +887,7 @@ function ActiveView() {
               sessions={visibleSessions}
               dags={store.dags.value}
               activeSessionId={sessionId}
-              onSelect={setSessionId}
+              onSelect={selectSession}
             />
             {selected ? (
               <ChatPane
@@ -881,7 +896,7 @@ function ActiveView() {
                 store={store}
                 onSend={handleSendMessage}
                 onCommand={handleCommand}
-                onNavigate={setSessionId}
+                onNavigate={selectSession}
               />
             ) : (
               <EmptyPane />

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -287,4 +287,33 @@ describe('App', () => {
     fireEvent.click(screen.getByTestId('session-item-s2'))
     await screen.findByTestId('transcript-upgrade-notice')
   })
+
+  it('updates the route hash when switching sessions from a routed session page', { timeout: 15000 }, async () => {
+    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
+      version: 1,
+      connections: [
+        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+      ],
+      activeId: 'c1',
+    }))
+    stubFetch([
+      session({ id: 's1', slug: 'brave-fox' }),
+      session({ id: 's2', slug: 'swift-cat' }),
+    ])
+    window.location.hash = '#/s/brave-fox'
+    try {
+      const App = (await import('../src/App')).default
+      render(<App />)
+
+      fireEvent.click(await screen.findByTestId('session-item-s2'))
+      await vi.waitFor(() => {
+        expect(window.location.hash).toBe('#/s/swift-cat')
+      })
+      await vi.waitFor(() => {
+        expect(screen.getByTestId('chat-pane').textContent).toContain('swift-cat')
+      })
+    } finally {
+      window.location.hash = ''
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- centralize session selection in `ActiveView` so selecting a thread updates both local `sessionId` and `#/s/<slug>`
- update all session-selection entry points (sidebar/mobile/session navigation/attention jumps/canvas to chat) to use the route-aware selector
- adjust route-sync effect to depend on route and session snapshot changes instead of re-running on every local selection change
- add regression coverage for refresh/routed-session switching to assert hash and selected chat update together

## Test plan
- `npm run typecheck` (fails in this branch due to missing ambient type defs: `whatwg-mimetype`, `ws`)
- `npm run lint`
- `npm run test` (has unrelated pre-existing failures in `test/components/ContextMenu.test.tsx`, `test/components/PrPreviewCard.test.tsx`, `test/store.test.ts`, `test/state/store.test.ts`)
- `npm run test -- test/App.test.tsx`