### PR TITLE
fix(docker): install playwright system dependencies in final stage

### DIFF
--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -46,6 +46,8 @@ RUN npm install -g \
       github-mcp-server \
       repomix
 
+RUN npx --yes playwright@latest install-deps chromium
+
 COPY --from=devtools /opt/devtools /opt/devtools
 COPY --from=uv-base /opt/uv-python /opt/uv-python
 COPY --from=uv-base /opt/uv-tools /opt/uv-tools


### PR DESCRIPTION
## Summary

- Fixed missing Playwright system libraries in the engine Docker image
- Adds `npx playwright install-deps chromium` to the final build stage

## Problem

The `playwright-base` stage ran `playwright install --with-deps chromium`, which installed the Chromium browser binary and all required system libraries (libglib-2.0, libnss3, libatk-bridge2.0, etc.) into standard Debian paths like `/usr/lib/x86_64-linux-gnu/`.

However, the final stage only copied `/opt/pw-browsers` from the playwright-base stage, bringing over the browser binary but **not** the system libraries it depends on. This caused the browser to fail at launch with:

```
error while loading shared libraries: libglib-2.0.so.0: cannot open shared object file: No such file or directory
```

## Solution

Install Playwright's system dependencies in the final stage (after npm/npx are available) by running:
```dockerfile
RUN npx --yes playwright@latest install-deps chromium
```

This installs just the dependencies (not the browser again) in the final `oven/bun:1.2-debian` stage, allowing the copied browser binaries from `/opt/pw-browsers` to find all required libraries.

## Test plan

- [ ] Build the updated Docker image: `cd docker && docker compose build`
- [ ] Start the engine: `docker compose up -d`
- [ ] Verify MCP Playwright tools work (e.g., navigate to a URL and take a screenshot)
- [ ] Confirm no library errors in container logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
