### PR TITLE
fix(mobile): ensure chat transcript is visible on child task view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,8 @@
         "@types/eventsource": "^1.1.15",
         "@types/node": "^22.14.0",
         "@types/web-push": "^3.6.4",
+        "@types/whatwg-mimetype": "^5.0.0",
+        "@types/ws": "^8.18.1",
         "autoprefixer": "^10.4.21",
         "concurrently": "^9.0.0",
         "eslint": "^10.1.0",
@@ -4471,6 +4473,23 @@
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
       "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-YYiBDCoqBgDIF2ByYn4qDb4RaXZ46cOQ6j2We1Ni3bikFNI7YFeL8jxSiYowWsriZrb1mw09CLZ+b+ZkIhsLVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "@types/eventsource": "^1.1.15",
     "@types/node": "^22.14.0",
     "@types/web-push": "^3.6.4",
+    "@types/whatwg-mimetype": "^5.0.0",
+    "@types/ws": "^8.18.1",
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.0.0",
     "eslint": "^10.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -339,11 +339,13 @@ function ChatPane({
                 readinessAvailable={hasFeature(store, 'merge-readiness')}
               />
             )}
-            {hasFeature(store, 'transcript') ? (
-              <TranscriptPane store={store} sessionId={session.id} />
-            ) : (
-              <TranscriptUpgradeNotice store={store} />
-            )}
+            <div class="flex-1 min-h-0 flex flex-col">
+              {hasFeature(store, 'transcript') ? (
+                <TranscriptPane store={store} sessionId={session.id} />
+              ) : (
+                <TranscriptUpgradeNotice store={store} />
+              )}
+            </div>
             <div class="shrink-0 border-t border-slate-200 dark:border-slate-700">
               <QuickActionsBar session={session} onAction={handleQuickAction} onShipAdvance={handleShipAdvance} />
               <SlashCommandMenu session={session} context={text} onPrefill={handlePrefillCommand} />

--- a/src/chat/DagStatusPanel.tsx
+++ b/src/chat/DagStatusPanel.tsx
@@ -143,7 +143,7 @@ export function DagStatusPanel({ session, store, onSelect, onLand }: DagStatusPa
 
   return (
     <div
-      class={`border-b ${graphTone} bg-white dark:bg-slate-800 shrink-0`}
+      class={`border-b ${graphTone} bg-white dark:bg-slate-800 shrink-0 max-h-48 md:max-h-none overflow-y-auto`}
       data-testid="dag-status-panel"
     >
       <div class="flex items-stretch">

--- a/src/components/PrPreviewCard.tsx
+++ b/src/components/PrPreviewCard.tsx
@@ -313,7 +313,7 @@ export function PrPreviewCard({ sessionId, prUrl, client, readinessAvailable = f
 
   return (
     <section
-      class="mx-3 mt-3 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden"
+      class="mx-3 mt-3 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden shrink-0 max-h-64 md:max-h-none overflow-y-auto"
       data-testid="pr-preview-card"
     >
       <header class="flex flex-wrap items-center gap-2 px-3 py-2 border-b border-slate-100 dark:border-slate-700">


### PR DESCRIPTION
## Summary

- Wrap TranscriptPane in flex container with `flex-1 min-h-0` to ensure it properly takes available vertical space
- Add `max-h-64` (16rem) constraint to PrPreviewCard on mobile to prevent it from dominating viewport
- Add `max-h-48` (12rem) constraint to DagStatusPanel on mobile to prevent it from dominating viewport
- Install missing `@types/ws` and `@types/whatwg-mimetype` packages to fix typecheck errors

## Test plan

- [ ] Verify chat transcript is visible and scrollable when viewing a child task on mobile
- [ ] Verify PR preview card is scrollable when it exceeds 16rem on mobile
- [ ] Verify DAG status panel is scrollable when expanded and exceeds 12rem on mobile
- [ ] Verify layout remains unchanged on desktop (md breakpoint and above)
- [ ] All unit tests pass
- [ ] Typecheck passes
- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
