### PR TITLE
feat(a11y): increase Send/Mic buttons to 44px with haptics

### DIFF
--- a/src/a11y/TouchTarget.tsx
+++ b/src/a11y/TouchTarget.tsx
@@ -1,0 +1,55 @@
+import type { ComponentChildren } from 'preact'
+import { MIN_TOUCH_TARGET_SIZE } from './constants'
+
+export interface TouchTargetProps {
+  children: ComponentChildren
+  className?: string
+  minSize?: number
+  onClick?: (e: MouseEvent) => void
+  onPointerDown?: (e: PointerEvent) => void
+  onPointerUp?: (e: PointerEvent) => void
+  disabled?: boolean
+  ariaLabel?: string
+  ariaPressed?: boolean
+  role?: string
+  type?: 'button' | 'submit' | 'reset'
+  tabIndex?: number
+}
+
+export function TouchTarget({
+  children,
+  className = '',
+  minSize = MIN_TOUCH_TARGET_SIZE,
+  onClick,
+  onPointerDown,
+  onPointerUp,
+  disabled = false,
+  ariaLabel,
+  ariaPressed,
+  role,
+  type = 'button',
+  tabIndex,
+}: TouchTargetProps) {
+  const style = {
+    minWidth: `${minSize}px`,
+    minHeight: `${minSize}px`,
+  }
+
+  const Element = onClick || onPointerDown || onPointerUp ? 'button' : 'div'
+
+  const props = {
+    class: `inline-flex items-center justify-center ${className}`,
+    style,
+    onClick,
+    onPointerDown,
+    onPointerUp,
+    disabled: Element === 'button' ? disabled : undefined,
+    'aria-label': ariaLabel,
+    'aria-pressed': ariaPressed,
+    role: role || (Element === 'button' ? undefined : 'button'),
+    type: Element === 'button' ? type : undefined,
+    tabIndex: tabIndex ?? (disabled ? -1 : 0),
+  }
+
+  return <Element {...props}>{children}</Element>
+}

--- a/src/a11y/constants.ts
+++ b/src/a11y/constants.ts
@@ -1,0 +1,12 @@
+export const MIN_TOUCH_TARGET_SIZE = 44
+
+export const HAPTIC_PATTERNS = {
+  light: 10,
+  medium: 25,
+  heavy: 50,
+  success: [10, 50, 10],
+  error: [50, 100, 50],
+  warning: [25, 50, 25],
+} as const
+
+export type HapticPattern = keyof typeof HAPTIC_PATTERNS

--- a/src/a11y/haptics.ts
+++ b/src/a11y/haptics.ts
@@ -1,0 +1,42 @@
+import { HAPTIC_PATTERNS, type HapticPattern } from './constants'
+
+export function vibrate(pattern: HapticPattern | number | number[]): void {
+  if (typeof navigator === 'undefined' || !navigator.vibrate) {
+    return
+  }
+
+  if (typeof pattern === 'string') {
+    const hapticValue = HAPTIC_PATTERNS[pattern]
+    navigator.vibrate(hapticValue)
+  } else {
+    navigator.vibrate(pattern)
+  }
+}
+
+export function vibrateLight(): void {
+  vibrate('light')
+}
+
+export function vibrateMedium(): void {
+  vibrate('medium')
+}
+
+export function vibrateHeavy(): void {
+  vibrate('heavy')
+}
+
+export function vibrateSuccess(): void {
+  vibrate('success')
+}
+
+export function vibrateError(): void {
+  vibrate('error')
+}
+
+export function vibrateWarning(): void {
+  vibrate('warning')
+}
+
+export function isHapticsSupported(): boolean {
+  return typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function'
+}

--- a/src/a11y/index.ts
+++ b/src/a11y/index.ts
@@ -1,0 +1,12 @@
+export { MIN_TOUCH_TARGET_SIZE, HAPTIC_PATTERNS, type HapticPattern } from './constants'
+export {
+  vibrate,
+  vibrateLight,
+  vibrateMedium,
+  vibrateHeavy,
+  vibrateSuccess,
+  vibrateError,
+  vibrateWarning,
+  isHapticsSupported,
+} from './haptics'
+export { TouchTarget, type TouchTargetProps } from './TouchTarget'

--- a/src/chat/MessageInput.tsx
+++ b/src/chat/MessageInput.tsx
@@ -4,6 +4,7 @@ import type { ConnectionStore } from '../state/types'
 import { useSpeechRecognition } from '../hooks/useSpeechRecognition'
 import { useImageAttachments, type ImageAttachment } from './ImageAttachments'
 import { hasFeature } from '../api/features'
+import { vibrateLight, MIN_TOUCH_TARGET_SIZE } from '../a11y'
 
 const PLACEHOLDER = 'Send instructions to the agent — Enter to send, Shift+Enter for newline'
 
@@ -81,6 +82,7 @@ export function MessageInput({ store, value, onValueChange, onSend }: MessageInp
         setErrorText('This engine does not advertise image support — needs sessions-create-images feature.')
         return
       }
+      vibrateLight()
       pendingRef.current = { text: trimmed, images: currentAttachments }
       setErrorText(null)
       setSending(true)
@@ -202,6 +204,7 @@ export function MessageInput({ store, value, onValueChange, onSend }: MessageInp
                 ? 'bg-red-600 hover:bg-red-700 active:bg-red-800 text-white border-red-600'
                 : 'bg-white dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600'
             }`}
+            style={{ minWidth: `${MIN_TOUCH_TARGET_SIZE}px`, minHeight: `${MIN_TOUCH_TARGET_SIZE}px` }}
             data-testid="mic-btn"
           >
             <MicIcon recording={recording} />
@@ -212,6 +215,7 @@ export function MessageInput({ store, value, onValueChange, onSend }: MessageInp
           onClick={() => void submit(value, attachments)}
           disabled={sending || (!trimmed && attachments.length === 0)}
           class="shrink-0 rounded-lg px-3.5 py-2 text-sm font-medium transition-colors text-white shadow-sm bg-indigo-600 hover:bg-indigo-700 active:bg-indigo-800 disabled:opacity-50 disabled:cursor-not-allowed"
+          style={{ minWidth: `${MIN_TOUCH_TARGET_SIZE}px`, minHeight: `${MIN_TOUCH_TARGET_SIZE}px` }}
           data-testid="send-btn"
           aria-label={sending ? 'Sending' : 'Send'}
         >
@@ -235,7 +239,7 @@ function ComposerToolbar({
 }) {
   return (
     <div
-      class="flex items-center gap-2 text-[10px] text-slate-500 dark:text-slate-400"
+      class="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400"
       data-testid="composer-toolbar"
     >
       <Kbd>Enter</Kbd>
@@ -281,7 +285,7 @@ function ComposerToolbar({
 
 function Kbd({ children }: { children: string }) {
   return (
-    <kbd class="rounded border border-slate-300 dark:border-slate-600 bg-slate-100 dark:bg-slate-700 px-1 py-px font-mono text-[10px] text-slate-600 dark:text-slate-300">
+    <kbd class="rounded border border-slate-300 dark:border-slate-600 bg-slate-100 dark:bg-slate-700 px-1 py-px font-mono text-xs text-slate-600 dark:text-slate-300">
       {children}
     </kbd>
   )

--- a/test/a11y/TouchTarget.test.tsx
+++ b/test/a11y/TouchTarget.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/preact'
+import { TouchTarget } from '../../src/a11y/TouchTarget'
+import { MIN_TOUCH_TARGET_SIZE } from '../../src/a11y/constants'
+
+describe('a11y/TouchTarget', () => {
+  describe('rendering', () => {
+    it('renders children', () => {
+      const { getByText } = render(<TouchTarget>Click me</TouchTarget>)
+      expect(getByText('Click me')).toBeTruthy()
+    })
+
+    it('renders as button when onClick provided', () => {
+      const { container } = render(<TouchTarget onClick={() => {}}>Click</TouchTarget>)
+      const button = container.querySelector('button')
+      expect(button).toBeTruthy()
+    })
+
+    it('renders as div when no interactive props provided', () => {
+      const { container } = render(<TouchTarget>Static</TouchTarget>)
+      const div = container.querySelector('div')
+      expect(div).toBeTruthy()
+    })
+
+    it('applies custom className', () => {
+      const { container } = render(<TouchTarget className="custom-class">Test</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.className).toContain('custom-class')
+    })
+
+    it('applies default minimum size', () => {
+      const { container } = render(<TouchTarget>Test</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.style.minWidth).toBe(`${MIN_TOUCH_TARGET_SIZE}px`)
+      expect(element.style.minHeight).toBe(`${MIN_TOUCH_TARGET_SIZE}px`)
+    })
+
+    it('applies custom minimum size', () => {
+      const customSize = 60
+      const { container } = render(<TouchTarget minSize={customSize}>Test</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.style.minWidth).toBe(`${customSize}px`)
+      expect(element.style.minHeight).toBe(`${customSize}px`)
+    })
+
+    it('includes flexbox centering classes', () => {
+      const { container } = render(<TouchTarget>Test</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.className).toContain('inline-flex')
+      expect(element.className).toContain('items-center')
+      expect(element.className).toContain('justify-center')
+    })
+  })
+
+  describe('accessibility attributes', () => {
+    it('sets aria-label when provided', () => {
+      const { container } = render(<TouchTarget ariaLabel="Close button">×</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.getAttribute('aria-label')).toBe('Close button')
+    })
+
+    it('sets aria-pressed when provided', () => {
+      const { container } = render(
+        <TouchTarget ariaPressed={true} onClick={() => {}}>
+          Toggle
+        </TouchTarget>
+      )
+      const element = container.firstChild as HTMLElement
+      expect(element.getAttribute('aria-pressed')).toBe('true')
+    })
+
+    it('sets custom role when provided', () => {
+      const { container } = render(<TouchTarget role="checkbox">Check</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.getAttribute('role')).toBe('checkbox')
+    })
+
+    it('sets role=button for non-button elements by default', () => {
+      const { container } = render(<TouchTarget>Static</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.getAttribute('role')).toBe('button')
+    })
+
+    it('does not set role for button elements', () => {
+      const { container } = render(<TouchTarget onClick={() => {}}>Click</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.getAttribute('role')).toBeNull()
+    })
+
+    it('sets tabIndex to 0 by default for enabled elements', () => {
+      const { container } = render(<TouchTarget>Test</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.getAttribute('tabindex')).toBe('0')
+    })
+
+    it('sets tabIndex to -1 when disabled', () => {
+      const { container } = render(<TouchTarget disabled>Test</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.getAttribute('tabindex')).toBe('-1')
+    })
+
+    it('respects custom tabIndex', () => {
+      const { container } = render(<TouchTarget tabIndex={2}>Test</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.getAttribute('tabindex')).toBe('2')
+    })
+  })
+
+  describe('button behavior', () => {
+    it('sets button type when specified', () => {
+      const { container } = render(
+        <TouchTarget type="submit" onClick={() => {}}>
+          Submit
+        </TouchTarget>
+      )
+      const button = container.querySelector('button')
+      expect(button?.getAttribute('type')).toBe('submit')
+    })
+
+    it('defaults to type=button', () => {
+      const { container } = render(<TouchTarget onClick={() => {}}>Click</TouchTarget>)
+      const button = container.querySelector('button')
+      expect(button?.getAttribute('type')).toBe('button')
+    })
+
+    it('sets disabled attribute on button', () => {
+      const { container } = render(
+        <TouchTarget disabled onClick={() => {}}>
+          Disabled
+        </TouchTarget>
+      )
+      const button = container.querySelector('button')
+      expect(button?.disabled).toBe(true)
+    })
+
+    it('does not set disabled on div elements', () => {
+      const { container } = render(<TouchTarget disabled>Static</TouchTarget>)
+      const div = container.querySelector('div')
+      expect(div?.hasAttribute('disabled')).toBe(false)
+    })
+  })
+
+  describe('event handlers', () => {
+    it('calls onClick handler when clicked', () => {
+      const onClick = vi.fn()
+      const { container } = render(<TouchTarget onClick={onClick}>Click</TouchTarget>)
+      const button = container.querySelector('button')!
+      fireEvent.click(button)
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onPointerDown handler', () => {
+      const onPointerDown = vi.fn()
+      const { container } = render(<TouchTarget onPointerDown={onPointerDown}>Press</TouchTarget>)
+      const button = container.querySelector('button')!
+      fireEvent.pointerDown(button)
+      expect(onPointerDown).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onPointerUp handler', () => {
+      const onPointerUp = vi.fn()
+      const { container } = render(<TouchTarget onPointerUp={onPointerUp}>Release</TouchTarget>)
+      const button = container.querySelector('button')!
+      fireEvent.pointerUp(button)
+      expect(onPointerUp).toHaveBeenCalledTimes(1)
+    })
+
+    it('has disabled attribute when disabled prop is true', () => {
+      const onClick = vi.fn()
+      const { container } = render(
+        <TouchTarget disabled onClick={onClick}>
+          Disabled
+        </TouchTarget>
+      )
+      const button = container.querySelector('button')!
+      expect(button.disabled).toBe(true)
+    })
+
+    it('renders as button when onPointerDown is provided', () => {
+      const { container } = render(<TouchTarget onPointerDown={() => {}}>Press</TouchTarget>)
+      expect(container.querySelector('button')).toBeTruthy()
+    })
+
+    it('renders as button when onPointerUp is provided', () => {
+      const { container } = render(<TouchTarget onPointerUp={() => {}}>Release</TouchTarget>)
+      expect(container.querySelector('button')).toBeTruthy()
+    })
+  })
+
+  describe('compound props', () => {
+    it('combines all interactive handlers', () => {
+      const onClick = vi.fn()
+      const onPointerDown = vi.fn()
+      const onPointerUp = vi.fn()
+      const { container } = render(
+        <TouchTarget onClick={onClick} onPointerDown={onPointerDown} onPointerUp={onPointerUp}>
+          Interactive
+        </TouchTarget>
+      )
+      const button = container.querySelector('button')!
+      fireEvent.pointerDown(button)
+      fireEvent.pointerUp(button)
+      fireEvent.click(button)
+      expect(onPointerDown).toHaveBeenCalledTimes(1)
+      expect(onPointerUp).toHaveBeenCalledTimes(1)
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('combines className with default classes', () => {
+      const { container } = render(<TouchTarget className="text-red-500">Test</TouchTarget>)
+      const element = container.firstChild as HTMLElement
+      expect(element.className).toContain('inline-flex')
+      expect(element.className).toContain('items-center')
+      expect(element.className).toContain('justify-center')
+      expect(element.className).toContain('text-red-500')
+    })
+  })
+})

--- a/test/a11y/constants.test.ts
+++ b/test/a11y/constants.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { MIN_TOUCH_TARGET_SIZE, HAPTIC_PATTERNS } from '../../src/a11y/constants'
+
+describe('a11y/constants', () => {
+  describe('MIN_TOUCH_TARGET_SIZE', () => {
+    it('should be 44px (WCAG 2.1 AA mobile minimum)', () => {
+      expect(MIN_TOUCH_TARGET_SIZE).toBe(44)
+    })
+
+    it('should be a positive number', () => {
+      expect(MIN_TOUCH_TARGET_SIZE).toBeGreaterThan(0)
+    })
+  })
+
+  describe('HAPTIC_PATTERNS', () => {
+    it('should define light pattern', () => {
+      expect(HAPTIC_PATTERNS.light).toBe(10)
+    })
+
+    it('should define medium pattern', () => {
+      expect(HAPTIC_PATTERNS.medium).toBe(25)
+    })
+
+    it('should define heavy pattern', () => {
+      expect(HAPTIC_PATTERNS.heavy).toBe(50)
+    })
+
+    it('should define success pattern as array', () => {
+      expect(HAPTIC_PATTERNS.success).toEqual([10, 50, 10])
+    })
+
+    it('should define error pattern as array', () => {
+      expect(HAPTIC_PATTERNS.error).toEqual([50, 100, 50])
+    })
+
+    it('should define warning pattern as array', () => {
+      expect(HAPTIC_PATTERNS.warning).toEqual([25, 50, 25])
+    })
+
+    it('should have all duration values as positive numbers', () => {
+      Object.values(HAPTIC_PATTERNS).forEach((value) => {
+        if (Array.isArray(value)) {
+          value.forEach((v) => expect(v).toBeGreaterThan(0))
+        } else {
+          expect(value).toBeGreaterThan(0)
+        }
+      })
+    })
+  })
+})

--- a/test/a11y/haptics.test.ts
+++ b/test/a11y/haptics.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  vibrate,
+  vibrateLight,
+  vibrateMedium,
+  vibrateHeavy,
+  vibrateSuccess,
+  vibrateError,
+  vibrateWarning,
+  isHapticsSupported,
+} from '../../src/a11y/haptics'
+import { HAPTIC_PATTERNS } from '../../src/a11y/constants'
+
+describe('a11y/haptics', () => {
+  let vibrateSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vibrateSpy = vi.fn()
+    Object.defineProperty(navigator, 'vibrate', {
+      writable: true,
+      value: vibrateSpy,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('isHapticsSupported', () => {
+    it('returns true when navigator.vibrate exists', () => {
+      expect(isHapticsSupported()).toBe(true)
+    })
+
+    it('returns false when navigator.vibrate does not exist', () => {
+      Object.defineProperty(navigator, 'vibrate', {
+        writable: true,
+        value: undefined,
+      })
+      expect(isHapticsSupported()).toBe(false)
+    })
+  })
+
+  describe('vibrate', () => {
+    it('calls navigator.vibrate with pattern name', () => {
+      vibrate('light')
+      expect(vibrateSpy).toHaveBeenCalledWith(HAPTIC_PATTERNS.light)
+    })
+
+    it('calls navigator.vibrate with numeric value', () => {
+      vibrate(100)
+      expect(vibrateSpy).toHaveBeenCalledWith(100)
+    })
+
+    it('calls navigator.vibrate with array pattern', () => {
+      const pattern = [10, 20, 30]
+      vibrate(pattern)
+      expect(vibrateSpy).toHaveBeenCalledWith(pattern)
+    })
+
+    it('does not throw when navigator.vibrate is unavailable', () => {
+      Object.defineProperty(navigator, 'vibrate', {
+        writable: true,
+        value: undefined,
+      })
+      expect(() => vibrate('light')).not.toThrow()
+    })
+
+    it('handles success pattern array', () => {
+      vibrate('success')
+      expect(vibrateSpy).toHaveBeenCalledWith(HAPTIC_PATTERNS.success)
+    })
+
+    it('handles error pattern array', () => {
+      vibrate('error')
+      expect(vibrateSpy).toHaveBeenCalledWith(HAPTIC_PATTERNS.error)
+    })
+  })
+
+  describe('convenience functions', () => {
+    it('vibrateLight calls vibrate with light pattern', () => {
+      vibrateLight()
+      expect(vibrateSpy).toHaveBeenCalledWith(HAPTIC_PATTERNS.light)
+    })
+
+    it('vibrateMedium calls vibrate with medium pattern', () => {
+      vibrateMedium()
+      expect(vibrateSpy).toHaveBeenCalledWith(HAPTIC_PATTERNS.medium)
+    })
+
+    it('vibrateHeavy calls vibrate with heavy pattern', () => {
+      vibrateHeavy()
+      expect(vibrateSpy).toHaveBeenCalledWith(HAPTIC_PATTERNS.heavy)
+    })
+
+    it('vibrateSuccess calls vibrate with success pattern', () => {
+      vibrateSuccess()
+      expect(vibrateSpy).toHaveBeenCalledWith(HAPTIC_PATTERNS.success)
+    })
+
+    it('vibrateError calls vibrate with error pattern', () => {
+      vibrateError()
+      expect(vibrateSpy).toHaveBeenCalledWith(HAPTIC_PATTERNS.error)
+    })
+
+    it('vibrateWarning calls vibrate with warning pattern', () => {
+      vibrateWarning()
+      expect(vibrateSpy).toHaveBeenCalledWith(HAPTIC_PATTERNS.warning)
+    })
+
+    it('all convenience functions work when vibrate is unavailable', () => {
+      Object.defineProperty(navigator, 'vibrate', {
+        writable: true,
+        value: undefined,
+      })
+      expect(() => {
+        vibrateLight()
+        vibrateMedium()
+        vibrateHeavy()
+        vibrateSuccess()
+        vibrateError()
+        vibrateWarning()
+      }).not.toThrow()
+    })
+  })
+})

--- a/test/chat/MessageInput.test.tsx
+++ b/test/chat/MessageInput.test.tsx
@@ -144,6 +144,28 @@ describe('MessageInput', () => {
     expect(placeholder.toLowerCase()).not.toContain('telegram')
     expect(placeholder).toContain('agent')
   })
+
+  it('Send button meets 44px touch target minimum', () => {
+    render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} />)
+    const sendBtn = getSendBtn()
+    expect(sendBtn.style.minWidth).toBe('44px')
+    expect(sendBtn.style.minHeight).toBe('44px')
+  })
+
+  it('triggers haptic feedback on send', async () => {
+    const vibrateSpy = vi.fn()
+    Object.defineProperty(navigator, 'vibrate', {
+      writable: true,
+      value: vibrateSpy,
+    })
+
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    render(<Controlled onSend={onSend} />)
+    fireEvent.input(getTextarea(), { target: { value: 'test haptics' } })
+    fireEvent.click(getSendBtn())
+
+    await waitFor(() => expect(vibrateSpy).toHaveBeenCalledWith(10))
+  })
 })
 
 describe('MessageInput · voice input', () => {
@@ -200,6 +222,35 @@ describe('MessageInput · voice input', () => {
       fireEvent.click(mic)
     })
     await waitFor(() => expect(mic.getAttribute('aria-pressed')).toBe('false'))
+  })
+
+  it('Mic button meets 44px touch target minimum when supported', () => {
+    class FakeRec extends EventTarget implements SpeechRecognition {
+      continuous = false
+      interimResults = false
+      lang = ''
+      maxAlternatives = 1
+      onstart: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null = null
+      onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null = null
+      onend: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      start() {
+        this.onstart?.call(this, new Event('start'))
+      }
+      stop() {
+        this.onend?.call(this, new Event('end'))
+      }
+      abort() {
+        this.onend?.call(this, new Event('end'))
+      }
+    }
+    w.SpeechRecognition = FakeRec as unknown as SpeechRecognitionConstructor
+    delete w.webkitSpeechRecognition
+
+    render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} />)
+    const micBtn = screen.getByTestId('mic-btn') as HTMLButtonElement
+    expect(micBtn.style.minWidth).toBe('44px')
+    expect(micBtn.style.minHeight).toBe('44px')
   })
 
   it('appends final transcript to existing input', async () => {


### PR DESCRIPTION
## Summary

- Send button: 44px minimum touch target (WCAG AA)
- Mic button: 44px minimum touch target (WCAG AA)
- Haptic feedback (light 10ms vibration) on message send
- Keyboard hints increased from 10px to 12px for better mobile readability

Builds on haptics utility from #mobile-a11y-foundation.

## Test plan

- [x] Unit tests verify button min-sizes are 44px
- [x] Unit test confirms haptic vibration triggers on send
- [x] All existing tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)