### PR TITLE
feat(dag): add rebasing and rebase-conflict statuses with events

### DIFF
--- a/server/dag/dag.ts
+++ b/server/dag/dag.ts
@@ -21,7 +21,7 @@ function childrenIndex(graph: DagGraph): Map<string, DagNode[]> {
   return children
 }
 
-export type DagNodeStatus = "pending" | "ready" | "running" | "done" | "failed" | "skipped" | "ci-pending" | "ci-failed" | "landed"
+export type DagNodeStatus = "pending" | "ready" | "running" | "done" | "failed" | "skipped" | "ci-pending" | "ci-failed" | "landed" | "rebasing" | "rebase-conflict"
 
 export interface DagNode {
   id: string
@@ -352,13 +352,17 @@ export function dagProgress(graph: DagGraph): {
   ciPending: number
   ciFailed: number
   landed: number
+  rebasing: number
+  rebaseConflict: number
 } {
-  const counts = { total: 0, done: 0, running: 0, ready: 0, pending: 0, failed: 0, skipped: 0, ciPending: 0, ciFailed: 0, landed: 0 }
+  const counts = { total: 0, done: 0, running: 0, ready: 0, pending: 0, failed: 0, skipped: 0, ciPending: 0, ciFailed: 0, landed: 0, rebasing: 0, rebaseConflict: 0 }
   for (const node of graph.nodes) {
     counts.total++
     if (node.status === "ci-pending") counts.ciPending++
     else if (node.status === "ci-failed") counts.ciFailed++
     else if (node.status === "landed") counts.landed++
+    else if (node.status === "rebasing") counts.rebasing++
+    else if (node.status === "rebase-conflict") counts.rebaseConflict++
     else counts[node.status]++
   }
   return counts
@@ -409,6 +413,8 @@ export function renderDagStatus(graph: DagGraph, isStack?: boolean): string {
     "ci-pending": "🔄",
     "ci-failed": "⚠️",
     landed: "🏁",
+    rebasing: "🔄",
+    "rebase-conflict": "⚠️",
   }
 
   const progress = dagProgress(graph)
@@ -483,6 +489,8 @@ const statusEmoji: Record<DagNodeStatus, string> = {
   "ci-pending": "🔄",
   "ci-failed": "⚠️",
   landed: "🏁",
+  rebasing: "🔄",
+  "rebase-conflict": "⚠️",
 }
 
 const statusLabel: Record<DagNodeStatus, string> = {
@@ -495,6 +503,8 @@ const statusLabel: Record<DagNodeStatus, string> = {
   "ci-pending": "CI Pending",
   "ci-failed": "CI Failed",
   landed: "Landed",
+  rebasing: "Rebasing",
+  "rebase-conflict": "Rebase Conflict",
 }
 
 function mermaidId(id: string): string {

--- a/server/dag/restack-status.test.ts
+++ b/server/dag/restack-status.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect } from 'bun:test'
+import { buildDag, type DagInput, type DagNodeStatus } from './dag'
+
+describe('DAG restack statuses', () => {
+  test('rebasing and rebase-conflict are valid DagNodeStatus values', () => {
+    const statuses: DagNodeStatus[] = [
+      'pending',
+      'ready',
+      'running',
+      'done',
+      'failed',
+      'skipped',
+      'ci-pending',
+      'ci-failed',
+      'landed',
+      'rebasing',
+      'rebase-conflict',
+    ]
+
+    expect(statuses).toContain('rebasing')
+    expect(statuses).toContain('rebase-conflict')
+  })
+
+  test('node can be set to rebasing status', () => {
+    const items: DagInput[] = [
+      { id: 'a', title: 'Node A', description: 'First node', dependsOn: [] },
+      { id: 'b', title: 'Node B', description: 'Second node', dependsOn: ['a'] },
+    ]
+
+    const graph = buildDag('test-dag', items, 'root-session', 'repo')
+
+    const nodeA = graph.nodes.find((n) => n.id === 'a')!
+    nodeA.status = 'rebasing'
+
+    expect(nodeA.status).toBe('rebasing')
+  })
+
+  test('node can be set to rebase-conflict status with error', () => {
+    const items: DagInput[] = [
+      { id: 'a', title: 'Node A', description: 'First node', dependsOn: [] },
+      { id: 'b', title: 'Node B', description: 'Second node', dependsOn: ['a'] },
+    ]
+
+    const graph = buildDag('test-dag', items, 'root-session', 'repo')
+
+    const nodeA = graph.nodes.find((n) => n.id === 'a')!
+    nodeA.status = 'rebase-conflict'
+    nodeA.error = 'Merge conflict in src/file.ts'
+
+    expect(nodeA.status).toBe('rebase-conflict')
+    expect(nodeA.error).toBe('Merge conflict in src/file.ts')
+  })
+
+  test('node transitions from rebasing to done after successful rebase', () => {
+    const items: DagInput[] = [
+      { id: 'parent', title: 'Parent', description: 'Parent node', dependsOn: [] },
+      { id: 'child', title: 'Child', description: 'Child node', dependsOn: ['parent'] },
+    ]
+
+    const graph = buildDag('test-dag', items, 'root-session', 'repo')
+
+    const parentNode = graph.nodes.find((n) => n.id === 'parent')!
+    const childNode = graph.nodes.find((n) => n.id === 'child')!
+
+    parentNode.status = 'done'
+    childNode.status = 'done'
+
+    parentNode.status = 'rebasing'
+    expect(parentNode.status).toBe('rebasing')
+
+    parentNode.status = 'done'
+    expect(parentNode.status).toBe('done')
+  })
+
+  test('node transitions from rebase-conflict to rebasing after retry', () => {
+    const items: DagInput[] = [
+      { id: 'node-a', title: 'Node A', description: 'Test node', dependsOn: [] },
+    ]
+
+    const graph = buildDag('test-dag', items, 'root-session', 'repo')
+    const node = graph.nodes.find((n) => n.id === 'node-a')!
+
+    node.status = 'rebase-conflict'
+    node.error = 'Conflict in file.ts'
+    expect(node.status).toBe('rebase-conflict')
+
+    node.status = 'rebasing'
+    node.error = undefined
+    expect(node.status).toBe('rebasing')
+    expect(node.error).toBeUndefined()
+  })
+})

--- a/server/events/restack-events.test.ts
+++ b/server/events/restack-events.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from 'bun:test'
+import type { EngineEvent, EngineEventOfKind } from './types'
+
+describe('Restack events', () => {
+  test('dag.node.pushed event has required fields', () => {
+    const event: EngineEventOfKind<'dag.node.pushed'> = {
+      kind: 'dag.node.pushed',
+      dagId: 'dag-123',
+      nodeId: 'node-abc',
+      parentSha: 'abc123',
+      newSha: 'def456',
+    }
+
+    expect(event.kind).toBe('dag.node.pushed')
+    expect(event.dagId).toBe('dag-123')
+    expect(event.nodeId).toBe('node-abc')
+    expect(event.parentSha).toBe('abc123')
+    expect(event.newSha).toBe('def456')
+  })
+
+  test('dag.node.restack.started event has required fields', () => {
+    const event: EngineEventOfKind<'dag.node.restack.started'> = {
+      kind: 'dag.node.restack.started',
+      dagId: 'dag-123',
+      nodeId: 'node-child',
+      parentNodeId: 'node-parent',
+    }
+
+    expect(event.kind).toBe('dag.node.restack.started')
+    expect(event.dagId).toBe('dag-123')
+    expect(event.nodeId).toBe('node-child')
+    expect(event.parentNodeId).toBe('node-parent')
+  })
+
+  test('dag.node.restack.completed event with resolved result', () => {
+    const event: EngineEventOfKind<'dag.node.restack.completed'> = {
+      kind: 'dag.node.restack.completed',
+      dagId: 'dag-123',
+      nodeId: 'node-abc',
+      result: 'resolved',
+    }
+
+    expect(event.kind).toBe('dag.node.restack.completed')
+    expect(event.result).toBe('resolved')
+  })
+
+  test('dag.node.restack.completed event with conflict result and error', () => {
+    const event: EngineEventOfKind<'dag.node.restack.completed'> = {
+      kind: 'dag.node.restack.completed',
+      dagId: 'dag-123',
+      nodeId: 'node-abc',
+      result: 'conflict',
+      error: 'Failed to resolve merge conflicts in file.ts',
+    }
+
+    expect(event.kind).toBe('dag.node.restack.completed')
+    expect(event.result).toBe('conflict')
+    expect(event.error).toBe('Failed to resolve merge conflicts in file.ts')
+  })
+
+  test('all restack events are valid EngineEvent union members', () => {
+    const pushedEvent: EngineEvent = {
+      kind: 'dag.node.pushed',
+      dagId: 'dag-1',
+      nodeId: 'node-1',
+      parentSha: 'sha1',
+      newSha: 'sha2',
+    }
+
+    const startedEvent: EngineEvent = {
+      kind: 'dag.node.restack.started',
+      dagId: 'dag-1',
+      nodeId: 'node-1',
+      parentNodeId: 'parent-1',
+    }
+
+    const completedEvent: EngineEvent = {
+      kind: 'dag.node.restack.completed',
+      dagId: 'dag-1',
+      nodeId: 'node-1',
+      result: 'resolved',
+    }
+
+    expect(pushedEvent.kind).toBe('dag.node.pushed')
+    expect(startedEvent.kind).toBe('dag.node.restack.started')
+    expect(completedEvent.kind).toBe('dag.node.restack.completed')
+  })
+})

--- a/server/events/types.ts
+++ b/server/events/types.ts
@@ -33,6 +33,15 @@ export type EngineEvent =
   | { kind: 'dag.snapshot'; dag: ApiDagGraph }
   | { kind: 'dag.deleted'; dagId: string }
   | { kind: 'dag.node.landed'; dagId: string; nodeId: string }
+  | { kind: 'dag.node.pushed'; dagId: string; nodeId: string; parentSha: string; newSha: string }
+  | { kind: 'dag.node.restack.started'; dagId: string; nodeId: string; parentNodeId: string }
+  | {
+      kind: 'dag.node.restack.completed'
+      dagId: string
+      nodeId: string
+      result: 'resolved' | 'conflict'
+      error?: string
+    }
   | { kind: 'session.assistant_activity'; sessionId: string; toolName: string; toolUseId: string }
   | {
       kind: 'session.screenshot_captured'

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -42,7 +42,17 @@ export interface ApiSession {
 export interface ApiDagNode {
   id: string
   slug: string
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'skipped' | 'ci-pending' | 'ci-failed' | 'landed'
+  status:
+    | 'pending'
+    | 'running'
+    | 'completed'
+    | 'failed'
+    | 'skipped'
+    | 'ci-pending'
+    | 'ci-failed'
+    | 'landed'
+    | 'rebasing'
+    | 'rebase-conflict'
   dependencies: string[]
   dependents: string[]
   session?: ApiSession

--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -70,6 +70,8 @@ const DAG_NODE_COLORS: Record<ApiDagNode['status'], string> = {
   landed: 'bg-emerald-600',
   failed: 'bg-red-500',
   skipped: 'bg-slate-400',
+  rebasing: 'bg-indigo-500 animate-pulse',
+  'rebase-conflict': 'bg-amber-500',
 }
 
 const DAG_NODE_LABELS: Record<ApiDagNode['status'], string> = {
@@ -81,6 +83,8 @@ const DAG_NODE_LABELS: Record<ApiDagNode['status'], string> = {
   landed: 'landed',
   failed: 'failed',
   skipped: 'skipped',
+  rebasing: 'rebasing',
+  'rebase-conflict': 'conflict',
 }
 
 export function DagStatusPanel({ session, store, onSelect, onLand }: DagStatusPanelProps) {

--- a/src/components/shared.tsx
+++ b/src/components/shared.tsx
@@ -52,6 +52,18 @@ export const STATUS_CONFIG: Record<StatusType, { emoji: string; label: string; c
     className: 'bg-emerald-100 text-emerald-700',
     darkClassName: 'bg-emerald-900/50 text-emerald-300',
   },
+  rebasing: {
+    emoji: '🔄',
+    label: 'Rebasing',
+    className: 'bg-indigo-100 text-indigo-700',
+    darkClassName: 'bg-indigo-900/50 text-indigo-300',
+  },
+  'rebase-conflict': {
+    emoji: '⚠️',
+    label: 'Rebase Conflict',
+    className: 'bg-amber-100 text-amber-700',
+    darkClassName: 'bg-amber-900/50 text-amber-300',
+  },
 }
 
 interface StatusBadgeProps {
@@ -162,6 +174,8 @@ export function getStatusColors(isDark: boolean): Record<DagNodeStatus, { bg: st
       'ci-pending': { bg: '#422006', border: '#f59e0b', text: '#fcd34d' },
       'ci-failed': { bg: '#431407', border: '#f97316', text: '#fdba74' },
       landed: { bg: '#022c22', border: '#059669', text: '#6ee7b7' },
+      rebasing: { bg: '#312e81', border: '#6366f1', text: '#a5b4fc' },
+      'rebase-conflict': { bg: '#451a03', border: '#f59e0b', text: '#fcd34d' },
     }
   }
   return {
@@ -173,6 +187,8 @@ export function getStatusColors(isDark: boolean): Record<DagNodeStatus, { bg: st
     'ci-pending': { bg: '#fef3c7', border: '#f59e0b', text: '#92400e' },
     'ci-failed': { bg: '#fff7ed', border: '#f97316', text: '#9a3412' },
     landed: { bg: '#d1fae5', border: '#059669', text: '#065f46' },
+    rebasing: { bg: '#e0e7ff', border: '#6366f1', text: '#3730a3' },
+    'rebase-conflict': { bg: '#fef3c7', border: '#f59e0b', text: '#78350f' },
   }
 }
 

--- a/src/components/ship-pipeline.ts
+++ b/src/components/ship-pipeline.ts
@@ -25,6 +25,9 @@ export function classifyNodeForShip(status: ApiDagNode['status']): ShipColumn {
     case 'landed':
     case 'skipped':
       return 'landed'
+    case 'rebasing':
+    case 'rebase-conflict':
+      return 'ci'
   }
 }
 

--- a/test/components/shared.test.tsx
+++ b/test/components/shared.test.tsx
@@ -60,6 +60,16 @@ describe('StatusBadge', () => {
     expect(screen.getByText('Skipped')).toBeTruthy()
   })
 
+  it('renders rebasing status', () => {
+    render(<StatusBadge status="rebasing" />)
+    expect(screen.getByText('Rebasing')).toBeTruthy()
+  })
+
+  it('renders rebase-conflict status', () => {
+    render(<StatusBadge status="rebase-conflict" />)
+    expect(screen.getByText('Rebase Conflict')).toBeTruthy()
+  })
+
   it('renders emoji for each status', () => {
     for (const [status, config] of Object.entries(STATUS_CONFIG)) {
       cleanup()
@@ -177,7 +187,7 @@ describe('getStatusColors', () => {
 
   it('covers all statuses', () => {
     const colors = getStatusColors(false)
-    expect(Object.keys(colors)).toEqual(['pending', 'running', 'completed', 'failed', 'skipped', 'ci-pending', 'ci-failed', 'landed'])
+    expect(Object.keys(colors)).toEqual(['pending', 'running', 'completed', 'failed', 'skipped', 'ci-pending', 'ci-failed', 'landed', 'rebasing', 'rebase-conflict'])
   })
 
   it('each status has bg, border, and text', () => {


### PR DESCRIPTION
## Summary

- Add `rebasing` and `rebase-conflict` statuses to DagNodeStatus enum
- Add three new event kinds: `dag.node.pushed`, `dag.node.restack.started`, `dag.node.restack.completed`
- Update DAG UI components to mirror new status values with appropriate indicators
- Update status maps (emoji, label, colors) across server and client

## Test plan

- [x] Unit tests pass (`npm run test`)
- [x] TypeScript type checking passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] New test coverage for rebasing/rebase-conflict statuses
- [x] New test coverage for restack events