### PR TITLE
feat(ui): add swipe-to-dismiss gestures for mobile modals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,7 @@ export const viewMode = signal<ViewMode>('list')
 
 function ViewToggle({ mode, onChange }: { mode: ViewMode; onChange: (m: ViewMode) => void }) {
   const tabClass = (active: boolean) =>
-    `px-1.5 sm:px-2.5 py-1 text-xs font-medium transition-colors ${
+    `px-3 sm:px-4 py-2.5 text-xs font-medium transition-colors min-h-[44px] flex items-center ${
       active
         ? 'bg-indigo-600 text-white'
         : 'bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700'
@@ -259,7 +259,7 @@ function ChatPane({
           <button
             type="button"
             onClick={() => onNavigate(parentSession.id)}
-            class="shrink-0 rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+            class="shrink-0 rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-3 py-2.5 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700 min-h-[44px]"
             title={`Back to parent: ${parentSession.slug}`}
             data-testid="chat-pane-parent-btn"
           >
@@ -289,7 +289,7 @@ function ChatPane({
               onClick={toggleFullscreen}
               title={fullscreen ? 'Exit full screen' : 'Expand chat to full screen'}
               aria-label={fullscreen ? 'Exit full screen' : 'Expand chat to full screen'}
-              class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+              class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-3 py-2.5 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700 min-h-[44px]"
               data-testid="chat-fullscreen-btn"
             >
               {fullscreen ? 'Collapse' : 'Expand'}
@@ -300,7 +300,7 @@ function ChatPane({
             onClick={() => void handleStop()}
             disabled={!stoppable || pending !== null}
             title={stoppable ? 'Stop this session' : 'Session is not running'}
-            class="rounded-md border border-amber-300 dark:border-amber-800 text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-950/40 px-2 py-1 text-xs font-medium hover:bg-amber-100 dark:hover:bg-amber-900/50 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="rounded-md border border-amber-300 dark:border-amber-800 text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-950/40 px-3 py-2.5 text-xs font-medium hover:bg-amber-100 dark:hover:bg-amber-900/50 disabled:opacity-40 disabled:cursor-not-allowed min-h-[44px]"
             data-testid="chat-stop-btn"
           >
             {pending === 'stop' ? 'Stopping…' : 'Stop'}
@@ -310,7 +310,7 @@ function ChatPane({
             onClick={() => void handleClose()}
             disabled={pending !== null}
             title="Close this session permanently"
-            class="rounded-md border border-red-300 dark:border-red-800 text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 px-2 py-1 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-900/50 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="rounded-md border border-red-300 dark:border-red-800 text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 px-3 py-2.5 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-900/50 disabled:opacity-40 disabled:cursor-not-allowed min-h-[44px]"
             data-testid="chat-close-btn"
           >
             {pending === 'close' ? 'Closing…' : 'Close'}
@@ -567,7 +567,7 @@ function MobileSessionStrip({
       <button
         type="button"
         onClick={toggle}
-        class="absolute right-1.5 top-1.5 rounded-md border border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 bg-white dark:bg-slate-800 px-1.5 text-[10px] font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+        class="absolute right-1.5 top-1.5 rounded-md border border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 bg-white dark:bg-slate-800 px-3 py-2.5 text-[10px] font-medium hover:bg-slate-100 dark:hover:bg-slate-700 min-h-[44px] min-w-[44px]"
         title="Collapse the session strip"
         aria-label="Collapse session strip"
         data-testid="mobile-strip-collapse"
@@ -800,7 +800,7 @@ function ActiveView() {
               <button
                 type="button"
                 onClick={() => { showMemory.value = true }}
-                class="relative rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
+                class="relative rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 min-h-[44px] min-w-[44px] flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
                 title="Memory proposals"
                 aria-label="Open memory drawer"
                 data-testid="header-memory-btn"
@@ -820,7 +820,7 @@ function ActiveView() {
               <button
                 type="button"
                 onClick={() => { showRuntime.value = 'config' }}
-                class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
+                class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 min-h-[44px] min-w-[44px] flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
                 title="Runtime config"
                 aria-label="Open runtime config"
                 data-testid="header-runtime-config-btn"
@@ -833,7 +833,7 @@ function ActiveView() {
                 type="button"
                 onClick={() => void handleClean()}
                 disabled={cleaning}
-                class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 min-h-[44px] min-w-[44px] flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
                 title={cleaning ? 'Cleaning…' : 'Clean unused worktrees, branches, and session state'}
                 aria-label={cleaning ? 'Cleaning…' : 'Clean unused worktrees, branches, and session state'}
                 data-testid="header-clean-btn"
@@ -844,7 +844,7 @@ function ActiveView() {
             <button
               type="button"
               onClick={() => void store.refresh()}
-              class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 h-7 w-7 flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
+              class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 min-h-[44px] min-w-[44px] flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
               title="Refetch sessions and DAGs from the minion"
               aria-label="Refetch sessions and DAGs from the minion"
               data-testid="header-refresh-btn"
@@ -965,7 +965,7 @@ function ActiveView() {
             <button
               type="button"
               onClick={() => { viewMode.value = 'list' }}
-              class="ml-auto rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+              class="ml-auto rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-3 py-2.5 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700 min-h-[44px]"
               data-testid="canvas-mobile-close"
               aria-label="Close canvas"
             >
@@ -987,7 +987,7 @@ function ActiveView() {
             <button
               type="button"
               onClick={() => { viewMode.value = 'list' }}
-              class="ml-auto rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+              class="ml-auto rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-3 py-2.5 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700 min-h-[44px]"
               data-testid="ship-mobile-close"
               aria-label="Close ship view"
             >
@@ -1063,7 +1063,7 @@ function PwaController() {
         <button
           type="button"
           onClick={() => void sw.updateServiceWorker(true)}
-          class="pointer-events-auto rounded-md bg-indigo-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-indigo-700"
+          class="pointer-events-auto rounded-md bg-indigo-600 px-3 py-2.5 text-xs font-medium text-white hover:bg-indigo-700 min-h-[44px]"
           data-testid="pwa-update-reload"
         >
           Reload
@@ -1072,7 +1072,7 @@ function PwaController() {
       <button
         type="button"
         onClick={close}
-        class="pointer-events-auto rounded-md border border-slate-300 dark:border-slate-600 px-2.5 py-1 text-xs font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+        class="pointer-events-auto rounded-md border border-slate-300 dark:border-slate-600 px-3 py-2.5 text-xs font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 min-h-[44px]"
         data-testid="pwa-status-dismiss"
       >
         Dismiss
@@ -1096,7 +1096,7 @@ export default function App() {
               </p>
               <button
                 onClick={() => { showSettings.value = true }}
-                class="mt-2 w-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                class="mt-2 w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-medium text-white hover:bg-indigo-700 min-h-[44px]"
               >
                 Add connection
               </button>

--- a/src/chat/ImageAttachments.tsx
+++ b/src/chat/ImageAttachments.tsx
@@ -114,7 +114,7 @@ export function useImageAttachments(disabled: boolean) {
         disabled={disabled}
         aria-label="Attach image"
         title="Attach image"
-        class="shrink-0 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors border shadow-sm disabled:opacity-50 disabled:cursor-not-allowed bg-white dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600"
+        class="shrink-0 rounded-lg px-3 py-3 text-sm font-medium transition-colors border shadow-sm disabled:opacity-50 disabled:cursor-not-allowed bg-white dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600 min-h-[44px]"
         data-testid="attach-btn"
       >
         <PaperclipIcon />
@@ -134,7 +134,7 @@ export function useImageAttachments(disabled: boolean) {
             <button
               type="button"
               onClick={() => removeAttachment(idx)}
-              class="absolute top-0 right-0 w-5 h-5 flex items-center justify-center bg-black/60 text-white text-[10px] rounded-bl"
+              class="absolute top-0 right-0 min-w-[32px] min-h-[32px] flex items-center justify-center bg-black/60 text-white text-sm rounded-bl"
               aria-label={`Remove attachment ${idx + 1}`}
               data-testid={`remove-attachment-${idx}`}
             >

--- a/src/chat/MessageInput.tsx
+++ b/src/chat/MessageInput.tsx
@@ -197,7 +197,7 @@ export function MessageInput({ store, value, onValueChange, onSend }: MessageInp
             aria-pressed={recording}
             aria-label={recording ? 'Stop voice input' : 'Start voice input'}
             title={recording ? 'Stop voice input' : 'Start voice input'}
-            class={`shrink-0 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors border shadow-sm disabled:opacity-50 disabled:cursor-not-allowed ${
+            class={`shrink-0 rounded-lg px-3 py-3 text-sm font-medium transition-colors border shadow-sm disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px] ${
               recording
                 ? 'bg-red-600 hover:bg-red-700 active:bg-red-800 text-white border-red-600'
                 : 'bg-white dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600'
@@ -211,7 +211,7 @@ export function MessageInput({ store, value, onValueChange, onSend }: MessageInp
           type="button"
           onClick={() => void submit(value, attachments)}
           disabled={sending || (!trimmed && attachments.length === 0)}
-          class="shrink-0 rounded-lg px-3.5 py-2 text-sm font-medium transition-colors text-white shadow-sm bg-indigo-600 hover:bg-indigo-700 active:bg-indigo-800 disabled:opacity-50 disabled:cursor-not-allowed"
+          class="shrink-0 rounded-lg px-4 py-3 text-sm font-medium transition-colors text-white shadow-sm bg-indigo-600 hover:bg-indigo-700 active:bg-indigo-800 disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]"
           data-testid="send-btn"
           aria-label={sending ? 'Sending' : 'Send'}
         >
@@ -281,7 +281,7 @@ function ComposerToolbar({
 
 function Kbd({ children }: { children: string }) {
   return (
-    <kbd class="rounded border border-slate-300 dark:border-slate-600 bg-slate-100 dark:bg-slate-700 px-1 py-px font-mono text-[10px] text-slate-600 dark:text-slate-300">
+    <kbd class="rounded border border-slate-300 dark:border-slate-600 bg-slate-100 dark:bg-slate-700 px-1.5 py-0.5 font-mono text-[10px] text-slate-600 dark:text-slate-300">
       {children}
     </kbd>
   )

--- a/src/chat/QuickActionsBar.tsx
+++ b/src/chat/QuickActionsBar.tsx
@@ -40,7 +40,7 @@ export function QuickActionsBar({ session, onAction, onShipAdvance }: QuickActio
             }
           }}
           disabled={stageConfig.disabled}
-          class={`text-xs font-medium px-3 py-1.5 rounded-full border transition-colors ${btnClass}`}
+          class={`text-xs font-medium px-4 py-3 rounded-full border transition-colors min-h-[44px] ${btnClass}`}
           data-testid="ship-advance-btn"
         >
           {stageConfig.label}
@@ -65,7 +65,7 @@ export function QuickActionsBar({ session, onAction, onShipAdvance }: QuickActio
         <button
           key={action.type}
           onClick={() => void onAction(action)}
-          class={`text-xs font-medium px-3 py-1.5 rounded-full border transition-colors ${btnClass}`}
+          class={`text-xs font-medium px-4 py-3 rounded-full border transition-colors min-h-[44px] ${btnClass}`}
         >
           {action.label}
         </button>

--- a/src/components/NodeDetailPopup.tsx
+++ b/src/components/NodeDetailPopup.tsx
@@ -155,7 +155,7 @@ export function NodeDetailPopup({
             </h3>
             <button
               onClick={onClose}
-              class={`shrink-0 w-7 h-7 flex items-center justify-center rounded-full transition-colors ${isDark ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-100 text-gray-500'}`}
+              class={`shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-full transition-colors ${isDark ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-100 text-gray-500'}`}
               aria-label="Close"
             >
               <span class="text-lg leading-none">&times;</span>
@@ -308,7 +308,7 @@ export function NodeDetailPopup({
           {isRebaseConflict && onRetryRebase && dagMatch && (
             <button
               onClick={() => onRetryRebase!(dagMatch.dag.id, dagMatch.node.id)}
-              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${isDark ? 'bg-amber-600 hover:bg-amber-700 text-white' : 'bg-amber-500 hover:bg-amber-600 text-white'}`}
+              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-3 text-sm font-medium rounded-lg transition-colors min-h-[44px] ${isDark ? 'bg-amber-600 hover:bg-amber-700 text-white' : 'bg-amber-500 hover:bg-amber-600 text-white'}`}
               data-testid="node-detail-retry-rebase-btn"
             >
               <span>Retry Rebase</span>
@@ -317,7 +317,7 @@ export function NodeDetailPopup({
           {hasChatAction && (
             <button
               onClick={() => onOpenChat!(session.id)}
-              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${isDark ? 'bg-blue-600 hover:bg-blue-700 text-white' : 'bg-blue-500 hover:bg-blue-600 text-white'}`}
+              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-3 text-sm font-medium rounded-lg transition-colors min-h-[44px] ${isDark ? 'bg-blue-600 hover:bg-blue-700 text-white' : 'bg-blue-500 hover:bg-blue-600 text-white'}`}
             >
               <span>Open Chat</span>
             </button>
@@ -325,7 +325,7 @@ export function NodeDetailPopup({
           {hasLogsAction && (
             <button
               onClick={() => onViewLogs!(session.id)}
-              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${isDark ? 'bg-slate-700 hover:bg-slate-600 text-slate-100' : 'bg-slate-100 hover:bg-slate-200 text-slate-800'}`}
+              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-3 text-sm font-medium rounded-lg transition-colors min-h-[44px] ${isDark ? 'bg-slate-700 hover:bg-slate-600 text-slate-100' : 'bg-slate-100 hover:bg-slate-200 text-slate-800'}`}
               data-testid="node-detail-view-logs-btn"
             >
               <span>View Logs</span>
@@ -334,7 +334,7 @@ export function NodeDetailPopup({
           {session.prUrl && (
             <button
               onClick={() => window.open(session.prUrl!, '_blank', 'noopener,noreferrer')}
-              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${isDark ? 'bg-gray-700 hover:bg-gray-600 text-gray-200' : 'bg-gray-100 hover:bg-gray-200 text-gray-800'}`}
+              class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-3 text-sm font-medium rounded-lg transition-colors min-h-[44px] ${isDark ? 'bg-gray-700 hover:bg-gray-600 text-gray-200' : 'bg-gray-100 hover:bg-gray-200 text-gray-800'}`}
             >
               <span>View PR</span>
             </button>

--- a/src/components/NodeDetailPopup.tsx
+++ b/src/components/NodeDetailPopup.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef } from 'preact/hooks'
 import type { ApiDagGraph, ApiDagNode, ApiSession } from '../api/types'
 import { useTheme } from '../hooks/useTheme'
+import { useMediaQuery } from '../hooks/useMediaQuery'
+import { useSwipeToDismiss } from '../hooks/useSwipeToDismiss'
 import { StatusBadge, AttentionBadge, formatRelativeTime } from './shared'
 import { PrLink } from './PrLink'
 
@@ -81,7 +83,19 @@ export function NodeDetailPopup({
 }: NodeDetailPopupProps) {
   const theme = useTheme()
   const isDark = theme.value === 'dark'
+  const isMobile = useMediaQuery('(max-width: 767px)')
   const popupRef = useRef<HTMLDivElement>(null)
+  const swipeRef = useSwipeToDismiss({
+    onDismiss: onClose,
+    threshold: 100,
+    enabled: isMobile.value,
+  })
+
+  useEffect(() => {
+    if (isMobile.value && popupRef.current) {
+      swipeRef.current = popupRef.current
+    }
+  }, [isMobile.value, swipeRef])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -137,6 +151,224 @@ export function NodeDetailPopup({
     childSessions.length > 0 ||
     dagMatch !== null ||
     (isShipCoordinator && session.stage !== undefined)
+
+  if (isMobile.value) {
+    return (
+      <div class="fixed inset-0 z-50">
+        <div class={`absolute inset-0 ${overlayBg}`} onClick={onClose} />
+        <div
+          ref={popupRef}
+          class={`absolute bottom-0 left-0 right-0 ${dialogBg} rounded-t-2xl shadow-xl flex flex-col max-h-[90dvh]`}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="node-detail-title"
+        >
+          <div class="flex justify-center pt-2 pb-1 shrink-0">
+            <div class={`w-10 h-1 rounded-full ${isDark ? 'bg-gray-600' : 'bg-gray-300'}`} />
+          </div>
+          <div class="overflow-y-auto flex-1">
+            <div class={`px-4 pt-3 pb-3 border-b ${borderColor}`}>
+              <div class="flex items-center justify-between gap-2">
+                <h3 id="node-detail-title" class={`text-base font-semibold ${titleColor} truncate`}>
+                  {session.slug}
+                </h3>
+                <button
+                  onClick={onClose}
+                  class={`shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-full transition-colors ${isDark ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-100 text-gray-500'}`}
+                  aria-label="Close"
+                >
+                  <span class="text-lg leading-none">&times;</span>
+                </button>
+              </div>
+              <div class="flex items-center gap-2 mt-1.5">
+                <StatusBadge status={session.status} />
+                {session.needsAttention && session.attentionReasons.length > 0 && (
+                  <AttentionBadge reason={session.attentionReasons[0]} darkMode={isDark} />
+                )}
+              </div>
+            </div>
+
+            {session.command && (
+              <div class={`px-4 py-3 border-b ${borderColor}`}>
+                <div class={`text-[11px] font-medium uppercase tracking-wide mb-1.5 ${mutedText}`}>Prompt</div>
+                <div
+                  class={`text-xs leading-relaxed rounded-lg p-2.5 ${secondaryBg}`}
+                  style={{ color: isDark ? '#d1d5db' : '#4b5563' }}
+                >
+                  {truncatedPrompt}
+                </div>
+              </div>
+            )}
+
+            {hasHierarchyMeta && (
+              <div class={`px-4 py-3 border-b ${borderColor} flex flex-col gap-2`} data-testid="node-detail-hierarchy">
+                {isShipCoordinator && session.stage && (
+                  <MetaRow label="Stage" isDark={isDark}>
+                    <span
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                      style={{
+                        backgroundColor: isDark ? 'rgba(167,139,250,0.2)' : 'rgba(124,58,237,0.1)',
+                        color: isDark ? '#a78bfa' : '#7c3aed',
+                      }}
+                      data-testid="node-detail-ship-stage"
+                    >
+                      {session.stage}
+                    </span>
+                  </MetaRow>
+                )}
+                {parentSession && (
+                  <MetaRow label="Parent" isDark={isDark}>
+                    <SessionLink session={parentSession} onClick={onSelectSession} isDark={isDark} />
+                  </MetaRow>
+                )}
+                {childSessions.length > 0 && !isShipCoordinator && (
+                  <MetaRow label={childSessions.length === 1 ? 'Child' : 'Children'} isDark={isDark}>
+                    <span class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                      {childSessions.map((child, i) => (
+                        <span key={child.id} class="inline-flex items-center">
+                          <SessionLink session={child} onClick={onSelectSession} isDark={isDark} />
+                          {i < childSessions.length - 1 && (
+                            <span class="ml-2" style={{ color: isDark ? '#4b5563' : '#d1d5db' }}>·</span>
+                          )}
+                        </span>
+                      ))}
+                    </span>
+                  </MetaRow>
+                )}
+                {childSessions.length > 0 && isShipCoordinator && (
+                  <MetaRow label="Workers" isDark={isDark}>
+                    <div class="flex flex-col gap-1">
+                      {childSessions.map((child) => (
+                        <div key={child.id} class="flex items-center gap-2">
+                          <SessionLink session={child} onClick={onSelectSession} isDark={isDark} />
+                          <StatusBadge status={child.status} />
+                        </div>
+                      ))}
+                    </div>
+                  </MetaRow>
+                )}
+                {dagMatch && (
+                  <MetaRow label="DAG" isDark={isDark}>
+                    <span class="font-mono text-[11px] truncate block" data-testid="node-detail-dag-id">
+                      {dagMatch.dag.id}
+                    </span>
+                  </MetaRow>
+                )}
+                {dagMatch && showDagStatus && (
+                  <MetaRow label="DAG node" isDark={isDark}>
+                    <span data-testid="node-detail-dag-node-status">
+                      <StatusBadge status={dagNodeStatus!} />
+                    </span>
+                  </MetaRow>
+                )}
+              </div>
+            )}
+
+            {isRebaseConflict && dagNodeError && (
+              <div
+                class={`mx-4 mt-3 mb-3 px-3 py-2.5 rounded-lg border ${isDark ? 'bg-amber-900/20 border-amber-700/50' : 'bg-amber-50 border-amber-200'}`}
+                data-testid="node-detail-rebase-error"
+              >
+                <div class={`text-xs font-medium mb-1 ${isDark ? 'text-amber-300' : 'text-amber-800'}`}>
+                  Rebase Conflict
+                </div>
+                <div class={`text-xs leading-relaxed ${isDark ? 'text-amber-200/90' : 'text-amber-900/90'}`}>
+                  {dagNodeError}
+                </div>
+              </div>
+            )}
+
+            {isRebasing && (
+              <div
+                class={`mx-4 mt-3 mb-3 px-3 py-2.5 rounded-lg border ${isDark ? 'bg-indigo-900/20 border-indigo-700/50' : 'bg-indigo-50 border-indigo-200'}`}
+                data-testid="node-detail-rebasing-status"
+              >
+                <div class="flex items-center gap-2">
+                  <span class="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                  <span class={`text-xs font-medium ${isDark ? 'text-indigo-300' : 'text-indigo-800'}`}>
+                    Rebasing in progress...
+                  </span>
+                </div>
+              </div>
+            )}
+
+            <div class={`px-4 py-3 border-b ${borderColor} flex flex-col gap-2`}>
+              {session.repo && (
+                <MetaRow label="Repo" isDark={isDark}>
+                  <span class="truncate block">{session.repo}</span>
+                </MetaRow>
+              )}
+              {session.branch && (
+                <MetaRow label="Branch" isDark={isDark}>
+                  <span class="truncate block font-mono text-[11px]">{session.branch}</span>
+                </MetaRow>
+              )}
+              {session.prUrl && (
+                <MetaRow label="PR" isDark={isDark}>
+                  <div onClick={(e: Event) => e.stopPropagation()}>
+                    <PrLink prUrl={session.prUrl} />
+                  </div>
+                </MetaRow>
+              )}
+              {session.mode && (
+                <MetaRow label="Mode" isDark={isDark}>
+                  {session.mode}
+                </MetaRow>
+              )}
+              <MetaRow label="Created" isDark={isDark}>
+                {formatRelativeTime(session.createdAt)}
+              </MetaRow>
+              <MetaRow label="Updated" isDark={isDark}>
+                {formatRelativeTime(session.updatedAt)}
+              </MetaRow>
+            </div>
+
+            <div class="px-4 py-3 flex flex-wrap gap-2">
+              {isRebaseConflict && onRetryRebase && dagMatch && (
+                <button
+                  onClick={() => onRetryRebase!(dagMatch.dag.id, dagMatch.node.id)}
+                  class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-3 text-sm font-medium rounded-lg transition-colors min-h-[44px] ${isDark ? 'bg-amber-600 hover:bg-amber-700 text-white' : 'bg-amber-500 hover:bg-amber-600 text-white'}`}
+                  data-testid="node-detail-retry-rebase-btn"
+                >
+                  <span>Retry Rebase</span>
+                </button>
+              )}
+              {hasChatAction && (
+                <button
+                  onClick={() => onOpenChat!(session.id)}
+                  class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-3 text-sm font-medium rounded-lg transition-colors min-h-[44px] ${isDark ? 'bg-blue-600 hover:bg-blue-700 text-white' : 'bg-blue-500 hover:bg-blue-600 text-white'}`}
+                >
+                  <span>Open Chat</span>
+                </button>
+              )}
+              {hasLogsAction && (
+                <button
+                  onClick={() => onViewLogs!(session.id)}
+                  class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-3 text-sm font-medium rounded-lg transition-colors min-h-[44px] ${isDark ? 'bg-slate-700 hover:bg-slate-600 text-slate-100' : 'bg-slate-100 hover:bg-slate-200 text-slate-800'}`}
+                  data-testid="node-detail-view-logs-btn"
+                >
+                  <span>View Logs</span>
+                </button>
+              )}
+              {session.prUrl && (
+                <button
+                  onClick={() => window.open(session.prUrl!, '_blank', 'noopener,noreferrer')}
+                  class={`flex-1 min-w-[8rem] flex items-center justify-center gap-2 px-3 py-3 text-sm font-medium rounded-lg transition-colors min-h-[44px] ${isDark ? 'bg-gray-700 hover:bg-gray-600 text-gray-200' : 'bg-gray-100 hover:bg-gray-200 text-gray-800'}`}
+                >
+                  <span>View PR</span>
+                </button>
+              )}
+              {!isRebaseConflict && !hasChatAction && !hasLogsAction && !session.prUrl && (
+                <div class={`flex-1 text-center text-sm py-2 ${mutedText}`}>
+                  No actions available
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div class="fixed inset-0 z-50 flex items-center justify-center">

--- a/src/connections/ConnectionPicker.tsx
+++ b/src/connections/ConnectionPicker.tsx
@@ -71,7 +71,7 @@ export function ConnectionPicker({ onManage }: ConnectionPickerProps) {
         onClick={handleToggle}
         aria-haspopup="listbox"
         aria-expanded={open.value}
-        class="w-full flex items-center gap-1.5 rounded-full border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 sm:px-3 py-1.5 text-sm font-medium text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors min-w-0"
+        class="w-full flex items-center gap-1.5 rounded-full border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 sm:px-4 py-2.5 text-sm font-medium text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors min-w-0 min-h-[44px]"
       >
         {activeConn ? (
           <>
@@ -107,7 +107,7 @@ export function ConnectionPicker({ onManage }: ConnectionPickerProps) {
                   tabIndex={0}
                   data-testid={`picker-option-${conn.id}`}
                   onClick={() => handleSelect(conn.id)}
-                  class={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-700 ${conn.id === activeId.value ? 'font-semibold text-slate-900 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'}`}
+                  class={`w-full flex items-center gap-2 px-3 py-3 text-sm text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-700 min-h-[44px] ${conn.id === activeId.value ? 'font-semibold text-slate-900 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'}`}
                 >
                   <span
                     class="h-2.5 w-2.5 rounded-full shrink-0"
@@ -122,7 +122,7 @@ export function ConnectionPicker({ onManage }: ConnectionPickerProps) {
             <button
               data-testid="picker-manage-btn"
               onClick={handleManage}
-              class="w-full px-3 py-2 text-sm text-left text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
+              class="w-full px-3 py-3 text-sm text-left text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100 transition-colors min-h-[44px]"
             >
               Manage connections
             </button>

--- a/src/connections/ConnectionSettings.tsx
+++ b/src/connections/ConnectionSettings.tsx
@@ -177,16 +177,20 @@ export function ConnectionSettings({ onClose, existing, embedded }: Props) {
                 type="button"
                 data-testid={`swatch-${c}`}
                 onClick={() => { color.value = c; customHex.value = '' }}
-                class="h-6 w-6 rounded-full border-2 transition-transform focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo-500"
-                style={{
-                  backgroundColor: c,
-                  borderColor: color.value === c ? 'white' : 'transparent',
-                  boxShadow: color.value === c ? `0 0 0 2px ${c}` : undefined,
-                  transform: color.value === c ? 'scale(1.15)' : undefined,
-                }}
+                class="min-h-[44px] min-w-[44px] rounded-full border-2 transition-transform focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo-500 flex items-center justify-center"
                 aria-label={`Color ${c}`}
                 aria-pressed={color.value === c}
-              />
+              >
+                <span
+                  class="h-6 w-6 rounded-full block"
+                  style={{
+                    backgroundColor: c,
+                    border: color.value === c ? `2px solid white` : undefined,
+                    boxShadow: color.value === c ? `0 0 0 2px ${c}` : undefined,
+                    transform: color.value === c ? 'scale(1.15)' : undefined,
+                  }}
+                />
+              </button>
             ))}
           </div>
           <div class="flex items-center gap-2">
@@ -250,14 +254,14 @@ export function ConnectionSettings({ onClose, existing, embedded }: Props) {
           <button
             type="button"
             onClick={onClose}
-            class="flex-1 rounded-lg border border-slate-200 dark:border-slate-600 px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700"
+            class="flex-1 rounded-lg border border-slate-200 dark:border-slate-600 px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 min-h-[44px]"
           >
             Cancel
           </button>
           <button
             type="submit"
             disabled={loading.value}
-            class="flex-1 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="flex-1 rounded-lg bg-indigo-600 px-4 py-3 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed min-h-[44px]"
           >
             {loading.value ? 'Connecting…' : existing ? 'Save' : 'Connect'}
           </button>

--- a/src/connections/ConnectionsDrawer.tsx
+++ b/src/connections/ConnectionsDrawer.tsx
@@ -1,11 +1,12 @@
 import { useSignal } from '@preact/signals'
-import { useEffect, useCallback } from 'preact/hooks'
+import { useEffect, useCallback, useRef } from 'preact/hooks'
 import { connections, activeId, removeConnection, setActive } from './store'
 import { confirm } from '../hooks/useConfirm'
 import { ConnectionSettings } from './ConnectionSettings'
 import type { Connection } from './types'
 import { useMediaQuery } from '../hooks/useMediaQuery'
 import { useTheme } from '../hooks/useTheme'
+import { useSwipeToDismiss } from '../hooks/useSwipeToDismiss'
 
 interface ConnectionsDrawerProps {
   onClose: () => void
@@ -19,6 +20,18 @@ export function ConnectionsDrawer({ onClose }: ConnectionsDrawerProps) {
   const isDesktop = useMediaQuery('(min-width: 768px)')
   const panel = useSignal<DrawerPanel>('list')
   const editingConn = useSignal<Connection | null>(null)
+  const drawerRef = useRef<HTMLDivElement>(null)
+  const swipeRef = useSwipeToDismiss({
+    onDismiss: onClose,
+    threshold: 100,
+    enabled: !isDesktop.value,
+  })
+
+  useEffect(() => {
+    if (!isDesktop.value && drawerRef.current) {
+      swipeRef.current = drawerRef.current
+    }
+  }, [isDesktop.value, swipeRef])
 
   const handleClose = useCallback(() => {
     panel.value = 'list'
@@ -172,6 +185,7 @@ export function ConnectionsDrawer({ onClose }: ConnectionsDrawerProps) {
         onClick={handleClose}
       />
       <div
+        ref={drawerRef}
         class={`absolute bottom-0 left-0 right-0 rounded-t-2xl shadow-2xl flex flex-col border-t max-h-[85dvh] ${borderColor} ${panelBg}`}
       >
         <div class="flex justify-center pt-2 pb-1 shrink-0">

--- a/src/connections/ConnectionsDrawer.tsx
+++ b/src/connections/ConnectionsDrawer.tsx
@@ -72,7 +72,7 @@ export function ConnectionsDrawer({ onClose }: ConnectionsDrawerProps) {
           <button
             data-testid="drawer-back-btn"
             onClick={() => { panel.value = 'list'; editingConn.value = null }}
-            class={`mr-1 text-sm ${isDark ? 'text-gray-400 hover:text-white' : 'text-slate-500 hover:text-slate-900'}`}
+            class={`mr-1 text-lg min-w-[44px] min-h-[44px] flex items-center justify-center ${isDark ? 'text-gray-400 hover:text-white' : 'text-slate-500 hover:text-slate-900'}`}
           >
             ←
           </button>
@@ -83,7 +83,7 @@ export function ConnectionsDrawer({ onClose }: ConnectionsDrawerProps) {
         <button
           data-testid="drawer-close-btn"
           onClick={handleClose}
-          class={`w-7 h-7 flex items-center justify-center rounded-full transition-colors ${isDark ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-100 text-slate-500'}`}
+          class={`min-w-[44px] min-h-[44px] flex items-center justify-center rounded-full transition-colors ${isDark ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-100 text-slate-500'}`}
           aria-label="Close drawer"
         >
           <span class="text-lg leading-none">&times;</span>
@@ -111,14 +111,14 @@ export function ConnectionsDrawer({ onClose }: ConnectionsDrawerProps) {
                   <button
                     data-testid={`drawer-edit-${conn.id}`}
                     onClick={() => handleEdit(conn)}
-                    class={`text-xs px-2 py-1 rounded transition-colors ${isDark ? 'text-gray-300 hover:bg-gray-700' : 'text-slate-600 hover:bg-slate-100'}`}
+                    class={`text-xs px-3 py-2.5 rounded transition-colors min-h-[44px] ${isDark ? 'text-gray-300 hover:bg-gray-700' : 'text-slate-600 hover:bg-slate-100'}`}
                   >
                     Edit
                   </button>
                   <button
                     data-testid={`drawer-delete-${conn.id}`}
                     onClick={() => void handleDelete(conn)}
-                    class="text-xs px-2 py-1 rounded transition-colors text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30"
+                    class="text-xs px-3 py-2.5 rounded transition-colors text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30 min-h-[44px]"
                   >
                     Delete
                   </button>

--- a/src/hooks/useSwipeToDismiss.ts
+++ b/src/hooks/useSwipeToDismiss.ts
@@ -1,0 +1,92 @@
+import { useRef, useEffect } from 'preact/hooks'
+
+export interface SwipeToDismissOptions {
+  onDismiss: () => void
+  threshold?: number
+  enabled?: boolean
+}
+
+interface TouchState {
+  startY: number
+  currentY: number
+  isDragging: boolean
+  startTime: number
+}
+
+export function useSwipeToDismiss<T extends HTMLElement = HTMLElement>({
+  onDismiss,
+  threshold = 150,
+  enabled = true,
+}: SwipeToDismissOptions) {
+  const elementRef = useRef<T | null>(null)
+  const stateRef = useRef<TouchState>({
+    startY: 0,
+    currentY: 0,
+    isDragging: false,
+    startTime: 0,
+  })
+
+  useEffect(() => {
+    const element = elementRef.current
+    if (!element || !enabled) return
+
+    const handleTouchStart = (e: TouchEvent) => {
+      const touch = e.touches[0]
+      stateRef.current = {
+        startY: touch.clientY,
+        currentY: touch.clientY,
+        isDragging: true,
+        startTime: Date.now(),
+      }
+    }
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (!stateRef.current.isDragging) return
+
+      const touch = e.touches[0]
+      const deltaY = touch.clientY - stateRef.current.startY
+
+      if (deltaY > 0) {
+        stateRef.current.currentY = touch.clientY
+        const translateY = Math.min(deltaY, threshold * 2)
+        element.style.transform = `translateY(${translateY}px)`
+        element.style.transition = 'none'
+      }
+    }
+
+    const handleTouchEnd = () => {
+      if (!stateRef.current.isDragging) return
+
+      const deltaY = stateRef.current.currentY - stateRef.current.startY
+      const duration = Date.now() - stateRef.current.startTime
+      const velocity = Math.abs(deltaY) / duration
+
+      element.style.transition = 'transform 0.3s ease-out'
+
+      if (deltaY > threshold || velocity > 0.5) {
+        element.style.transform = `translateY(100%)`
+        setTimeout(() => {
+          onDismiss()
+        }, 300)
+      } else {
+        element.style.transform = 'translateY(0)'
+      }
+
+      stateRef.current.isDragging = false
+    }
+
+    element.addEventListener('touchstart', handleTouchStart, { passive: true })
+    element.addEventListener('touchmove', handleTouchMove, { passive: true })
+    element.addEventListener('touchend', handleTouchEnd)
+    element.addEventListener('touchcancel', handleTouchEnd)
+
+    return () => {
+      element.removeEventListener('touchstart', handleTouchStart)
+      element.removeEventListener('touchmove', handleTouchMove)
+      element.removeEventListener('touchend', handleTouchEnd)
+      element.removeEventListener('touchcancel', handleTouchEnd)
+    }
+  }, [enabled, threshold, onDismiss])
+
+  return elementRef
+}

--- a/test/accessibility/touch-targets.test.tsx
+++ b/test/accessibility/touch-targets.test.tsx
@@ -1,0 +1,208 @@
+import { render, screen, waitFor } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { signal } from '@preact/signals'
+import { useState } from 'preact/hooks'
+import { MessageInput } from '../../src/chat/MessageInput'
+import { ConnectionsDrawer } from '../../src/connections/ConnectionsDrawer'
+import { ConnectionPicker } from '../../src/connections/ConnectionPicker'
+import { QuickActionsBar } from '../../src/chat/QuickActionsBar'
+import { NodeDetailPopup } from '../../src/components/NodeDetailPopup'
+import { ConnectionSettings } from '../../src/connections/ConnectionSettings'
+import type { ApiSession, QuickAction } from '../../src/api/types'
+import type { ConnectionStore } from '../../src/state/types'
+
+beforeEach(() => {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    })
+  }
+})
+
+const MIN_TOUCH_TARGET = 44
+
+function assertMinTouchTarget(el: HTMLElement, name: string) {
+  const classNames = el.className
+  const hasMinHeight = classNames.includes('min-h-[44px]') || classNames.includes('min-h-11')
+  const hasMinWidth = classNames.includes('min-w-[44px]') || classNames.includes('min-w-11')
+
+  const paddingMatch = classNames.match(/py-(\d+(?:\.\d+)?)/)?.[1]
+  const hasSufficientPadding = paddingMatch && parseFloat(paddingMatch) >= 2.5
+
+  const hasValidTouchTarget = hasMinHeight || (hasMinWidth && hasSufficientPadding)
+
+  expect(
+    hasValidTouchTarget,
+    `${name} should have min-h-[44px] or equivalent touch target classes. Classes: ${classNames}`,
+  ).toBe(true)
+}
+
+describe('Touch Target Accessibility', () => {
+  describe('MessageInput', () => {
+    const mockSession: ApiSession = {
+      id: 's1',
+      slug: 'test',
+      status: 'running',
+      command: '/task foo',
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+      childIds: [],
+      needsAttention: false,
+      attentionReasons: [],
+      quickActions: [],
+      mode: 'task',
+      conversation: [],
+    }
+
+    const mockStore = {
+      version: signal({ apiVersion: '2.0.0', libraryVersion: '0.1.0', features: ['sessions-create-images'] as string[] }),
+    } as unknown as ConnectionStore
+
+    function Controlled() {
+      const [text, setText] = useState('')
+      return <MessageInput session={mockSession} store={mockStore} onSend={vi.fn()} value={text} onValueChange={setText} />
+    }
+
+    it('Send button meets 44px minimum touch target', () => {
+      render(<Controlled />)
+      const sendBtn = screen.getByTestId('send-btn')
+      assertMinTouchTarget(sendBtn, 'Send button')
+    })
+
+    it('Attach button meets 44px minimum touch target', () => {
+      render(<Controlled />)
+      const attachBtn = screen.getByTestId('attach-btn')
+      assertMinTouchTarget(attachBtn, 'Attach button')
+    })
+  })
+
+  describe('ConnectionsDrawer', () => {
+    it('Close button meets 44px minimum touch target', () => {
+      render(<ConnectionsDrawer onClose={vi.fn()} />)
+      const closeBtn = screen.getByTestId('drawer-close-btn')
+      assertMinTouchTarget(closeBtn, 'Drawer close button')
+    })
+
+    it('Back button meets 44px minimum touch target when visible', async () => {
+      render(<ConnectionsDrawer onClose={vi.fn()} />)
+      const addBtn = screen.getByTestId('drawer-add-btn')
+      addBtn.click()
+      await waitFor(() => {
+        const backBtn = screen.getByTestId('drawer-back-btn')
+        assertMinTouchTarget(backBtn, 'Drawer back button')
+      })
+    })
+  })
+
+  describe('ConnectionPicker', () => {
+    it('Trigger button meets 44px minimum touch target', () => {
+      render(<ConnectionPicker onManage={vi.fn()} />)
+      const trigger = screen.getByTestId('connection-picker-trigger')
+      assertMinTouchTarget(trigger, 'Connection picker trigger')
+    })
+  })
+
+  describe('QuickActionsBar', () => {
+    const mockSession: ApiSession = {
+      id: 's1',
+      slug: 'test',
+      status: 'running',
+      command: '/task foo',
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+      childIds: [],
+      needsAttention: false,
+      attentionReasons: [],
+      quickActions: [
+        { type: 'approve', label: 'Approve', message: '/approve' },
+        { type: 'reject', label: 'Reject', message: '/reject' },
+      ] as QuickAction[],
+      mode: 'task',
+      conversation: [],
+    }
+
+    it('Quick action buttons meet 44px minimum touch target', () => {
+      render(<QuickActionsBar session={mockSession} onAction={vi.fn()} />)
+      const buttons = screen.getAllByRole('button')
+      buttons.forEach((btn, i) => {
+        assertMinTouchTarget(btn, `Quick action button ${i}`)
+      })
+    })
+
+    it('Ship advance button meets 44px minimum touch target', () => {
+      const shipSession: ApiSession = {
+        ...mockSession,
+        mode: 'ship',
+        stage: 'think',
+      }
+      render(<QuickActionsBar session={shipSession} onAction={vi.fn()} onShipAdvance={vi.fn()} />)
+      const advanceBtn = screen.getByTestId('ship-advance-btn')
+      assertMinTouchTarget(advanceBtn, 'Ship advance button')
+    })
+  })
+
+  describe('NodeDetailPopup', () => {
+    const mockSession: ApiSession = {
+      id: 's1',
+      slug: 'test-session',
+      status: 'completed',
+      command: '/task test',
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+      childIds: [],
+      needsAttention: false,
+      attentionReasons: [],
+      quickActions: [],
+      mode: 'task',
+      conversation: [],
+      prUrl: 'https://github.com/test/test/pull/1',
+    }
+
+    it('Close button meets 44px minimum touch target', () => {
+      render(<NodeDetailPopup session={mockSession} onClose={vi.fn()} />)
+      const dialog = screen.getByRole('dialog')
+      const closeBtn = dialog.querySelector('[aria-label="Close"]') as HTMLElement
+      expect(closeBtn).toBeTruthy()
+      assertMinTouchTarget(closeBtn, 'Popup close button')
+    })
+
+    it('Action buttons meet 44px minimum touch target', () => {
+      render(<NodeDetailPopup session={mockSession} onClose={vi.fn()} onOpenChat={vi.fn()} onViewLogs={vi.fn()} />)
+      const buttons = screen.getAllByRole('button').filter(btn =>
+        btn.textContent?.includes('Open Chat') ||
+        btn.textContent?.includes('View Logs') ||
+        btn.textContent?.includes('View PR')
+      )
+      buttons.forEach((btn) => {
+        assertMinTouchTarget(btn, `${btn.textContent} button`)
+      })
+    })
+  })
+
+  describe('ConnectionSettings', () => {
+    it('Submit and Cancel buttons meet 44px minimum touch target', () => {
+      render(<ConnectionSettings onClose={vi.fn()} />)
+      const buttons = screen.getAllByRole('button')
+      const submitBtn = buttons.find(btn => btn.textContent === 'Connect')
+      const cancelBtn = buttons.find(btn => btn.textContent === 'Cancel')
+      expect(submitBtn).toBeTruthy()
+      expect(cancelBtn).toBeTruthy()
+      assertMinTouchTarget(submitBtn!, 'Submit button')
+      assertMinTouchTarget(cancelBtn!, 'Cancel button')
+    })
+
+    it('Color swatch buttons meet 44px minimum touch target', () => {
+      render(<ConnectionSettings onClose={vi.fn()} />)
+      const swatchContainer = screen.getByTestId('color-swatches')
+      const swatches = swatchContainer.querySelectorAll('button')
+      swatches.forEach((swatch, i) => {
+        assertMinTouchTarget(swatch, `Color swatch ${i}`)
+      })
+    })
+  })
+})

--- a/test/accessibility/touch-targets.test.tsx
+++ b/test/accessibility/touch-targets.test.tsx
@@ -24,8 +24,6 @@ beforeEach(() => {
   }
 })
 
-const MIN_TOUCH_TARGET = 44
-
 function assertMinTouchTarget(el: HTMLElement, name: string) {
   const classNames = el.className
   const hasMinHeight = classNames.includes('min-h-[44px]') || classNames.includes('min-h-11')
@@ -119,9 +117,9 @@ describe('Touch Target Accessibility', () => {
       needsAttention: false,
       attentionReasons: [],
       quickActions: [
-        { type: 'approve', label: 'Approve', message: '/approve' },
-        { type: 'reject', label: 'Reject', message: '/reject' },
-      ] as QuickAction[],
+        { type: 'retry', label: 'Retry', message: '/retry' },
+        { type: 'resume', label: 'Resume', message: '/resume' },
+      ] satisfies QuickAction[],
       mode: 'task',
       conversation: [],
     }

--- a/test/components/NodeDetailPopup.test.tsx
+++ b/test/components/NodeDetailPopup.test.tsx
@@ -578,3 +578,53 @@ describe('NodeDetailPopup hierarchy metadata', () => {
     expect(document.querySelector('[data-testid="node-detail-rebase-error"]')).toBeFalsy()
   })
 })
+
+describe('NodeDetailPopup mobile bottom sheet', () => {
+  const originalMatchMedia = window.matchMedia
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(max-width: 767px)',
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  })
+
+  afterEach(() => {
+    cleanup()
+    window.matchMedia = originalMatchMedia
+  })
+
+  it('renders as bottom sheet on mobile', () => {
+    const session = makeSession()
+    render(<NodeDetailPopup session={session} onClose={vi.fn()} />)
+    const sheet = document.querySelector('.absolute.bottom-0.left-0.right-0')
+    expect(sheet).toBeTruthy()
+    expect(sheet!.className).toContain('rounded-t-2xl')
+  })
+
+  it('shows drag handle on mobile', () => {
+    const session = makeSession()
+    render(<NodeDetailPopup session={session} onClose={vi.fn()} />)
+    const handle = document.querySelector('.w-10.h-1.rounded-full')
+    expect(handle).toBeTruthy()
+  })
+
+  it('renders as centered modal on desktop', () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query !== '(max-width: 767px)',
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+
+    const session = makeSession()
+    const { container } = render(<NodeDetailPopup session={session} onClose={vi.fn()} />)
+    const modal = container.querySelector('.flex.items-center.justify-center')
+    expect(modal).toBeTruthy()
+    const handle = container.querySelector('.w-10.h-1.rounded-full')
+    expect(handle).toBeFalsy()
+  })
+})

--- a/test/connections/ConnectionsDrawer.test.tsx
+++ b/test/connections/ConnectionsDrawer.test.tsx
@@ -101,4 +101,36 @@ describe('ConnectionsDrawer', () => {
     fireEvent.click(screen.getByTestId('drawer-close-btn'))
     expect(onClose).toHaveBeenCalled()
   })
+
+  it('renders with drag handle on mobile', async () => {
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(max-width: 767px)',
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+
+    await setup()
+    const handle = document.querySelector('.w-10.h-1.rounded-full')
+    expect(handle).toBeTruthy()
+
+    window.matchMedia = originalMatchMedia
+  })
+
+  it('renders as sidebar on desktop without drag handle', async () => {
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query !== '(max-width: 767px)',
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+
+    await setup()
+    const handle = document.querySelector('.w-10.h-1.rounded-full')
+    expect(handle).toBeFalsy()
+
+    window.matchMedia = originalMatchMedia
+  })
 })

--- a/test/hooks/useSwipeToDismiss.test.tsx
+++ b/test/hooks/useSwipeToDismiss.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/preact'
+import { useSwipeToDismiss } from '../../src/hooks/useSwipeToDismiss'
+
+function TestComponent({
+  onDismiss,
+  threshold,
+  enabled = true,
+}: {
+  onDismiss: () => void
+  threshold?: number
+  enabled?: boolean
+}) {
+  const ref = useSwipeToDismiss<HTMLDivElement>({ onDismiss, threshold, enabled })
+  return <div ref={ref} data-testid="swipeable" />
+}
+
+describe('useSwipeToDismiss', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('attaches event listeners to the element', () => {
+    const onDismiss = vi.fn()
+    render(<TestComponent onDismiss={onDismiss} />)
+    const el = document.querySelector('[data-testid="swipeable"]') as HTMLElement
+    expect(el).toBeTruthy()
+  })
+
+  it('triggers onDismiss when swiped down beyond threshold', () => {
+    const onDismiss = vi.fn()
+    const threshold = 100
+    render(<TestComponent onDismiss={onDismiss} threshold={threshold} />)
+    const el = document.querySelector('[data-testid="swipeable"]') as HTMLElement
+
+    const touchStart = new TouchEvent('touchstart', {
+      touches: [{ clientY: 100 } as Touch],
+    })
+    const touchMove = new TouchEvent('touchmove', {
+      touches: [{ clientY: 250 } as Touch],
+    })
+    const touchEnd = new TouchEvent('touchend', {
+      touches: [],
+    })
+
+    el.dispatchEvent(touchStart)
+    el.dispatchEvent(touchMove)
+    el.dispatchEvent(touchEnd)
+
+    expect(el.style.transform).toBe('translateY(100%)')
+    vi.advanceTimersByTime(300)
+    expect(onDismiss).toHaveBeenCalled()
+  })
+
+  it('snaps back when swipe does not exceed threshold', () => {
+    const onDismiss = vi.fn()
+    const threshold = 150
+    render(<TestComponent onDismiss={onDismiss} threshold={threshold} />)
+    const el = document.querySelector('[data-testid="swipeable"]') as HTMLElement
+
+    const touchStart = new TouchEvent('touchstart', {
+      touches: [{ clientY: 100 } as Touch],
+    })
+
+    el.dispatchEvent(touchStart)
+
+    vi.advanceTimersByTime(200)
+
+    const touchMove = new TouchEvent('touchmove', {
+      touches: [{ clientY: 180 } as Touch],
+    })
+    const touchEnd = new TouchEvent('touchend', {
+      touches: [],
+    })
+
+    el.dispatchEvent(touchMove)
+    el.dispatchEvent(touchEnd)
+
+    expect(el.style.transform).toBe('translateY(0)')
+    vi.advanceTimersByTime(300)
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('triggers onDismiss with high velocity even below threshold', () => {
+    const onDismiss = vi.fn()
+    const threshold = 150
+    render(<TestComponent onDismiss={onDismiss} threshold={threshold} />)
+    const el = document.querySelector('[data-testid="swipeable"]') as HTMLElement
+
+    const touchStart = new TouchEvent('touchstart', {
+      touches: [{ clientY: 100 } as Touch],
+    })
+
+    el.dispatchEvent(touchStart)
+
+    vi.advanceTimersByTime(50)
+
+    const touchMove = new TouchEvent('touchmove', {
+      touches: [{ clientY: 150 } as Touch],
+    })
+    const touchEnd = new TouchEvent('touchend', {
+      touches: [],
+    })
+
+    el.dispatchEvent(touchMove)
+    el.dispatchEvent(touchEnd)
+
+    expect(el.style.transform).toBe('translateY(100%)')
+    vi.advanceTimersByTime(300)
+    expect(onDismiss).toHaveBeenCalled()
+  })
+
+  it('does not attach listeners when enabled is false', () => {
+    const onDismiss = vi.fn()
+    render(<TestComponent onDismiss={onDismiss} enabled={false} />)
+    const el = document.querySelector('[data-testid="swipeable"]') as HTMLElement
+
+    const touchStart = new TouchEvent('touchstart', {
+      touches: [{ clientY: 100 } as Touch],
+    })
+    const touchMove = new TouchEvent('touchmove', {
+      touches: [{ clientY: 250 } as Touch],
+    })
+    const touchEnd = new TouchEvent('touchend', {
+      touches: [],
+    })
+
+    el.dispatchEvent(touchStart)
+    el.dispatchEvent(touchMove)
+    el.dispatchEvent(touchEnd)
+
+    vi.advanceTimersByTime(300)
+    expect(onDismiss).not.toHaveBeenCalled()
+    expect(el.style.transform).toBe('')
+  })
+
+  it('does not respond to upward swipes', () => {
+    const onDismiss = vi.fn()
+    render(<TestComponent onDismiss={onDismiss} threshold={100} />)
+    const el = document.querySelector('[data-testid="swipeable"]') as HTMLElement
+
+    const touchStart = new TouchEvent('touchstart', {
+      touches: [{ clientY: 200 } as Touch],
+    })
+    const touchMove = new TouchEvent('touchmove', {
+      touches: [{ clientY: 50 } as Touch],
+    })
+    const touchEnd = new TouchEvent('touchend', {
+      touches: [],
+    })
+
+    el.dispatchEvent(touchStart)
+    el.dispatchEvent(touchMove)
+    el.dispatchEvent(touchEnd)
+
+    vi.advanceTimersByTime(300)
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('handles touchcancel like touchend', () => {
+    const onDismiss = vi.fn()
+    render(<TestComponent onDismiss={onDismiss} threshold={100} />)
+    const el = document.querySelector('[data-testid="swipeable"]') as HTMLElement
+
+    const touchStart = new TouchEvent('touchstart', {
+      touches: [{ clientY: 100 } as Touch],
+    })
+    const touchMove = new TouchEvent('touchmove', {
+      touches: [{ clientY: 250 } as Touch],
+    })
+    const touchCancel = new TouchEvent('touchcancel', {
+      touches: [],
+    })
+
+    el.dispatchEvent(touchStart)
+    el.dispatchEvent(touchMove)
+    el.dispatchEvent(touchCancel)
+
+    expect(el.style.transform).toBe('translateY(100%)')
+    vi.advanceTimersByTime(300)
+    expect(onDismiss).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Implements swipe-to-dismiss gestures for mobile modals to improve native app-like UX:

- **NodeDetailPopup**: Converts from centered modal to bottom sheet on mobile (<768px) with swipe-to-dismiss
- **ConnectionsDrawer**: Adds swipe-to-dismiss to existing mobile bottom sheet
- **useSwipeToDismiss hook**: Reusable gesture handler with threshold (150px) and velocity (0.5px/ms) detection

Builds on mobile touch target improvements from previous task.

## Test plan

- [x] Unit tests pass (878 tests, including 7 new gesture tests)
- [x] ESLint passes
- [x] TypeScript compiles (pre-existing type def warnings unrelated)
- [x] Gesture hook tests cover:
  - Swipe beyond threshold triggers dismiss
  - Swipe below threshold snaps back
  - High velocity dismisses even below threshold
  - Upward swipes ignored
  - Disabled state works correctly
  - Touch cancel handled like touch end
- [x] Component tests verify mobile/desktop rendering variants
- [ ] Manual test: Open NodeDetailPopup on mobile, swipe down to dismiss
- [ ] Manual test: Open ConnectionsDrawer on mobile, swipe down to dismiss
- [ ] Manual test: Desktop modals still work as centered overlays

🤖 Generated with [Claude Code](https://claude.com/claude-code)