### PR TITLE
fix(api): flush SSE through proxy buffers

### DIFF
--- a/server/api/sse.test.ts
+++ b/server/api/sse.test.ts
@@ -120,6 +120,8 @@ describe('auth middleware', () => {
     const app = makeApp(testDb)
     const res = await app.fetch(new Request('http://localhost/api/events'))
     expect(res.status).toBe(200)
+    expect(res.headers.get('cache-control')).toContain('no-transform')
+    expect(res.headers.get('x-accel-buffering')).toBe('no')
     res.body?.cancel()
   })
 
@@ -156,6 +158,21 @@ describe('auth middleware', () => {
 })
 
 describe('snapshot on connect', () => {
+  test('starts with a proxy flush frame', async () => {
+    const app = makeApp(testDb)
+    const res = await app.fetch(new Request('http://localhost/api/events'))
+    expect(res.status).toBe(200)
+
+    const reader = new ReadableStreamDefaultReader<Uint8Array>(res.body as ReadableStream<Uint8Array>)
+    const chunk = await reader.read()
+    reader.cancel()
+
+    expect(chunk.done).toBe(false)
+    const text = new TextDecoder().decode(chunk.value)
+    expect(text.startsWith(': ')).toBe(true)
+    expect(text.length).toBeGreaterThanOrEqual(4098)
+  })
+
   test('emits an immediate non-empty keepalive when there are no snapshots', async () => {
     const app = makeApp(testDb)
     const res = await app.fetch(new Request('http://localhost/api/events'))
@@ -211,7 +228,10 @@ describe('live event projection', () => {
       conversation: [],
     }
 
-    const collectPromise = reader.read(2)
+    const ready = await reader.read(1)
+    expect(ready[0]!.event).toBe('keepalive')
+
+    const collectPromise = reader.read(1)
     bus.emit({ kind: 'session.snapshot', session })
     const events = await collectPromise
     reader.cancel()
@@ -246,7 +266,10 @@ describe('live event projection', () => {
       conversation: [],
     }
 
-    const firstCollect = reader.read(2)
+    const ready = await reader.read(1)
+    expect(ready[0]!.event).toBe('keepalive')
+
+    const firstCollect = reader.read(1)
     bus.emit({ kind: 'session.snapshot', session })
     const first = await firstCollect
     const firstMessage = first.find((e) => e.event === 'message')

--- a/server/api/sse.ts
+++ b/server/api/sse.ts
@@ -8,9 +8,15 @@ import { getEventBus } from '../events/bus'
 import { getDb, prepared } from '../db/sqlite'
 import { sessionRowToApi, dagToApi, eventRowToTranscript } from './wire-mappers'
 
+const PROXY_FLUSH_BYTES = 4096
+
 export function registerSseRoute(app: Hono, dbProvider?: () => Database): void {
   const resolveDb = dbProvider ?? getDb
   app.get('/api/events', (c) => sseHandler(c, resolveDb))
+}
+
+function proxyFlushFrame(): string {
+  return `: ${' '.repeat(PROXY_FLUSH_BYTES)}\n\n`
 }
 
 function keepaliveData(): string {
@@ -18,7 +24,9 @@ function keepaliveData(): string {
 }
 
 async function sseHandler(c: Context, dbProvider: () => Database): Promise<Response> {
-  return streamSSE(c, async (stream) => {
+  const response = streamSSE(c, async (stream) => {
+    await stream.write(proxyFlushFrame())
+
     const db = dbProvider()
     const seenSessionIds = new Set<string>()
     const seenDagIds = new Set<string>()
@@ -82,6 +90,9 @@ async function sseHandler(c: Context, dbProvider: () => Database): Promise<Respo
       stream.onAbort(resolve)
     })
   })
+  response.headers.set('Cache-Control', 'no-cache, no-transform')
+  response.headers.set('X-Accel-Buffering', 'no')
+  return response
 }
 
 function projectEvent(


### PR DESCRIPTION
## What changed
- Send an initial SSE comment padding frame before snapshots so Cloudflare/proxy buffers forward bytes immediately.
- Mark SSE responses as `no-transform` and `X-Accel-Buffering: no`.
- Cover the proxy flush frame and live-event readiness in SSE tests.

## Why
The deployed quick tunnel returned `200 text/event-stream` but forwarded zero body bytes for the SSE stream. Local engine SSE flushed correctly, which pointed to proxy buffering of the initial small frames.

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun test server/ shared/`
- `bun run build`
