### PR TITLE
Add SSE projections for memory events

### DIFF
--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -61,6 +61,7 @@ import {
   updateMemory,
   type MemoryRow,
 } from '../db/memories'
+import { getEventBus } from '../events/bus'
 
 const API_VERSION = '2.0.0'
 const LIBRARY_VERSION = '0.1.0'
@@ -1176,6 +1177,7 @@ export function registerApiRoutes(
       }
 
       const apiMemory = memoryRowToApi(memory)
+      getEventBus().emit({ kind: 'memory.proposed', memory: apiMemory })
       const response: ApiResponse<MemoryEntry> = { data: apiMemory }
       return c.json(response, 201)
     } catch (err) {
@@ -1252,6 +1254,7 @@ export function registerApiRoutes(
     if (existing.status === 'pending_deletion' && parsed.data.status === 'approved') {
       try {
         deleteMemory(db, memoryId)
+        getEventBus().emit({ kind: 'memory.deleted', memoryId })
         const response: ApiResponse<{ deleted: true }> = { data: { deleted: true } }
         return c.json(response)
       } catch (err) {
@@ -1275,6 +1278,7 @@ export function registerApiRoutes(
       }
 
       const apiMemory = memoryRowToApi(updated)
+      getEventBus().emit({ kind: 'memory.reviewed', memory: apiMemory })
       const response: ApiResponse<MemoryEntry> = { data: apiMemory }
       return c.json(response)
     } catch (err) {
@@ -1298,6 +1302,7 @@ export function registerApiRoutes(
 
     try {
       deleteMemory(db, memoryId)
+      getEventBus().emit({ kind: 'memory.deleted', memoryId })
       const response: ApiResponse<{ deleted: true }> = { data: { deleted: true } }
       return c.json(response)
     } catch (err) {

--- a/server/api/sse.test.ts
+++ b/server/api/sse.test.ts
@@ -298,4 +298,136 @@ describe('live event projection', () => {
     expect(second.length).toBe(1)
     expect(JSON.parse(second[0]!.data)).toMatchObject({ type: 'session_updated' })
   })
+
+  test('memory.proposed emits memory_proposed', async () => {
+    const app = makeApp(testDb)
+    const bus = getEventBus()
+    const res = await app.fetch(new Request('http://localhost/api/events'))
+    expect(res.status).toBe(200)
+
+    const reader = new SseReader(res)
+    const ready = await reader.read(1)
+    expect(ready[0]!.event).toBe('keepalive')
+
+    const memory = {
+      id: 1,
+      repo: 'test/repo',
+      kind: 'user' as const,
+      title: 'Test memory',
+      body: 'Test content',
+      status: 'pending' as const,
+      sourceSessionId: null,
+      sourceDagId: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      supersededBy: null,
+      reviewedAt: null,
+      pinned: false,
+    }
+
+    const collectPromise = reader.read(1)
+    bus.emit({ kind: 'memory.proposed', memory })
+    const events = await collectPromise
+    reader.cancel()
+
+    expect(events).toHaveLength(1)
+    const parsed = JSON.parse(events[0]!.data) as { type: string; memory: { id: number } }
+    expect(parsed.type).toBe('memory_proposed')
+    expect(parsed.memory.id).toBe(1)
+  })
+
+  test('memory.updated emits memory_updated', async () => {
+    const app = makeApp(testDb)
+    const bus = getEventBus()
+    const res = await app.fetch(new Request('http://localhost/api/events'))
+    expect(res.status).toBe(200)
+
+    const reader = new SseReader(res)
+    const ready = await reader.read(1)
+    expect(ready[0]!.event).toBe('keepalive')
+
+    const memory = {
+      id: 2,
+      repo: 'test/repo',
+      kind: 'feedback' as const,
+      title: 'Updated memory',
+      body: 'Updated content',
+      status: 'approved' as const,
+      sourceSessionId: null,
+      sourceDagId: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      supersededBy: null,
+      reviewedAt: null,
+      pinned: false,
+    }
+
+    const collectPromise = reader.read(1)
+    bus.emit({ kind: 'memory.updated', memory })
+    const events = await collectPromise
+    reader.cancel()
+
+    expect(events).toHaveLength(1)
+    const parsed = JSON.parse(events[0]!.data) as { type: string; memory: { id: number } }
+    expect(parsed.type).toBe('memory_updated')
+    expect(parsed.memory.id).toBe(2)
+  })
+
+  test('memory.reviewed emits memory_reviewed', async () => {
+    const app = makeApp(testDb)
+    const bus = getEventBus()
+    const res = await app.fetch(new Request('http://localhost/api/events'))
+    expect(res.status).toBe(200)
+
+    const reader = new SseReader(res)
+    const ready = await reader.read(1)
+    expect(ready[0]!.event).toBe('keepalive')
+
+    const memory = {
+      id: 3,
+      repo: 'test/repo',
+      kind: 'project' as const,
+      title: 'Reviewed memory',
+      body: 'Reviewed content',
+      status: 'approved' as const,
+      sourceSessionId: null,
+      sourceDagId: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      supersededBy: null,
+      reviewedAt: Date.now(),
+      pinned: false,
+    }
+
+    const collectPromise = reader.read(1)
+    bus.emit({ kind: 'memory.reviewed', memory })
+    const events = await collectPromise
+    reader.cancel()
+
+    expect(events).toHaveLength(1)
+    const parsed = JSON.parse(events[0]!.data) as { type: string; memory: { id: number } }
+    expect(parsed.type).toBe('memory_reviewed')
+    expect(parsed.memory.id).toBe(3)
+  })
+
+  test('memory.deleted emits memory_deleted', async () => {
+    const app = makeApp(testDb)
+    const bus = getEventBus()
+    const res = await app.fetch(new Request('http://localhost/api/events'))
+    expect(res.status).toBe(200)
+
+    const reader = new SseReader(res)
+    const ready = await reader.read(1)
+    expect(ready[0]!.event).toBe('keepalive')
+
+    const collectPromise = reader.read(1)
+    bus.emit({ kind: 'memory.deleted', memoryId: 42 })
+    const events = await collectPromise
+    reader.cancel()
+
+    expect(events).toHaveLength(1)
+    const parsed = JSON.parse(events[0]!.data) as { type: string; memoryId: number }
+    expect(parsed.type).toBe('memory_deleted')
+    expect(parsed.memoryId).toBe(42)
+  })
 })

--- a/server/api/sse.ts
+++ b/server/api/sse.ts
@@ -164,5 +164,21 @@ function projectEvent(
     return { type: 'resource', snapshot: event.snapshot }
   }
 
+  if (event.kind === 'memory.proposed') {
+    return { type: 'memory_proposed', memory: event.memory }
+  }
+
+  if (event.kind === 'memory.updated') {
+    return { type: 'memory_updated', memory: event.memory }
+  }
+
+  if (event.kind === 'memory.reviewed') {
+    return { type: 'memory_reviewed', memory: event.memory }
+  }
+
+  if (event.kind === 'memory.deleted') {
+    return { type: 'memory_deleted', memoryId: event.memoryId }
+  }
+
   return null
 }

--- a/server/events/types.ts
+++ b/server/events/types.ts
@@ -1,4 +1,4 @@
-import type { TranscriptEvent, ApiSession, ApiDagGraph, ResourceSnapshot } from '../../shared/api-types'
+import type { TranscriptEvent, ApiSession, ApiDagGraph, ResourceSnapshot, MemoryEntry } from '../../shared/api-types'
 
 export type SessionRunState = 'completed' | 'errored' | 'quota_exhausted' | 'stream_stalled'
 
@@ -50,6 +50,10 @@ export type EngineEvent =
       results: Array<{ name: string; passed: boolean; output: string }>
     }
   | { kind: 'resource'; snapshot: ResourceSnapshot }
+  | { kind: 'memory.proposed'; memory: MemoryEntry }
+  | { kind: 'memory.updated'; memory: MemoryEntry }
+  | { kind: 'memory.reviewed'; memory: MemoryEntry }
+  | { kind: 'memory.deleted'; memoryId: number }
 
 export type EngineEventKind = EngineEvent['kind']
 export type EngineEventOfKind<K extends EngineEventKind> = Extract<EngineEvent, { kind: K }>

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -23,6 +23,7 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
   const transcripts = new Map<string, TranscriptStore>()
   const resourceSnapshot = signal<ResourceSnapshot | null>(null)
   const runtimeConfig = signal<RuntimeConfigResponse | null>(null)
+  const memoryProposalsCount = signal<number>(0)
 
   function getTranscript(sessionId: string): TranscriptStore | null {
     const existing = transcripts.get(sessionId)
@@ -176,6 +177,18 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
         break
       case 'session_screenshot_captured':
         break
+      case 'memory_proposed':
+        memoryProposalsCount.value++
+        break
+      case 'memory_updated':
+        break
+      case 'memory_reviewed':
+        if (memoryProposalsCount.value > 0) {
+          memoryProposalsCount.value--
+        }
+        break
+      case 'memory_deleted':
+        break
     }
   }
 
@@ -255,6 +268,7 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
     diffStatsBySessionId,
     resourceSnapshot,
     runtimeConfig,
+    memoryProposalsCount,
     loadDiffStats,
     refresh,
     async sendCommand(cmd) {

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -35,6 +35,7 @@ export interface ConnectionStore {
   diffStatsBySessionId: ReadonlySignal<Map<string, DiffStats>>
   resourceSnapshot: ReadonlySignal<ResourceSnapshot | null>
   runtimeConfig: ReadonlySignal<RuntimeConfigResponse | null>
+  memoryProposalsCount: ReadonlySignal<number>
   loadDiffStats(sessionId: string): Promise<void>
   refresh(): Promise<void>
   sendCommand(cmd: MinionCommand): Promise<CommandResult>

--- a/test/chat/NewTaskBar.test.tsx
+++ b/test/chat/NewTaskBar.test.tsx
@@ -83,6 +83,7 @@ function makeStore(opts: {
     diffStatsBySessionId: signal(new Map()),
     resourceSnapshot: signal(null),
     runtimeConfig: signal(null),
+    memoryProposalsCount: signal(0),
     loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi.fn(async () => ({ success: true })),

--- a/test/chat/transcript/TranscriptUpgradeNotice.test.tsx
+++ b/test/chat/transcript/TranscriptUpgradeNotice.test.tsx
@@ -19,6 +19,7 @@ function makeStore(version: VersionInfo | null): ConnectionStore {
     diffStatsBySessionId: signal(new Map()),
     resourceSnapshot: signal(null),
     runtimeConfig: signal(null),
+    memoryProposalsCount: signal(0),
     loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi.fn(async () => ({ success: true })),

--- a/test/components/ResourceChip.test.tsx
+++ b/test/components/ResourceChip.test.tsx
@@ -19,6 +19,7 @@ function makeStore(snapshot: ResourceSnapshot | null): ConnectionStore {
     diffStatsBySessionId: signal(new Map()),
     resourceSnapshot: signal(snapshot),
     runtimeConfig: signal(null),
+    memoryProposalsCount: signal(0),
     loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi.fn(async () => ({ success: true })),

--- a/test/components/RunningBadge.test.tsx
+++ b/test/components/RunningBadge.test.tsx
@@ -36,6 +36,7 @@ function makeStore(sessions: ApiSession[]): ConnectionStore {
     diffStatsBySessionId: signal(new Map()),
     resourceSnapshot: signal(null),
     runtimeConfig: signal(null),
+    memoryProposalsCount: signal(0),
     loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi.fn(async () => ({ success: true })),

--- a/test/components/WorktreeHeader.test.tsx
+++ b/test/components/WorktreeHeader.test.tsx
@@ -49,6 +49,7 @@ function makeStore(opts: {
     diffStatsBySessionId,
     resourceSnapshot: signal(null),
     runtimeConfig: signal(null),
+    memoryProposalsCount: signal(0),
     loadDiffStats: opts.loadDiffStats ?? (async () => {}),
     refresh: async () => {},
     sendCommand: async () => ({ success: true }),

--- a/test/groups/VariantGroupView.test.tsx
+++ b/test/groups/VariantGroupView.test.tsx
@@ -59,6 +59,7 @@ function makeStore(opts: {
     diffStatsBySessionId: signal(new Map()),
     resourceSnapshot: signal(null),
     runtimeConfig: signal(null),
+    memoryProposalsCount: signal(0),
     loadDiffStats: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
     sendCommand: vi

--- a/test/state/store.test.ts
+++ b/test/state/store.test.ts
@@ -298,4 +298,146 @@ describe('createConnectionStore snapshot integration', () => {
     window.dispatchEvent(new Event('online'))
     expect(mock.constructedUrls).toHaveLength(1)
   })
+
+  it('increments memoryProposalsCount on memory_proposed event', async () => {
+    mockLoadSnapshot.mockResolvedValue(null)
+    vi.stubGlobal('fetch', makeResponses())
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-memory-proposed')
+
+    expect(store.memoryProposalsCount.value).toBe(0)
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({
+      type: 'memory_proposed',
+      memory: {
+        id: 1,
+        repo: 'test/repo',
+        kind: 'user',
+        title: 'Test',
+        body: 'Body',
+        status: 'pending',
+        sourceSessionId: null,
+        sourceDagId: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        supersededBy: null,
+        reviewedAt: null,
+        pinned: false,
+      },
+    })
+
+    expect(store.memoryProposalsCount.value).toBe(1)
+
+    es?.push({
+      type: 'memory_proposed',
+      memory: {
+        id: 2,
+        repo: 'test/repo',
+        kind: 'feedback',
+        title: 'Test 2',
+        body: 'Body 2',
+        status: 'pending',
+        sourceSessionId: null,
+        sourceDagId: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        supersededBy: null,
+        reviewedAt: null,
+        pinned: false,
+      },
+    })
+
+    expect(store.memoryProposalsCount.value).toBe(2)
+    store.dispose()
+  })
+
+  it('decrements memoryProposalsCount on memory_reviewed event', async () => {
+    mockLoadSnapshot.mockResolvedValue(null)
+    vi.stubGlobal('fetch', makeResponses())
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-memory-reviewed')
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({
+      type: 'memory_proposed',
+      memory: {
+        id: 1,
+        repo: 'test/repo',
+        kind: 'user',
+        title: 'Test',
+        body: 'Body',
+        status: 'pending',
+        sourceSessionId: null,
+        sourceDagId: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        supersededBy: null,
+        reviewedAt: null,
+        pinned: false,
+      },
+    })
+
+    expect(store.memoryProposalsCount.value).toBe(1)
+
+    es?.push({
+      type: 'memory_reviewed',
+      memory: {
+        id: 1,
+        repo: 'test/repo',
+        kind: 'user',
+        title: 'Test',
+        body: 'Body',
+        status: 'approved',
+        sourceSessionId: null,
+        sourceDagId: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        supersededBy: null,
+        reviewedAt: Date.now(),
+        pinned: false,
+      },
+    })
+
+    expect(store.memoryProposalsCount.value).toBe(0)
+    store.dispose()
+  })
+
+  it('does not decrement memoryProposalsCount below zero', async () => {
+    mockLoadSnapshot.mockResolvedValue(null)
+    vi.stubGlobal('fetch', makeResponses())
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-memory-floor')
+
+    expect(store.memoryProposalsCount.value).toBe(0)
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({
+      type: 'memory_reviewed',
+      memory: {
+        id: 1,
+        repo: 'test/repo',
+        kind: 'user',
+        title: 'Test',
+        body: 'Body',
+        status: 'approved',
+        sourceSessionId: null,
+        sourceDagId: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        supersededBy: null,
+        reviewedAt: Date.now(),
+        pinned: false,
+      },
+    })
+
+    expect(store.memoryProposalsCount.value).toBe(0)
+    store.dispose()
+  })
 })


### PR DESCRIPTION
## Summary

- Added four memory event types to `EngineEvent`: `memory.proposed`, `memory.updated`, `memory.reviewed`, `memory.deleted`
- Extended SSE `projectEvent()` to project these engine events as `memory_proposed`, `memory_updated`, `memory_reviewed`, `memory_deleted` SSE events
- Emit memory events from memory API endpoints (POST, PATCH, DELETE) via the event bus
- Added `memoryProposalsCount` signal to UI `ConnectionStore` that tracks pending memory proposals
- Signal increments on `memory_proposed` events and decrements on `memory_reviewed` events (with floor at 0)

## Test plan

- [x] Server SSE tests: `bun test server/api/sse.test.ts` — validates that memory engine events project correctly to SSE events
- [x] UI store tests: `npm test -- test/state/store.test.ts` — validates that memory SSE events update the proposals count signal
- [x] Memory API tests: `bun test server/api/routes.memories.test.ts` — validates existing memory endpoints still work
- [x] Full test suite: all UI tests pass, server tests pass except pre-existing FTS5 failure in sqlite.test.ts (unrelated)
- [x] Lint: all modified files pass ESLint (pre-existing error in memory-preamble.test.ts is outside scope)