### PR TITLE
feat(ui): add memory drawer stub with feature flag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,12 +42,14 @@ import { formatRoute } from './routing/route'
 import { VariantGroupView } from './groups/VariantGroupView'
 import type { ApiSession, AttentionReason, MinionCommand, QuickAction } from './api/types'
 import { HeaderMenu } from './components/HeaderMenu'
+import { MemoryDrawer } from './components/MemoryDrawer'
 
 export type ViewMode = 'list' | 'canvas' | 'ship'
 
 const showSettings = signal(false)
 const showDrawer = signal(false)
 const showRuntime = signal<RuntimeTab | null>(null)
+const showMemory = signal(false)
 export const viewMode = signal<ViewMode>('list')
 
 function ViewToggle({ mode, onChange }: { mode: ViewMode; onChange: (m: ViewMode) => void }) {
@@ -769,6 +771,26 @@ function ActiveView() {
           <div class="ml-auto flex items-center gap-1 sm:gap-1.5 shrink-0">
             <ViewToggle mode={mode} onChange={(m) => { viewMode.value = m }} />
             <ThemeToggle />
+            {hasFeature(store, 'memory') && (
+              <button
+                type="button"
+                onClick={() => { showMemory.value = true }}
+                class="relative rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
+                title="Memory proposals"
+                aria-label="Open memory drawer"
+                data-testid="header-memory-btn"
+              >
+                <span aria-hidden="true">🧠</span>
+                {store.memoryProposalsCount.value > 0 && (
+                  <span
+                    class="absolute -top-1 -right-1 rounded-full bg-indigo-600 text-white text-[10px] font-medium px-1 min-w-[16px] h-4 flex items-center justify-center"
+                    data-testid="memory-proposals-badge"
+                  >
+                    {store.memoryProposalsCount.value}
+                  </span>
+                )}
+              </button>
+            )}
             {hasFeature(store, 'runtime-config') && (
               <button
                 type="button"
@@ -808,9 +830,12 @@ function ActiveView() {
         ) : (
           <div class="ml-auto">
             <HeaderMenu
+              onMemory={hasFeature(store, 'memory') ? () => { showMemory.value = true } : undefined}
               onRuntimeConfig={hasFeature(store, 'runtime-config') ? () => { showRuntime.value = 'config' } : undefined}
               onClean={hasFeature(store, 'messages') ? handleClean : undefined}
               onRefresh={() => void store.refresh()}
+              showMemory={hasFeature(store, 'memory')}
+              memoryProposalsCount={store.memoryProposalsCount.value}
               showRuntimeConfig={hasFeature(store, 'runtime-config')}
               showClean={hasFeature(store, 'messages')}
               cleaning={cleaning}
@@ -957,6 +982,12 @@ function ActiveView() {
           store={store}
           initialTab={showRuntime.value}
           onClose={() => { showRuntime.value = null }}
+        />
+      )}
+      {showMemory.value && (
+        <MemoryDrawer
+          store={store}
+          onClose={() => { showMemory.value = false }}
         />
       )}
       {logsSessionId !== null && (() => {

--- a/src/api/features.ts
+++ b/src/api/features.ts
@@ -15,6 +15,7 @@ export type FeatureName =
   | 'resource-metrics'
   | 'runtime-config'
   | 'ship-coordinator'
+  | 'memory'
 
 export function hasFeature(
   source: ConnectionStore | VersionInfo | null | undefined,

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -9,16 +9,22 @@ const menuOpen = signal(false)
 export { menuOpen }
 
 export function HeaderMenu({
+  onMemory,
   onRuntimeConfig,
   onClean,
   onRefresh,
+  showMemory,
+  memoryProposalsCount,
   showRuntimeConfig,
   showClean,
   cleaning,
 }: {
+  onMemory?: () => void
   onRuntimeConfig?: () => void
   onClean?: () => void
   onRefresh: () => void
+  showMemory: boolean
+  memoryProposalsCount?: number
   showRuntimeConfig: boolean
   showClean: boolean
   cleaning: boolean
@@ -103,6 +109,31 @@ export function HeaderMenu({
             <span class="text-sm text-slate-700 dark:text-slate-200">Theme</span>
             <ThemeToggle />
           </div>
+          {showMemory && onMemory && (
+            <>
+              <div class="border-t border-slate-200 dark:border-slate-700 my-1" />
+              <button
+                type="button"
+                onClick={() => {
+                  onMemory()
+                  closeMenu()
+                }}
+                class="w-full flex items-center gap-3 px-3 py-2 text-sm text-left text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+                data-testid="menu-memory"
+              >
+                <span aria-hidden="true">🧠</span>
+                <span>Memory</span>
+                {memoryProposalsCount !== undefined && memoryProposalsCount > 0 && (
+                  <span
+                    class="ml-auto rounded-full bg-indigo-600 text-white text-xs font-medium px-2 py-0.5"
+                    data-testid="menu-memory-badge"
+                  >
+                    {memoryProposalsCount}
+                  </span>
+                )}
+              </button>
+            </>
+          )}
           {showRuntimeConfig && onRuntimeConfig && (
             <>
               <div class="border-t border-slate-200 dark:border-slate-700 my-1" />

--- a/src/components/MemoryDrawer.tsx
+++ b/src/components/MemoryDrawer.tsx
@@ -1,0 +1,108 @@
+import { useEffect } from 'preact/hooks'
+import type { ConnectionStore } from '../state/types'
+import { useMediaQuery } from '../hooks/useMediaQuery'
+import { useTheme } from '../hooks/useTheme'
+import { hasFeature } from '../api/features'
+
+interface Props {
+  store: ConnectionStore
+  onClose: () => void
+}
+
+export function MemoryDrawer({ store, onClose }: Props) {
+  const theme = useTheme()
+  const isDark = theme.value === 'dark'
+  const isDesktop = useMediaQuery('(min-width: 768px)')
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  const panelBg = isDark ? 'bg-gray-800' : 'bg-white'
+  const borderColor = isDark ? 'border-gray-700' : 'border-gray-200'
+
+  const inner = (
+    <div class={`flex flex-col h-full ${panelBg}`} data-testid="memory-drawer">
+      <header class={`flex items-center gap-2 px-4 py-3 border-b shrink-0 ${borderColor}`}>
+        <span class={`flex-1 font-semibold text-sm ${isDark ? 'text-white' : 'text-slate-900'}`}>
+          Memory
+        </span>
+        {store.memoryProposalsCount.value > 0 && (
+          <span
+            class="rounded-full bg-indigo-600 text-white text-xs font-medium px-2 py-0.5"
+            data-testid="memory-proposals-badge"
+          >
+            {store.memoryProposalsCount.value}
+          </span>
+        )}
+        <button
+          onClick={onClose}
+          class={`w-7 h-7 flex items-center justify-center rounded-full transition-colors ${isDark ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-100 text-slate-500'}`}
+          aria-label="Close drawer"
+          data-testid="memory-drawer-close"
+        >
+          <span class="text-lg leading-none">&times;</span>
+        </button>
+      </header>
+
+      <div class="flex-1 overflow-y-auto">
+        {hasFeature(store, 'memory') ? (
+          <div class="p-8 flex flex-col items-center justify-center gap-3 text-center">
+            <div class={`text-sm ${isDark ? 'text-gray-300' : 'text-slate-700'}`}>
+              Memory drawer implementation coming soon.
+            </div>
+            <div class={`text-xs ${isDark ? 'text-gray-400' : 'text-slate-500'}`}>
+              This is a placeholder for the full memory UI (PR 2).
+            </div>
+          </div>
+        ) : (
+          <div class="p-8 flex flex-col items-center justify-center gap-3 text-center">
+            <div class={`text-sm font-medium ${isDark ? 'text-gray-300' : 'text-slate-700'}`}>
+              Memory not available
+            </div>
+            <div class={`text-xs ${isDark ? 'text-gray-400' : 'text-slate-500'}`}>
+              This minion engine does not support the memory feature. Please upgrade to a version with memory support.
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+
+  if (isDesktop.value) {
+    return (
+      <div class="fixed inset-x-0 top-0 z-50 flex h-[100dvh]">
+        <div
+          class="absolute inset-0 bg-black/50"
+          data-testid="drawer-backdrop"
+          onClick={onClose}
+        />
+        <div class={`relative ml-auto w-full max-w-md h-full shadow-2xl flex flex-col border-l ${borderColor} ${panelBg}`}>
+          {inner}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div class="fixed inset-x-0 top-0 z-50 h-[100dvh]">
+      <div
+        class="absolute inset-0 bg-black/50"
+        data-testid="drawer-backdrop"
+        onClick={onClose}
+      />
+      <div
+        class={`absolute bottom-0 left-0 right-0 rounded-t-2xl shadow-2xl flex flex-col border-t max-h-[85dvh] ${borderColor} ${panelBg}`}
+      >
+        <div class="flex justify-center pt-2 pb-1 shrink-0">
+          <div class={`w-10 h-1 rounded-full ${isDark ? 'bg-gray-600' : 'bg-gray-300'}`} />
+        </div>
+        {inner}
+      </div>
+    </div>
+  )
+}

--- a/test/api/features.test.ts
+++ b/test/api/features.test.ts
@@ -41,4 +41,13 @@ describe('hasFeature', () => {
     expect(hasFeature(v, 'web-push')).toBe(true)
     expect(hasFeature(v, 'diff')).toBe(false)
   })
+
+  it('recognizes memory feature', () => {
+    const store = makeStore({
+      apiVersion: '1',
+      libraryVersion: '1.110.0',
+      features: ['memory', 'messages'],
+    })
+    expect(hasFeature(store, 'memory')).toBe(true)
+  })
 })

--- a/test/components/MemoryDrawer.test.tsx
+++ b/test/components/MemoryDrawer.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { signal } from '@preact/signals'
+import type { ConnectionStore } from '../../src/state/types'
+
+vi.mock('../../src/hooks/useTheme', () => ({
+  useTheme: () => signal('light'),
+}))
+
+vi.mock('../../src/hooks/useMediaQuery', () => ({
+  useMediaQuery: () => signal(true),
+}))
+
+function makeStore(features: string[], proposalsCount = 0): ConnectionStore {
+  return {
+    version: signal({
+      apiVersion: '1',
+      libraryVersion: '1.110.0',
+      features,
+    }),
+    memoryProposalsCount: signal(proposalsCount),
+  } as unknown as ConnectionStore
+}
+
+describe('MemoryDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  async function setup(store: ConnectionStore, onClose = vi.fn()) {
+    const { MemoryDrawer } = await import('../../src/components/MemoryDrawer')
+    render(<MemoryDrawer store={store} onClose={onClose} />)
+    return { onClose }
+  }
+
+  it('renders when feature is available', async () => {
+    const store = makeStore(['memory'])
+    await setup(store)
+    expect(screen.getByTestId('memory-drawer')).toBeTruthy()
+  })
+
+  it('shows placeholder when feature is available', async () => {
+    const store = makeStore(['memory'])
+    await setup(store)
+    expect(screen.getByText(/Memory drawer implementation coming soon/i)).toBeTruthy()
+  })
+
+  it('shows upgrade notice when feature is not available', async () => {
+    const store = makeStore([])
+    await setup(store)
+    expect(screen.getByText(/Memory not available/i)).toBeTruthy()
+    expect(screen.getByText(/does not support the memory feature/i)).toBeTruthy()
+  })
+
+  it('close button calls onClose', async () => {
+    const store = makeStore(['memory'])
+    const { onClose } = await setup(store)
+    fireEvent.click(screen.getByTestId('memory-drawer-close'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('escape key calls onClose', async () => {
+    const store = makeStore(['memory'])
+    const { onClose } = await setup(store)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows proposals count badge when count > 0', async () => {
+    const store = makeStore(['memory'], 3)
+    await setup(store)
+    const badge = screen.getByTestId('memory-proposals-badge')
+    expect(badge.textContent).toBe('3')
+  })
+
+  it('hides proposals count badge when count = 0', async () => {
+    const store = makeStore(['memory'], 0)
+    await setup(store)
+    expect(screen.queryByTestId('memory-proposals-badge')).toBeFalsy()
+  })
+
+  it('backdrop click calls onClose', async () => {
+    const store = makeStore(['memory'])
+    const { onClose } = await setup(store)
+    fireEvent.click(screen.getByTestId('drawer-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- Added `memory` to `FeatureName` union in `src/api/features.ts`
- Created stub `MemoryDrawer` component that shows:
  - Feature flag gate (upgrade notice if memory not supported)
  - Placeholder content for full implementation (PR 2)
  - Proposals count badge in header
- Wired drawer into main app layout:
  - Desktop: brain icon button in header with badge
  - Mobile: menu item with badge
  - Uses existing `memoryProposalsCount` signal from store
- Added comprehensive tests for drawer and feature flag

## Test plan

- [x] Unit tests pass for MemoryDrawer component
- [x] Feature flag test passes
- [x] Linting passes for UI code
- [x] TypeScript typecheck passes for UI code (tsconfig.json)
- [ ] Verify drawer renders with feature flag on
- [ ] Verify upgrade notice shows when feature flag off
- [ ] Verify proposals badge displays correctly
- [ ] Full integration test pending PR merge

Note: Server-side typecheck currently fails due to missing `@modelcontextprotocol/sdk` dependency from parallel work in other minions (MCP memory server). UI code typechecks cleanly.

Generated with [Claude Code](https://claude.com/claude-code)