### PR TITLE
feat(ui): add status pills and unread indicators to ConnectionPicker

### DIFF
--- a/src/connections/ConnectionPicker.tsx
+++ b/src/connections/ConnectionPicker.tsx
@@ -1,9 +1,10 @@
-import { useSignal } from '@preact/signals'
+import { useSignal, useComputed } from '@preact/signals'
 import { useEffect, useRef, useCallback } from 'preact/hooks'
-import { connections, activeId, setActive } from './store'
+import { connections, activeId, setActive, getAllStores } from './store'
 import { useMediaQuery } from '../hooks/useMediaQuery'
 import { useSwipeToDismiss } from '../hooks/useSwipeToDismiss'
 import { useHaptics } from '../hooks/useHaptics'
+import { computeConnectionStats, type ConnectionStats } from './stats'
 
 interface ConnectionPickerProps {
   onManage: () => void
@@ -17,6 +18,21 @@ export function ConnectionPicker({ onManage }: ConnectionPickerProps) {
   const isDesktop = useMediaQuery('(min-width: 768px)')
   const activeConn = connections.value.find((c) => c.id === activeId.value) ?? null
   const { vibrate } = useHaptics()
+
+  const connectionStats = useComputed<Map<string, ConnectionStats>>(() => {
+    const stores = getAllStores()
+    const statsMap = new Map<string, ConnectionStats>()
+    for (const conn of connections.value) {
+      const store = stores.get(conn.id)
+      if (store) {
+        statsMap.set(
+          conn.id,
+          computeConnectionStats(store.sessions.value, store.dags.value),
+        )
+      }
+    }
+    return statsMap
+  })
 
   const handleClose = useCallback(() => {
     open.value = false
@@ -92,6 +108,8 @@ export function ConnectionPicker({ onManage }: ConnectionPickerProps) {
     return () => document.removeEventListener('keydown', handler)
   }, [open.value, open, isDesktop.value])
 
+  const activeStats = activeConn ? connectionStats.value.get(activeConn.id) : null
+
   const triggerButton = (
     <button
       data-testid="connection-picker-trigger"
@@ -102,11 +120,20 @@ export function ConnectionPicker({ onManage }: ConnectionPickerProps) {
     >
       {activeConn ? (
         <>
-          <span
-            class="h-2.5 w-2.5 rounded-full shrink-0"
-            style={{ backgroundColor: activeConn.color }}
-            data-testid="picker-active-dot"
-          />
+          <span class="relative shrink-0">
+            <span
+              class="h-2.5 w-2.5 rounded-full block"
+              style={{ backgroundColor: activeConn.color }}
+              data-testid="picker-active-dot"
+            />
+            {activeStats && activeStats.unreadCount > 0 && (
+              <span
+                class="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-red-500 ring-1 ring-white dark:ring-slate-800"
+                data-testid="picker-trigger-unread"
+                aria-label={`${activeStats.unreadCount} unread`}
+              />
+            )}
+          </span>
           <span class="flex-1 min-w-0 truncate text-left">{activeConn.label}</span>
         </>
       ) : (
@@ -123,24 +150,54 @@ export function ConnectionPicker({ onManage }: ConnectionPickerProps) {
       aria-label="Connections"
       class={isDesktop.value ? 'max-h-64 overflow-y-auto' : ''}
     >
-      {connections.value.map((conn) => (
-        <li key={conn.id}>
-          <button
-            role="option"
-            aria-selected={conn.id === activeId.value}
-            tabIndex={0}
-            data-testid={`picker-option-${conn.id}`}
-            onClick={() => handleSelect(conn.id)}
-            class={`w-full flex items-center gap-2 px-3 py-3 text-sm text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-700 min-h-[44px] ${conn.id === activeId.value ? 'font-semibold text-slate-900 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'}`}
-          >
-            <span
-              class="h-2.5 w-2.5 rounded-full shrink-0"
-              style={{ backgroundColor: conn.color }}
-            />
-            <span class="truncate">{conn.label}</span>
-          </button>
-        </li>
-      ))}
+      {connections.value.map((conn) => {
+        const stats = connectionStats.value.get(conn.id)
+        return (
+          <li key={conn.id}>
+            <button
+              role="option"
+              aria-selected={conn.id === activeId.value}
+              tabIndex={0}
+              data-testid={`picker-option-${conn.id}`}
+              onClick={() => handleSelect(conn.id)}
+              class={`w-full flex items-center gap-2 px-3 py-3 text-sm text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-700 min-h-[44px] ${conn.id === activeId.value ? 'font-semibold text-slate-900 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'}`}
+            >
+              <span class="relative shrink-0">
+                <span
+                  class="h-2.5 w-2.5 rounded-full block"
+                  style={{ backgroundColor: conn.color }}
+                />
+                {stats && stats.unreadCount > 0 && (
+                  <span
+                    class="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-red-500 ring-1 ring-white dark:ring-slate-800"
+                    data-testid={`picker-unread-${conn.id}`}
+                    aria-label={`${stats.unreadCount} unread`}
+                  />
+                )}
+              </span>
+              <span class="truncate flex-1 min-w-0">{conn.label}</span>
+              {stats?.dagProgress && (
+                <span
+                  class="shrink-0 flex items-center gap-1 text-[10px] tabular-nums text-slate-500 dark:text-slate-400"
+                  data-testid={`picker-dag-stats-${conn.id}`}
+                >
+                  <span class="text-green-600 dark:text-green-400">{stats.dagProgress.done}</span>
+                  <span>/</span>
+                  <span>{stats.dagProgress.total}</span>
+                  {stats.dagProgress.failed > 0 && (
+                    <>
+                      <span class="mx-0.5">·</span>
+                      <span class="text-red-600 dark:text-red-400">
+                        {stats.dagProgress.failed} failed
+                      </span>
+                    </>
+                  )}
+                </span>
+              )}
+            </button>
+          </li>
+        )
+      })}
     </ul>
   )
 

--- a/src/connections/stats.ts
+++ b/src/connections/stats.ts
@@ -1,0 +1,52 @@
+import type { ApiDagGraph, ApiSession } from '../api/types'
+
+export interface ConnectionStats {
+  unreadCount: number
+  dagProgress: DagProgress | null
+}
+
+export interface DagProgress {
+  done: number
+  total: number
+  failed: number
+  running: number
+}
+
+export function computeConnectionStats(
+  sessions: ApiSession[],
+  dags: ApiDagGraph[],
+): ConnectionStats {
+  const unreadCount = sessions.filter((s) => s.needsAttention).length
+
+  let totalDagNodes = 0
+  let doneDagNodes = 0
+  let failedDagNodes = 0
+  let runningDagNodes = 0
+
+  for (const dag of dags) {
+    const nodes = Object.values(dag.nodes)
+    totalDagNodes += nodes.length
+    doneDagNodes += nodes.filter((n) => n.status === 'completed' || n.status === 'landed').length
+    failedDagNodes += nodes.filter(
+      (n) => n.status === 'failed' || n.status === 'ci-failed',
+    ).length
+    runningDagNodes += nodes.filter(
+      (n) =>
+        n.status === 'running' ||
+        n.status === 'ci-pending' ||
+        n.status === 'rebasing',
+    ).length
+  }
+
+  const dagProgress: DagProgress | null =
+    totalDagNodes > 0
+      ? {
+          done: doneDagNodes,
+          total: totalDagNodes,
+          failed: failedDagNodes,
+          running: runningDagNodes,
+        }
+      : null
+
+  return { unreadCount, dagProgress }
+}

--- a/src/connections/store.ts
+++ b/src/connections/store.ts
@@ -101,6 +101,10 @@ export function getActiveStore(): ConnectionStore | null {
   return getOrCreateStore(id)
 }
 
+export function getAllStores(): Map<string, ConnectionStore> {
+  return storeCache
+}
+
 export function disposeAll(): void {
   for (const store of storeCache.values()) {
     store.dispose()

--- a/test/connections/ConnectionPicker.stats.test.tsx
+++ b/test/connections/ConnectionPicker.stats.test.tsx
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { signal } from '@preact/signals'
+import { ConnectionPicker } from '../../src/connections/ConnectionPicker'
+import * as store from '../../src/connections/store'
+import type { Connection } from '../../src/connections/types'
+import type { ConnectionStore } from '../../src/state/types'
+import type { ApiSession, ApiDagGraph, ApiDagNode } from '../../src/api/types'
+
+vi.mock('../../src/connections/store', () => ({
+  connections: signal<Connection[]>([]),
+  activeId: signal<string | null>(null),
+  setActive: vi.fn(),
+  getAllStores: vi.fn(() => new Map()),
+}))
+
+vi.mock('../../src/hooks/useMediaQuery', () => ({
+  useMediaQuery: () => signal(true),
+}))
+
+vi.mock('../../src/hooks/useSwipeToDismiss', () => ({
+  useSwipeToDismiss: () => ({ current: null }),
+}))
+
+vi.mock('../../src/hooks/useHaptics', () => ({
+  useHaptics: () => ({ vibrate: vi.fn() }),
+}))
+
+function createMockConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'conn-1',
+    label: 'Test Connection',
+    baseUrl: 'http://localhost:8080',
+    token: 'token',
+    color: '#3b82f6',
+    ...overrides,
+  }
+}
+
+function createMockSession(overrides: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 'session-1',
+    slug: 'test',
+    status: 'running',
+    command: '/task test',
+    mode: 'task',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    conversation: [],
+    ...overrides,
+  }
+}
+
+function createMockDagNode(overrides: Partial<ApiDagNode> = {}): ApiDagNode {
+  return {
+    id: 'node-1',
+    slug: 'node-1',
+    status: 'pending',
+    dependencies: [],
+    dependents: [],
+    ...overrides,
+  }
+}
+
+function createMockDag(overrides: Partial<ApiDagGraph> = {}): ApiDagGraph {
+  return {
+    id: 'dag-1',
+    rootTaskId: 'root-1',
+    nodes: {},
+    status: 'pending',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function createMockStore(
+  sessions: ApiSession[],
+  dags: ApiDagGraph[],
+): Partial<ConnectionStore> {
+  return {
+    sessions: signal(sessions) as ConnectionStore['sessions'],
+    dags: signal(dags) as ConnectionStore['dags'],
+  }
+}
+
+describe('ConnectionPicker status indicators', () => {
+  let connectionsSignal: ReturnType<typeof signal<Connection[]>>
+  let activeIdSignal: ReturnType<typeof signal<string | null>>
+
+  beforeEach(() => {
+    connectionsSignal = signal<Connection[]>([])
+    activeIdSignal = signal<string | null>(null)
+    ;(vi.mocked(store).connections as typeof connectionsSignal) = connectionsSignal
+    ;(vi.mocked(store).activeId as typeof activeIdSignal) = activeIdSignal
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows unread indicator on active connection trigger when attention is needed', () => {
+    const conn = createMockConnection()
+    connectionsSignal.value = [conn]
+    activeIdSignal.value = conn.id
+
+    const mockStore = createMockStore(
+      [createMockSession({ needsAttention: true, attentionReasons: ['failed'] })],
+      [],
+    )
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([[conn.id, mockStore as ConnectionStore]]),
+    )
+
+    render(<ConnectionPicker onManage={vi.fn()} />)
+
+    const unreadDot = screen.getByTestId('picker-trigger-unread')
+    expect(unreadDot).toBeTruthy()
+    expect(unreadDot.getAttribute('aria-label')).toBe('1 unread')
+  })
+
+  it('hides unread indicator when no attention needed', () => {
+    const conn = createMockConnection()
+    connectionsSignal.value = [conn]
+    activeIdSignal.value = conn.id
+
+    const mockStore = createMockStore([createMockSession()], [])
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([[conn.id, mockStore as ConnectionStore]]),
+    )
+
+    render(<ConnectionPicker onManage={vi.fn()} />)
+
+    expect(screen.queryByTestId('picker-trigger-unread')).toBeFalsy()
+  })
+
+  it('shows DAG stats in connection list when DAGs exist', () => {
+    const conn = createMockConnection()
+    connectionsSignal.value = [conn]
+    activeIdSignal.value = null
+
+    const dag = createMockDag({
+      nodes: {
+        'node-1': createMockDagNode({ status: 'completed' }),
+        'node-2': createMockDagNode({ status: 'running' }),
+        'node-3': createMockDagNode({ status: 'pending' }),
+      },
+    })
+
+    const mockStore = createMockStore([], [dag])
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([[conn.id, mockStore as ConnectionStore]]),
+    )
+
+    render(<ConnectionPicker onManage={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('connection-picker-trigger'))
+
+    const dagStats = screen.getByTestId(`picker-dag-stats-${conn.id}`)
+    expect(dagStats.textContent).toContain('1')
+    expect(dagStats.textContent).toContain('/3')
+  })
+
+  it('shows failed count in DAG stats when failures exist', () => {
+    const conn = createMockConnection()
+    connectionsSignal.value = [conn]
+    activeIdSignal.value = null
+
+    const dag = createMockDag({
+      nodes: {
+        'node-1': createMockDagNode({ status: 'completed' }),
+        'node-2': createMockDagNode({ status: 'failed' }),
+        'node-3': createMockDagNode({ status: 'ci-failed' }),
+        'node-4': createMockDagNode({ status: 'pending' }),
+      },
+    })
+
+    const mockStore = createMockStore([], [dag])
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([[conn.id, mockStore as ConnectionStore]]),
+    )
+
+    render(<ConnectionPicker onManage={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('connection-picker-trigger'))
+
+    const dagStats = screen.getByTestId(`picker-dag-stats-${conn.id}`)
+    expect(dagStats.textContent).toContain('1/4')
+    expect(dagStats.textContent).toContain('2 failed')
+  })
+
+  it('hides DAG stats when no DAGs exist', () => {
+    const conn = createMockConnection()
+    connectionsSignal.value = [conn]
+    activeIdSignal.value = null
+
+    const mockStore = createMockStore([], [])
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([[conn.id, mockStore as ConnectionStore]]),
+    )
+
+    render(<ConnectionPicker onManage={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('connection-picker-trigger'))
+
+    expect(screen.queryByTestId(`picker-dag-stats-${conn.id}`)).toBeFalsy()
+  })
+
+  it('shows unread indicator in connection list', () => {
+    const conn = createMockConnection()
+    connectionsSignal.value = [conn]
+    activeIdSignal.value = null
+
+    const mockStore = createMockStore(
+      [
+        createMockSession({ needsAttention: true, attentionReasons: ['failed'] }),
+        createMockSession({
+          id: 'session-2',
+          needsAttention: true,
+          attentionReasons: ['interrupted'],
+        }),
+      ],
+      [],
+    )
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([[conn.id, mockStore as ConnectionStore]]),
+    )
+
+    render(<ConnectionPicker onManage={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('connection-picker-trigger'))
+
+    const unreadDot = screen.getByTestId(`picker-unread-${conn.id}`)
+    expect(unreadDot).toBeTruthy()
+    expect(unreadDot.getAttribute('aria-label')).toBe('2 unread')
+  })
+
+  it('shows both unread and DAG stats for a connection', () => {
+    const conn = createMockConnection()
+    connectionsSignal.value = [conn]
+    activeIdSignal.value = null
+
+    const dag = createMockDag({
+      nodes: {
+        'node-1': createMockDagNode({ status: 'completed' }),
+        'node-2': createMockDagNode({ status: 'failed' }),
+      },
+    })
+
+    const mockStore = createMockStore(
+      [createMockSession({ needsAttention: true, attentionReasons: ['ci_fix'] })],
+      [dag],
+    )
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([[conn.id, mockStore as ConnectionStore]]),
+    )
+
+    render(<ConnectionPicker onManage={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('connection-picker-trigger'))
+
+    expect(screen.getByTestId(`picker-unread-${conn.id}`)).toBeTruthy()
+    const dagStats = screen.getByTestId(`picker-dag-stats-${conn.id}`)
+    expect(dagStats.textContent).toContain('1/2')
+    expect(dagStats.textContent).toContain('1 failed')
+  })
+
+  it('updates stats when store signals change', () => {
+    const conn = createMockConnection()
+    connectionsSignal.value = [conn]
+    activeIdSignal.value = conn.id
+
+    const sessionsSignal = signal<ApiSession[]>([])
+    const dagsSignal = signal<ApiDagGraph[]>([])
+
+    const mockStore = {
+      sessions: sessionsSignal,
+      dags: dagsSignal,
+    }
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([[conn.id, mockStore as ConnectionStore]]),
+    )
+
+    const { rerender } = render(<ConnectionPicker onManage={vi.fn()} />)
+
+    expect(screen.queryByTestId('picker-trigger-unread')).toBeFalsy()
+
+    sessionsSignal.value = [
+      createMockSession({ needsAttention: true, attentionReasons: ['failed'] }),
+    ]
+
+    rerender(<ConnectionPicker onManage={vi.fn()} />)
+
+    expect(screen.getByTestId('picker-trigger-unread')).toBeTruthy()
+  })
+
+  it('handles multiple connections with different stats', () => {
+    const conn1 = createMockConnection({ id: 'conn-1', label: 'Connection 1' })
+    const conn2 = createMockConnection({ id: 'conn-2', label: 'Connection 2' })
+    connectionsSignal.value = [conn1, conn2]
+    activeIdSignal.value = null
+
+    const store1 = createMockStore(
+      [createMockSession({ needsAttention: true, attentionReasons: ['failed'] })],
+      [],
+    )
+
+    const store2 = createMockStore(
+      [],
+      [
+        createMockDag({
+          nodes: {
+            'node-1': createMockDagNode({ status: 'completed' }),
+            'node-2': createMockDagNode({ status: 'running' }),
+          },
+        }),
+      ],
+    )
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([
+        [conn1.id, store1 as ConnectionStore],
+        [conn2.id, store2 as ConnectionStore],
+      ]),
+    )
+
+    render(<ConnectionPicker onManage={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('connection-picker-trigger'))
+
+    expect(screen.getByTestId(`picker-unread-${conn1.id}`)).toBeTruthy()
+    expect(screen.queryByTestId(`picker-dag-stats-${conn1.id}`)).toBeFalsy()
+
+    expect(screen.queryByTestId(`picker-unread-${conn2.id}`)).toBeFalsy()
+    expect(screen.getByTestId(`picker-dag-stats-${conn2.id}`).textContent).toContain('1/2')
+  })
+})

--- a/test/connections/ConnectionPicker.test.tsx
+++ b/test/connections/ConnectionPicker.test.tsx
@@ -11,7 +11,8 @@ vi.mock('../../src/connections/store', async () => {
   const setActive = vi.fn((id: string | null) => {
     activeId.value = id
   })
-  return { connections, activeId, setActive }
+  const getAllStores = vi.fn(() => new Map())
+  return { connections, activeId, setActive, getAllStores }
 })
 
 vi.mock('../../src/hooks/useHaptics', () => ({

--- a/test/connections/stats.test.ts
+++ b/test/connections/stats.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest'
+import { computeConnectionStats } from '../../src/connections/stats'
+import type { ApiSession, ApiDagGraph, ApiDagNode } from '../../src/api/types'
+
+function createSession(overrides: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 'session-1',
+    slug: 'test',
+    status: 'running',
+    command: '/task test',
+    mode: 'task',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    conversation: [],
+    ...overrides,
+  }
+}
+
+function createDagNode(overrides: Partial<ApiDagNode> = {}): ApiDagNode {
+  return {
+    id: 'node-1',
+    slug: 'node-1',
+    status: 'pending',
+    dependencies: [],
+    dependents: [],
+    ...overrides,
+  }
+}
+
+function createDag(overrides: Partial<ApiDagGraph> = {}): ApiDagGraph {
+  return {
+    id: 'dag-1',
+    rootTaskId: 'root-1',
+    nodes: {},
+    status: 'pending',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('computeConnectionStats', () => {
+  it('returns zero unread count when no sessions need attention', () => {
+    const sessions = [createSession(), createSession({ id: 'session-2' })]
+    const dags: ApiDagGraph[] = []
+
+    const stats = computeConnectionStats(sessions, dags)
+
+    expect(stats.unreadCount).toBe(0)
+  })
+
+  it('counts sessions needing attention', () => {
+    const sessions = [
+      createSession({ needsAttention: true, attentionReasons: ['failed'] }),
+      createSession({ id: 'session-2', needsAttention: true, attentionReasons: ['ci_fix'] }),
+      createSession({ id: 'session-3', needsAttention: false }),
+    ]
+    const dags: ApiDagGraph[] = []
+
+    const stats = computeConnectionStats(sessions, dags)
+
+    expect(stats.unreadCount).toBe(2)
+  })
+
+  it('returns null dagProgress when no DAGs exist', () => {
+    const sessions: ApiSession[] = []
+    const dags: ApiDagGraph[] = []
+
+    const stats = computeConnectionStats(sessions, dags)
+
+    expect(stats.dagProgress).toBeNull()
+  })
+
+  it('computes DAG progress correctly', () => {
+    const sessions: ApiSession[] = []
+    const dags = [
+      createDag({
+        nodes: {
+          'node-1': createDagNode({ id: 'node-1', status: 'completed' }),
+          'node-2': createDagNode({ id: 'node-2', status: 'landed' }),
+          'node-3': createDagNode({ id: 'node-3', status: 'running' }),
+          'node-4': createDagNode({ id: 'node-4', status: 'pending' }),
+          'node-5': createDagNode({ id: 'node-5', status: 'failed' }),
+        },
+      }),
+    ]
+
+    const stats = computeConnectionStats(sessions, dags)
+
+    expect(stats.dagProgress).toEqual({
+      done: 2,
+      total: 5,
+      failed: 1,
+      running: 1,
+    })
+  })
+
+  it('aggregates multiple DAGs', () => {
+    const sessions: ApiSession[] = []
+    const dags = [
+      createDag({
+        id: 'dag-1',
+        nodes: {
+          'node-1': createDagNode({ id: 'node-1', status: 'completed' }),
+          'node-2': createDagNode({ id: 'node-2', status: 'running' }),
+        },
+      }),
+      createDag({
+        id: 'dag-2',
+        nodes: {
+          'node-3': createDagNode({ id: 'node-3', status: 'landed' }),
+          'node-4': createDagNode({ id: 'node-4', status: 'failed' }),
+          'node-5': createDagNode({ id: 'node-5', status: 'ci-failed' }),
+        },
+      }),
+    ]
+
+    const stats = computeConnectionStats(sessions, dags)
+
+    expect(stats.dagProgress).toEqual({
+      done: 2,
+      total: 5,
+      failed: 2,
+      running: 1,
+    })
+  })
+
+  it('counts ci-pending and rebasing as running', () => {
+    const sessions: ApiSession[] = []
+    const dags = [
+      createDag({
+        nodes: {
+          'node-1': createDagNode({ id: 'node-1', status: 'ci-pending' }),
+          'node-2': createDagNode({ id: 'node-2', status: 'rebasing' }),
+          'node-3': createDagNode({ id: 'node-3', status: 'running' }),
+        },
+      }),
+    ]
+
+    const stats = computeConnectionStats(sessions, dags)
+
+    expect(stats.dagProgress).toEqual({
+      done: 0,
+      total: 3,
+      failed: 0,
+      running: 3,
+    })
+  })
+
+  it('counts ci-failed as failed', () => {
+    const sessions: ApiSession[] = []
+    const dags = [
+      createDag({
+        nodes: {
+          'node-1': createDagNode({ id: 'node-1', status: 'ci-failed' }),
+          'node-2': createDagNode({ id: 'node-2', status: 'failed' }),
+        },
+      }),
+    ]
+
+    const stats = computeConnectionStats(sessions, dags)
+
+    expect(stats.dagProgress).toEqual({
+      done: 0,
+      total: 2,
+      failed: 2,
+      running: 0,
+    })
+  })
+
+  it('combines unread and DAG stats correctly', () => {
+    const sessions = [
+      createSession({ needsAttention: true, attentionReasons: ['failed'] }),
+      createSession({ id: 'session-2', needsAttention: true, attentionReasons: ['interrupted'] }),
+    ]
+    const dags = [
+      createDag({
+        nodes: {
+          'node-1': createDagNode({ status: 'completed' }),
+          'node-2': createDagNode({ status: 'failed' }),
+          'node-3': createDagNode({ status: 'running' }),
+        },
+      }),
+    ]
+
+    const stats = computeConnectionStats(sessions, dags)
+
+    expect(stats.unreadCount).toBe(2)
+    expect(stats.dagProgress).toEqual({
+      done: 1,
+      total: 3,
+      failed: 1,
+      running: 1,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Add mini-DAG status display (3/7 done, 1 failed) and per-connection unread indicators to the connection picker. Builds on existing web push infrastructure to surface attention events and DAG progress in real time.

### Visual indicators added:
- **Unread dot**: Red notification dot on connection color badge when sessions need attention
- **DAG progress pill**: Inline stats showing done/total/failed counts for active DAGs (e.g., "3/7 · 1 failed")
- Both indicators appear on the trigger button (active connection) and in the dropdown/sheet list

### Implementation:
1. `src/connections/stats.ts` - Helper to compute connection-level stats (DAG progress + attention count)
2. `src/connections/ConnectionPicker.tsx` - Visual indicators integrated via `useComputed` signal
3. `src/connections/store.ts` - Added `getAllStores()` export for stat computation
4. Comprehensive unit and integration tests for stats helper and UI integration

### Mobile/Desktop support:
- Works in both desktop dropdown and mobile bottom sheet
- Uses same visual language as existing AttentionBar and DagStatusPanel
- Reactive updates via signals when SSE events arrive

## Test plan

- [x] Unit tests pass for stats computation (8 tests)
- [x] Integration tests pass for ConnectionPicker indicators (9 tests)
- [x] All existing ConnectionPicker tests pass (13 tests)
- [x] TypeScript compilation succeeds (no errors in changed files)
- [x] ESLint passes
- [ ] Manual: Open app with multiple connections, verify unread dots appear when sessions need attention
- [ ] Manual: Create a DAG, verify progress pills show correct done/total/failed counts
- [ ] Manual: Test on mobile viewport, verify indicators appear in bottom sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)