### PR TITLE
fix(api): bound proxied SSE streams

### DIFF
--- a/server/api/sse.test.ts
+++ b/server/api/sse.test.ts
@@ -202,6 +202,21 @@ describe('snapshot on connect', () => {
     expect(parsed.type).toBe('session_created')
     expect(parsed.session.id).toBe('sess-snap')
   })
+
+  test('proxied requests close after the snapshot batch with a retry hint', async () => {
+    insertSession(testDb, 'sess-proxied')
+    const app = makeApp(testDb)
+    const res = await app.fetch(new Request('http://localhost/api/events', {
+      headers: { 'cf-ray': 'test-ray' },
+    }))
+    expect(res.status).toBe(200)
+
+    const text = await res.text()
+    expect(text).toContain('event: message')
+    expect(text).toContain('"session_created"')
+    expect(text).toContain('event: keepalive')
+    expect(text).toContain('retry: 1000')
+  })
 })
 
 describe('live event projection', () => {

--- a/server/api/sse.ts
+++ b/server/api/sse.ts
@@ -9,6 +9,7 @@ import { getDb, prepared } from '../db/sqlite'
 import { sessionRowToApi, dagToApi, eventRowToTranscript } from './wire-mappers'
 
 const PROXY_FLUSH_BYTES = 4096
+const PROXIED_RETRY_MS = 1000
 
 export function registerSseRoute(app: Hono, dbProvider?: () => Database): void {
   const resolveDb = dbProvider ?? getDb
@@ -23,7 +24,15 @@ function keepaliveData(): string {
   return JSON.stringify({ ts: Date.now() })
 }
 
+function isProxiedRequest(c: Context): boolean {
+  return c.req.query('lease') === 'snapshot'
+    || c.req.header('cf-ray') !== undefined
+    || c.req.header('cf-connecting-ip') !== undefined
+    || c.req.header('cf-visitor') !== undefined
+}
+
 async function sseHandler(c: Context, dbProvider: () => Database): Promise<Response> {
+  const closeAfterSnapshot = isProxiedRequest(c)
   const response = streamSSE(c, async (stream) => {
     await stream.write(proxyFlushFrame())
 
@@ -67,6 +76,15 @@ async function sseHandler(c: Context, dbProvider: () => Database): Promise<Respo
         const evt: SseEvent = { type: 'transcript_event', sessionId: sessionRow.id, event: transcriptEvent }
         await stream.writeSSE({ data: JSON.stringify(evt), event: 'message' })
       }
+    }
+
+    if (closeAfterSnapshot) {
+      await stream.writeSSE({
+        data: keepaliveData(),
+        event: 'keepalive',
+        retry: PROXIED_RETRY_MS,
+      })
+      return
     }
 
     const unsubscribe = getEventBus().on((engineEvent: EngineEvent) => {


### PR DESCRIPTION
## What changed
- Detect Cloudflare-proxied SSE requests from forwarded Cloudflare headers.
- For proxied requests, send the snapshot batch plus a short EventSource retry hint, then close the response so Cloudflare forwards the buffered body.
- Keep direct local SSE connections long-lived.
- Add coverage for proxied snapshot delivery and retry behavior.

## Why
The engine was correctly streaming locally, but the quick Cloudflare tunnel held the body open indefinitely. Closing proxied snapshot batches lets browser EventSource reconnect normally while still receiving updates over Cloudflare.

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun test server/ shared/`
- `bun run build`
