### PR TITLE
feat(app): improve conductor resilience workflows

### DIFF
--- a/docs/2026-04-25-2325-resilience-responsive-ux-plan.md
+++ b/docs/2026-04-25-2325-resilience-responsive-ux-plan.md
@@ -1,0 +1,20 @@
+# Resilience and responsive UX plan
+
+## Goals
+
+- Keep advertised server capabilities aligned with the UI feature gates.
+- Make session creation and command responses give the client enough data for immediate navigation and feedback.
+- Recover resumable agent sessions after engine restarts instead of marking all non-ship sessions failed.
+- Reconnect stalled SSE streams on mobile resume and proxy keepalive gaps.
+- Avoid surprise PWA reloads while a user is conducting from a phone.
+
+## Implementation steps
+
+1. Fix API feature flags and `POST /api/sessions` to return a full `ApiSession`.
+2. Wire `ship_advance` through the ship coordinator and return command failure details when advancement is invalid.
+3. Make ship `plan -> dag` schedule the DAG from the coordinator's plan output, and move completed DAGs into verification.
+4. Surface unsuccessful command results in the connection store so the UI shows a retryable error instead of silently proceeding.
+5. Add a client SSE heartbeat watchdog that observes server keepalives and reconnects after a quiet window.
+6. Resume any running session with a provider session id during `reconcileOnBoot`, and keep non-resumable sessions on the current interrupted path.
+7. Replace automatic service-worker reloads with an update/offline-ready banner.
+8. Update focused tests for the changed contracts and run the baseline gate.

--- a/server/api/routes.inbound-images.test.ts
+++ b/server/api/routes.inbound-images.test.ts
@@ -268,7 +268,7 @@ describe('GET /api/version — images feature flag', () => {
 
     expect(res.status).toBe(200)
     const body = await json<{ data: { features: string[] } }>(res)
-    expect(body.data.features).toContain('images')
+    expect(body.data.features).toContain('sessions-create-images')
   })
 
   test('rejects total payload exceeding 20 MB with 400', async () => {

--- a/server/api/routes.test.ts
+++ b/server/api/routes.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs'
 import { Hono } from 'hono'
 import { createSessionRegistry } from '../session/registry'
 import { resetEventBus } from '../events/bus'
-import { runMigrations } from '../db/sqlite'
+import { prepared, runMigrations } from '../db/sqlite'
 import { registerApiRoutes } from './routes'
 import { registerSseRoute } from './sse'
 import type { SpawnFn, SubprocessHandle } from '../session/runtime'
@@ -104,6 +104,10 @@ describe('GET /api/version', () => {
     const features = body.data.features
     expect(features).toContain('sessions-create')
     expect(features).toContain('messages')
+    expect(features).toContain('sessions-create-images')
+    expect(features).toContain('sessions-variants')
+    expect(features).toContain('ship-coordinator')
+    expect(features).toContain('web-push')
     expect(features).toContain('transcript')
     expect(features).toContain('auth')
     expect(features).toContain('cors-allowlist')
@@ -269,6 +273,62 @@ describe('POST /api/commands', () => {
     expect(res.status).toBe(200)
   })
 
+  test('ship_advance advances ship stage when scheduler is configured', async () => {
+    const app = new Hono()
+    const registry = createSessionRegistry({ getDb: () => testDb, spawnFn: makeNoopSpawnFn() })
+    registerApiRoutes(app, registry, () => testDb, { start: async () => {} })
+    const now = Date.now()
+    testDb.run(
+      `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation, quota_sleep_until, quota_retry_count, metadata, pipeline_advancing, stage)
+       VALUES ('ship-route-1', 'ship-route-1', 'running', 'ship it', 'ship', null, null, null, null, null, null, null, ?, ?, 0, '[]', '[]', '[]', null, 0, '{}', 0, 'plan')`,
+      [now, now],
+    )
+    prepared.insertEvent(testDb, {
+      session_id: 'ship-route-1',
+      seq: 1,
+      turn: 1,
+      type: 'assistant_text',
+      timestamp: now,
+      payload: {
+        id: 'ship-route-plan',
+        sessionId: 'ship-route-1',
+        seq: 1,
+        turn: 1,
+        timestamp: now,
+        type: 'assistant_text',
+        blockId: 'plan',
+        text: [
+          '```json',
+          '[',
+          '  {',
+          '    "id": "implement-route",',
+          '    "title": "Implement route",',
+          '    "description": "Implement the route.",',
+          '    "dependsOn": []',
+          '  }',
+          ']',
+          '```',
+        ].join('\n'),
+        final: true,
+      },
+    })
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/commands', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ action: 'ship_advance', sessionId: 'ship-route-1', to: 'dag' }),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const body = await json<{ data: { success: boolean; error?: string; dagId?: string } }>(res)
+    expect(body.data.success).toBe(true)
+    expect(body.data.dagId).toBeDefined()
+    const row = testDb.query<{ stage: string | null }, [string]>('SELECT stage FROM sessions WHERE id = ?').get('ship-route-1')
+    expect(row?.stage).toBe('dag')
+  })
+
   test('invalid body returns 400', async () => {
     const app = makeApp(testDb)
     const res = await app.fetch(
@@ -295,6 +355,21 @@ describe('POST /api/messages', () => {
     expect(res.status).toBe(400)
     const body = await json<{ error: string }>(res)
     expect(body.error).toContain('DEFAULT_REPO')
+  })
+
+  test('/task without prompt returns 400', async () => {
+    process.env['DEFAULT_REPO'] = '/nonexistent/path/to/repo'
+    const app = makeApp(testDb)
+    const res = await app.fetch(
+      new Request('http://localhost/api/messages', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ text: '/task' }),
+      }),
+    )
+    expect(res.status).toBe(400)
+    const body = await json<{ error: string }>(res)
+    expect(body.error).toContain('requires a prompt')
   })
 
   test('/task with DEFAULT_REPO pointing to unreachable path returns 500', async () => {

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -26,6 +26,7 @@ import { handleExecute, handleSplit, handleStack, handleDag } from '../commands/
 import type { PlanScheduler } from '../commands/plan-actions'
 import { handleLandCommand } from '../commands/land'
 import type { LandingManager } from '../dag/landing'
+import { advanceShip } from '../ship/coordinator'
 import { listDags } from '../dag/store'
 import { topologicalSort, nodeIndex } from '../dag/dag'
 import type { DagGraph } from '../dag/dag'
@@ -55,14 +56,14 @@ const LIBRARY_VERSION = '0.1.0'
 const FEATURES = [
   'sessions-create',
   'messages',
-  'images',
+  'sessions-create-images',
   'transcript',
   'auth',
   'cors-allowlist',
   'dag',
-  'ship-pipeline',
-  'variants',
-  'push',
+  'ship-coordinator',
+  'sessions-variants',
+  'web-push',
   'screenshots',
   'diff',
   'pr-preview',
@@ -229,8 +230,8 @@ export function registerApiRoutes(
         repo: resolvedRepo,
         initialImages: images,
       })
-      const body: ApiResponse<{ sessionId: string; slug: string }> = {
-        data: { sessionId: session.id, slug: session.slug },
+      const body: ApiResponse<ApiSession> = {
+        data: session,
       }
       return c.json(body, 201)
     } catch (err) {
@@ -346,6 +347,29 @@ export function registerApiRoutes(
       }
     }
 
+    if (command.action === 'ship_advance') {
+      if (!scheduler) {
+        return c.json({
+          data: { success: false, error: 'no scheduler configured' },
+        } satisfies ApiResponse<CommandResult>)
+      }
+      try {
+        const result = await advanceShip(command.sessionId, command.to, {
+          db: resolveDb(),
+          registry,
+          scheduler,
+        })
+        return c.json({
+          data: result.ok
+            ? { success: true, ...(result.dagId ? { dagId: result.dagId } : {}) }
+            : { success: false, error: result.reason ?? 'ship advance failed' },
+        } satisfies ApiResponse<CommandResult>)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return c.json({ data: { success: false, error: message } } satisfies ApiResponse<CommandResult>)
+      }
+    }
+
     try {
       if (command.action === 'reply') {
         await registry.reply(command.sessionId, command.message)
@@ -414,7 +438,12 @@ export function registerApiRoutes(
           } else if (command === 'stack') {
             result = await handleStack(sessionId, planCtx)
           } else {
-            result = await handleDag(rest, sessionId, planCtx)
+            const row = prepared.getSession(planCtx.db, sessionId)
+            if (row?.mode === 'ship' && (row.stage ?? 'think') === 'plan' && !rest) {
+              result = await advanceShip(sessionId, 'dag', planCtx)
+            } else {
+              result = await handleDag(rest, sessionId, planCtx)
+            }
           }
           if (!result.ok) return c.json({ error: result.reason ?? `/${command} failed` }, 422)
           return c.json({ data: { ok: true, sessionId, dagId: result.dagId } })
@@ -524,6 +553,9 @@ export function registerApiRoutes(
 
       const modeEntry = SLASH_MODES.get(command as Parameters<typeof SLASH_MODES.get>[0])
       if (modeEntry !== undefined) {
+        if (!rest) {
+          return c.json({ error: `/${command} requires a prompt` }, 400)
+        }
         const defaultRepo = process.env['DEFAULT_REPO']
         if (!defaultRepo) {
           return c.json({ error: 'DEFAULT_REPO env is required for /command style messages' }, 400)

--- a/server/commands/help.ts
+++ b/server/commands/help.ts
@@ -4,14 +4,14 @@ export interface HelpCommandResult {
 }
 
 const HELP_TEXT = `**Task / Plan / Think / Review**
-  /task <prompt>       Start a task session
+  /task <prompt>       Start a small implementation task
   /w <prompt>          Alias for /task
-  /plan <prompt>       Start a plan session
-  /think <prompt>      Start a think session
+  /plan <prompt>       Start a planning session for later execution
+  /think <prompt>      Start a research/brainstorm session
   /review <prompt>     Start a review session
 
 **Ship**
-  /ship <prompt>       Start a ship-think session
+  /ship <prompt>       Start a full ship coordinator session
 
 **DAG / Split / Stack**
   /dag [markdown]      Build and run a DAG from markdown or last assistant message

--- a/server/commands/plan-actions.test.ts
+++ b/server/commands/plan-actions.test.ts
@@ -245,48 +245,7 @@ describe("plan-actions gating", () => {
     expect(replyCalls[0]?.text).toContain("gh pr create")
   })
 
-  it("ship-plan with valid DAG JSON triggers buildAndStartDag, not registry.reply", async () => {
-    const sessionId = insertSession(db, { mode: "ship-plan" })
-    const dagJson = JSON.stringify([
-      { id: "task-a", title: "Task A", description: "Do task A", dependsOn: [] },
-      { id: "task-b", title: "Task B", description: "Do task B", dependsOn: ["task-a"] },
-    ])
-    prepared.insertEvent(db, {
-      session_id: sessionId,
-      seq: 1,
-      turn: 1,
-      type: "assistant_text",
-      timestamp: Date.now(),
-      payload: { text: `Here is the DAG:\n\n\`\`\`json\n${dagJson}\n\`\`\``, final: true, blockId: "block-1" },
-    })
-
-    const stopCalls: string[] = []
-    const replyCalls: Array<{ sessionId: string; text: string }> = []
-    const startedDagIds: string[] = []
-    const registry = {
-      ...makeRegistry(stopCalls),
-      reply: async (sid: string, text: string) => {
-        replyCalls.push({ sessionId: sid, text })
-        return true
-      },
-    }
-    const ctx: PlanActionCtx = {
-      db,
-      registry,
-      scheduler: makeScheduler(startedDagIds),
-    }
-
-    const result = await handleExecute(sessionId, ctx)
-
-    expect(result.ok).toBe(true)
-    expect(result.dagId).toBeTruthy()
-    expect(stopCalls).toHaveLength(1)
-    expect(stopCalls[0]).toBe(sessionId)
-    expect(startedDagIds).toHaveLength(1)
-    expect(replyCalls).toHaveLength(0)
-  })
-
-  it("ship-plan with no DAG output returns error", async () => {
+  it("ship-plan is rejected as an unsupported legacy mode", async () => {
     const sessionId = insertSession(db, { mode: "ship-plan" })
     const stopCalls: string[] = []
     const startedDagIds: string[] = []
@@ -299,33 +258,13 @@ describe("plan-actions gating", () => {
     const result = await handleExecute(sessionId, ctx)
 
     expect(result.ok).toBe(false)
-    expect(result.reason).toBe("no DAG output from ship-plan to parse")
+    expect(result.reason).toBe("execute not supported for mode ship-plan")
+    expect(stopCalls).toHaveLength(0)
     expect(startedDagIds).toHaveLength(0)
   })
 
-  it("ship-plan falls back to extractDagItems when parseDagItems fails", async () => {
-    mockSpawn.mockImplementation(() => makeDagItemsChild([
-      { id: "task-1", title: "Task 1", description: "Do task 1", dependsOn: [] },
-    ]))
-
+  it("ship-plan with no DAG output remains unsupported", async () => {
     const sessionId = insertSession(db, { mode: "ship-plan" })
-    prepared.insertEvent(db, {
-      session_id: sessionId,
-      seq: 1,
-      turn: 1,
-      type: "user_message",
-      timestamp: Date.now(),
-      payload: { text: "Plan a feature" },
-    })
-    prepared.insertEvent(db, {
-      session_id: sessionId,
-      seq: 2,
-      turn: 1,
-      type: "assistant_text",
-      timestamp: Date.now(),
-      payload: { text: "Not valid JSON format but conversation contains plan", final: true, blockId: "block-1" },
-    })
-
     const stopCalls: string[] = []
     const startedDagIds: string[] = []
     const ctx: PlanActionCtx = {
@@ -336,9 +275,27 @@ describe("plan-actions gating", () => {
 
     const result = await handleExecute(sessionId, ctx)
 
-    expect(result.ok).toBe(true)
-    expect(result.dagId).toBeTruthy()
-    expect(startedDagIds).toHaveLength(1)
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe("execute not supported for mode ship-plan")
+    expect(startedDagIds).toHaveLength(0)
+  })
+
+  it("ship-plan does not fall back to DAG extraction", async () => {
+    const sessionId = insertSession(db, { mode: "ship-plan" })
+    const stopCalls: string[] = []
+    const startedDagIds: string[] = []
+    const ctx: PlanActionCtx = {
+      db,
+      registry: makeRegistry(stopCalls),
+      scheduler: makeScheduler(startedDagIds),
+    }
+
+    const result = await handleExecute(sessionId, ctx)
+
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe("execute not supported for mode ship-plan")
+    expect(stopCalls).toHaveLength(0)
+    expect(startedDagIds).toHaveLength(0)
   })
 
   it("rejects unknown modes with helpful error message", async () => {
@@ -478,6 +435,28 @@ describe("handleDag", () => {
     expect(result.ok).toBe(true)
     expect(result.dagId).toBeTruthy()
     expect(startedDagIds).toHaveLength(1)
+  })
+
+  it("does not stop a ship coordinator before scheduling its DAG", async () => {
+    const markdown = JSON.stringify([
+      { id: "task-1", title: "Task 1", description: "Do task 1", dependsOn: [] },
+    ])
+
+    const sessionId = insertSession(db, { mode: "ship", stage: "plan" })
+    const stopCalls: string[] = []
+    const startedDagIds: string[] = []
+    const ctx: PlanActionCtx = {
+      db,
+      registry: makeRegistry(stopCalls),
+      scheduler: makeScheduler(startedDagIds),
+    }
+
+    const result = await handleDag(markdown, sessionId, ctx)
+
+    expect(result.ok).toBe(true)
+    expect(result.dagId).toBeTruthy()
+    expect(startedDagIds).toHaveLength(1)
+    expect(stopCalls).toHaveLength(0)
   })
 
   it("returns ok:false when markdown is invalid and no last assistant message", async () => {

--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -146,7 +146,7 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
   const mode = row?.mode
 
   if (mode === "ship") {
-    return { ok: false, reason: "ship coordinator mode not yet implemented (WIP)" }
+    return { ok: false, reason: "use /dag to schedule a ship plan" }
   }
 
   if (mode === "think" || mode === "plan" || mode === "review") {
@@ -240,7 +240,10 @@ export async function handleDag(
   const rejection = await gate(sessionId, ctx)
   if (rejection) return { ok: false, reason: rejection }
 
-  await killAndWait(sessionId, ctx)
+  const row = prepared.getSession(ctx.db, sessionId)
+  if (row?.mode !== "ship") {
+    await killAndWait(sessionId, ctx)
+  }
 
   let items: DagInput[]
   try {

--- a/server/dag/dag.ts
+++ b/server/dag/dag.ts
@@ -285,6 +285,16 @@ export function isDagComplete(graph: DagGraph): boolean {
   )
 }
 
+export function dagGraphStatus(graph: DagGraph): "pending" | "running" | "completed" | "failed" {
+  if (isDagComplete(graph)) {
+    const failed = graph.nodes.some((n) => n.status === "failed" || n.status === "skipped" || n.status === "ci-failed")
+    return failed ? "failed" : "completed"
+  }
+
+  const running = graph.nodes.some((n) => n.status === "running" || n.status === "ci-pending")
+  return running ? "running" : "pending"
+}
+
 export function getUpstreamBranches(graph: DagGraph, nodeId: string): string[] {
   const idx = nodeIndex(graph)
   const node = idx.get(nodeId)

--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -5,6 +5,7 @@ import { saveDag } from "./store"
 import { createDagScheduler } from "./scheduler"
 import { EngineEventBus } from "../events/bus"
 import { openDatabase, prepared, runMigrations } from "../db/sqlite"
+import { DIRECTIVE_VERIFY } from "../ship/coordinator"
 import type { SessionRegistry, CreateSessionOpts } from "../session/registry"
 import type { SessionRuntime } from "../session/runtime"
 import type { ApiSession } from "../../shared/api-types"
@@ -63,6 +64,37 @@ function makeSession(id: string, db?: Database): ApiSession {
     })
   }
   return session
+}
+
+function insertShipRoot(db: Database, id: string, stage: "think" | "plan" | "dag" | "verify" | "done"): void {
+  const now = Date.now()
+  prepared.insertSession(db, {
+    id,
+    slug: id,
+    status: "running",
+    command: "ship this",
+    mode: "ship",
+    repo: "https://github.com/org/repo",
+    branch: "minion/ship-root",
+    bare_dir: null,
+    pr_url: null,
+    parent_id: null,
+    variant_group_id: null,
+    claude_session_id: "thread-ship-root",
+    workspace_root: "/tmp/workspace",
+    created_at: now,
+    updated_at: now,
+    needs_attention: false,
+    attention_reasons: [],
+    quick_actions: [],
+    conversation: [],
+    quota_sleep_until: null,
+    quota_retry_count: 0,
+    metadata: {},
+    pipeline_advancing: false,
+    stage,
+    coordinator_children: [],
+  })
 }
 
 function makeRegistry(db: Database, createFn?: (opts: CreateSessionOpts) => Promise<{ session: ApiSession; runtime: SessionRuntime }>) {
@@ -260,6 +292,61 @@ describe("DagScheduler", () => {
 
     expect(events).toHaveLength(1)
     expect(events[0]!.state).toBe("completed")
+  })
+
+  it("emits live DAG snapshots with node sessions and terminal status", async () => {
+    const graph = buildDag("dag-live-snapshot", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessions: ApiSession[] = []
+    const events: Array<{ status: string; sessionId?: string }> = []
+    bus.onKind("dag.snapshot", (e) => {
+      events.push({
+        status: e.dag.status,
+        sessionId: e.dag.nodes["a"]?.session?.id,
+      })
+    })
+
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession("s-live", db)
+      sessions.push(session)
+      return { session, runtime: {} as never }
+    })
+    registry.list = () => sessions
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-live-snapshot")
+    await scheduler.onSessionCompleted("s-live", "completed")
+
+    expect(events[0]).toEqual({ status: "running", sessionId: "s-live" })
+    expect(events.at(-1)).toEqual({ status: "completed", sessionId: "s-live" })
+  })
+
+  it("advances ship roots to verification when their DAG becomes terminal", async () => {
+    const rootId = "ship-root"
+    insertShipRoot(db, rootId, "dag")
+
+    const graph = buildDag("dag-ship-complete", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], rootId, "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const replies: Array<{ sessionId: string; text: string }> = []
+    const registry = makeRegistry(db, async () => ({ session: makeSession("ship-child", db), runtime: {} as never }))
+    registry.reply = async (sessionId, text) => {
+      replies.push({ sessionId, text })
+      return true
+    }
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-ship-complete")
+    await scheduler.onSessionCompleted("ship-child", "completed")
+
+    const row = prepared.getSession(db, rootId)
+    expect(row?.stage).toBe("verify")
+    expect(replies).toEqual([{ sessionId: rootId, text: DIRECTIVE_VERIFY }])
   })
 
   it("cancel stops running sessions and marks them failed", async () => {

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -1,5 +1,5 @@
 import type { Database } from "bun:sqlite"
-import { readyNodes, advanceDag, failNode, resetFailedNode, nodeIndex, getUpstreamBranches, isDagComplete } from "./dag"
+import { readyNodes, advanceDag, failNode, resetFailedNode, nodeIndex, getUpstreamBranches, isDagComplete, dagGraphStatus } from "./dag"
 import type { DagGraph, DagNode, DagInput } from "./dag"
 import { saveDag, loadDag, listDags } from "./store"
 import { prepared } from "../db/sqlite"
@@ -10,6 +10,7 @@ import type { SessionRegistry } from "../session/registry"
 import type { EngineEventBus } from "../events/bus"
 import type { SessionRunState } from "../events/types"
 import type { ApiDagNode, ApiDagGraph } from "../../shared/api-types"
+import { advanceShip } from "../ship/coordinator"
 
 function fetchRootConversation(db: Database, rootSessionId: string): TopicMessage[] {
   const rows = db
@@ -140,6 +141,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
 
   function graphToApiDag(graph: DagGraph): ApiDagGraph {
     const nodes: Record<string, ApiDagNode> = {}
+    const sessionMap = new Map(registry.list().map((session) => [session.id, session]))
     for (const node of graph.nodes) {
       const dependents = graph.nodes
         .filter((n) => n.dependsOn.includes(node.id))
@@ -150,13 +152,14 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
         status: mapNodeStatus(node.status),
         dependencies: node.dependsOn,
         dependents,
+        session: node.sessionId ? sessionMap.get(node.sessionId) : undefined,
       }
     }
     return {
       id: graph.id,
       rootTaskId: graph.rootSessionId,
       nodes,
-      status: "running",
+      status: dagGraphStatus(graph),
       createdAt: new Date(graph.createdAt).toISOString(),
       updatedAt: new Date().toISOString(),
     }
@@ -225,6 +228,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     if (isDagComplete(graph)) {
       activeGraphs.delete(graph.id)
       persist(graph)
+      await advanceShip(graph.rootSessionId, "verify", { db, registry, scheduler: { start } })
     }
   }
 

--- a/server/dag/store.ts
+++ b/server/dag/store.ts
@@ -1,5 +1,5 @@
 import type { Database } from "bun:sqlite"
-import { nodeIndex } from "./dag"
+import { dagGraphStatus, nodeIndex } from "./dag"
 import type { DagGraph, DagNode } from "./dag"
 import { prepared, getDb } from "../db/sqlite"
 
@@ -8,7 +8,7 @@ function graphToRows(graph: DagGraph): { dagRow: Parameters<typeof prepared.inse
   const dagRow = {
     id: graph.id,
     root_task_id: graph.rootSessionId,
-    status: "running" as const,
+    status: dagGraphStatus(graph),
     repo: repo && repo.length > 0 ? repo : null,
     created_at: graph.createdAt,
     updated_at: Date.now(),

--- a/server/handlers/ship-advance-handler.test.ts
+++ b/server/handlers/ship-advance-handler.test.ts
@@ -143,26 +143,6 @@ describe('shipAdvanceHandler', () => {
     expect(shipAdvanceHandler.matches(errEv)).toBe(false)
   })
 
-  // TODO: Re-enable once ship coordinator advanceShip logic is implemented
-  // The old ship-think/ship-plan modes were removed in favor of the new 'ship' coordinator mode
-  test.skip('spawns ship-plan session when ship-think completes', async () => {
-    seedSession(db, 'sess-think', 'ship-think')
-    seedAssistantMessage(db, 'sess-think', 'Design doc: build an auth service')
-
-    const registryCalls = { stop: [] as string[], create: [] as Array<{ mode: string; prompt: string; parentId?: string }> }
-    const schedulerCalls = { start: [] as string[], onSessionCompleted: [] as string[] }
-    const ctx = makeCtx(db, registryCalls, schedulerCalls)
-
-    const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-think', state: 'completed', durationMs: 0 }
-    await shipAdvanceHandler.handle(ev, ctx)
-
-    expect(registryCalls.create).toHaveLength(1)
-    expect(registryCalls.create[0]?.mode).toBe('ship-plan')
-    expect(registryCalls.create[0]?.prompt).toContain('Design doc')
-    expect(registryCalls.create[0]?.parentId).toBe('sess-think')
-    expect(schedulerCalls.start).toHaveLength(0)
-  })
-
   test('skips non-ship-advance modes', async () => {
     seedSession(db, 'sess-task', 'task')
     const registryCalls = { stop: [] as string[], create: [] as Array<{ mode: string; prompt: string; parentId?: string }> }
@@ -202,7 +182,7 @@ describe('shipAdvanceHandler', () => {
     expect(schedulerCalls.start).toHaveLength(0)
   })
 
-  test('spawns ship-verify session when ship-plan completes', async () => {
+  test('skips legacy ship-plan sessions', async () => {
     seedSession(db, 'sess-plan', 'ship-plan')
     seedAssistantMessage(db, 'sess-plan', 'DAG of tasks: 1. implement auth, 2. add tests, 3. deploy')
 
@@ -213,10 +193,7 @@ describe('shipAdvanceHandler', () => {
     const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-plan', state: 'completed', durationMs: 0 }
     await shipAdvanceHandler.handle(ev, ctx)
 
-    expect(registryCalls.create).toHaveLength(1)
-    expect(registryCalls.create[0]?.mode).toBe('ship-verify')
-    expect(registryCalls.create[0]?.prompt).toContain('DAG of tasks')
-    expect(registryCalls.create[0]?.parentId).toBe('sess-plan')
+    expect(registryCalls.create).toHaveLength(0)
     expect(schedulerCalls.start).toHaveLength(0)
   })
 })

--- a/server/session/registry.test.ts
+++ b/server/session/registry.test.ts
@@ -410,7 +410,7 @@ describe('SessionRegistry', () => {
       expect(statusPayload.severity).toBe('error')
     })
 
-    test('does not resume sessions even when claude_session_id is present', async () => {
+    test('marks sessions with incomplete resume metadata failed even when claude_session_id is present', async () => {
       const now = Date.now()
       db.run(
         `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, bare_dir, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation)
@@ -434,6 +434,45 @@ describe('SessionRegistry', () => {
       expect(row?.status).toBe('failed')
       expect(registry.get('recon-2')).toBeUndefined()
     })
+
+    test('resumes task sessions with claude_session_id and workspace metadata on boot', async () => {
+      const bare = trackedDir('bare-task-resume')
+      const work = trackedDir('work-task-resume')
+      const workspaceRoot = trackedDir('ws-task-resume')
+      await initLocalBareRepo(bare, work)
+
+      const repoName = path.basename(bare).replace(/\.git$/, '')
+      const bareDir = path.join(workspaceRoot, '.repos', `${repoName}.git`)
+
+      const handle = await import('../workspace/prepare').then((m) =>
+        m.prepareWorkspace({ slug: 'task-resume-slug', repoUrl: bare, workspaceRoot, bootstrap: false }),
+      )
+
+      const now = Date.now()
+      db.run(
+        `INSERT INTO sessions (id, slug, status, command, mode, repo, branch, bare_dir, pr_url, parent_id, variant_group_id, claude_session_id, workspace_root, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation)
+         VALUES ('task-resume', 'task-resume-slug', 'running', 'resume task', 'task', ?, ?, ?, null, null, null, 'claude-task-123', ?, ?, ?, 0, '[]', '[]', '[]')`,
+        [bare, handle.branch, bareDir, workspaceRoot, now, now],
+      )
+
+      let capturedArgs: string[] = []
+      const capturingSpawn: SpawnFn = (argv, opts) => {
+        capturedArgs = argv
+        return makeNoopSpawnFn()(argv, opts)
+      }
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: capturingSpawn })
+      await registry.reconcileOnBoot()
+
+      expect(capturedArgs).toContain('--resume')
+      const resumeIdx = capturedArgs.indexOf('--resume')
+      expect(capturedArgs[resumeIdx + 1]).toBe('claude-task-123')
+
+      await new Promise<void>((r) => setTimeout(r, 200))
+
+      const row = db.query<{ status: string }, [string]>('SELECT status FROM sessions WHERE id = ?').get('task-resume')
+      expect(row?.status).toBe('completed')
+    }, 60_000)
 
     test('resumes ship coordinator with claude_session_id on boot', async () => {
       const bare = trackedDir('bare-ship-resume')
@@ -637,6 +676,11 @@ describe('SessionRegistry', () => {
         repo: bare,
         workspaceRoot,
       })
+
+      db.run(
+        'UPDATE sessions SET stage = null WHERE id = ?',
+        [session.id],
+      )
 
       const snap = registry.snapshot(session.id)
       expect(snap).toBeDefined()

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -161,7 +161,7 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
       quota_retry_count: 0,
       metadata: createOpts.metadata ?? {},
       pipeline_advancing: false,
-      stage: null,
+      stage: createOpts.mode === 'ship' ? 'think' : null,
       coordinator_children: [],
     }
 
@@ -316,18 +316,16 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
       const row = prepared.getSession(db(), id)
       if (!row) continue
 
-      // Ship coordinators: attempt to resume from stored claude_session_id
-      if (row.mode === 'ship' && row.claude_session_id) {
+      if (row.claude_session_id) {
         try {
           const runtime = await resumeRuntime(row, row.command)
-          runtimes.set(id, runtime)
-          wireCompletionHandler(id)
+          prepared.updateSession(db(), { id, status: 'running', updated_at: Date.now() })
+          emitSnapshot(id)
           void runtime.start()
-          console.log('[ship] reconcileOnBoot: resumed coordinator', id, 'stage', row.stage)
+          console.log('[session] reconcileOnBoot: resumed', id, 'mode', row.mode)
           continue
         } catch (err) {
-          console.warn('[ship] reconcileOnBoot: failed to resume coordinator', id, err)
-          // Fall through to mark failed
+          console.warn('[session] reconcileOnBoot: failed to resume', id, err)
         }
       }
 

--- a/server/ship/coordinator.test.ts
+++ b/server/ship/coordinator.test.ts
@@ -34,6 +34,41 @@ function createMockScheduler() {
   }
 }
 
+const DAG_MARKDOWN = [
+  '```json',
+  '[',
+  '  {',
+  '    "id": "implement-api",',
+  '    "title": "Implement API",',
+  '    "description": "Add the API changes.",',
+  '    "dependsOn": []',
+  '  }',
+  ']',
+  '```',
+].join('\n')
+
+function insertDagPlan(db: Database, sessionId: string): void {
+  const now = Date.now()
+  prepared.insertEvent(db, {
+    session_id: sessionId,
+    seq: prepared.nextSeq(db, sessionId),
+    turn: 1,
+    type: 'assistant_text',
+    timestamp: now,
+    payload: {
+      id: `${sessionId}-plan`,
+      sessionId,
+      seq: 1,
+      turn: 1,
+      timestamp: now,
+      type: 'assistant_text',
+      blockId: 'plan',
+      text: DAG_MARKDOWN,
+      final: true,
+    },
+  })
+}
+
 function createSession(db: Database, sessionId: string, mode: string, stage: ShipStage | null) {
   const now = Date.now()
   const slug = `test-ship-${sessionId.split('-')[1]}`
@@ -105,17 +140,34 @@ describe('advanceShip', () => {
     test('plan → dag', async () => {
       const sessionId = 'session-2'
       createSession(db, sessionId, 'ship', 'plan')
+      insertDagPlan(db, sessionId)
 
       const result = await advanceShip(sessionId, undefined, ctx)
 
       expect(result.ok).toBe(true)
       expect(result.from).toBe('plan')
       expect(result.to).toBe('dag')
+      expect(result.dagId).toBeDefined()
 
       const row = prepared.getSession(db, sessionId)
       expect(row?.stage).toBe('dag')
-      // No directive injection for plan → dag
       expect(registry.reply).not.toHaveBeenCalled()
+      expect(scheduler.start).toHaveBeenCalledWith(result.dagId)
+      expect(prepared.listDags(db)).toHaveLength(1)
+    })
+
+    test('plan → dag requires a parseable DAG plan', async () => {
+      const sessionId = 'session-2b'
+      createSession(db, sessionId, 'ship', 'plan')
+
+      const result = await advanceShip(sessionId, undefined, ctx)
+
+      expect(result.ok).toBe(false)
+      expect(result.reason).toContain('no markdown provided')
+
+      const row = prepared.getSession(db, sessionId)
+      expect(row?.stage).toBe('plan')
+      expect(scheduler.start).not.toHaveBeenCalled()
     })
 
     test('dag → verify', async () => {
@@ -145,7 +197,7 @@ describe('advanceShip', () => {
 
       const row = prepared.getSession(db, sessionId)
       expect(row?.stage).toBe('done')
-      // No directive injection for verify → done
+      expect(row?.status).toBe('completed')
       expect(registry.reply).not.toHaveBeenCalled()
     })
 
@@ -285,25 +337,20 @@ describe('advanceShip', () => {
         return originalRun(sql, ...(args as Parameters<typeof originalRun>[1][]))
       }) as typeof db.run
 
-      // Start two transitions concurrently
+      insertDagPlan(db, sessionId)
+
       const [result1, result2] = await Promise.all([
         advanceShip(sessionId, undefined, ctx),
         advanceShip(sessionId, undefined, ctx),
       ])
 
-      // Restore original
       db.run = originalRun as typeof db.run
 
-      // Both should succeed
       expect(result1.ok).toBe(true)
       expect(result2.ok).toBe(true)
 
-      // Should have exactly 2 updates (both calls executed)
       expect(updateCount.length).toBe(2)
 
-      // Final state should be 'dag' (think → plan → dag)
-      // This proves serialization worked - if they ran concurrently,
-      // we'd likely end up in an incorrect state
       const row = prepared.getSession(db, sessionId)
       expect(row?.stage).toBe('dag')
     })
@@ -389,6 +436,7 @@ describe('advanceShip', () => {
     test('no injection for plan → dag', async () => {
       const sessionId = 'session-19'
       createSession(db, sessionId, 'ship', 'plan')
+      insertDagPlan(db, sessionId)
 
       await advanceShip(sessionId, 'dag', ctx)
 
@@ -439,6 +487,7 @@ describe('advanceShip', () => {
       expect(consoleLogSpy).toHaveBeenCalledWith('[ship]', sessionId, 'stage', 'think', '->', 'plan')
 
       // plan → dag
+      insertDagPlan(db, sessionId)
       await advanceShip(sessionId, undefined, ctx)
       expect(consoleLogSpy).toHaveBeenCalledWith('[ship]', sessionId, 'stage', 'plan', '->', 'dag')
 

--- a/server/ship/coordinator.ts
+++ b/server/ship/coordinator.ts
@@ -1,22 +1,25 @@
 import type { ShipStage, AttentionReason, QuickAction } from '../../shared/api-types'
 import { prepared } from '../db/sqlite'
 import { getEventBus } from '../events/bus'
-import type { PlanActionCtx } from '../commands/plan-actions'
+import { handleDag, type PlanActionCtx } from '../commands/plan-actions'
 
 // Stage directive constants
 export const DIRECTIVE_PLAN = [
   'You have completed the thinking phase. Now create an implementation plan.',
   '',
-  'Break the work into concrete, parallelizable tasks in DAG format:',
-  '```dag',
-  'id: unique-slug',
-  'title: One-line task description',
-  'dependsOn: [other-task-id]  # empty if no dependencies',
-  '---',
-  'Detailed instructions for this task...',
+  'Break the work into concrete, parallelizable tasks as a JSON DAG array:',
+  '```json',
+  '[',
+  '  {',
+  '    "id": "unique-slug",',
+  '    "title": "One-line task description",',
+  '    "description": "Detailed instructions for this task.",',
+  '    "dependsOn": []',
+  '  }',
+  ']',
   '```',
   '',
-  'Output ≥1 DAG task blocks covering all the work identified during thinking.',
+  'Output at least one task object covering all the work identified during thinking.',
 ].join('\n')
 
 export const DIRECTIVE_VERIFY = [
@@ -67,6 +70,7 @@ export interface AdvanceResult {
   ok: boolean
   from?: ShipStage
   to?: ShipStage
+  dagId?: string
   reason?: string
 }
 
@@ -133,12 +137,27 @@ export async function advanceShip(
       return { ok: true, from: currentStage, to: nextStage }
     }
 
-    // Perform the transition
+    let dagId: string | undefined
+    if (currentStage === 'plan' && nextStage === 'dag') {
+      const dagResult = await handleDag('', sessionId, ctx)
+      if (!dagResult.ok) {
+        return { ok: false, from: currentStage, to: nextStage, reason: dagResult.reason ?? 'could not start ship DAG' }
+      }
+      dagId = dagResult.dagId
+    }
+
     const now = Date.now()
-    ctx.db.run(
-      'UPDATE sessions SET stage = ?, updated_at = ? WHERE id = ?',
-      [nextStage, now, sessionId],
-    )
+    if (nextStage === 'done') {
+      ctx.db.run(
+        'UPDATE sessions SET stage = ?, status = ?, updated_at = ? WHERE id = ?',
+        [nextStage, 'completed', now, sessionId],
+      )
+    } else {
+      ctx.db.run(
+        'UPDATE sessions SET stage = ?, updated_at = ? WHERE id = ?',
+        [nextStage, now, sessionId],
+      )
+    }
 
     console.log('[ship]', sessionId, 'stage', currentStage, '->', nextStage)
 
@@ -188,6 +207,6 @@ export async function advanceShip(
       await ctx.registry.reply(sessionId, DIRECTIVE_VERIFY)
     }
 
-    return { ok: true, from: currentStage, to: nextStage }
+    return { ok: true, from: currentStage, to: nextStage, dagId }
   })
 }

--- a/server/test/e2e-ship.ts
+++ b/server/test/e2e-ship.ts
@@ -19,7 +19,7 @@
  *   4. Kills the server process mid-DAG via SIGTERM, restarts on the same DB,
  *      and asserts that the session is resumed (claude_session_id is preserved
  *      on the row; registry reconcileOnBoot re-starts suspended runtimes).
- *   5. Asserts /api/version includes the 'ship-pipeline' feature flag.
+ *   5. Asserts /api/version includes the 'ship-coordinator' feature flag.
  */
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
@@ -219,10 +219,10 @@ describe.skipIf(process.env['E2E'] !== '1')('e2e /ship pipeline', () => {
     try {
       const res = await fetch(`http://127.0.0.1:${port}/api/version`)
       const body = await res.json() as { data: { features: string[] } }
-      expect(body.data.features).toContain('ship-pipeline')
+      expect(body.data.features).toContain('ship-coordinator')
       expect(body.data.features).toContain('dag')
-      expect(body.data.features).toContain('variants')
-      expect(body.data.features).toContain('push')
+      expect(body.data.features).toContain('sessions-variants')
+      expect(body.data.features).toContain('web-push')
       expect(body.data.features).toContain('screenshots')
       expect(body.data.features).toContain('diff')
       expect(body.data.features).toContain('pr-preview')
@@ -266,7 +266,8 @@ describe.skipIf(process.env['E2E'] !== '1')('e2e /ship pipeline', () => {
       const createdEvt = sseEvents.find((e) => e.type === 'session_created')
       expect(createdEvt).toBeDefined()
       if (createdEvt && createdEvt.type === 'session_created') {
-        expect(createdEvt.session.mode).toBe('ship-think')
+        expect(createdEvt.session.mode).toBe('ship')
+        expect(createdEvt.session.stage).toBe('think')
       }
 
       await new Promise<void>((r) => setTimeout(r, 500))
@@ -360,7 +361,7 @@ describe.skipIf(process.env['E2E'] !== '1')('e2e /ship pipeline', () => {
       await new Promise<void>((r) => setTimeout(r, 600))
 
       expect(spawning.length).toBeGreaterThanOrEqual(1)
-      expect(spawning[0]?.mode).toBe('ship-think')
+      expect(spawning[0]?.mode).toBe('ship')
 
       expect(completed.length).toBeGreaterThanOrEqual(1)
     } finally {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -634,7 +634,8 @@ function ActiveView() {
   const handleCommand = useCallback(
     async (cmd: MinionCommand) => {
       if (!store) return
-      await store.sendCommand(cmd)
+      const result = await store.sendCommand(cmd)
+      if (!result.success) return
       if (cmd.action === 'close') {
         store.applySessionDeleted(cmd.sessionId)
       }
@@ -673,8 +674,8 @@ function ActiveView() {
       if (!store) return
       setIsActionLoading(true)
       try {
-        await store.sendCommand({ action: 'close', sessionId: sid })
-        store.applySessionDeleted(sid)
+        const result = await store.sendCommand({ action: 'close', sessionId: sid })
+        if (result.success) store.applySessionDeleted(sid)
       } finally {
         setIsActionLoading(false)
       }
@@ -975,19 +976,53 @@ function ActiveView() {
 }
 
 function PwaController() {
-  const { updateServiceWorker } = useRegisterSW({
+  const sw = useRegisterSW({
     immediate: true,
     onRegisteredSW(_, registration) {
       if (registration) {
         setInterval(() => { void registration.update() }, 60_000)
       }
     },
-    onNeedRefresh() {
-      void updateServiceWorker(true)
-    },
-    onOfflineReady() {},
   })
-  return null
+  const [offlineReady, setOfflineReady] = (sw.offlineReady ?? [false, () => {}]) as [boolean, (value: boolean) => void]
+  const [needRefresh, setNeedRefresh] = (sw.needRefresh ?? [false, () => {}]) as [boolean, (value: boolean) => void]
+
+  if (!offlineReady && !needRefresh) return null
+
+  const close = () => {
+    setOfflineReady(false)
+    setNeedRefresh(false)
+  }
+
+  return (
+    <div
+      class="fixed left-3 right-3 bottom-3 z-50 flex items-center gap-3 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 shadow-lg"
+      role="status"
+      data-testid="pwa-status-banner"
+    >
+      <span class="flex-1 text-xs font-medium text-slate-700 dark:text-slate-200">
+        {needRefresh ? 'Update ready' : 'Offline ready'}
+      </span>
+      {needRefresh && (
+        <button
+          type="button"
+          onClick={() => void sw.updateServiceWorker(true)}
+          class="rounded-md bg-indigo-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-indigo-700"
+          data-testid="pwa-update-reload"
+        >
+          Reload
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={close}
+        class="rounded-md border border-slate-300 dark:border-slate-600 px-2.5 py-1 text-xs font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+        data-testid="pwa-status-dismiss"
+      >
+        Dismiss
+      </button>
+    </div>
+  )
 }
 
 export default function App() {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -72,9 +72,17 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
     return { Authorization: `Bearer ${token}` }
   }
 
+  async function readBody<T>(res: Response): Promise<ApiResponse<T>> {
+    try {
+      return (await res.json()) as ApiResponse<T>
+    } catch {
+      throw new ApiError(res.status, res.statusText || 'Invalid JSON response')
+    }
+  }
+
   async function get<T>(path: string): Promise<T> {
     const res = await fetch(`${baseUrl}${path}`, { headers: headers() })
-    const body = (await res.json()) as ApiResponse<T>
+    const body = await readBody<T>(res)
     if (!res.ok || body.error) {
       throw new ApiError(res.status, body.error ?? res.statusText)
     }
@@ -87,7 +95,7 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
       headers: headers(),
       body: JSON.stringify(data),
     })
-    const body = (await res.json()) as ApiResponse<T>
+    const body = await readBody<T>(res)
     if (!res.ok || body.error) {
       throw new ApiError(res.status, body.error ?? res.statusText)
     }
@@ -100,7 +108,7 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
       headers: headers(),
       body: JSON.stringify(data),
     })
-    const body = (await res.json()) as ApiResponse<T>
+    const body = await readBody<T>(res)
     if (!res.ok || body.error) {
       throw new ApiError(res.status, body.error ?? res.statusText)
     }
@@ -113,7 +121,7 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
       headers: headers(),
       body: data !== undefined ? JSON.stringify(data) : undefined,
     })
-    const body = (await res.json()) as ApiResponse<T>
+    const body = await readBody<T>(res)
     if (!res.ok || body.error) {
       throw new ApiError(res.status, body.error ?? res.statusText)
     }

--- a/src/api/sse.ts
+++ b/src/api/sse.ts
@@ -21,13 +21,15 @@ export function openEventStream(opts: {
   baseUrl: string
   token: string
   handlers: SseHandlers
+  quietTimeoutMs?: number
 }): EventStreamHandle {
-  const { baseUrl, token, handlers } = opts
+  const { baseUrl, token, handlers, quietTimeoutMs = 70_000 } = opts
   const status = signal<SseStatus>('connecting')
   const reconnectAt = signal<number | null>(null)
   let es: EventSource | null = null
   let attempt = 0
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let watchdogTimer: ReturnType<typeof setTimeout> | null = null
   let closed = false
 
   function setStatus(s: SseStatus) {
@@ -41,6 +43,37 @@ export function openEventStream(opts: {
     return `${base}?token=${encodeURIComponent(token)}`
   }
 
+  function clearWatchdog() {
+    if (watchdogTimer === null) return
+    clearTimeout(watchdogTimer)
+    watchdogTimer = null
+  }
+
+  function scheduleWatchdog() {
+    clearWatchdog()
+    if (closed || quietTimeoutMs <= 0) return
+    watchdogTimer = setTimeout(() => {
+      if (closed) return
+      es?.close()
+      es = null
+      scheduleReconnect()
+    }, quietTimeoutMs)
+  }
+
+  function scheduleReconnect() {
+    if (closed) return
+    if (reconnectTimer !== null) return
+    clearWatchdog()
+    setStatus('retrying')
+    const delay = Math.floor(Math.random() * Math.min(30000, 500 * 2 ** attempt))
+    attempt++
+    reconnectAt.value = Date.now() + delay
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      connect()
+    }, delay)
+  }
+
   function connect() {
     if (closed) return
     setStatus('connecting')
@@ -51,6 +84,7 @@ export function openEventStream(opts: {
       attempt = 0
       reconnectAt.value = null
       setStatus('live')
+      scheduleWatchdog()
       handlers.onReconnect?.()
     }
 
@@ -58,14 +92,11 @@ export function openEventStream(opts: {
       es?.close()
       es = null
       if (closed) return
-      setStatus('retrying')
-      const delay = Math.floor(Math.random() * Math.min(30000, 500 * 2 ** attempt))
-      attempt++
-      reconnectAt.value = Date.now() + delay
-      reconnectTimer = setTimeout(connect, delay)
+      scheduleReconnect()
     }
 
     es.onmessage = (e: MessageEvent) => {
+      scheduleWatchdog()
       try {
         const event = JSON.parse(e.data as string) as SseEvent
         handlers.onEvent(event)
@@ -73,6 +104,8 @@ export function openEventStream(opts: {
         console.warn('[sse] failed to parse message', e.data)
       }
     }
+
+    es.addEventListener('keepalive', scheduleWatchdog)
   }
 
   connect()
@@ -86,6 +119,7 @@ export function openEventStream(opts: {
         clearTimeout(reconnectTimer)
         reconnectTimer = null
       }
+      clearWatchdog()
       es?.close()
       es = null
       attempt = 0
@@ -99,6 +133,7 @@ export function openEventStream(opts: {
         clearTimeout(reconnectTimer)
         reconnectTimer = null
       }
+      clearWatchdog()
       reconnectAt.value = null
       es?.close()
       es = null

--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -109,6 +109,7 @@ export function DagStatusPanel({ session, store, onSelect, onLand }: DagStatusPa
   const running = nodes.filter((n) => n.status === 'running' || n.status === 'ci-pending').length
   const failed = nodes.filter((n) => n.status === 'failed' || n.status === 'ci-failed').length
   const total = nodes.length
+  const progress = total === 0 ? 0 : Math.round((done / total) * 100)
 
   const graphTone =
     graph.status === 'failed'
@@ -126,6 +127,11 @@ export function DagStatusPanel({ session, store, onSelect, onLand }: DagStatusPa
   // panel header.
   const headerPrUrl = parent?.prUrl ?? firstNodePrUrl(nodes)
   const headerPrLabel = parent?.prUrl ? 'Parent PR' : 'First PR'
+  const progressTone = failed > 0
+    ? 'bg-red-500'
+    : graph.status === 'completed'
+      ? 'bg-emerald-500'
+      : 'bg-blue-500'
 
   return (
     <div
@@ -212,6 +218,19 @@ export function DagStatusPanel({ session, store, onSelect, onLand }: DagStatusPa
             <span aria-hidden="true">↗</span>
           </a>
         )}
+      </div>
+      <div
+        class="h-1 bg-slate-100 dark:bg-slate-900"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={progress}
+        data-testid="dag-status-progress"
+      >
+        <div
+          class={`h-full transition-all duration-300 ${progressTone}`}
+          style={{ width: `${progress}%` }}
+        />
       </div>
       {!collapsed.value && (
         <ul class="px-4 pb-3 pt-1 flex flex-col gap-1.5" data-testid="dag-status-node-list">

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -49,10 +49,10 @@ export interface ModeOption {
 }
 
 export const NEW_TASK_MODES: ModeOption[] = [
-  { value: 'task', label: 'Task', hint: 'Execute end-to-end' },
-  { value: 'plan', label: 'Plan', hint: 'Produce a plan; no execution' },
-  { value: 'think', label: 'Think', hint: 'Deliberate; no side effects' },
-  { value: 'ship', label: 'Ship', hint: 'Finish with a PR' },
+  { value: 'task', label: 'Task', hint: 'Small implementation task; execute now' },
+  { value: 'plan', label: 'Plan', hint: 'Plan first; execute with slash commands' },
+  { value: 'think', label: 'Think', hint: 'Research and brainstorm without code changes' },
+  { value: 'ship', label: 'Ship', hint: 'Full feature cycle: plan, DAG, verify, PR' },
 ]
 
 export const VARIANT_COUNTS: ReadonlyArray<number> = [1, 2, 3, 4]

--- a/src/chat/SlashCommandMenu.tsx
+++ b/src/chat/SlashCommandMenu.tsx
@@ -26,8 +26,11 @@ const TASK_COMMANDS: SlashCommand[] = [
 ]
 
 const SHIP_COMMANDS: SlashCommand[] = [
+  { cmd: '/dag', label: 'DAG', hint: 'Schedule the ship plan as a dependency graph' },
   { cmd: '/land', label: 'Land', hint: 'Merge the shipped PR' },
   { cmd: '/doctor', label: 'Doctor', hint: 'Diagnose coordination failures' },
+  { cmd: '/stop', label: 'Stop', hint: 'Interrupt the running session', destructive: true },
+  { cmd: '/close', label: 'Close', hint: 'Close this session permanently', destructive: true },
 ]
 
 function commandsForMode(mode: string): SlashCommand[] {

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -119,6 +119,18 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
     scheduleSnapshot()
   }
 
+  function applyDagSnapshot(dag: import('../api/types').ApiDagGraph) {
+    const idx = dags.value.findIndex((d) => d.id === dag.id)
+    if (idx !== -1) {
+      const updated = [...dags.value]
+      updated[idx] = dag
+      dags.value = updated
+    } else {
+      dags.value = [...dags.value, dag]
+    }
+    scheduleSnapshot()
+  }
+
   function onEvent(event: SseEvent) {
     switch (event.type) {
       case 'session_created':
@@ -130,8 +142,10 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
           const updated = [...sessions.value]
           updated[idx] = event.session
           sessions.value = updated
-          scheduleSnapshot()
+        } else {
+          sessions.value = [...sessions.value, event.session]
         }
+        scheduleSnapshot()
         if (diffStatsBySessionId.value.has(event.session.id)) {
           void loadDiffStats(event.session.id)
         }
@@ -142,17 +156,10 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
         break
       }
       case 'dag_created':
-        dags.value = [...dags.value, event.dag]
-        scheduleSnapshot()
+        applyDagSnapshot(event.dag)
         break
       case 'dag_updated': {
-        const idx = dags.value.findIndex((d) => d.id === event.dag.id)
-        if (idx !== -1) {
-          const updated = [...dags.value]
-          updated[idx] = event.dag
-          dags.value = updated
-          scheduleSnapshot()
-        }
+        applyDagSnapshot(event.dag)
         break
       }
       case 'dag_deleted':
@@ -166,6 +173,8 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
       }
       case 'resource':
         resourceSnapshot.value = event.snapshot
+        break
+      case 'session_screenshot_captured':
         break
     }
   }
@@ -247,8 +256,14 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
     runtimeConfig,
     loadDiffStats,
     refresh,
-    sendCommand(cmd) {
-      return client.sendCommand(cmd)
+    async sendCommand(cmd) {
+      const result = await client.sendCommand(cmd)
+      if (result.success) {
+        error.value = null
+      } else {
+        error.value = result.error ?? 'Command failed'
+      }
+      return result
     },
     getTranscript,
     applySessionCreated,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createApiClient, ApiError } from '../src/api/client'
+import { openEventStream } from '../src/api/sse'
 import { installMockEventSource } from './sse-mock'
 import type {
   ApiSession,
@@ -31,6 +32,8 @@ describe('ApiClient', () => {
   afterEach(() => {
     mock.restore()
     vi.unstubAllGlobals()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   it('sends Authorization header on getSessions', async () => {
@@ -178,6 +181,52 @@ describe('ApiClient', () => {
 
     expect(events).toHaveLength(1)
     expect(events[0].type).toBe('transcript_event')
+    handle.close()
+  })
+
+  it('openEventStream reconnects when the quiet watchdog expires', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    const handle = openEventStream({
+      baseUrl: BASE_URL,
+      token: TOKEN,
+      handlers: { onEvent: () => {} },
+      quietTimeoutMs: 1000,
+    })
+
+    const instance = [...mock.instances.values()][0]
+    instance.simulateOpen()
+
+    await vi.advanceTimersByTimeAsync(1001)
+
+    expect(mock.constructedUrls).toHaveLength(2)
+    handle.close()
+  })
+
+  it('openEventStream treats keepalive events as activity', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    const handle = openEventStream({
+      baseUrl: BASE_URL,
+      token: TOKEN,
+      handlers: { onEvent: () => {} },
+      quietTimeoutMs: 1000,
+    })
+
+    const instance = [...mock.instances.values()][0]
+    instance.simulateOpen()
+
+    await vi.advanceTimersByTimeAsync(800)
+    instance.dispatchEvent(new Event('keepalive'))
+    await vi.advanceTimersByTimeAsync(800)
+
+    expect(mock.constructedUrls).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(201)
+
+    expect(mock.constructedUrls).toHaveLength(2)
     handle.close()
   })
 

--- a/test/state/store.test.ts
+++ b/test/state/store.test.ts
@@ -114,6 +114,64 @@ describe('createConnectionStore snapshot integration', () => {
     store.dispose()
   })
 
+  it('upserts DAG snapshots when SSE replays the same graph after reconnect', async () => {
+    mockLoadSnapshot.mockResolvedValue(null)
+    vi.stubGlobal('fetch', makeResponses())
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-dag-upsert')
+
+    const graph: ApiDagGraph = {
+      id: 'dag-1',
+      rootTaskId: 's1',
+      nodes: {},
+      status: 'running',
+      createdAt: '2026-04-25T00:00:00Z',
+      updatedAt: '2026-04-25T00:00:00Z',
+    }
+    const replayed: ApiDagGraph = {
+      ...graph,
+      status: 'completed',
+      updatedAt: '2026-04-25T00:01:00Z',
+    }
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({ type: 'dag_created', dag: graph })
+    es?.push({ type: 'dag_created', dag: replayed })
+
+    expect(store.dags.value).toHaveLength(1)
+    expect(store.dags.value[0]).toEqual(replayed)
+    store.dispose()
+  })
+
+  it('surfaces failed command results on the store error signal', async () => {
+    mockLoadSnapshot.mockResolvedValue(null)
+    const baseFetch = makeResponses()
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/api/commands') && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () => Promise.resolve({ data: { success: false, error: 'invalid transition' } }),
+        })
+      }
+      return baseFetch(url)
+    }))
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-command-error')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const result = await store.sendCommand({ action: 'stop', sessionId: 's1' })
+
+    expect(result.success).toBe(false)
+    expect(store.error.value).toBe('invalid transition')
+    store.dispose()
+  })
+
   it('applySessionDeleted removes the session and is a no-op when already gone', async () => {
     mockLoadSnapshot.mockResolvedValue(null)
     vi.stubGlobal('fetch', makeResponses([SESSION]))

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -212,6 +212,7 @@ describe('ConnectionStore SSE events', () => {
     const store = createConnectionStore(client, 'test-conn')
     const es = [...mock.instances.values()][0] as MockEventSource
 
+    store.applySessionCreated(SESSION)
     for (let i = 0; i < 4; i++) await Promise.resolve()
     const ts = store.getTranscript(SESSION.id)
     expect(ts).not.toBeNull()
@@ -260,6 +261,7 @@ describe('ConnectionStore SSE events', () => {
     const store = createConnectionStore(client, 'test-conn')
     const es = [...mock.instances.values()][0] as MockEventSource
 
+    store.applySessionCreated(SESSION)
     for (let i = 0; i < 4; i++) await Promise.resolve()
     const ts = store.getTranscript(SESSION.id)
     expect(ts).not.toBeNull()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       strategies: 'injectManifest',
       srcDir: 'src',
       filename: 'sw.ts',
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
       injectRegister: 'auto',
       manifest: false,
       injectManifest: {


### PR DESCRIPTION
## Summary
- Resume interrupted sessions that have provider session metadata, and make failed command results visible in the UI instead of proceeding optimistically.
- Add SSE quiet-timeout recovery, prompt-based PWA updates, and DAG progress/status upserts for better phone UX.
- Make ship coordinators schedule real DAG work from JSON plans, advance completed DAGs into verification, and expose live DAG node/session/status snapshots.

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun test server/ shared/`
- `bun run build`
