### PR TITLE
feat(memory): add memories API endpoints

### DIFF
--- a/server/api/routes.memories.test.ts
+++ b/server/api/routes.memories.test.ts
@@ -1,0 +1,368 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { readFileSync } from 'node:fs'
+import { Hono } from 'hono'
+import { createSessionRegistry } from '../session/registry'
+import { resetEventBus } from '../events/bus'
+import { runMigrations } from '../db/sqlite'
+import { registerApiRoutes } from './routes'
+import type { SpawnFn, SubprocessHandle } from '../session/runtime'
+import type { ApiResponse, CreateMemoryRequest, MemoryEntry, ReviewMemoryRequest, UpdateMemoryRequest } from '../../shared/api-types'
+
+function setupTestDb(): Database {
+  const db = new Database(':memory:')
+  const schemaPath = new URL('../db/schema.sql', import.meta.url).pathname
+  const schema = readFileSync(schemaPath, 'utf8')
+  db.exec(schema)
+  runMigrations(db)
+  return db
+}
+
+function makeNoopSpawnFn(): SpawnFn {
+  return (): SubprocessHandle => {
+    let resolveExit!: (code: number) => void
+    const exitedPromise = new Promise<number>((r) => { resolveExit = r })
+    let stdoutCtrl!: ReadableStreamDefaultController<Uint8Array>
+    let stderrCtrl!: ReadableStreamDefaultController<Uint8Array>
+    let closed = false
+
+    function closeAll(code: number): void {
+      if (closed) return
+      closed = true
+      try { stderrCtrl.close() } catch { /* already closed */ }
+      try { stdoutCtrl.close() } catch { /* already closed */ }
+      resolveExit(code)
+    }
+
+    const proc: SubprocessHandle = {
+      pid: 1,
+      killed: false,
+      stdin: { async write() {}, flush() {} },
+      stdout: new ReadableStream<Uint8Array>({ start(c) { stdoutCtrl = c } }),
+      stderr: new ReadableStream<Uint8Array>({ start(c) { stderrCtrl = c } }),
+      exited: exitedPromise,
+      kill() {
+        this.killed = true
+        closeAll(0)
+      },
+    }
+
+    void Promise.resolve().then(() => { closeAll(0) })
+
+    return proc
+  }
+}
+
+function makeApp(db: Database): Hono {
+  const app = new Hono()
+  const registry = createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn() })
+  registerApiRoutes(app, registry, () => db)
+  return app
+}
+
+async function json<T>(res: Response): Promise<T> {
+  return res.json() as Promise<T>
+}
+
+let testDb: Database
+let originalToken: string | undefined
+
+beforeEach(() => {
+  originalToken = process.env['MINION_API_TOKEN']
+  delete process.env['MINION_API_TOKEN']
+  testDb = setupTestDb()
+  resetEventBus()
+})
+
+afterEach(() => {
+  if (originalToken !== undefined) {
+    process.env['MINION_API_TOKEN'] = originalToken
+  } else {
+    delete process.env['MINION_API_TOKEN']
+  }
+  testDb.close()
+  resetEventBus()
+})
+
+describe('POST /api/memories', () => {
+  test('creates a memory with required fields', async () => {
+    const app = makeApp(testDb)
+    const body: CreateMemoryRequest = {
+      kind: 'user',
+      title: 'User prefers TypeScript',
+      body: 'The user has indicated a strong preference for TypeScript over JavaScript.',
+    }
+    const res = await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }))
+    expect(res.status).toBe(201)
+    const result = await json<ApiResponse<MemoryEntry>>(res)
+    expect(result.data).toBeDefined()
+    expect(result.data.kind).toBe('user')
+    expect(result.data.title).toBe('User prefers TypeScript')
+    expect(result.data.status).toBe('pending')
+    expect(result.data.id).toBeGreaterThan(0)
+  })
+
+  test('creates a memory with all optional fields', async () => {
+    const app = makeApp(testDb)
+    const body: CreateMemoryRequest = {
+      repo: 'https://github.com/test/repo',
+      kind: 'feedback',
+      title: 'Avoid mocking database',
+      body: 'User prefers integration tests with real database.\n\n**Why:** Previous mock divergence caused production failures.\n\n**How to apply:** Use real DB for all integration tests.',
+      pinned: true,
+    }
+    const res = await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }))
+    expect(res.status).toBe(201)
+    const result = await json<ApiResponse<MemoryEntry>>(res)
+    expect(result.data.repo).toBe('https://github.com/test/repo')
+    expect(result.data.pinned).toBe(true)
+  })
+
+  test('rejects memory with missing required fields', async () => {
+    const app = makeApp(testDb)
+    const body = { kind: 'user' }
+    const res = await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }))
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('GET /api/memories', () => {
+  test('returns empty list when no memories exist', async () => {
+    const app = makeApp(testDb)
+    const res = await app.fetch(new Request('http://localhost/api/memories'))
+    expect(res.status).toBe(200)
+    const result = await json<ApiResponse<{ memories: MemoryEntry[]; pendingCount: number }>>(res)
+    expect(result.data.memories).toEqual([])
+    expect(result.data.pendingCount).toBe(0)
+  })
+
+  test('returns all memories', async () => {
+    const app = makeApp(testDb)
+
+    const mem1: CreateMemoryRequest = { kind: 'user', title: 'Memory 1', body: 'Body 1' }
+    const mem2: CreateMemoryRequest = { kind: 'feedback', title: 'Memory 2', body: 'Body 2' }
+
+    await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(mem1),
+    }))
+    await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(mem2),
+    }))
+
+    const res = await app.fetch(new Request('http://localhost/api/memories'))
+    expect(res.status).toBe(200)
+    const result = await json<ApiResponse<{ memories: MemoryEntry[]; pendingCount: number }>>(res)
+    expect(result.data.memories).toHaveLength(2)
+    expect(result.data.pendingCount).toBe(2)
+  })
+
+  test('filters memories by status', async () => {
+    const app = makeApp(testDb)
+
+    const mem1: CreateMemoryRequest = { kind: 'user', title: 'Memory 1', body: 'Body 1' }
+    await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(mem1),
+    }))
+
+    const createRes = await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'user', title: 'Memory 2', body: 'Body 2' }),
+    }))
+    const created = await json<ApiResponse<MemoryEntry>>(createRes)
+
+    await app.fetch(new Request(`http://localhost/api/memories/${created.data.id}/review`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'approved' } satisfies ReviewMemoryRequest),
+    }))
+
+    const res = await app.fetch(new Request('http://localhost/api/memories?status=approved'))
+    expect(res.status).toBe(200)
+    const result = await json<ApiResponse<{ memories: MemoryEntry[]; pendingCount: number }>>(res)
+    expect(result.data.memories).toHaveLength(1)
+    expect(result.data.memories[0]?.status).toBe('approved')
+    expect(result.data.pendingCount).toBe(1)
+  })
+
+  test('searches memories using FTS', async () => {
+    const app = makeApp(testDb)
+
+    await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'user', title: 'TypeScript preference', body: 'User loves TypeScript' }),
+    }))
+    await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'feedback', title: 'Python linting', body: 'Use ruff for Python linting' }),
+    }))
+
+    const res = await app.fetch(new Request('http://localhost/api/memories?q=TypeScript'))
+    expect(res.status).toBe(200)
+    const result = await json<ApiResponse<{ memories: MemoryEntry[]; pendingCount: number }>>(res)
+    expect(result.data.memories).toHaveLength(1)
+    expect(result.data.memories[0]?.title).toContain('TypeScript')
+  })
+})
+
+describe('PATCH /api/memories/:id', () => {
+  test('updates memory title and body', async () => {
+    const app = makeApp(testDb)
+
+    const createRes = await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'user', title: 'Original', body: 'Original body' }),
+    }))
+    const created = await json<ApiResponse<MemoryEntry>>(createRes)
+
+    const update: UpdateMemoryRequest = { title: 'Updated', body: 'Updated body' }
+    const res = await app.fetch(new Request(`http://localhost/api/memories/${created.data.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(update),
+    }))
+
+    expect(res.status).toBe(200)
+    const result = await json<ApiResponse<MemoryEntry>>(res)
+    expect(result.data.title).toBe('Updated')
+    expect(result.data.body).toBe('Updated body')
+  })
+
+  test('returns 404 for non-existent memory', async () => {
+    const app = makeApp(testDb)
+    const res = await app.fetch(new Request('http://localhost/api/memories/9999', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Updated' }),
+    }))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('PATCH /api/memories/:id/review', () => {
+  test('approves a pending memory', async () => {
+    const app = makeApp(testDb)
+
+    const createRes = await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'user', title: 'Test', body: 'Test body' }),
+    }))
+    const created = await json<ApiResponse<MemoryEntry>>(createRes)
+
+    const review: ReviewMemoryRequest = { status: 'approved' }
+    const res = await app.fetch(new Request(`http://localhost/api/memories/${created.data.id}/review`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(review),
+    }))
+
+    expect(res.status).toBe(200)
+    const result = await json<ApiResponse<MemoryEntry>>(res)
+    expect(result.data.status).toBe('approved')
+    expect(result.data.reviewedAt).toBeGreaterThan(0)
+  })
+
+  test('rejects a pending memory', async () => {
+    const app = makeApp(testDb)
+
+    const createRes = await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'user', title: 'Test', body: 'Test body' }),
+    }))
+    const created = await json<ApiResponse<MemoryEntry>>(createRes)
+
+    const review: ReviewMemoryRequest = { status: 'rejected' }
+    const res = await app.fetch(new Request(`http://localhost/api/memories/${created.data.id}/review`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(review),
+    }))
+
+    expect(res.status).toBe(200)
+    const result = await json<ApiResponse<MemoryEntry>>(res)
+    expect(result.data.status).toBe('rejected')
+  })
+
+  test('deletes memory when approving pending_deletion', async () => {
+    const app = makeApp(testDb)
+
+    const createRes = await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'user', title: 'Test', body: 'Test body' }),
+    }))
+    const created = await json<ApiResponse<MemoryEntry>>(createRes)
+
+    await app.fetch(new Request(`http://localhost/api/memories/${created.data.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'pending_deletion' }),
+    }))
+
+    const review: ReviewMemoryRequest = { status: 'approved' }
+    const res = await app.fetch(new Request(`http://localhost/api/memories/${created.data.id}/review`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(review),
+    }))
+
+    expect(res.status).toBe(200)
+    const result = await json<ApiResponse<{ deleted: true }>>(res)
+    expect(result.data.deleted).toBe(true)
+  })
+})
+
+describe('DELETE /api/memories/:id', () => {
+  test('deletes a memory', async () => {
+    const app = makeApp(testDb)
+
+    const createRes = await app.fetch(new Request('http://localhost/api/memories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'user', title: 'Test', body: 'Test body' }),
+    }))
+    const created = await json<ApiResponse<MemoryEntry>>(createRes)
+
+    const res = await app.fetch(new Request(`http://localhost/api/memories/${created.data.id}`, {
+      method: 'DELETE',
+    }))
+
+    expect(res.status).toBe(200)
+    const result = await json<ApiResponse<{ deleted: true }>>(res)
+    expect(result.data.deleted).toBe(true)
+
+    const getRes = await app.fetch(new Request(`http://localhost/api/memories/${created.data.id}`))
+    expect(getRes.status).toBe(404)
+  })
+
+  test('returns 404 for non-existent memory', async () => {
+    const app = makeApp(testDb)
+    const res = await app.fetch(new Request('http://localhost/api/memories/9999', {
+      method: 'DELETE',
+    }))
+    expect(res.status).toBe(404)
+  })
+})

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -8,6 +8,7 @@ import type {
   ApiSession,
   CommandResult,
   CreateSessionVariantsResult,
+  MemoryEntry,
   MinionCommand,
   OverrideField,
   ResourceSnapshot,
@@ -50,6 +51,16 @@ import { handleLoopsCommand } from '../commands/loops'
 import { handleDoneCommand } from '../commands/done'
 import { handleDoctorCommand } from '../commands/doctor'
 import { getProvider } from '../session/providers/index'
+import {
+  countPendingMemories,
+  deleteMemory,
+  getMemory,
+  insertMemory,
+  listMemories,
+  searchMemories,
+  updateMemory,
+  type MemoryRow,
+} from '../db/memories'
 
 const API_VERSION = '2.0.0'
 const LIBRARY_VERSION = '0.1.0'
@@ -69,6 +80,7 @@ const FEATURES = [
   'pr-preview',
   'resource-metrics',
   'runtime-config',
+  'memory',
 ]
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
@@ -120,6 +132,28 @@ const MessageSchema = z.object({
   images: z.array(ImageSchema).optional(),
 })
 
+const CreateMemorySchema = z.object({
+  repo: z.string().nullable().optional(),
+  kind: z.enum(['user', 'feedback', 'project', 'reference']),
+  title: z.string().min(1),
+  body: z.string().min(1),
+  sourceSessionId: z.string().optional(),
+  sourceDagId: z.string().optional(),
+  pinned: z.boolean().optional(),
+})
+
+const UpdateMemorySchema = z.object({
+  title: z.string().min(1).optional(),
+  body: z.string().min(1).optional(),
+  kind: z.enum(['user', 'feedback', 'project', 'reference']).optional(),
+  status: z.enum(['pending', 'approved', 'rejected', 'superseded', 'pending_deletion']).optional(),
+  pinned: z.boolean().optional(),
+})
+
+const ReviewMemorySchema = z.object({
+  status: z.enum(['approved', 'rejected']),
+})
+
 const SLASH_MODES = new Map([
   ['task', 'task'],
   ['w', 'task'],
@@ -152,6 +186,24 @@ function findDagForSession(db: Database, sessionId: string): DagGraph | null {
 
 function formatZod(issues: Array<{ path: Array<string | number>; message: string }>): string {
   return issues.map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`).join('; ')
+}
+
+function memoryRowToApi(row: MemoryRow): MemoryEntry {
+  return {
+    id: row.id,
+    repo: row.repo,
+    kind: row.kind,
+    title: row.title,
+    body: row.body,
+    status: row.status,
+    sourceSessionId: row.source_session_id,
+    sourceDagId: row.source_dag_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    supersededBy: row.superseded_by,
+    reviewedAt: row.reviewed_at,
+    pinned: row.pinned,
+  }
 }
 
 export interface RuntimeBaseConfig {
@@ -1059,5 +1111,198 @@ export function registerApiRoutes(
     }
     unsubscribe(parsed.data.endpoint, resolveDb)
     return c.json({ data: { ok: true } })
+  })
+
+  app.get('/api/memories', (c) => {
+    const db = resolveDb()
+    const repo = c.req.query('repo')
+    const status = c.req.query('status')
+    const kind = c.req.query('kind')
+    const q = c.req.query('q')
+
+    let memories: MemoryRow[]
+    if (q) {
+      memories = searchMemories(db, q, {
+        repo: repo ?? undefined,
+        status: status as MemoryRow['status'] | undefined,
+        kind: kind as MemoryRow['kind'] | undefined,
+      })
+    } else {
+      memories = listMemories(db, {
+        repo: repo ?? undefined,
+        status: status as MemoryRow['status'] | undefined,
+        kind: kind as MemoryRow['kind'] | undefined,
+      })
+    }
+
+    const data = memories.map(memoryRowToApi)
+    const pendingCount = countPendingMemories(db, repo ?? undefined)
+    const body: ApiResponse<{ memories: MemoryEntry[]; pendingCount: number }> = {
+      data: { memories: data, pendingCount },
+    }
+    return c.json(body)
+  })
+
+  app.post('/api/memories', async (c) => {
+    const raw = await c.req.json().catch(() => null)
+    const parsed = CreateMemorySchema.safeParse(raw)
+    if (!parsed.success) {
+      return c.json({ error: formatZod(parsed.error.issues) }, 400)
+    }
+    const { repo, kind, title, body, sourceSessionId, sourceDagId, pinned } = parsed.data
+
+    const db = resolveDb()
+    const now = Date.now()
+
+    try {
+      const id = insertMemory(db, {
+        repo: repo ?? null,
+        kind,
+        title,
+        body,
+        status: 'pending',
+        source_session_id: sourceSessionId ?? null,
+        source_dag_id: sourceDagId ?? null,
+        created_at: now,
+        updated_at: now,
+        superseded_by: null,
+        reviewed_at: null,
+        pinned: pinned ?? false,
+      })
+
+      const memory = getMemory(db, id)
+      if (!memory) {
+        return c.json({ error: 'Failed to retrieve created memory' }, 500)
+      }
+
+      const apiMemory = memoryRowToApi(memory)
+      const response: ApiResponse<MemoryEntry> = { data: apiMemory }
+      return c.json(response, 201)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 500)
+    }
+  })
+
+  app.patch('/api/memories/:id', async (c) => {
+    const { id } = c.req.param()
+    const memoryId = parseInt(id, 10)
+    if (!Number.isFinite(memoryId)) {
+      return c.json({ error: 'Invalid memory ID' }, 400)
+    }
+
+    const raw = await c.req.json().catch(() => null)
+    const parsed = UpdateMemorySchema.safeParse(raw)
+    if (!parsed.success) {
+      return c.json({ error: formatZod(parsed.error.issues) }, 400)
+    }
+
+    const db = resolveDb()
+    const existing = getMemory(db, memoryId)
+    if (!existing) {
+      return c.json({ error: 'Memory not found' }, 404)
+    }
+
+    if (existing.status !== 'approved' && existing.status !== 'pending' && parsed.data.status === undefined) {
+      return c.json({ error: 'Only approved or pending memories can be updated' }, 422)
+    }
+
+    const updates = parsed.data
+    const now = Date.now()
+
+    try {
+      updateMemory(db, memoryId, {
+        ...updates,
+        updated_at: now,
+      })
+
+      const updated = getMemory(db, memoryId)
+      if (!updated) {
+        return c.json({ error: 'Failed to retrieve updated memory' }, 500)
+      }
+
+      const apiMemory = memoryRowToApi(updated)
+      const response: ApiResponse<MemoryEntry> = { data: apiMemory }
+      return c.json(response)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 500)
+    }
+  })
+
+  app.patch('/api/memories/:id/review', async (c) => {
+    const { id } = c.req.param()
+    const memoryId = parseInt(id, 10)
+    if (!Number.isFinite(memoryId)) {
+      return c.json({ error: 'Invalid memory ID' }, 400)
+    }
+
+    const raw = await c.req.json().catch(() => null)
+    const parsed = ReviewMemorySchema.safeParse(raw)
+    if (!parsed.success) {
+      return c.json({ error: formatZod(parsed.error.issues) }, 400)
+    }
+
+    const db = resolveDb()
+    const existing = getMemory(db, memoryId)
+    if (!existing) {
+      return c.json({ error: 'Memory not found' }, 404)
+    }
+
+    if (existing.status === 'pending_deletion' && parsed.data.status === 'approved') {
+      try {
+        deleteMemory(db, memoryId)
+        const response: ApiResponse<{ deleted: true }> = { data: { deleted: true } }
+        return c.json(response)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return c.json({ error: message }, 500)
+      }
+    }
+
+    const now = Date.now()
+
+    try {
+      updateMemory(db, memoryId, {
+        status: parsed.data.status,
+        reviewed_at: now,
+        updated_at: now,
+      })
+
+      const updated = getMemory(db, memoryId)
+      if (!updated) {
+        return c.json({ error: 'Failed to retrieve reviewed memory' }, 500)
+      }
+
+      const apiMemory = memoryRowToApi(updated)
+      const response: ApiResponse<MemoryEntry> = { data: apiMemory }
+      return c.json(response)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 500)
+    }
+  })
+
+  app.delete('/api/memories/:id', async (c) => {
+    const { id } = c.req.param()
+    const memoryId = parseInt(id, 10)
+    if (!Number.isFinite(memoryId)) {
+      return c.json({ error: 'Invalid memory ID' }, 400)
+    }
+
+    const db = resolveDb()
+    const existing = getMemory(db, memoryId)
+    if (!existing) {
+      return c.json({ error: 'Memory not found' }, 404)
+    }
+
+    try {
+      deleteMemory(db, memoryId)
+      const response: ApiResponse<{ deleted: true }> = { data: { deleted: true } }
+      return c.json(response)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 500)
+    }
   })
 }

--- a/server/db/memories.test.ts
+++ b/server/db/memories.test.ts
@@ -1,0 +1,498 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { readFileSync } from 'node:fs'
+import { runMigrations } from './sqlite'
+import {
+  countPendingMemories,
+  deleteMemory,
+  getMemory,
+  insertMemory,
+  listMemories,
+  searchMemories,
+  updateMemory,
+} from './memories'
+
+function setupTestDb(): Database {
+  const db = new Database(':memory:')
+  const schemaPath = new URL('./schema.sql', import.meta.url).pathname
+  const schema = readFileSync(schemaPath, 'utf8')
+  db.exec(schema)
+  runMigrations(db)
+  return db
+}
+
+let testDb: Database
+
+beforeEach(() => {
+  testDb = setupTestDb()
+})
+
+describe('insertMemory', () => {
+  test('inserts a memory and returns the ID', () => {
+    const now = Date.now()
+    const id = insertMemory(testDb, {
+      repo: 'https://github.com/test/repo',
+      kind: 'user',
+      title: 'Test Memory',
+      body: 'This is a test memory',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    expect(id).toBeGreaterThan(0)
+
+    const memory = getMemory(testDb, id)
+    expect(memory).toBeDefined()
+    expect(memory?.title).toBe('Test Memory')
+    expect(memory?.kind).toBe('user')
+    expect(memory?.status).toBe('pending')
+  })
+
+  test('inserts a memory with pinned=true', () => {
+    const now = Date.now()
+    const id = insertMemory(testDb, {
+      repo: null,
+      kind: 'feedback',
+      title: 'Pinned Memory',
+      body: 'Important feedback',
+      status: 'approved',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: now,
+      pinned: true,
+    })
+
+    const memory = getMemory(testDb, id)
+    expect(memory?.pinned).toBe(true)
+  })
+})
+
+describe('updateMemory', () => {
+  test('updates memory fields', () => {
+    const now = Date.now()
+    const id = insertMemory(testDb, {
+      repo: null,
+      kind: 'user',
+      title: 'Original Title',
+      body: 'Original Body',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    updateMemory(testDb, id, {
+      title: 'Updated Title',
+      body: 'Updated Body',
+      status: 'approved',
+      reviewed_at: now + 1000,
+      updated_at: now + 1000,
+    })
+
+    const memory = getMemory(testDb, id)
+    expect(memory?.title).toBe('Updated Title')
+    expect(memory?.body).toBe('Updated Body')
+    expect(memory?.status).toBe('approved')
+    expect(memory?.reviewed_at).toBe(now + 1000)
+  })
+
+  test('updates only specified fields', () => {
+    const now = Date.now()
+    const id = insertMemory(testDb, {
+      repo: null,
+      kind: 'user',
+      title: 'Original Title',
+      body: 'Original Body',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    updateMemory(testDb, id, {
+      title: 'Updated Title',
+      updated_at: now + 1000,
+    })
+
+    const memory = getMemory(testDb, id)
+    expect(memory?.title).toBe('Updated Title')
+    expect(memory?.body).toBe('Original Body')
+    expect(memory?.status).toBe('pending')
+  })
+})
+
+describe('getMemory', () => {
+  test('returns memory by ID', () => {
+    const now = Date.now()
+    const id = insertMemory(testDb, {
+      repo: null,
+      kind: 'user',
+      title: 'Test',
+      body: 'Body',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    const memory = getMemory(testDb, id)
+    expect(memory).toBeDefined()
+    expect(memory?.id).toBe(id)
+  })
+
+  test('returns null for non-existent ID', () => {
+    const memory = getMemory(testDb, 9999)
+    expect(memory).toBeNull()
+  })
+})
+
+describe('listMemories', () => {
+  test('returns all memories when no filters applied', () => {
+    const now = Date.now()
+    insertMemory(testDb, {
+      repo: 'repo1',
+      kind: 'user',
+      title: 'Memory 1',
+      body: 'Body 1',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+    insertMemory(testDb, {
+      repo: 'repo2',
+      kind: 'feedback',
+      title: 'Memory 2',
+      body: 'Body 2',
+      status: 'approved',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    const memories = listMemories(testDb)
+    expect(memories).toHaveLength(2)
+  })
+
+  test('filters by repo', () => {
+    const now = Date.now()
+    insertMemory(testDb, {
+      repo: 'repo1',
+      kind: 'user',
+      title: 'Memory 1',
+      body: 'Body 1',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+    insertMemory(testDb, {
+      repo: 'repo2',
+      kind: 'user',
+      title: 'Memory 2',
+      body: 'Body 2',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    const memories = listMemories(testDb, { repo: 'repo1' })
+    expect(memories).toHaveLength(1)
+    expect(memories[0]?.repo).toBe('repo1')
+  })
+
+  test('filters by status', () => {
+    const now = Date.now()
+    insertMemory(testDb, {
+      repo: null,
+      kind: 'user',
+      title: 'Memory 1',
+      body: 'Body 1',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+    insertMemory(testDb, {
+      repo: null,
+      kind: 'user',
+      title: 'Memory 2',
+      body: 'Body 2',
+      status: 'approved',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    const memories = listMemories(testDb, { status: 'approved' })
+    expect(memories).toHaveLength(1)
+    expect(memories[0]?.status).toBe('approved')
+  })
+
+  test('filters by kind', () => {
+    const now = Date.now()
+    insertMemory(testDb, {
+      repo: null,
+      kind: 'user',
+      title: 'Memory 1',
+      body: 'Body 1',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+    insertMemory(testDb, {
+      repo: null,
+      kind: 'feedback',
+      title: 'Memory 2',
+      body: 'Body 2',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    const memories = listMemories(testDb, { kind: 'feedback' })
+    expect(memories).toHaveLength(1)
+    expect(memories[0]?.kind).toBe('feedback')
+  })
+})
+
+describe('searchMemories', () => {
+  test('searches memories using FTS', () => {
+    const now = Date.now()
+    insertMemory(testDb, {
+      repo: null,
+      kind: 'user',
+      title: 'TypeScript preference',
+      body: 'User prefers TypeScript over JavaScript',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+    insertMemory(testDb, {
+      repo: null,
+      kind: 'feedback',
+      title: 'Python linting',
+      body: 'Use ruff for Python linting',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    const memories = searchMemories(testDb, 'TypeScript')
+    expect(memories).toHaveLength(1)
+    expect(memories[0]?.title).toContain('TypeScript')
+  })
+
+  test('combines search with filters', () => {
+    const now = Date.now()
+    insertMemory(testDb, {
+      repo: null,
+      kind: 'user',
+      title: 'TypeScript preference',
+      body: 'User prefers TypeScript',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+    insertMemory(testDb, {
+      repo: null,
+      kind: 'user',
+      title: 'TypeScript approved',
+      body: 'Use TypeScript everywhere',
+      status: 'approved',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    const memories = searchMemories(testDb, 'TypeScript', { status: 'approved' })
+    expect(memories).toHaveLength(1)
+    expect(memories[0]?.status).toBe('approved')
+  })
+})
+
+describe('deleteMemory', () => {
+  test('deletes a memory', () => {
+    const now = Date.now()
+    const id = insertMemory(testDb, {
+      repo: null,
+      kind: 'user',
+      title: 'Test',
+      body: 'Body',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    deleteMemory(testDb, id)
+
+    const memory = getMemory(testDb, id)
+    expect(memory).toBeNull()
+  })
+})
+
+describe('countPendingMemories', () => {
+  test('counts pending memories', () => {
+    const now = Date.now()
+    insertMemory(testDb, {
+      repo: 'repo1',
+      kind: 'user',
+      title: 'Pending 1',
+      body: 'Body',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+    insertMemory(testDb, {
+      repo: 'repo1',
+      kind: 'user',
+      title: 'Pending 2',
+      body: 'Body',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+    insertMemory(testDb, {
+      repo: 'repo1',
+      kind: 'user',
+      title: 'Approved',
+      body: 'Body',
+      status: 'approved',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    const count = countPendingMemories(testDb)
+    expect(count).toBe(2)
+  })
+
+  test('counts pending memories for specific repo', () => {
+    const now = Date.now()
+    insertMemory(testDb, {
+      repo: 'repo1',
+      kind: 'user',
+      title: 'Pending repo1',
+      body: 'Body',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+    insertMemory(testDb, {
+      repo: 'repo2',
+      kind: 'user',
+      title: 'Pending repo2',
+      body: 'Body',
+      status: 'pending',
+      source_session_id: null,
+      source_dag_id: null,
+      created_at: now,
+      updated_at: now,
+      superseded_by: null,
+      reviewed_at: null,
+      pinned: false,
+    })
+
+    const count = countPendingMemories(testDb, 'repo1')
+    expect(count).toBe(1)
+  })
+})

--- a/server/db/memories.ts
+++ b/server/db/memories.ts
@@ -1,0 +1,225 @@
+import type { Database } from 'bun:sqlite'
+
+export type MemoryKind = 'user' | 'feedback' | 'project' | 'reference'
+export type MemoryStatus = 'pending' | 'approved' | 'rejected' | 'superseded' | 'pending_deletion'
+
+export interface MemoryRow {
+  id: number
+  repo: string | null
+  kind: MemoryKind
+  title: string
+  body: string
+  status: MemoryStatus
+  source_session_id: string | null
+  source_dag_id: string | null
+  created_at: number
+  updated_at: number
+  superseded_by: number | null
+  reviewed_at: number | null
+  pinned: boolean
+}
+
+interface MemoryDbRow {
+  id: number
+  repo: string | null
+  kind: MemoryKind
+  title: string
+  body: string
+  status: MemoryStatus
+  source_session_id: string | null
+  source_dag_id: string | null
+  created_at: number
+  updated_at: number
+  superseded_by: number | null
+  reviewed_at: number | null
+  pinned: number
+}
+
+type MemoryStmtCache = {
+  insertMemory?: ReturnType<Database['prepare']>
+  updateMemory?: ReturnType<Database['prepare']>
+  getMemory?: ReturnType<Database['prepare']>
+  listMemories?: ReturnType<Database['prepare']>
+  deleteMemory?: ReturnType<Database['prepare']>
+  searchMemories?: ReturnType<Database['prepare']>
+  countPendingMemories?: ReturnType<Database['prepare']>
+}
+
+const memoryCaches = new WeakMap<Database, MemoryStmtCache>()
+
+function memoryStmts(db: Database): MemoryStmtCache {
+  let c = memoryCaches.get(db)
+  if (!c) {
+    c = {}
+    memoryCaches.set(db, c)
+  }
+  return c
+}
+
+function mapMemoryRow(row: MemoryDbRow): MemoryRow {
+  return {
+    ...row,
+    pinned: row.pinned !== 0,
+  }
+}
+
+export function insertMemory(
+  db: Database,
+  row: Omit<MemoryRow, 'id'>,
+): number {
+  const c = memoryStmts(db)
+  if (!c.insertMemory) {
+    c.insertMemory = db.prepare(
+      `INSERT INTO memories (repo, kind, title, body, status, source_session_id, source_dag_id, created_at, updated_at, superseded_by, reviewed_at, pinned)
+       VALUES ($repo, $kind, $title, $body, $status, $source_session_id, $source_dag_id, $created_at, $updated_at, $superseded_by, $reviewed_at, $pinned)`,
+    )
+  }
+  c.insertMemory.run({
+    $repo: row.repo,
+    $kind: row.kind,
+    $title: row.title,
+    $body: row.body,
+    $status: row.status,
+    $source_session_id: row.source_session_id,
+    $source_dag_id: row.source_dag_id,
+    $created_at: row.created_at,
+    $updated_at: row.updated_at,
+    $superseded_by: row.superseded_by,
+    $reviewed_at: row.reviewed_at,
+    $pinned: row.pinned ? 1 : 0,
+  })
+  return db.query<{ id: number }, []>('SELECT last_insert_rowid() as id').get()!.id
+}
+
+export function updateMemory(
+  db: Database,
+  id: number,
+  updates: Partial<Omit<MemoryRow, 'id' | 'created_at'>>,
+): void {
+  const c = memoryStmts(db)
+  if (!c.updateMemory) {
+    c.updateMemory = db.prepare(
+      `UPDATE memories
+       SET repo = COALESCE($repo, repo),
+           kind = COALESCE($kind, kind),
+           title = COALESCE($title, title),
+           body = COALESCE($body, body),
+           status = COALESCE($status, status),
+           source_session_id = COALESCE($source_session_id, source_session_id),
+           source_dag_id = COALESCE($source_dag_id, source_dag_id),
+           updated_at = COALESCE($updated_at, updated_at),
+           superseded_by = COALESCE($superseded_by, superseded_by),
+           reviewed_at = COALESCE($reviewed_at, reviewed_at),
+           pinned = COALESCE($pinned, pinned)
+       WHERE id = $id`,
+    )
+  }
+  c.updateMemory.run({
+    $id: id,
+    $repo: updates.repo ?? null,
+    $kind: updates.kind ?? null,
+    $title: updates.title ?? null,
+    $body: updates.body ?? null,
+    $status: updates.status ?? null,
+    $source_session_id: updates.source_session_id ?? null,
+    $source_dag_id: updates.source_dag_id ?? null,
+    $updated_at: updates.updated_at ?? null,
+    $superseded_by: updates.superseded_by ?? null,
+    $reviewed_at: updates.reviewed_at ?? null,
+    $pinned: updates.pinned !== undefined ? (updates.pinned ? 1 : 0) : null,
+  })
+}
+
+export function getMemory(db: Database, id: number): MemoryRow | null {
+  const c = memoryStmts(db)
+  if (!c.getMemory) {
+    c.getMemory = db.prepare('SELECT * FROM memories WHERE id = ?')
+  }
+  const row = c.getMemory.get(id) as MemoryDbRow | undefined
+  return row ? mapMemoryRow(row) : null
+}
+
+export function listMemories(
+  db: Database,
+  filters?: { repo?: string | null; status?: MemoryStatus; kind?: MemoryKind },
+): MemoryRow[] {
+  let sql = 'SELECT * FROM memories WHERE 1=1'
+  const params: (string | number | null)[] = []
+
+  if (filters?.repo !== undefined) {
+    if (filters.repo === null) {
+      sql += ' AND repo IS NULL'
+    } else {
+      sql += ' AND repo = ?'
+      params.push(filters.repo)
+    }
+  }
+  if (filters?.status) {
+    sql += ' AND status = ?'
+    params.push(filters.status)
+  }
+  if (filters?.kind) {
+    sql += ' AND kind = ?'
+    params.push(filters.kind)
+  }
+
+  sql += ' ORDER BY updated_at DESC LIMIT 1000'
+
+  const rows = db.query<MemoryDbRow, (string | number | null)[]>(sql).all(...params)
+  return rows.map(mapMemoryRow)
+}
+
+export function searchMemories(
+  db: Database,
+  query: string,
+  filters?: { repo?: string | null; status?: MemoryStatus; kind?: MemoryKind },
+): MemoryRow[] {
+  let sql = `
+    SELECT m.*
+    FROM memories m
+    JOIN memories_fts fts ON m.id = fts.rowid
+    WHERE memories_fts MATCH ?
+  `
+  const params: (string | number | null)[] = [query]
+
+  if (filters?.repo !== undefined) {
+    if (filters.repo === null) {
+      sql += ' AND m.repo IS NULL'
+    } else {
+      sql += ' AND m.repo = ?'
+      params.push(filters.repo)
+    }
+  }
+  if (filters?.status) {
+    sql += ' AND m.status = ?'
+    params.push(filters.status)
+  }
+  if (filters?.kind) {
+    sql += ' AND m.kind = ?'
+    params.push(filters.kind)
+  }
+
+  sql += ' ORDER BY m.updated_at DESC LIMIT 100'
+
+  const rows = db.query<MemoryDbRow, (string | number | null)[]>(sql).all(...params)
+  return rows.map(mapMemoryRow)
+}
+
+export function deleteMemory(db: Database, id: number): void {
+  const c = memoryStmts(db)
+  if (!c.deleteMemory) {
+    c.deleteMemory = db.prepare('DELETE FROM memories WHERE id = ?')
+  }
+  c.deleteMemory.run(id)
+}
+
+export function countPendingMemories(db: Database, repo?: string | null): number {
+  const c = memoryStmts(db)
+  if (!c.countPendingMemories) {
+    c.countPendingMemories = db.prepare(
+      'SELECT COUNT(*) as count FROM memories WHERE status = ? AND (? IS NULL OR repo = ?)',
+    )
+  }
+  const row = c.countPendingMemories.get('pending', repo ?? null, repo ?? null) as { count: number } | undefined
+  return row?.count ?? 0
+}

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -76,6 +76,10 @@ export type SseEvent =
       url: string
       capturedAt: string
     }
+  | { type: 'memory_proposed'; memory: MemoryEntry }
+  | { type: 'memory_updated'; memory: MemoryEntry }
+  | { type: 'memory_reviewed'; memory: MemoryEntry }
+  | { type: 'memory_deleted'; memoryId: number }
 
 export type LimitSource = 'cgroup' | 'host'
 
@@ -468,4 +472,45 @@ export function isTranscriptEventOfType<T extends TranscriptEventType>(
   type: T,
 ): event is Extract<TranscriptEvent, { type: T }> {
   return event.type === type
+}
+
+export type MemoryKind = 'user' | 'feedback' | 'project' | 'reference'
+export type MemoryStatus = 'pending' | 'approved' | 'rejected' | 'superseded' | 'pending_deletion'
+
+export interface MemoryEntry {
+  id: number
+  repo: string | null
+  kind: MemoryKind
+  title: string
+  body: string
+  status: MemoryStatus
+  sourceSessionId: string | null
+  sourceDagId: string | null
+  createdAt: number
+  updatedAt: number
+  supersededBy: number | null
+  reviewedAt: number | null
+  pinned: boolean
+}
+
+export interface CreateMemoryRequest {
+  repo?: string | null
+  kind: MemoryKind
+  title: string
+  body: string
+  sourceSessionId?: string
+  sourceDagId?: string
+  pinned?: boolean
+}
+
+export interface UpdateMemoryRequest {
+  title?: string
+  body?: string
+  kind?: MemoryKind
+  status?: MemoryStatus
+  pinned?: boolean
+}
+
+export interface ReviewMemoryRequest {
+  status: 'approved' | 'rejected'
 }


### PR DESCRIPTION
## Summary

Implements the RESTful API layer for the persistent memory system. Agents can propose memories via MCP tools, and users can review/approve them through the UI (coming in PR #2).

**API endpoints:**
- `GET /api/memories` — list/search memories with filters (`?repo=`, `?status=`, `?kind=`, `?q=` for FTS)
- `POST /api/memories` — create memory (defaults to `status: pending`)
- `PATCH /api/memories/:id` — update title/body/kind/status/pinned
- `PATCH /api/memories/:id/review` — approve/reject (sets `reviewed_at`, handles `pending_deletion` → hard delete)
- `DELETE /api/memories/:id` — hard delete

**Database layer** (`server/db/memories.ts`):
- CRUD operations with prepared statements
- FTS5 search via `searchMemories()`
- `countPendingMemories()` for inbox badge

**Types** (`shared/api-types.ts`):
- Wire types: `MemoryEntry`, `CreateMemoryRequest`, `UpdateMemoryRequest`, `ReviewMemoryRequest`
- SSE events: `memory_proposed`, `memory_updated`, `memory_reviewed`, `memory_deleted`

**Feature flag:** Added `'memory'` to `FEATURES` array for capability detection.

**Upstream dependency:** Builds on the schema migration and MCP server from prior PRs.

## Test plan

- [x] Unit tests for database layer (15 tests, all passing)
- [x] Integration tests for API endpoints (14 tests, all passing)
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Full test suite passes (776 tests)
- [ ] Manual testing: will verify with Postman/curl after merge
- [ ] UI integration: will be tested in PR #2 (Memory drawer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)