### PR TITLE
fix(memory): handle invalid API responses and prevent filter TypeError

### DIFF
--- a/src/components/MemoryDrawer.tsx
+++ b/src/components/MemoryDrawer.tsx
@@ -121,13 +121,16 @@ export function MemoryDrawer({ store, onClose }: Props) {
   const borderColor = isDark ? 'border-gray-700' : 'border-gray-200'
 
   const filteredMemories = useMemo(() => {
+    const memories = memoryStore.memories.value
+    if (!Array.isArray(memories)) return []
+
     if (activeTab === 'inbox') {
-      return memoryStore.memories.value.filter((m) => m.status === 'pending')
+      return memories.filter((m) => m.status === 'pending')
     }
     if (activeTab === 'library') {
-      return memoryStore.memories.value.filter((m) => m.status === 'approved')
+      return memories.filter((m) => m.status === 'approved')
     }
-    return memoryStore.memories.value.filter(
+    return memories.filter(
       (m) => m.status === 'rejected' || m.status === 'superseded' || m.status === 'pending_deletion',
     )
   }, [memoryStore.memories.value, activeTab])

--- a/src/state/memory-store.ts
+++ b/src/state/memory-store.ts
@@ -39,9 +39,13 @@ export function createMemoryStore(client: ApiClient): MemoryStore {
       const statusParam =
         filters.value.status && filters.value.status !== 'all' ? filters.value.status : undefined
       const result = await client.getMemories(filters.value.query, statusParam)
+      if (!Array.isArray(result)) {
+        throw new Error('Invalid response: expected array of memories')
+      }
       memories.value = result
     } catch (e) {
       error.value = e instanceof Error ? e.message : String(e)
+      memories.value = []
     } finally {
       loading.value = false
       fetchInFlight = false


### PR DESCRIPTION
## Summary

- Fixed `TypeError: f.memories.value.filter is not a function` in MemoryDrawer
- Added defensive array validation in `filteredMemories` useMemo
- Added API response validation in memory-store `fetch()` to ensure array type
- Set `memories.value = []` on fetch errors to guarantee valid state

## Context

The memory drawer was crashing when `memories.value` was not an array, which could occur if:
- The API returned malformed data
- Network errors occurred during fetch
- The backend sent an unexpected response format

## Changes

**MemoryDrawer.tsx**: Added `Array.isArray()` check before calling `.filter()`, returning empty array as fallback

**memory-store.ts**: 
- Validate API response is an array, throw clear error if not
- Reset `memories.value = []` in catch block to ensure valid state after errors

## Test plan

- [x] Unit tests pass
- [x] Linter passes
- [ ] Open memory drawer and verify it loads without errors
- [ ] Test with simulated API errors to ensure graceful degradation
