### PR TITLE
fix(runtime): finalize in-flight assistant text on session close

### DIFF
--- a/server/session/runtime.ts
+++ b/server/session/runtime.ts
@@ -308,6 +308,11 @@ export class SessionRuntime {
     this.clearTimers()
     this.state = 'done'
 
+    const flushed = this.translator.flushAllBuffers()
+    for (const evt of flushed) {
+      this.persistAndEmit(evt)
+    }
+
     const closeEvt = this.translator.closeTurn(undefined, undefined, true)
     if (closeEvt) {
       this.persistAndEmit(closeEvt)

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -169,7 +169,7 @@ export class TranscriptTranslator {
     return [evt]
   }
 
-  private flushAllBuffers(): TranscriptEvent[] {
+  flushAllBuffers(): TranscriptEvent[] {
     const out: TranscriptEvent[] = []
     for (const [, buf] of this.textBuffers) {
       out.push({ ...this.base(), type: 'assistant_text', blockId: buf.blockId, text: buf.text, final: true })


### PR DESCRIPTION
## Summary

When a session closes due to errors or stream stalls, in-flight assistant text blocks were left non-finalized (`final: false`). This caused `/stack` and `/execute` commands to fail with "no items extracted" because `getConversationMessages` only includes assistant messages with `final: true`.

**Root cause:** `runtime.ts:onClose()` called `closeTurn` directly without flushing the translator's text buffers.

**Fix:** Made `TranscriptTranslator.flushAllBuffers()` public and call it in `onClose()` before closing the turn, ensuring all buffered assistant text is emitted with `final: true`.

## Test plan

- [x] All existing tests pass (776 passed)
- [x] Lint passes
- [ ] Manual test: Run `/think` with a long analysis → let it time out due to inactivity → run `/stack` on the failed session → verify it can now extract items instead of failing with "no items extracted"