### PR TITLE
fix(dag): trigger ci babysit on completion for dag-task sessions

### DIFF
--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -130,6 +130,11 @@ describe("DagScheduler", () => {
       db,
       bus,
       workspace: "/tmp",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
       updateStackComment: async () => { stackCommentCallCount++ },
     })
   }

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -11,6 +11,7 @@ import type { EngineEventBus } from "../events/bus"
 import type { SessionRunState } from "../events/types"
 import type { ApiDagNode, ApiDagGraph } from "../../shared/api-types"
 import { advanceShip } from "../ship/coordinator"
+import type { CIBabysitter } from "../handlers/types"
 
 function fetchRootConversation(db: Database, rootSessionId: string): TopicMessage[] {
   const rows = db
@@ -101,6 +102,7 @@ export interface DagSchedulerOpts {
   db: Database
   bus: EngineEventBus
   workspace: string
+  ciBabysitter: CIBabysitter
   updateStackComment?: (graph: DagGraph) => Promise<void>
 }
 
@@ -116,7 +118,7 @@ export interface DagScheduler {
 }
 
 export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
-  const { registry, db, bus } = opts
+  const { registry, db, bus, ciBabysitter } = opts
   const commentUpdater = opts.updateStackComment ?? updateStackComment
 
   const activeGraphs = new Map<string, DagGraph>()
@@ -264,6 +266,32 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
       const { prUrl, branch } = readNodePrInfo(db, sessionId)
       if (branch) node.branch = branch
       if (prUrl) node.prUrl = prUrl
+
+      if (prUrl) {
+        const metaRow = db
+          .query<{ metadata: string }, [string]>("SELECT metadata FROM sessions WHERE id = ?")
+          .get(sessionId)
+
+        let metadata: Record<string, unknown>
+        try {
+          const parsed = metaRow?.metadata ? JSON.parse(metaRow.metadata) : {}
+          metadata = (parsed && typeof parsed === "object") ? parsed as Record<string, unknown> : {}
+        } catch {
+          metadata = {}
+        }
+
+        if (!metadata.ciBabysitStartedAt) {
+          metadata.ciBabysitStartedAt = Date.now()
+          metadata.ciBabysitTrigger = "completion"
+          prepared.updateSession(db, {
+            id: sessionId,
+            metadata,
+            updated_at: Date.now(),
+          })
+          void ciBabysitter.babysitDagChildCI(sessionId, prUrl)
+        }
+      }
+
       node.status = "done"
       advanceDag(graph)
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -74,7 +74,8 @@ const reconciledRows = db
 const reconciled = reconciledRows?.count ?? 0
 console.log(`[minion] engine on :${PORT}, ${reconciled} sessions resumed`)
 
-const scheduler = createDagScheduler({ registry, db, bus, workspace: WORKSPACE_ROOT })
+const ciBabysitter = createRealCIBabysitter(registry, db)
+const scheduler = createDagScheduler({ registry, db, bus, workspace: WORKSPACE_ROOT, ciBabysitter })
 await scheduler.reconcileOnBoot()
 
 bus.onKind('session.resumed', (ev) => { void scheduler.onSessionResumed(ev.sessionId) })
@@ -113,7 +114,7 @@ const ctx: HandlerCtx = {
   bus,
   scheduler,
   loopScheduler,
-  ciBabysitter: createRealCIBabysitter(registry, db),
+  ciBabysitter,
   qualityGates: createRealQualityGates(),
   digest: createDigestBuilder(),
   profileStore: createNoopProfileStore(),


### PR DESCRIPTION
## Summary
- DAG task completions now trigger CI babysit via `babysitDagChildCI`
- Checks `metadata.ciBabysitStartedAt` to dedupe against stream-path triggers
- Ensures DAG nodes with PRs always get babysat, not just those where the final assistant turn contained the URL

## Test plan
- [x] All DAG scheduler tests pass (17/17)
- [x] Lint and typecheck pass
- [x] Verified deduplication logic prevents double-babysitting when stream path already claimed
- [x] CI will verify integration

Fixes the gap where `task-completion-handler.ts` returns early for `dag-task` mode, leaving completion-side babysit disabled for DAG nodes.
