### PR TITLE
feat(mobile): add kanban swimlane view for mobile devices

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,8 +35,9 @@ import { VariantGroupView } from './groups/VariantGroupView'
 import type { ApiSession, AttentionReason, MinionCommand } from './api/types'
 import { HeaderMenu } from './components/HeaderMenu'
 import { MemoryDrawer } from './components/MemoryDrawer'
+import { KanbanView } from './components/KanbanView'
 
-export type ViewMode = 'list' | 'canvas' | 'ship'
+export type ViewMode = 'list' | 'canvas' | 'ship' | 'kanban'
 
 const showSettings = signal(false)
 const showDrawer = signal(false)
@@ -44,7 +45,7 @@ const showRuntime = signal<RuntimeTab | null>(null)
 const showMemory = signal(false)
 export const viewMode = signal<ViewMode>('list')
 
-function ViewToggle({ mode, onChange }: { mode: ViewMode; onChange: (m: ViewMode) => void }) {
+function ViewToggle({ mode, onChange, showKanban }: { mode: ViewMode; onChange: (m: ViewMode) => void; showKanban?: boolean }) {
   const tabClass = (active: boolean) =>
     `px-3 sm:px-4 py-2.5 text-xs font-medium transition-colors min-h-[44px] flex items-center ${
       active
@@ -69,6 +70,20 @@ function ViewToggle({ mode, onChange }: { mode: ViewMode; onChange: (m: ViewMode
         <span class="sm:hidden" aria-hidden="true">☰</span>
         <span class="hidden sm:inline">List</span>
       </button>
+      {showKanban && (
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'kanban'}
+          aria-label="Kanban"
+          onClick={() => onChange('kanban')}
+          class={`${tabClass(mode === 'kanban')} border-l border-slate-300 dark:border-slate-600`}
+          data-testid="view-toggle-kanban"
+        >
+          <span class="sm:hidden" aria-hidden="true">📋</span>
+          <span class="hidden sm:inline">Kanban</span>
+        </button>
+      )}
       <button
         type="button"
         role="tab"
@@ -547,7 +562,7 @@ function ActiveView() {
         <RunningBadge store={store} onSelect={handleOpenChat} />
         {isDesktop.value ? (
           <div class="ml-auto flex items-center gap-1 sm:gap-1.5 shrink-0">
-            <ViewToggle mode={mode} onChange={(m) => { viewMode.value = m }} />
+            <ViewToggle mode={mode} onChange={(m) => { viewMode.value = m }} showKanban={false} />
             <ThemeToggle />
             {hasFeature(store, 'memory') && (
               <button
@@ -638,6 +653,14 @@ function ActiveView() {
         ) : mode === 'ship' ? (
           <div class="flex flex-1 min-h-0" data-testid="ship-pane">
             <ShipPipelineView dags={dags} onOpenChat={handleOpenChat} />
+          </div>
+        ) : mode === 'kanban' ? (
+          <div class="flex flex-1 min-h-0" data-testid="kanban-pane">
+            <KanbanView
+              sessions={sessions}
+              dags={dags}
+              onSessionSelect={handleOpenChat}
+            />
           </div>
         ) : (
           <DesktopBody
@@ -738,6 +761,32 @@ function ActiveView() {
           </div>
           <div class="flex-1 min-h-0 flex flex-col">
             <ShipPipelineView dags={dags} onOpenChat={handleOpenChat} />
+          </div>
+        </div>
+      )}
+      {!isDesktop.value && mode === 'kanban' && (
+        <div
+          class="fixed inset-0 z-40 bg-slate-50 dark:bg-slate-900 flex flex-col"
+          data-testid="kanban-mobile-modal"
+        >
+          <div class="flex items-center gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0">
+            <span class="text-sm font-medium text-slate-900 dark:text-slate-100">Kanban</span>
+            <button
+              type="button"
+              onClick={() => { viewMode.value = 'list' }}
+              class="ml-auto rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-3 py-2.5 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700 min-h-[44px]"
+              data-testid="kanban-mobile-close"
+              aria-label="Close kanban view"
+            >
+              Close
+            </button>
+          </div>
+          <div class="flex-1 min-h-0">
+            <KanbanView
+              sessions={sessions}
+              dags={dags}
+              onSessionSelect={handleOpenChat}
+            />
           </div>
         </div>
       )}

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -84,6 +84,17 @@ export function HeaderMenu({
           </button>
           <button
             type="button"
+            onClick={() => handleViewChange('kanban')}
+            class={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-slate-100 dark:hover:bg-slate-700 ${
+              viewMode.value === 'kanban' ? 'bg-indigo-50 dark:bg-indigo-950/30 text-indigo-700 dark:text-indigo-300 font-medium' : 'text-slate-700 dark:text-slate-200'
+            }`}
+            data-testid="menu-view-kanban"
+          >
+            <span aria-hidden="true">📋</span>
+            <span>Kanban</span>
+          </button>
+          <button
+            type="button"
             onClick={() => handleViewChange('canvas')}
             class={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-slate-100 dark:hover:bg-slate-700 ${
               viewMode.value === 'canvas' ? 'bg-indigo-50 dark:bg-indigo-950/30 text-indigo-700 dark:text-indigo-300 font-medium' : 'text-slate-700 dark:text-slate-200'

--- a/src/components/KanbanView.tsx
+++ b/src/components/KanbanView.tsx
@@ -1,0 +1,285 @@
+import { useMemo, useCallback, useState, useRef, useEffect } from 'preact/hooks'
+import type { ApiSession, ApiDagGraph } from '../api/types'
+import { StatusBadge, AttentionIconStack, formatRelativeTime } from './shared'
+import { PrLink } from './PrLink'
+import { useTheme } from '../hooks/useTheme'
+import { useHaptics } from '../hooks/useHaptics'
+import { connections, activeId, setActive } from '../connections/store'
+
+interface KanbanCardProps {
+  session: ApiSession
+  onClick: (sessionId: string) => void
+  isDark: boolean
+}
+
+function KanbanCard({ session, onClick, isDark }: KanbanCardProps) {
+  const { vibrate } = useHaptics()
+
+  const handleClick = useCallback(() => {
+    vibrate('light')
+    onClick(session.id)
+  }, [session.id, onClick, vibrate])
+
+  const bgColor = isDark ? 'bg-slate-800' : 'bg-white'
+  const borderColor = session.needsAttention
+    ? 'border-amber-500 dark:border-amber-600'
+    : 'border-slate-200 dark:border-slate-700'
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      class={`${bgColor} ${borderColor} border-2 rounded-lg p-3 w-full text-left shadow-sm active:scale-[0.98] transition-transform min-h-[88px] flex flex-col gap-2`}
+      data-testid={`kanban-card-${session.id}`}
+    >
+      <div class="flex items-start justify-between gap-2">
+        <div class="font-semibold text-sm text-slate-900 dark:text-slate-100 truncate flex-1">
+          {session.slug}
+        </div>
+        <StatusBadge status={session.status} />
+      </div>
+
+      {session.needsAttention && session.attentionReasons.length > 0 && (
+        <div class="flex items-center gap-1.5">
+          <AttentionIconStack reasons={session.attentionReasons} darkMode={isDark} />
+        </div>
+      )}
+
+      <div class="flex items-center justify-between gap-2 mt-auto">
+        {session.prUrl ? (
+          <div onClick={(e: Event) => e.stopPropagation()}>
+            <PrLink prUrl={session.prUrl} compact />
+          </div>
+        ) : session.branch ? (
+          <div class="text-[11px] text-slate-500 dark:text-slate-400 truncate max-w-[140px]">
+            {session.branch}
+          </div>
+        ) : session.command ? (
+          <div class="text-[11px] text-slate-500 dark:text-slate-400 truncate max-w-[140px]">
+            {session.command}
+          </div>
+        ) : (
+          <div />
+        )}
+        {session.updatedAt && (
+          <span class="text-[10px] text-slate-400 dark:text-slate-500 shrink-0">
+            {formatRelativeTime(session.updatedAt)}
+          </span>
+        )}
+      </div>
+    </button>
+  )
+}
+
+interface KanbanColumnProps {
+  title: string
+  emoji: string
+  sessions: ApiSession[]
+  onCardClick: (sessionId: string) => void
+  isDark: boolean
+}
+
+function KanbanColumn({ title, emoji, sessions, onCardClick, isDark }: KanbanColumnProps) {
+  const bgColor = isDark ? 'bg-slate-900' : 'bg-slate-50'
+  const headerBg = isDark ? 'bg-slate-800' : 'bg-slate-100'
+
+  return (
+    <div class={`${bgColor} rounded-lg flex flex-col h-full`}>
+      <div class={`${headerBg} rounded-t-lg px-3 py-2 sticky top-0 z-10`}>
+        <div class="flex items-center gap-2">
+          <span class="text-lg" aria-hidden="true">{emoji}</span>
+          <span class="font-semibold text-sm text-slate-900 dark:text-slate-100">
+            {title}
+          </span>
+          <span class="ml-auto text-xs font-medium text-slate-500 dark:text-slate-400">
+            {sessions.length}
+          </span>
+        </div>
+      </div>
+
+      <div class="flex-1 overflow-y-auto p-2 space-y-2">
+        {sessions.length === 0 ? (
+          <div class="text-center py-8 text-xs text-slate-400 dark:text-slate-500">
+            No sessions
+          </div>
+        ) : (
+          sessions.map((session) => (
+            <KanbanCard
+              key={session.id}
+              session={session}
+              onClick={onCardClick}
+              isDark={isDark}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface ConnectionDotProps {
+  active: boolean
+  color: string
+  onClick: () => void
+}
+
+function ConnectionDot({ active, color, onClick }: ConnectionDotProps) {
+  const { vibrate } = useHaptics()
+
+  const handleClick = useCallback(() => {
+    vibrate('light')
+    onClick()
+  }, [onClick, vibrate])
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      class={`w-2 h-2 rounded-full transition-transform ${active ? 'scale-150' : 'scale-100'}`}
+      style={{ backgroundColor: color }}
+      aria-label="Switch connection"
+    />
+  )
+}
+
+export interface KanbanViewProps {
+  sessions: ApiSession[]
+  dags: ApiDagGraph[]
+  onSessionSelect: (sessionId: string) => void
+}
+
+export function KanbanView({ sessions, onSessionSelect }: KanbanViewProps) {
+  const theme = useTheme()
+  const isDark = theme.value === 'dark'
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [currentConnIndex, setCurrentConnIndex] = useState(0)
+  const { vibrate } = useHaptics()
+
+  const conns = connections.value
+  const activeConnId = activeId.value
+
+  useEffect(() => {
+    const idx = conns.findIndex((c) => c.id === activeConnId)
+    if (idx !== -1) setCurrentConnIndex(idx)
+  }, [activeConnId, conns])
+
+  const columns = useMemo(() => {
+    const running = sessions.filter((s) => s.status === 'running')
+    const done = sessions.filter((s) => s.status === 'completed' || s.status === 'failed')
+    const waiting = sessions.filter((s) =>
+      s.status !== 'running' &&
+      s.status !== 'completed' &&
+      s.status !== 'failed'
+    )
+
+    return { running, waiting, done }
+  }, [sessions])
+
+  const handleSwipe = useCallback(
+    (direction: 'left' | 'right') => {
+      if (conns.length <= 1) return
+
+      const nextIndex =
+        direction === 'left'
+          ? (currentConnIndex + 1) % conns.length
+          : (currentConnIndex - 1 + conns.length) % conns.length
+
+      const nextConn = conns[nextIndex]
+      if (nextConn) {
+        vibrate('medium')
+        setActive(nextConn.id)
+        setCurrentConnIndex(nextIndex)
+      }
+    },
+    [conns, currentConnIndex, vibrate]
+  )
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    let startX = 0
+    let startY = 0
+    let deltaX = 0
+    let deltaY = 0
+
+    const handleTouchStart = (e: TouchEvent) => {
+      startX = e.touches[0].clientX
+      startY = e.touches[0].clientY
+      deltaX = 0
+      deltaY = 0
+    }
+
+    const handleTouchMove = (e: TouchEvent) => {
+      deltaX = e.touches[0].clientX - startX
+      deltaY = e.touches[0].clientY - startY
+    }
+
+    const handleTouchEnd = () => {
+      const absDeltaX = Math.abs(deltaX)
+      const absDeltaY = Math.abs(deltaY)
+
+      if (absDeltaX > 80 && absDeltaX > absDeltaY * 1.5) {
+        handleSwipe(deltaX > 0 ? 'right' : 'left')
+      }
+    }
+
+    container.addEventListener('touchstart', handleTouchStart)
+    container.addEventListener('touchmove', handleTouchMove)
+    container.addEventListener('touchend', handleTouchEnd)
+
+    return () => {
+      container.removeEventListener('touchstart', handleTouchStart)
+      container.removeEventListener('touchmove', handleTouchMove)
+      container.removeEventListener('touchend', handleTouchEnd)
+    }
+  }, [handleSwipe])
+
+  return (
+    <div class="flex flex-col h-full" data-testid="kanban-view">
+      {conns.length > 1 && (
+        <div class="flex items-center justify-center gap-2 py-3 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
+          {conns.map((conn, idx) => (
+            <ConnectionDot
+              key={conn.id}
+              active={idx === currentConnIndex}
+              color={conn.color}
+              onClick={() => {
+                setActive(conn.id)
+                setCurrentConnIndex(idx)
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      <div
+        ref={containerRef}
+        class="flex-1 grid grid-cols-3 gap-2 p-2 overflow-hidden"
+        style={{ touchAction: 'pan-y' }}
+      >
+        <KanbanColumn
+          title="Running"
+          emoji="⚡"
+          sessions={columns.running}
+          onCardClick={onSessionSelect}
+          isDark={isDark}
+        />
+        <KanbanColumn
+          title="Waiting"
+          emoji="💬"
+          sessions={columns.waiting}
+          onCardClick={onSessionSelect}
+          isDark={isDark}
+        />
+        <KanbanColumn
+          title="Done"
+          emoji="✅"
+          sessions={columns.done}
+          onCardClick={onSessionSelect}
+          isDark={isDark}
+        />
+      </div>
+    </div>
+  )
+}

--- a/test/KanbanView.test.tsx
+++ b/test/KanbanView.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { KanbanView } from '../src/components/KanbanView'
+import type { ApiSession, ApiDagGraph } from '../src/api/types'
+import { connections, activeId } from '../src/connections/store'
+
+vi.mock('../src/hooks/useHaptics', () => ({
+  useHaptics: () => ({ vibrate: vi.fn() }),
+}))
+
+vi.mock('../src/hooks/useTheme', () => ({
+  useTheme: () => ({ value: 'light' }),
+}))
+
+const mockSession = (overrides: Partial<ApiSession> = {}): ApiSession => ({
+  id: 'test-id',
+  slug: 'test-slug',
+  status: 'pending',
+  command: '/task do something',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  childIds: [],
+  needsAttention: false,
+  attentionReasons: [],
+  quickActions: [],
+  mode: 'task',
+  conversation: [],
+  ...overrides,
+})
+
+describe('KanbanView', () => {
+  const mockOnSessionSelect = vi.fn()
+  const mockDags: ApiDagGraph[] = []
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    connections.value = [
+      { id: 'conn-1', label: 'Test Connection', baseUrl: 'http://test', token: 'token', color: '#ff0000' },
+    ]
+    activeId.value = 'conn-1'
+  })
+
+  it('renders three columns: Running, Waiting, Done', () => {
+    const sessions: ApiSession[] = []
+    render(<KanbanView sessions={sessions} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    expect(screen.getByText('Running')).toBeTruthy()
+    expect(screen.getByText('Waiting')).toBeTruthy()
+    expect(screen.getByText('Done')).toBeTruthy()
+  })
+
+  it('categorizes running sessions correctly', () => {
+    const sessions = [
+      mockSession({ id: 's1', slug: 'running-1', status: 'running' }),
+      mockSession({ id: 's2', slug: 'running-2', status: 'running' }),
+    ]
+    render(<KanbanView sessions={sessions} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    const runningCards = screen.getAllByTestId(/^kanban-card-s[12]$/)
+    expect(runningCards).toHaveLength(2)
+  })
+
+  it('categorizes pending sessions as waiting', () => {
+    const sessions = [
+      mockSession({ id: 's1', slug: 'pending-1', status: 'pending' }),
+      mockSession({ id: 's2', slug: 'pending-2', status: 'pending', needsAttention: true, attentionReasons: ['waiting_for_feedback'] }),
+    ]
+    render(<KanbanView sessions={sessions} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    expect(screen.getByText('pending-1')).toBeTruthy()
+    expect(screen.getByText('pending-2')).toBeTruthy()
+  })
+
+  it('categorizes completed and failed sessions as done', () => {
+    const sessions = [
+      mockSession({ id: 's1', slug: 'completed-1', status: 'completed' }),
+      mockSession({ id: 's2', slug: 'failed-1', status: 'failed' }),
+    ]
+    render(<KanbanView sessions={sessions} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    expect(screen.getByText('completed-1')).toBeTruthy()
+    expect(screen.getByText('failed-1')).toBeTruthy()
+  })
+
+  it('calls onSessionSelect when card is clicked', () => {
+    const session = mockSession({ id: 's1', slug: 'test-session' })
+    render(<KanbanView sessions={[session]} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    const card = screen.getByTestId('kanban-card-s1')
+    fireEvent.click(card)
+
+    expect(mockOnSessionSelect).toHaveBeenCalledWith('s1')
+  })
+
+  it('displays session details on cards', () => {
+    const session = mockSession({
+      id: 's1',
+      slug: 'detailed-session',
+      status: 'running',
+      branch: 'feature/test',
+      prUrl: 'https://github.com/test/repo/pull/123',
+    })
+    render(<KanbanView sessions={[session]} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    expect(screen.getByText('detailed-session')).toBeTruthy()
+    expect(screen.getByText(/#123/)).toBeTruthy()
+  })
+
+  it('shows attention indicators on cards', () => {
+    const session = mockSession({
+      id: 's1',
+      slug: 'attention-session',
+      status: 'pending',
+      needsAttention: true,
+      attentionReasons: ['failed', 'waiting_for_feedback'],
+    })
+    render(<KanbanView sessions={[session]} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    const card = screen.getByTestId('kanban-card-s1')
+    expect(card.className).toContain('border-amber-500')
+  })
+
+  it('displays connection dots when multiple connections exist', () => {
+    connections.value = [
+      { id: 'conn-1', label: 'Conn 1', baseUrl: 'http://test1', token: 'token1', color: '#ff0000' },
+      { id: 'conn-2', label: 'Conn 2', baseUrl: 'http://test2', token: 'token2', color: '#00ff00' },
+    ]
+    activeId.value = 'conn-1'
+
+    render(<KanbanView sessions={[]} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    const dots = screen.getAllByLabelText('Switch connection')
+    expect(dots).toHaveLength(2)
+  })
+
+  it('does not display connection dots for single connection', () => {
+    connections.value = [
+      { id: 'conn-1', label: 'Single Conn', baseUrl: 'http://test', token: 'token', color: '#ff0000' },
+    ]
+    activeId.value = 'conn-1'
+
+    render(<KanbanView sessions={[]} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    const dots = screen.queryAllByLabelText('Switch connection')
+    expect(dots).toHaveLength(0)
+  })
+
+  it('shows empty state when no sessions in column', () => {
+    render(<KanbanView sessions={[]} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    const emptyMessages = screen.getAllByText('No sessions')
+    expect(emptyMessages).toHaveLength(3)
+  })
+
+  it('distributes sessions across columns correctly', () => {
+    const sessions = [
+      mockSession({ id: 's1', slug: 'run-1', status: 'running' }),
+      mockSession({ id: 's2', slug: 'run-2', status: 'running' }),
+      mockSession({ id: 's3', slug: 'pend-1', status: 'pending' }),
+      mockSession({ id: 's4', slug: 'done-1', status: 'completed' }),
+      mockSession({ id: 's5', slug: 'fail-1', status: 'failed' }),
+    ]
+    render(<KanbanView sessions={sessions} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    expect(screen.getByText('run-1')).toBeTruthy()
+    expect(screen.getByText('run-2')).toBeTruthy()
+    expect(screen.getByText('pend-1')).toBeTruthy()
+    expect(screen.getByText('done-1')).toBeTruthy()
+    expect(screen.getByText('fail-1')).toBeTruthy()
+  })
+
+  it('shows correct count badges in column headers', () => {
+    const sessions = [
+      mockSession({ id: 's1', status: 'running' }),
+      mockSession({ id: 's2', status: 'running' }),
+      mockSession({ id: 's3', status: 'pending' }),
+      mockSession({ id: 's4', status: 'completed' }),
+    ]
+    render(<KanbanView sessions={sessions} dags={mockDags} onSessionSelect={mockOnSessionSelect} />)
+
+    const counts = screen.getAllByText(/^[0-9]+$/)
+    const countValues = counts.map(el => el.textContent)
+    expect(countValues).toContain('2')
+    expect(countValues).toContain('1')
+  })
+})


### PR DESCRIPTION
## Summary
- Implements mobile-optimized kanban board as alternative to UniverseCanvas
- Three columns: Running (⚡), Waiting (💬), Done (✅)
- Swipe navigation between deployments with connection dots
- Accessible via mobile menu (📋 Kanban button)

## Features
- Touch-optimized card layout with haptic feedback on interactions
- Session cards display status badges, attention indicators, and PR links
- Horizontal swipe gestures to switch between connections
- Connection dots for multi-deployment navigation
- Full-screen modal on mobile, inline pane on desktop
- Empty state messaging for columns with no sessions

## Implementation Details
- `KanbanView` component categorizes sessions into three columns
- Swipe detection via touch event listeners (80px threshold)
- Integrates with existing `StatusBadge`, `AttentionIconStack`, and `PrLink` components
- Uses `useHaptics` for tactile feedback
- Added fourth view mode ('kanban') to App ViewMode type
- Mobile menu updated with kanban option

## Test Plan
- [x] All 12 unit tests pass
- [x] Sessions correctly categorized into Running/Waiting/Done columns
- [x] Click on card triggers onSessionSelect with session ID
- [x] Connection dots visible for multiple connections
- [x] Empty state displayed when columns have no sessions
- [x] Attention indicators and PR links render correctly on cards
- [ ] Manual testing: View kanban on mobile device
- [ ] Manual testing: Swipe between connections
- [ ] Manual testing: Verify haptic feedback on touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)