### PR TITLE
fix(ui): keep proxied sse reconnects quiet

### DIFF
--- a/src/api/sse.ts
+++ b/src/api/sse.ts
@@ -7,7 +7,7 @@ export type SseStatus = 'connecting' | 'live' | 'retrying' | 'closed'
 export interface SseHandlers {
   onEvent: (event: SseEvent) => void
   onStatusChange?: (status: SseStatus) => void
-  onReconnect?: () => void
+  onReconnect?: (event: { quiet: boolean }) => void
 }
 
 export interface EventStreamHandle {
@@ -16,6 +16,9 @@ export interface EventStreamHandle {
   status: Signal<SseStatus>
   reconnectAt: Signal<number | null>
 }
+
+const QUIET_RECONNECT_DELAY_MS = 1000
+const RECENT_ACTIVITY_RECONNECT_MS = 5000
 
 export function openEventStream(opts: {
   baseUrl: string
@@ -31,6 +34,8 @@ export function openEventStream(opts: {
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   let watchdogTimer: ReturnType<typeof setTimeout> | null = null
   let closed = false
+  let lastActivityAt = 0
+  let quietReconnectsSinceActivity = 0
 
   function setStatus(s: SseStatus) {
     status.value = s
@@ -56,27 +61,54 @@ export function openEventStream(opts: {
       if (closed) return
       es?.close()
       es = null
-      scheduleReconnect()
+      scheduleReconnect(false)
     }, quietTimeoutMs)
   }
 
-  function scheduleReconnect() {
+  function markActivity() {
+    lastActivityAt = Date.now()
+    quietReconnectsSinceActivity = 0
+    attempt = 0
+    reconnectAt.value = null
+    if (status.value !== 'live') {
+      setStatus('live')
+    }
+    scheduleWatchdog()
+  }
+
+  function shouldReconnectQuietly(): boolean {
+    return status.value === 'live'
+      && lastActivityAt > 0
+      && Date.now() - lastActivityAt <= RECENT_ACTIVITY_RECONNECT_MS
+      && quietReconnectsSinceActivity === 0
+  }
+
+  function scheduleReconnect(quiet: boolean) {
     if (closed) return
     if (reconnectTimer !== null) return
     clearWatchdog()
-    setStatus('retrying')
-    const delay = Math.floor(Math.random() * Math.min(30000, 500 * 2 ** attempt))
-    attempt++
-    reconnectAt.value = Date.now() + delay
+    const delay = quiet
+      ? QUIET_RECONNECT_DELAY_MS
+      : Math.floor(Math.random() * Math.min(30000, 500 * 2 ** attempt))
+    if (quiet) {
+      quietReconnectsSinceActivity++
+      reconnectAt.value = null
+    } else {
+      setStatus('retrying')
+      attempt++
+      reconnectAt.value = Date.now() + delay
+    }
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null
-      connect()
+      connect(quiet)
     }, delay)
   }
 
-  function connect() {
+  function connect(quiet = false) {
     if (closed) return
-    setStatus('connecting')
+    if (!quiet || status.value !== 'live') {
+      setStatus('connecting')
+    }
     reconnectAt.value = null
     es = new EventSource(buildUrl())
 
@@ -85,18 +117,18 @@ export function openEventStream(opts: {
       reconnectAt.value = null
       setStatus('live')
       scheduleWatchdog()
-      handlers.onReconnect?.()
+      handlers.onReconnect?.({ quiet })
     }
 
     es.onerror = () => {
       es?.close()
       es = null
       if (closed) return
-      scheduleReconnect()
+      scheduleReconnect(shouldReconnectQuietly())
     }
 
     es.onmessage = (e: MessageEvent) => {
-      scheduleWatchdog()
+      markActivity()
       try {
         const event = JSON.parse(e.data as string) as SseEvent
         handlers.onEvent(event)
@@ -105,7 +137,7 @@ export function openEventStream(opts: {
       }
     }
 
-    es.addEventListener('keepalive', scheduleWatchdog)
+    es.addEventListener('keepalive', markActivity)
   }
 
   connect()
@@ -123,6 +155,8 @@ export function openEventStream(opts: {
       es?.close()
       es = null
       attempt = 0
+      lastActivityAt = 0
+      quietReconnectsSinceActivity = 0
       reconnectAt.value = null
       connect()
     },

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -197,7 +197,8 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
     onStatusChange(s: SseStatus) {
       status.value = s
     },
-    onReconnect() {
+    onReconnect(event) {
+      if (event.quiet) return
       void refresh()
       for (const ts of transcripts.values()) {
         void ts.reconcile()

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -230,6 +230,81 @@ describe('ApiClient', () => {
     handle.close()
   })
 
+  it('openEventStream keeps the stream live across proxied snapshot closes', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    const statuses: string[] = []
+    const reconnects: boolean[] = []
+    const handle = openEventStream({
+      baseUrl: BASE_URL,
+      token: TOKEN,
+      handlers: {
+        onEvent: () => {},
+        onStatusChange: (status) => statuses.push(status),
+        onReconnect: (event) => reconnects.push(event.quiet),
+      },
+      quietTimeoutMs: 1000,
+    })
+
+    const instance = [...mock.instances.values()][0]
+    instance.simulateOpen()
+    instance.dispatchEvent(new Event('keepalive'))
+    instance.simulateError()
+
+    expect(handle.status.value).toBe('live')
+    expect(handle.reconnectAt.value).toBeNull()
+    expect(statuses).not.toContain('retrying')
+    expect(reconnects).toEqual([false])
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    const reconnected = [...mock.instances.values()][0]
+    reconnected.simulateOpen()
+
+    expect(mock.constructedUrls).toHaveLength(2)
+    expect(handle.status.value).toBe('live')
+    expect(handle.reconnectAt.value).toBeNull()
+    expect(statuses).not.toContain('retrying')
+    expect(statuses.filter((status) => status === 'connecting')).toHaveLength(1)
+    expect(reconnects).toEqual([false, true])
+
+    handle.close()
+  })
+
+  it('openEventStream surfaces retrying when a quiet reconnect gets no activity', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    const statuses: string[] = []
+    const handle = openEventStream({
+      baseUrl: BASE_URL,
+      token: TOKEN,
+      handlers: {
+        onEvent: () => {},
+        onStatusChange: (status) => statuses.push(status),
+      },
+      quietTimeoutMs: 1000,
+    })
+
+    const first = [...mock.instances.values()][0]
+    first.simulateOpen()
+    first.dispatchEvent(new Event('keepalive'))
+    first.simulateError()
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    const second = [...mock.instances.values()][0]
+    second.simulateOpen()
+    second.simulateError()
+
+    expect(handle.status.value).toBe('retrying')
+    expect(handle.reconnectAt.value).not.toBeNull()
+    expect(statuses).toContain('retrying')
+
+    handle.close()
+  })
+
   it('strips trailing slash from baseUrl', async () => {
     const fetchMock = mockFetch({ data: { apiVersion: '1', libraryVersion: '0.0.1', features: [] } as VersionInfo })
     vi.stubGlobal('fetch', fetchMock)

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -83,6 +83,7 @@ describe('ConnectionStore SSE events', () => {
     mock.restore()
     vi.unstubAllGlobals()
     vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   function setup(initialSessions: ApiSession[] = [], initialDags: ApiDagGraph[] = []) {
@@ -178,6 +179,33 @@ describe('ConnectionStore SSE events', () => {
     await Promise.resolve()
 
     expect(fetchMock.mock.calls.length).toBeGreaterThan(countBefore)
+    store.dispose()
+  })
+
+  it('quiet reconnect does not trigger refresh', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    const fetchMock = makeResponses()
+    vi.stubGlobal('fetch', fetchMock)
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'test-conn')
+    const first = [...mock.instances.values()][0] as MockEventSource
+
+    await Promise.resolve()
+    first.simulateOpen()
+    await Promise.resolve()
+    const countBeforeQuietReconnect = fetchMock.mock.calls.length
+
+    first.dispatchEvent(new Event('keepalive'))
+    first.simulateError()
+    await vi.advanceTimersByTimeAsync(1000)
+
+    const second = [...mock.instances.values()][0] as MockEventSource
+    second.simulateOpen()
+    await Promise.resolve()
+
+    expect(fetchMock.mock.calls.length).toBe(countBeforeQuietReconnect)
     store.dispose()
   })
 


### PR DESCRIPTION
## Summary
- Keep the SSE badge live across expected proxied snapshot stream closes after recent keepalive/message activity.
- Mark quiet reconnect opens so the store does not refresh REST snapshots every second while Cloudflare-bound streams reconnect.
- Preserve visible retrying for initial failures, watchdog stalls, and quiet reconnects that fail before fresh activity.

## Validation
- bun run typecheck
- bun run lint
- bun run test
