### PR TITLE
fix(execute): handle think mode and empty turns

### DIFF
--- a/server/commands/plan-actions.test.ts
+++ b/server/commands/plan-actions.test.ts
@@ -203,6 +203,50 @@ describe("plan-actions gating", () => {
     expect(createCalls[0]?.parentId).toBe(sessionId)
     expect(createCalls[0]?.prompt).toContain("Here is my analysis of the problem")
     expect(createCalls[0]?.prompt).toContain("gh pr create")
+    // think mode gets the "pick the highest-leverage item" directive
+    expect(createCalls[0]?.prompt).toContain("highest-leverage item")
+    expect(createCalls[0]?.prompt).toContain("research/analysis, not a concrete implementation plan")
+  })
+
+  it("uses the plain implementation directive for plan/review modes (not the think variant)", async () => {
+    const sessionId = insertSession(db, { mode: "plan" })
+    prepared.insertEvent(db, {
+      session_id: sessionId,
+      seq: 1,
+      turn: 1,
+      type: "assistant_text",
+      timestamp: Date.now(),
+      payload: { text: "Step 1: do X. Step 2: do Y.", final: true, blockId: "block-1" },
+    })
+    const createCalls: Array<{ mode: string; prompt: string }> = []
+    const mockRuntime: Partial<SessionRuntime> = {
+      running: false,
+      currentProviderSessionId: undefined,
+      start: async () => {},
+      injectInput: async () => false,
+      stop: async () => {},
+    }
+    const registry: SessionRegistry = {
+      ...makeRegistry([]),
+      create: async (opts) => {
+        createCalls.push({ mode: opts.mode, prompt: opts.prompt })
+        return {
+          session: { id: "child" } as ApiSession,
+          runtime: mockRuntime as SessionRuntime,
+        }
+      },
+    }
+    const ctx: PlanActionCtx = {
+      db,
+      registry,
+      scheduler: makeScheduler([]),
+    }
+
+    await handleExecute(sessionId, ctx)
+
+    expect(createCalls[0]?.prompt).toContain("Implement your plan now")
+    expect(createCalls[0]?.prompt).not.toContain("highest-leverage item")
+    expect(createCalls[0]?.prompt).not.toContain("research/analysis, not a concrete implementation plan")
   })
 
   it("returns ok:false when there is no plan to execute for think/plan/review modes", async () => {

--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -126,7 +126,7 @@ async function buildAndStartDag(
 }
 
 
-const EXECUTE_DIRECTIVE = [
+const EXECUTE_DIRECTIVE_PLAN = [
   "Implement your plan now, in this session — do NOT wait for another turn.",
   "",
   "1. Write the code.",
@@ -135,6 +135,22 @@ const EXECUTE_DIRECTIVE = [
   "4. `git push -u origin HEAD`. Auth is preconfigured via GIT_ASKPASS.",
   "5. `gh pr create` targeting `main` (no --draft, no --no-verify). Include a short summary and a test plan.",
   "6. End your turn with a single trailing line: `PR: <url>` — so the orchestrator can link the PR.",
+  "",
+  "If blocked, end with `BLOCKED: <one-line reason>` instead of stopping silently.",
+].join("\n")
+
+const EXECUTE_DIRECTIVE_THINK = [
+  "Your previous output is research/analysis, not a concrete implementation plan.",
+  "Pick the SINGLE highest-leverage item from your analysis above and implement only that one item now. If multiple items are equally compelling, choose the smallest scope first.",
+  "Do NOT wait for another turn or ask which to pick — make the call yourself and act.",
+  "",
+  "1. State in one sentence which item you picked and why.",
+  "2. Write the code.",
+  "3. Run the unit/integration tests (NOT e2e or browser tests — too expensive).",
+  "4. `git add -A && git commit -m \"<descriptive message>\"`.",
+  "5. `git push -u origin HEAD`. Auth is preconfigured via GIT_ASKPASS.",
+  "6. `gh pr create` targeting `main` (no --draft, no --no-verify). Include a short summary and a test plan.",
+  "7. End your turn with a single trailing line: `PR: <url>` — so the orchestrator can link the PR.",
   "",
   "If blocked, end with `BLOCKED: <one-line reason>` instead of stopping silently.",
 ].join("\n")
@@ -160,7 +176,8 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
         return { ok: false, reason: "no plan/analysis to execute" }
       }
 
-      const prompt = [plan, "", EXECUTE_DIRECTIVE].join("\n")
+      const directive = mode === "think" ? EXECUTE_DIRECTIVE_THINK : EXECUTE_DIRECTIVE_PLAN
+      const prompt = [plan, "", directive].join("\n")
 
       const { session } = await ctx.registry.create({
         mode: "dag-task",
@@ -179,7 +196,7 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
 
   if (mode === "task" || mode === "dag-task" || mode === "ship-verify") {
     try {
-      const ok = await ctx.registry.reply(sessionId, EXECUTE_DIRECTIVE)
+      const ok = await ctx.registry.reply(sessionId, EXECUTE_DIRECTIVE_PLAN)
       if (!ok) return { ok: false, reason: "could not inject execute directive into session" }
       return { ok: true }
     } catch (err) {

--- a/server/session/runtime.test.ts
+++ b/server/session/runtime.test.ts
@@ -64,16 +64,20 @@ function makeFakeProc(ndjsonLines: string[], stderrText = '', exitCode = 0): Fak
   }
 
   void (async () => {
-    await new Promise<void>((r) => setTimeout(r, 5))
-    const enc = new TextEncoder()
-    for (const line of ndjsonLines) {
-      stdoutCtrl.enqueue(enc.encode(line + '\n'))
-      await new Promise<void>((r) => setTimeout(r, 1))
+    try {
+      await new Promise<void>((r) => setTimeout(r, 5))
+      const enc = new TextEncoder()
+      for (const line of ndjsonLines) {
+        stdoutCtrl.enqueue(enc.encode(line + '\n'))
+        await new Promise<void>((r) => setTimeout(r, 1))
+      }
+      stderrCtrl.enqueue(enc.encode(stderrText))
+      stderrCtrl.close()
+      stdoutCtrl.close()
+      resolveExit(exitCode)
+    } catch {
+      // proc was killed externally before pump finished; ignore double-close races
     }
-    stderrCtrl.enqueue(enc.encode(stderrText))
-    stderrCtrl.close()
-    stdoutCtrl.close()
-    resolveExit(exitCode)
   })()
 
   return sub
@@ -125,7 +129,8 @@ beforeEach(() => {
   resetEventBus()
 })
 
-afterEach(() => {
+afterEach(async () => {
+  await new Promise<void>((r) => setTimeout(r, 20))
   db.close()
 })
 
@@ -294,6 +299,51 @@ describe('SessionRuntime', () => {
 
       expect(completed).toHaveLength(1)
       expect(completed[0]?.state).toBe('errored')
+    })
+  })
+
+  describe('empty-turn detection on autoExit modes', () => {
+    test('one-shot turn that completes with no tool_call or assistant_text → errored + empty_turn status', async () => {
+      const bus = getEventBus()
+      const completed: Array<Extract<EngineEvent, { kind: 'session.completed' }>> = []
+      bus.onKind('session.completed', (e) => { completed.push(e) })
+      const streamEvents: TranscriptEvent[] = []
+      bus.onKind('session.stream', (e) => { streamEvents.push(e.event) })
+
+      const oneShotProvider: AgentProvider = {
+        name: 'claude',
+        buildSpawnArgs() {
+          return { argv: ['x'], env: {} }
+        },
+        serializeInitialInput(prompt: string) {
+          return JSON.stringify({ type: 'user', content: prompt })
+        },
+        serializeUserReply(prompt: string) {
+          return JSON.stringify({ type: 'user', content: prompt })
+        },
+        parseLine(line: string) {
+          if (line.includes('result')) {
+            return { events: [{ kind: 'turn_complete', totalTokens: null, totalCostUsd: null, numTurns: null }] }
+          }
+          return { events: [] }
+        },
+        resumeArgs: () => [],
+        isQuotaError: () => false,
+      }
+
+      currentProc = makeFakeProc(['{"type":"result"}'], '', 0)
+      const rt = new SessionRuntime({
+        ...makeOpts(currentProc, { mode: 'dag-task' }),
+        provider: oneShotProvider,
+      })
+      await rt.start()
+
+      expect(completed).toHaveLength(1)
+      expect(completed[0]?.state).toBe('errored')
+      const emptyTurnStatus = streamEvents.find(
+        (e) => e.type === 'status' && (e as { kind?: string }).kind === 'empty_turn',
+      )
+      expect(emptyTurnStatus).toBeDefined()
     })
   })
 

--- a/server/session/runtime.ts
+++ b/server/session/runtime.ts
@@ -68,6 +68,8 @@ export class SessionRuntime {
   private hardTimer: ReturnType<typeof setTimeout> | null = null
   private retriedForStall = false
   private stoppedForStall = false
+  private stoppedForEmptyTurn = false
+  private producedOutputThisTurn = false
   private stderrChunks: string[] = []
   private totalTokens: number | undefined
   private totalCostUsd: number | undefined
@@ -277,6 +279,16 @@ export class SessionRuntime {
 
           const cfg = getModeConfig(this.provider.name, this.opts.mode as AllSessionMode)
           if (cfg.autoExitOnComplete && this.state !== 'done') {
+            if (!this.producedOutputThisTurn) {
+              this.stoppedForEmptyTurn = true
+              this.persistAndEmit(
+                this.translator.status(
+                  'empty_turn',
+                  'agent produced no tool calls or assistant text before exiting; marked as errored',
+                  { severity: 'error' },
+                ),
+              )
+            }
             void this.stop('auto_exit')
           }
         }
@@ -332,6 +344,8 @@ export class SessionRuntime {
 
     if (this.stoppedForStall) {
       runState = 'stream_stalled'
+    } else if (this.stoppedForEmptyTurn) {
+      runState = 'errored'
     } else if (exitCode === 0) {
       runState = 'completed'
     } else if (this.provider.isQuotaError(stderrText)) {
@@ -360,6 +374,12 @@ export class SessionRuntime {
   }
 
   private persistAndEmit(event: TranscriptEvent): void {
+    if (event.type === 'turn_started') {
+      this.producedOutputThisTurn = false
+    } else if (event.type === 'assistant_text' || event.type === 'tool_call') {
+      this.producedOutputThisTurn = true
+    }
+
     const db = this.getDb()
     const payload: Record<string, unknown> = { ...event }
     prepared.insertEvent(db, {


### PR DESCRIPTION
## Summary

Two bugs surfaced from `slow-grove-5763`, where think→execute completed silently with zero tool calls or text:

1. **`EXECUTE_DIRECTIVE` assumed an actionable plan from the parent.** `think` mode produces multi-option research, not a single plan, so the agent stalled in thinking ("which item should I pick?"). Split the directive: `think` now gets a "pick the single highest-leverage item and implement only that one" prompt; `plan`/`review` keep the original form.

2. **autoExit modes silently flipped to `status=completed` on empty turns.** A turn that finished with zero `tool_call` and zero `assistant_text` is a failure mode — the runtime now tracks per-turn output via `persistAndEmit`, treats an empty turn as `state=errored`, and emits a status event with `kind=empty_turn` so the failure is visible in the transcript.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run test` (846 pass)
- [x] `bun test server/commands/plan-actions.test.ts` — added test asserting think gets the new directive, plan gets the old
- [x] `bun test server/session/runtime.test.ts` — added test asserting one-shot turn with no output → `state=errored` + `empty_turn` status event
- [ ] Deploy to `mini` and re-run a think→execute flow to confirm the dag-task child either acts or fails loudly
