### PR TITLE
fix(memory): unwrap memories array from new GET /api/memories shape

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -228,12 +228,15 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
       return patch<RuntimeConfigResponse>('/api/config/runtime', patchBody)
     },
 
-    getMemories(query?: string, status?: string) {
+    async getMemories(query?: string, status?: string) {
       const params = new URLSearchParams()
       if (query) params.set('q', query)
       if (status) params.set('status', status)
       const qs = params.toString()
-      return get<MemoryEntry[]>(`/api/memories${qs ? `?${qs}` : ''}`)
+      const result = await get<{ memories: MemoryEntry[]; pendingCount: number }>(
+        `/api/memories${qs ? `?${qs}` : ''}`,
+      )
+      return result.memories
     },
 
     createMemory(req: CreateMemoryRequest) {


### PR DESCRIPTION
## Summary

The Memory drawer was showing `Error loading memories — Invalid response: expected array of memories`.

The engine's `GET /api/memories` now returns `{ data: { memories: MemoryEntry[]; pendingCount: number } }` instead of the older `{ data: MemoryEntry[] }`. The UI client was still typing the response as a flat array, so the validation guard added in #167 fired on every load.

This updates `client.getMemories()` to type the response with the new shape and return `result.memories`. The store-facing API stays `Promise<MemoryEntry[]>`, so no changes are needed in `memory-store.ts` or `MemoryDrawer.tsx`.

`pendingCount` is currently discarded — the badge count is driven by SSE events (`memory_proposed` / `memory_reviewed`) and starts at 0 each session. Wiring up the initial count is a separate follow-up.

## Test plan
- [x] `npm run test` (846 passed)
- [x] `npm run lint` (clean)
- [ ] Open the Memory drawer against a live engine and confirm Inbox / Library / Archive load without the error banner
