### PR TITLE
feat(ui): add rebase conflict affordances with error display and retry button

### DIFF
--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -124,6 +124,7 @@ const CommandSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('close'), sessionId: z.string() }),
   z.object({ action: z.literal('plan_action'), sessionId: z.string(), planAction: z.enum(['execute', 'split', 'stack', 'dag']), markdown: z.string().optional() }),
   z.object({ action: z.literal('land'), dagId: z.string(), nodeId: z.string() }),
+  z.object({ action: z.literal('retry_rebase'), dagId: z.string(), nodeId: z.string() }),
   z.object({ action: z.literal('ship_advance'), sessionId: z.string(), to: z.enum(['think', 'plan', 'dag', 'verify', 'done']).optional() }),
 ])
 
@@ -394,6 +395,21 @@ export function registerApiRoutes(
           data: result.ok ? { success: true } : { success: false, error: result.error ?? 'land failed' },
         }
         return c.json(body)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return c.json({ data: { success: false, error: message } } satisfies ApiResponse<CommandResult>)
+      }
+    }
+
+    if (command.action === 'retry_rebase') {
+      if (!scheduler?.retryNode) {
+        return c.json({
+          data: { success: false, error: 'no scheduler configured' },
+        } satisfies ApiResponse<CommandResult>)
+      }
+      try {
+        await scheduler.retryNode(command.nodeId, command.dagId)
+        return c.json({ data: { success: true } } satisfies ApiResponse<CommandResult>)
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         return c.json({ data: { success: false, error: message } } satisfies ApiResponse<CommandResult>)

--- a/server/api/wire-mappers.ts
+++ b/server/api/wire-mappers.ts
@@ -58,6 +58,7 @@ export function sessionRowToApi(row: SessionRow): ApiSession {
 export function dagToApi(dag: DagRow, nodes: DagNodeRow[], sessionMap: Map<string, ApiSession>): ApiDagGraph {
   const nodeRecords: Record<string, ApiDagNode> = {}
   for (const node of nodes) {
+    const error = typeof node.payload.error === 'string' ? node.payload.error : undefined
     nodeRecords[node.id] = {
       id: node.id,
       slug: node.slug,
@@ -65,6 +66,7 @@ export function dagToApi(dag: DagRow, nodes: DagNodeRow[], sessionMap: Map<strin
       dependencies: node.dependencies,
       dependents: node.dependents,
       session: node.session_id !== null ? sessionMap.get(node.session_id) : undefined,
+      error,
     }
   }
   return {

--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -9,6 +9,7 @@ import { prepared } from "../db/sqlite"
 
 export interface PlanScheduler {
   start(dagId: string): Promise<void>
+  retryNode?(nodeId: string, dagId: string): Promise<void>
 }
 
 export interface PlanActionCtx {

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -56,6 +56,7 @@ export interface ApiDagNode {
   dependencies: string[]
   dependents: string[]
   session?: ApiSession
+  error?: string
 }
 
 export interface ApiDagGraph {
@@ -202,6 +203,7 @@ export type MinionCommand =
   | { action: 'plan_action'; sessionId: string; planAction: PlanActionType; markdown?: string }
   | { action: 'ship_advance'; sessionId: string; to?: ShipStage }
   | { action: 'land'; dagId: string; nodeId: string }
+  | { action: 'retry_rebase'; dagId: string; nodeId: string }
 
 export interface RepoEntry {
   alias: string

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -694,6 +694,19 @@ function ActiveView() {
     setLogsSessionId(sid)
   }, [])
 
+  const handleRetryRebase = useCallback(
+    async (dagId: string, nodeId: string) => {
+      if (!store) return
+      setIsActionLoading(true)
+      try {
+        await store.sendCommand({ action: 'retry_rebase', dagId, nodeId })
+      } finally {
+        setIsActionLoading(false)
+      }
+    },
+    [store]
+  )
+
   const [cleaning, setCleaning] = useState(false)
   const handleClean = useCallback(async () => {
     if (!store) return
@@ -749,6 +762,7 @@ function ActiveView() {
     onOpenThread: () => {},
     onOpenChat: handleOpenChat,
     onViewLogs: handleOpenLogs,
+    onRetryRebase: handleRetryRebase,
     isActionLoading,
     accentColor: conn.color,
   }

--- a/src/components/NodeDetailPopup.tsx
+++ b/src/components/NodeDetailPopup.tsx
@@ -12,6 +12,7 @@ interface NodeDetailPopupProps {
   sessions?: ApiSession[]
   dags?: ApiDagGraph[]
   onSelectSession?: (session: ApiSession) => void
+  onRetryRebase?: (dagId: string, nodeId: string) => Promise<void>
 }
 
 function MetaRow({ label, children, isDark }: { label: string; children: preact.ComponentChildren; isDark: boolean }) {
@@ -76,6 +77,7 @@ export function NodeDetailPopup({
   sessions,
   dags,
   onSelectSession,
+  onRetryRebase,
 }: NodeDetailPopupProps) {
   const theme = useTheme()
   const isDark = theme.value === 'dark'
@@ -109,7 +111,10 @@ export function NodeDetailPopup({
 
   const dagMatch = useMemo(() => findOwningDag(session.id, dags), [session.id, dags])
   const dagNodeStatus = dagMatch?.node.status
+  const dagNodeError = dagMatch?.node.error
   const showDagStatus = dagNodeStatus && dagNodeStatus !== session.status
+  const isRebaseConflict = dagNodeStatus === 'rebase-conflict'
+  const isRebasing = dagNodeStatus === 'rebasing'
 
   const isShipCoordinator = session.mode === 'ship'
 
@@ -240,6 +245,34 @@ export function NodeDetailPopup({
           </div>
         )}
 
+        {isRebaseConflict && dagNodeError && (
+          <div
+            class={`mx-4 mt-3 mb-3 px-3 py-2.5 rounded-lg border ${isDark ? 'bg-amber-900/20 border-amber-700/50' : 'bg-amber-50 border-amber-200'}`}
+            data-testid="node-detail-rebase-error"
+          >
+            <div class={`text-xs font-medium mb-1 ${isDark ? 'text-amber-300' : 'text-amber-800'}`}>
+              Rebase Conflict
+            </div>
+            <div class={`text-xs leading-relaxed ${isDark ? 'text-amber-200/90' : 'text-amber-900/90'}`}>
+              {dagNodeError}
+            </div>
+          </div>
+        )}
+
+        {isRebasing && (
+          <div
+            class={`mx-4 mt-3 mb-3 px-3 py-2.5 rounded-lg border ${isDark ? 'bg-indigo-900/20 border-indigo-700/50' : 'bg-indigo-50 border-indigo-200'}`}
+            data-testid="node-detail-rebasing-status"
+          >
+            <div class="flex items-center gap-2">
+              <span class="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
+              <span class={`text-xs font-medium ${isDark ? 'text-indigo-300' : 'text-indigo-800'}`}>
+                Rebasing in progress...
+              </span>
+            </div>
+          </div>
+        )}
+
         <div class={`px-4 py-3 border-b ${borderColor} flex flex-col gap-2`}>
           {session.repo && (
             <MetaRow label="Repo" isDark={isDark}>
@@ -272,6 +305,15 @@ export function NodeDetailPopup({
         </div>
 
         <div class="px-4 py-3 flex flex-wrap gap-2">
+          {isRebaseConflict && onRetryRebase && dagMatch && (
+            <button
+              onClick={() => onRetryRebase!(dagMatch.dag.id, dagMatch.node.id)}
+              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${isDark ? 'bg-amber-600 hover:bg-amber-700 text-white' : 'bg-amber-500 hover:bg-amber-600 text-white'}`}
+              data-testid="node-detail-retry-rebase-btn"
+            >
+              <span>Retry Rebase</span>
+            </button>
+          )}
           {hasChatAction && (
             <button
               onClick={() => onOpenChat!(session.id)}
@@ -297,7 +339,7 @@ export function NodeDetailPopup({
               <span>View PR</span>
             </button>
           )}
-          {!hasChatAction && !hasLogsAction && !session.prUrl && (
+          {!isRebaseConflict && !hasChatAction && !hasLogsAction && !session.prUrl && (
             <div class={`flex-1 text-center text-sm py-2 ${mutedText}`}>
               No actions available
             </div>

--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -70,6 +70,7 @@ function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
 
   const hasSession = Boolean(session)
   const isActive = session?.status === 'running' || session?.status === 'pending'
+  const isRebasing = data.status === 'rebasing'
   const isCoordinator = data.nodeType === 'ship'
 
   const nodeTypeLabel = data.nodeType === 'dag' ? 'DAG' : data.nodeType === 'parent-child' ? 'Tree' : null
@@ -125,6 +126,14 @@ function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
         </div>
 
         <div class="flex items-center gap-2 mt-1">
+          {isRebasing && (
+            <span class="inline-flex items-center gap-1.5 text-xs" data-testid="rebasing-indicator">
+              <span
+                class="inline-block w-2.5 h-2.5 border-2 border-current border-t-transparent rounded-full animate-spin"
+                style={{ color: colors.border }}
+              />
+            </span>
+          )}
           <StatusBadge status={status} />
           {session?.needsAttention && session.attentionReasons.length > 0 && (
             <AttentionIconStack reasons={session.attentionReasons} darkMode={isDark} />
@@ -183,6 +192,7 @@ export interface UniverseCanvasProps {
   onNodeSelect?: (session: ApiSession) => void
   onOpenChat?: (sessionId: string) => void
   onViewLogs?: (sessionId: string) => void
+  onRetryRebase?: (dagId: string, nodeId: string) => Promise<void>
   accentColor?: string
 }
 
@@ -206,6 +216,7 @@ function UniverseCanvasInner({
   onNodeSelect,
   onOpenChat,
   onViewLogs,
+  onRetryRebase,
 }: UniverseCanvasProps) {
   const theme = useTheme()
   const isDark = theme.value === 'dark'
@@ -431,6 +442,7 @@ function UniverseCanvasInner({
           sessions={sessions}
           dags={dags}
           onSelectSession={(s) => setDetailSession(s)}
+          onRetryRebase={onRetryRebase}
         />
       )}
     </div>

--- a/test/components/NodeDetailPopup.test.tsx
+++ b/test/components/NodeDetailPopup.test.tsx
@@ -439,4 +439,142 @@ describe('NodeDetailPopup hierarchy metadata', () => {
     expect(hierarchy.innerHTML).toContain('Workers')
     expect(hierarchy.innerHTML).not.toContain('Child')
   })
+
+  it('renders rebase conflict error message when DAG node status is rebase-conflict', () => {
+    const session = makeSession({ id: 'sess-1', slug: 'conflict-session', status: 'running' })
+    const dag = makeDag({
+      nodes: {
+        'node-a': {
+          id: 'node-a',
+          slug: 'conflict-session',
+          status: 'rebase-conflict',
+          dependencies: [],
+          dependents: [],
+          session,
+          error: 'Rebase failed: merge conflict in src/app.ts',
+        },
+      },
+    })
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        sessions={[session]}
+        dags={[dag]}
+      />
+    )
+    const errorBox = document.querySelector('[data-testid="node-detail-rebase-error"]')
+    expect(errorBox).toBeTruthy()
+    expect(errorBox!.textContent).toContain('Rebase Conflict')
+    expect(errorBox!.textContent).toContain('Rebase failed: merge conflict in src/app.ts')
+  })
+
+  it('renders retry rebase button when DAG node status is rebase-conflict', () => {
+    const session = makeSession({ id: 'sess-1', slug: 'conflict-session', status: 'running' })
+    const dag = makeDag({
+      nodes: {
+        'node-a': {
+          id: 'node-a',
+          slug: 'conflict-session',
+          status: 'rebase-conflict',
+          dependencies: [],
+          dependents: [],
+          session,
+          error: 'Rebase conflict detected',
+        },
+      },
+    })
+    const onRetryRebase = vi.fn()
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        sessions={[session]}
+        dags={[dag]}
+        onRetryRebase={onRetryRebase}
+      />
+    )
+    const retryBtn = document.querySelector('[data-testid="node-detail-retry-rebase-btn"]') as HTMLButtonElement | null
+    expect(retryBtn).toBeTruthy()
+    fireEvent.click(retryBtn!)
+    expect(onRetryRebase).toHaveBeenCalledWith('dag-xyz', 'node-a')
+  })
+
+  it('does not render retry button when onRetryRebase is not provided', () => {
+    const session = makeSession({ id: 'sess-1', slug: 'conflict-session', status: 'running' })
+    const dag = makeDag({
+      nodes: {
+        'node-a': {
+          id: 'node-a',
+          slug: 'conflict-session',
+          status: 'rebase-conflict',
+          dependencies: [],
+          dependents: [],
+          session,
+          error: 'Rebase conflict detected',
+        },
+      },
+    })
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        sessions={[session]}
+        dags={[dag]}
+      />
+    )
+    expect(document.querySelector('[data-testid="node-detail-retry-rebase-btn"]')).toBeFalsy()
+  })
+
+  it('renders rebasing status indicator when DAG node status is rebasing', () => {
+    const session = makeSession({ id: 'sess-1', slug: 'rebasing-session', status: 'running' })
+    const dag = makeDag({
+      nodes: {
+        'node-a': {
+          id: 'node-a',
+          slug: 'rebasing-session',
+          status: 'rebasing',
+          dependencies: [],
+          dependents: [],
+          session,
+        },
+      },
+    })
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        sessions={[session]}
+        dags={[dag]}
+      />
+    )
+    const rebasingBox = document.querySelector('[data-testid="node-detail-rebasing-status"]')
+    expect(rebasingBox).toBeTruthy()
+    expect(rebasingBox!.textContent).toContain('Rebasing in progress')
+  })
+
+  it('does not render rebase error when no error is present', () => {
+    const session = makeSession({ id: 'sess-1', slug: 'conflict-session', status: 'running' })
+    const dag = makeDag({
+      nodes: {
+        'node-a': {
+          id: 'node-a',
+          slug: 'conflict-session',
+          status: 'rebase-conflict',
+          dependencies: [],
+          dependents: [],
+          session,
+        },
+      },
+    })
+    render(
+      <NodeDetailPopup
+        session={session}
+        onClose={vi.fn()}
+        sessions={[session]}
+        dags={[dag]}
+      />
+    )
+    expect(document.querySelector('[data-testid="node-detail-rebase-error"]')).toBeFalsy()
+  })
 })

--- a/test/components/UniverseCanvas.test.tsx
+++ b/test/components/UniverseCanvas.test.tsx
@@ -424,4 +424,28 @@ describe('UniverseCanvas', () => {
       throw new Error('dag node not found')
     }
   })
+
+  it('renders rebasing spinner indicator when node status is rebasing', () => {
+    const dag = createDag({
+      nodes: {
+        'node-1': {
+          id: 'node-1',
+          slug: 'rebasing-node',
+          status: 'rebasing',
+          dependencies: [],
+          dependents: [],
+          session: createSession({ id: 'dag-session-1', slug: 'rebasing-node', status: 'running' }),
+        },
+      },
+    })
+    render(<UniverseCanvas {...defaultProps} dags={[dag]} />)
+    const rebasingIndicator = document.querySelector('[data-testid="rebasing-indicator"]')
+    expect(rebasingIndicator).toBeTruthy()
+  })
+
+  it('does not render rebasing spinner for non-rebasing nodes', () => {
+    const sessions = [createSession({ id: 's1', slug: 'normal-node', status: 'running' })]
+    render(<UniverseCanvas {...defaultProps} sessions={sessions} />)
+    expect(document.querySelector('[data-testid="rebasing-indicator"]')).toBeFalsy()
+  })
 })


### PR DESCRIPTION
## Summary

Adds UI affordances for rebase conflicts in the DAG restack flow:

- Displays rebase-conflict error messages in NodeDetailPopup
- Shows retry rebase button when conflicts occur
- Renders rebasing spinner in canvas nodes during rebase operations
- Adds `error` field to ApiDagNode type and wire mapper
- Adds `retry_rebase` command to MinionCommand type
- Wires up retry handler through App → UniverseCanvas → NodeDetailPopup

## Test plan

- [x] Unit tests pass for NodeDetailPopup (error display, retry button)
- [x] Unit tests pass for UniverseCanvas (rebasing spinner indicator)
- [x] All existing tests pass (785 passed)
- [x] ESLint passes with no errors

## Integration notes

This PR depends on the server-side restack infrastructure already in place (rebase-resolver mode, RestackManager). The UI now correctly:

1. Displays conflict errors from DagNode.error field
2. Shows visual feedback during rebasing (spinner)
3. Provides retry action via POST /api/commands with retry_rebase command

The retry_rebase handler is not implemented in this PR — that's being handled by the core RestackManager implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
