### PR TITLE
chore(workflow): enforce safe gh pr body handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ If an implementation agent encounters ambiguity, unresolved design questions, or
 - Commit messages follow conventional commits: `feat(ui): ...`, `fix(api): ...`.
 - Never add "Generated with Claude Code" / co-author tags / "committed by agent" verbiage.
 - PR description: what changed, why, how to validate.
+- Never pass PR markdown via inline `--body "..."` to `gh pr create`; shell expansion can corrupt backticks/code fences.
+- Always create PRs with `bash scripts/create-pr.sh "<title>" <<'PR_BODY' ... PR_BODY` (quoted heredoc) or `gh pr create --body-file - <<'PR_BODY' ... PR_BODY`.
 
 ## Worktree hygiene
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,8 @@ public/
 - **No code comments** except rare WHY lines (hidden constraint, subtle invariant, workaround for a named bug).
 - **Never** use `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, or `_unused` prefix workarounds. Fix the underlying code.
 - **No** "Generated with Claude Code" / co-author tags / "committed by agent" verbiage in PRs or commits.
+- **Never** pass PR markdown via inline `gh pr create --body "..."`; shell expansion can break backticks/code fences.
+- **Always** use `bash scripts/create-pr.sh "<title>" <<'PR_BODY' ... PR_BODY` (or `gh pr create --body-file -` with a quoted heredoc).
 - Prefer the `Grep` tool (ripgrep) over raw `grep`.
 - Preact 10 + `@preact/signals` only. No React hooks for global state.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,22 @@ Standalone PWA frontend for the minions engine. Built with Preact, Vite, and Tai
 | `npm run lint` | Run ESLint across the project |
 | `npm run test` | Run unit tests with Vitest (jsdom) |
 | `npm run test:watch` | Run tests in watch mode |
+| `npm run pr:create -- "<title>"` | Create a PR safely; pass body via quoted heredoc to avoid shell expanding backticks |
 | `npm run format` | Format all files with Prettier |
+
+Example:
+
+```sh
+npm run pr:create -- "feat(ui): add install prompt" <<'PR_BODY'
+## Summary
+- Added install prompt flow
+
+## Test plan
+- npm run typecheck
+- npm run lint
+- npm run test
+PR_BODY
+```
 
 ## Dev proxy
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:install": "playwright install --with-deps",
+    "pr:create": "bash scripts/create-pr.sh",
     "format": "prettier --write .",
     "prepare": "husky || true",
     "docker:build": "docker build -f docker/engine.Dockerfile -t minions-engine ."

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: bash scripts/create-pr.sh \"<title>\" [base-branch]" >&2
+  echo "Pass PR body via stdin using a quoted heredoc." >&2
+  echo "Example:" >&2
+  echo "  bash scripts/create-pr.sh \"feat(ui): add install prompt\" <<'PR_BODY'" >&2
+  echo "  ## Summary" >&2
+  echo "  - Added install prompt flow" >&2
+  echo "  PR_BODY" >&2
+  exit 2
+fi
+
+if [[ -t 0 ]]; then
+  echo "Error: PR body must be provided on stdin (use a quoted heredoc)." >&2
+  exit 2
+fi
+
+title="$1"
+base_branch="${2:-}"
+
+cmd=(gh pr create --title "$title" --body-file -)
+if [[ -n "$base_branch" ]]; then
+  cmd+=(--base "$base_branch")
+fi
+
+"${cmd[@]}"


### PR DESCRIPTION
## Summary
- add `scripts/create-pr.sh` wrapper that forces `--body-file -` and stdin body input
- add `npm run pr:create -- "<title>"` as the standard safe entrypoint
- update agent guidance in `AGENTS.md` and `CLAUDE.md` to forbid inline `gh pr create --body "..."`
- document safe PR creation usage in `README.md`

## Why
Inline `--body "..."` is vulnerable to shell expansion of backticks and substitutions, which repeatedly produced malformed PR bodies.

## Validation
- `bash -n scripts/create-pr.sh`
- attempted baseline gate: `npm run typecheck && npm run lint && npm run test`
- current workspace blocker: `npm run typecheck` fails with missing type definition files `whatwg-mimetype` and `ws`
