### PR TITLE
Fix PR lifecycle: persist PR URL, start CI babysit on PR line

### DIFF
--- a/server/ci/pr-lifecycle.test.ts
+++ b/server/ci/pr-lifecycle.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { EngineEventBus, resetEventBus } from '../events/bus'
+import { openDatabase, runMigrations } from '../db/sqlite'
+import { resolvePrLifecycleAction, wirePrLifecycle } from './pr-lifecycle'
+
+function seedSession(
+  db: Database,
+  id: string,
+  opts: {
+    mode?: string
+    prUrl?: string | null
+    metadata?: Record<string, unknown>
+    status?: string
+  } = {},
+): void {
+  const now = Date.now()
+  db.run(
+    `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, bare_dir, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation, quota_sleep_until, quota_retry_count, metadata, pipeline_advancing)
+     VALUES (?, 'session-slug', ?, 'cmd', ?, null, null, null, ?, null, null, null, null, ?, ?, 0, '[]', '[]', '[]', null, 0, ?, 0)`,
+    [id, opts.status ?? 'running', opts.mode ?? 'task', opts.prUrl ?? null, now, now, JSON.stringify(opts.metadata ?? {})],
+  )
+}
+
+describe('pr lifecycle', () => {
+  let db: Database
+
+  beforeEach(() => {
+    resetEventBus()
+    db = openDatabase(':memory:')
+    runMigrations(db)
+  })
+
+  test('resolvePrLifecycleAction stores pr_url and claims babysit for task mode', () => {
+    seedSession(db, 'sess-1', { mode: 'task', prUrl: null })
+
+    const action = resolvePrLifecycleAction(
+      db,
+      'sess-1',
+      'Work complete.\nPR: https://github.com/acme/repo/pull/12',
+    )
+
+    expect(action).not.toBeNull()
+    expect(action?.babysitClaimed).toBe(true)
+    expect(action?.explicitPrLine).toBe(true)
+    expect(action?.prUrl).toBe('https://github.com/acme/repo/pull/12')
+
+    const row = db
+      .query<{ pr_url: string | null; metadata: string }, [string]>(
+        'SELECT pr_url, metadata FROM sessions WHERE id = ?',
+      )
+      .get('sess-1')
+
+    expect(row?.pr_url).toBe('https://github.com/acme/repo/pull/12')
+    const meta = row ? (JSON.parse(row.metadata) as Record<string, unknown>) : {}
+    expect(typeof meta['ciBabysitStartedAt']).toBe('number')
+    expect(meta['ciBabysitTrigger']).toBe('stream')
+  })
+
+  test('resolvePrLifecycleAction does not claim babysit outside task modes', () => {
+    seedSession(db, 'sess-plan', { mode: 'plan', prUrl: null })
+
+    const action = resolvePrLifecycleAction(
+      db,
+      'sess-plan',
+      'Done.\nPR: https://github.com/acme/repo/pull/22',
+    )
+
+    expect(action).not.toBeNull()
+    expect(action?.babysitClaimed).toBe(false)
+
+    const row = db
+      .query<{ pr_url: string | null; metadata: string }, [string]>(
+        'SELECT pr_url, metadata FROM sessions WHERE id = ?',
+      )
+      .get('sess-plan')
+    expect(row?.pr_url).toBe('https://github.com/acme/repo/pull/22')
+    const meta = row ? (JSON.parse(row.metadata) as Record<string, unknown>) : {}
+    expect(meta['ciBabysitStartedAt']).toBeUndefined()
+  })
+
+  test('resolvePrLifecycleAction does not claim babysit when already started', () => {
+    seedSession(db, 'sess-started', {
+      mode: 'task',
+      prUrl: null,
+      metadata: { ciBabysitStartedAt: Date.now() - 10_000, ciBabysitTrigger: 'stream' },
+    })
+
+    const action = resolvePrLifecycleAction(
+      db,
+      'sess-started',
+      'PR: https://github.com/acme/repo/pull/77',
+    )
+
+    expect(action).not.toBeNull()
+    expect(action?.babysitClaimed).toBe(false)
+  })
+
+  test('wirePrLifecycle triggers babysit and auto-stop for explicit PR line', async () => {
+    seedSession(db, 'sess-wire', { mode: 'task', prUrl: null })
+    const bus = new EngineEventBus()
+    const babysitCalls: Array<{ sessionId: string; prUrl: string }> = []
+    const stopCalls: Array<{ sessionId: string; reason?: string }> = []
+
+    const unbind = wirePrLifecycle({
+      bus,
+      db,
+      ciBabysitter: {
+        async babysitPR(sessionId, prUrl) {
+          babysitCalls.push({ sessionId, prUrl })
+        },
+        async queueDeferredBabysit() {},
+        async babysitDagChildCI() {},
+      },
+      stopSession: async (sessionId, reason) => {
+        stopCalls.push({ sessionId, reason })
+      },
+    })
+
+    bus.emit({
+      kind: 'session.stream',
+      sessionId: 'sess-wire',
+      event: {
+        seq: 1,
+        id: 'evt-1',
+        sessionId: 'sess-wire',
+        turn: 1,
+        timestamp: Date.now(),
+        type: 'assistant_text',
+        blockId: 'b1',
+        text: 'Implemented.\nPR: https://github.com/acme/repo/pull/9',
+        final: true,
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    unbind()
+
+    expect(babysitCalls).toEqual([{ sessionId: 'sess-wire', prUrl: 'https://github.com/acme/repo/pull/9' }])
+    expect(stopCalls).toEqual([{ sessionId: 'sess-wire', reason: 'auto_exit_after_pr' }])
+  })
+})
+

--- a/server/ci/pr-lifecycle.ts
+++ b/server/ci/pr-lifecycle.ts
@@ -1,0 +1,163 @@
+import type { Database } from 'bun:sqlite'
+import type { EngineEventBus } from '../events/bus'
+import { prepared } from '../db/sqlite'
+import type { CIBabysitter, SessionMetadata } from '../handlers/types'
+import type { EngineEventOfKind } from '../events/types'
+
+const STRUCTURED_PR_LINE_RE = /^\s*PR:\s*<?(https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+)>?\s*$/im
+const PR_URL_RE = /https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+/g
+
+interface SessionLifecycleRow {
+  mode: string
+  pr_url: string | null
+  metadata: string
+}
+
+interface SessionMetadataWithCI extends SessionMetadata {
+  ciBabysitStartedAt?: number
+  ciBabysitTrigger?: 'stream' | 'completion'
+}
+
+interface DetectionResult {
+  prUrl: string
+  explicitPrLine: boolean
+}
+
+export interface PrLifecycleAction {
+  mode: string
+  explicitPrLine: boolean
+  babysitClaimed: boolean
+  parentThreadId?: string
+  prUrl: string
+}
+
+export interface PrLifecycleWireOpts {
+  bus: EngineEventBus
+  db: Database
+  ciBabysitter: CIBabysitter
+  stopSession: (sessionId: string, reason?: string) => Promise<void>
+}
+
+function parseMetadata(raw: string): SessionMetadataWithCI {
+  try {
+    const parsed = JSON.parse(raw) as SessionMetadataWithCI
+    if (parsed && typeof parsed === 'object') return parsed
+    return {}
+  } catch {
+    return {}
+  }
+}
+
+function detectPrUrl(text: string): DetectionResult | null {
+  const lineMatch = text.match(STRUCTURED_PR_LINE_RE)
+  if (lineMatch?.[1]) return { prUrl: lineMatch[1], explicitPrLine: true }
+
+  const all = [...text.matchAll(PR_URL_RE)]
+  if (all.length === 0) return null
+
+  const last = all[all.length - 1]?.[0]
+  if (!last) return null
+  return { prUrl: last, explicitPrLine: false }
+}
+
+export function resolvePrLifecycleAction(
+  db: Database,
+  sessionId: string,
+  assistantText: string,
+): PrLifecycleAction | null {
+  const detection = detectPrUrl(assistantText)
+  if (!detection) return null
+
+  let action: PrLifecycleAction | null = null
+  const now = Date.now()
+
+  db.transaction(() => {
+    const row = db
+      .query<SessionLifecycleRow, [string]>(
+        'SELECT mode, pr_url, metadata FROM sessions WHERE id = ?',
+      )
+      .get(sessionId)
+
+    if (!row) return
+
+    if (row.pr_url !== detection.prUrl) {
+      prepared.updateSession(db, {
+        id: sessionId,
+        pr_url: detection.prUrl,
+        updated_at: now,
+      })
+    }
+
+    const mode = row.mode
+    if (mode !== 'task' && mode !== 'dag-task') {
+      action = {
+        mode,
+        explicitPrLine: detection.explicitPrLine,
+        babysitClaimed: false,
+        prUrl: detection.prUrl,
+      }
+      return
+    }
+
+    const metadata = parseMetadata(row.metadata)
+    if (metadata.ciBabysitStartedAt) {
+      action = {
+        mode,
+        explicitPrLine: detection.explicitPrLine,
+        babysitClaimed: false,
+        parentThreadId: metadata.parentThreadId,
+        prUrl: detection.prUrl,
+      }
+      return
+    }
+
+    metadata.ciBabysitStartedAt = now
+    metadata.ciBabysitTrigger = 'stream'
+
+    prepared.updateSession(db, {
+      id: sessionId,
+      metadata: { ...metadata },
+      updated_at: now,
+    })
+
+    action = {
+      mode,
+      explicitPrLine: detection.explicitPrLine,
+      babysitClaimed: true,
+      parentThreadId: metadata.parentThreadId,
+      prUrl: detection.prUrl,
+    }
+  })()
+
+  return action
+}
+
+async function handleStreamEvent(
+  event: EngineEventOfKind<'session.stream'>,
+  opts: PrLifecycleWireOpts,
+): Promise<void> {
+  if (event.event.type !== 'assistant_text' || !event.event.final) return
+
+  const action = resolvePrLifecycleAction(opts.db, event.sessionId, event.event.text)
+  if (!action) return
+
+  if (action.babysitClaimed) {
+    if (action.parentThreadId) {
+      void opts.ciBabysitter.queueDeferredBabysit(event.sessionId, action.parentThreadId)
+    } else {
+      void opts.ciBabysitter.babysitPR(event.sessionId, action.prUrl)
+    }
+  }
+
+  if (action.explicitPrLine && (action.mode === 'task' || action.mode === 'dag-task')) {
+    await opts.stopSession(event.sessionId, 'auto_exit_after_pr')
+  }
+}
+
+export function wirePrLifecycle(opts: PrLifecycleWireOpts): () => void {
+  return opts.bus.onKind('session.stream', (event) => {
+    void handleStreamEvent(event, opts).catch((err: unknown) => {
+      console.error(`[pr-lifecycle] failed for ${event.sessionId}:`, err)
+    })
+  })
+}

--- a/server/handlers/ci-babysit-handler.test.ts
+++ b/server/handlers/ci-babysit-handler.test.ts
@@ -105,4 +105,20 @@ describe('ciBabysitHandler', () => {
     expect(babysitCalls).toHaveLength(0)
     expect(deferredCalls).toHaveLength(0)
   })
+
+  test('does not run again when ci babysit already started in metadata', async () => {
+    seedSession(db, 'sess-started', 'https://github.com/org/repo/pull/7', {
+      ciBabysitStartedAt: Date.now() - 1000,
+      ciBabysitTrigger: 'stream',
+    })
+    const babysitCalls: BabysitCall[] = []
+    const deferredCalls: DeferredCall[] = []
+    const ctx = makeCtx(db, makeCIBabysitter(babysitCalls, deferredCalls))
+
+    const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-started', state: 'completed', durationMs: 0 }
+    await ciBabysitHandler.handle(ev, ctx)
+
+    expect(babysitCalls).toHaveLength(0)
+    expect(deferredCalls).toHaveLength(0)
+  })
 })

--- a/server/handlers/ci-babysit-handler.ts
+++ b/server/handlers/ci-babysit-handler.ts
@@ -1,4 +1,5 @@
 import type { CompletionHandler, HandlerCtx, SessionCompletedEvent, SessionMetadata } from './types'
+import { prepared } from '../db/sqlite'
 
 export const ciBabysitHandler: CompletionHandler = {
   name: 'ci-babysit',
@@ -17,7 +18,22 @@ export const ciBabysitHandler: CompletionHandler = {
 
     if (!row?.pr_url) return
 
-    const meta = JSON.parse(row.metadata) as SessionMetadata
+    let meta: SessionMetadata
+    try {
+      meta = JSON.parse(row.metadata) as SessionMetadata
+    } catch {
+      meta = {}
+    }
+    if (meta.ciBabysitStartedAt) return
+
+    const now = Date.now()
+    meta.ciBabysitStartedAt = now
+    meta.ciBabysitTrigger = 'completion'
+    prepared.updateSession(ctx.db, {
+      id: ev.sessionId,
+      metadata: { ...meta },
+      updated_at: now,
+    })
 
     if (meta.parentThreadId) {
       await ctx.ciBabysitter.queueDeferredBabysit(ev.sessionId, meta.parentThreadId)

--- a/server/handlers/types.ts
+++ b/server/handlers/types.ts
@@ -88,4 +88,6 @@ export interface SessionMetadata {
   dagNodeId?: string
   parentThreadId?: string
   pendingFeedback?: string[]
+  ciBabysitStartedAt?: number
+  ciBabysitTrigger?: 'stream' | 'completion'
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -37,6 +37,7 @@ import { ReplyQueue as DiskReplyQueue } from './session/reply-queue'
 import { startPushNotifier } from './push/notifier'
 import { startTokenProvider } from './github/token-provider'
 import { installAskpass } from './github/askpass'
+import { wirePrLifecycle } from './ci/pr-lifecycle'
 
 const PORT = Number(process.env['PORT'] ?? 8080)
 const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? '/tmp/minion-workspace'
@@ -131,6 +132,13 @@ dispatcher.register(qualityGateHandler)
 dispatcher.register(digestHandler)
 dispatcher.register(ciBabysitHandler)
 dispatcher.register(parentNotifyHandler)
+
+wirePrLifecycle({
+  bus,
+  db,
+  ciBabysitter: ctx.ciBabysitter,
+  stopSession: (sessionId, reason) => ctx.registry.stop(sessionId, reason),
+})
 
 const loopsEnabled = (process.env['ENABLE_LOOPS'] ?? 'false').toLowerCase() === 'true'
 if (loopsEnabled) {


### PR DESCRIPTION
## Summary
- add a PR lifecycle stream wire that detects GitHub PR URLs from final assistant output
- persist  as soon as the assistant emits a PR URL, then claim CI babysit immediately for / modes
- auto-stop task runtimes when the assistant emits an explicit  line so completion handlers can run without waiting for manual stop
- prevent duplicate babysit runs by recording  metadata and skipping completion-triggered babysit when already started
- add server tests for PR lifecycle wiring and duplicate-suppression behavior

## Test Plan
- bun test v1.2.23 (cf136713) (pass)
- 
> minions-ui@0.1.0 lint
> eslint . (pass)
- 
> minions-ui@0.1.0 test
> vitest run


 RUN  v4.1.4 /workspace/warm-wood-2957

 ❯ test/components/ContextMenu.test.tsx (35 tests | 3 failed) 177ms
     × calls onLongPress after holding touch for 500ms 10ms
     × does not call onLongPress if touch is released early 1ms
     × cancels long press on touch move 2ms
 ❯ test/components/PrPreviewCard.test.tsx (18 tests | 3 failed) 135ms
     × re-polls every PR_PREVIEW_POLL_MS while the PR is open 20ms
     × stops polling once the PR transitions to merged 4ms
     × teardown on unmount aborts pending polls 2ms
 ❯ test/store.test.ts (11 tests | 1 failed) 22ms
     × backoff delay is less than 30000ms on error 9ms
 ❯ test/state/store.test.ts (9 tests | 1 failed) 32ms
     × refresh() success calls saveSnapshot 14ms

 Test Files  4 failed | 57 passed (61)
      Tests  8 failed | 760 passed (768)
   Start at  21:35:09
   Duration  16.95s (transform 2.38s, setup 6.26s, import 2.64s, tests 5.13s, environment 23.24s) (fails on pre-existing unrelated frontend timeout tests: , , , )
- 
> minions-ui@0.1.0 typecheck
> tsc -b --noEmit

error TS2688: Cannot find type definition file for 'whatwg-mimetype'.
  The file is in the program because:
    Entry point for implicit type library 'whatwg-mimetype'
error TS2688: Cannot find type definition file for 'ws'.
  The file is in the program because:
    Entry point for implicit type library 'ws'
error TS2688: Cannot find type definition file for 'whatwg-mimetype'.
  The file is in the program because:
    Entry point for implicit type library 'whatwg-mimetype'
error TS2688: Cannot find type definition file for 'ws'.
  The file is in the program because:
    Entry point for implicit type library 'ws' (fails in this environment due missing ambient type definitions  and ;  is blocked by permissions in  and this runner uses Node 18 while several deps require Node 20+)
