### PR TITLE
fix(dag): sort DAG nodes numerically by step number

### DIFF
--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -108,7 +108,11 @@ export function DagStatusPanel({ session, store, onSelect, onLand }: DagStatusPa
   const parent = parentSession.value
   const isViewingParent = !!parent && parent.id === session.id
 
-  const nodes = Object.values(graph.nodes)
+  const nodes = Object.values(graph.nodes).sort((a, b) => {
+    const aNum = parseInt(a.id.match(/\d+$/)?.[0] ?? '0', 10)
+    const bNum = parseInt(b.id.match(/\d+$/)?.[0] ?? '0', 10)
+    return aNum - bNum
+  })
   const done = nodes.filter((n) => n.status === 'completed' || n.status === 'landed').length
   const running = nodes.filter((n) => n.status === 'running' || n.status === 'ci-pending').length
   const failed = nodes.filter((n) => n.status === 'failed' || n.status === 'ci-failed').length


### PR DESCRIPTION
## Summary
- Fixed DAG node display order in DagStatusPanel to sort numerically instead of alphabetically
- Nodes with IDs like "step-1", "step-10", "step-2" now display as step-1, step-2, ..., step-9, step-10 instead of step-1, step-10, ..., step-2

## Test plan
- [x] `npm run typecheck` (pre-existing unrelated errors)
- [x] `npm run lint` passed
- [x] `npm run test` — all 855 tests passed
- [ ] Manual: verify DAG nodes display in correct numeric order in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)