### PR TITLE
fix(ui): improve mobile spacing and remove debug labels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -553,7 +553,7 @@ function ActiveView() {
           Offline — showing last snapshot
         </div>
       )}
-      <header class="flex items-center gap-1.5 sm:gap-2 px-2 sm:px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0 overflow-x-clip">
+      <header class="flex items-center gap-2 sm:gap-2 px-3 sm:px-4 py-2.5 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0 overflow-x-clip">
         <ConnectionPicker onManage={() => { showDrawer.value = true }} />
         <ConnectionStatusBadge status={store.status.value} reconnectAt={store.reconnectAt.value} />
         {hasFeature(store, 'resource-metrics') && (

--- a/src/chat/ChatPane.tsx
+++ b/src/chat/ChatPane.tsx
@@ -134,7 +134,7 @@ export function ChatPane({
 
   return (
     <div class={rootClass} data-testid="chat-pane" data-fullscreen={mobileFullscreen ? 'true' : 'false'}>
-      <header class="flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-700 shrink-0">
+      <header class="flex items-center gap-2.5 px-4 py-2.5 border-b border-slate-200 dark:border-slate-700 shrink-0">
         {parentSession && onNavigate && (
           <button
             type="button"

--- a/src/chat/ChatPanel.tsx
+++ b/src/chat/ChatPanel.tsx
@@ -71,7 +71,7 @@ export function ChatPanel({
           class="mt-1 text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wide font-medium px-3 py-1 hover:text-slate-600 dark:hover:text-slate-300 min-h-[24px]"
           data-testid="chat-panel-snap-indicator"
         >
-          {currentSnap === 'peek' ? 'Swipe up' : currentSnap === 'half' ? 'Half' : 'Full'}
+          {currentSnap === 'peek' ? 'Swipe up' : currentSnap === 'half' ? 'Swipe up' : 'Swipe down'}
         </button>
       </div>
       <div class="flex-1 min-h-0 overflow-hidden">

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -266,11 +266,11 @@ export function NewTaskBar({
 
   return (
     <div
-      class="flex flex-col gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
+      class="flex flex-col gap-3 px-3 py-3 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
       data-testid="new-task-bar"
     >
-      <div class="flex flex-wrap items-center gap-2">
-        <div class="flex gap-1" role="radiogroup" aria-label="Task mode" data-testid="mode-picker">
+      <div class="flex flex-wrap items-center gap-2.5">
+        <div class="flex gap-1.5" role="radiogroup" aria-label="Task mode" data-testid="mode-picker">
           {availableModes.map((m) => {
             const active = mode.value === m.value
             const btnClass = active
@@ -286,7 +286,7 @@ export function NewTaskBar({
                 disabled={sending.value}
                 onClick={() => { mode.value = m.value }}
                 data-testid={`mode-${m.value}`}
-                class={`rounded-full border px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${btnClass}`}
+                class={`rounded-full border px-3.5 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 ${btnClass}`}
               >
                 {m.label}
               </button>
@@ -358,7 +358,7 @@ export function NewTaskBar({
         </div>
       )}
 
-      <div class="flex items-end gap-2">
+      <div class="flex items-end gap-2.5">
         <input
           ref={fileInputRef}
           type="file"
@@ -374,7 +374,7 @@ export function NewTaskBar({
           disabled={sending.value}
           aria-label="Attach image"
           title="Attach image"
-          class="shrink-0 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors border shadow-sm disabled:opacity-50 disabled:cursor-not-allowed bg-white dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600"
+          class="shrink-0 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors border shadow-sm disabled:opacity-50 disabled:cursor-not-allowed bg-white dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600"
           data-testid="new-task-attach-btn"
         >
           <PaperclipIcon />
@@ -391,14 +391,14 @@ export function NewTaskBar({
           disabled={sending.value}
           rows={2}
           placeholder={`New ${mode.value}: describe what you want…`}
-          class="flex-1 resize-y rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 placeholder:text-slate-400 disabled:opacity-50"
+          class="flex-1 resize-y rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2.5 text-sm text-slate-900 dark:text-slate-100 placeholder:text-slate-400 disabled:opacity-50"
           data-testid="new-task-prompt"
         />
         <button
           type="button"
           onClick={() => void submit()}
           disabled={!canSubmit}
-          class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          class="rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
           data-testid="new-task-send"
         >
           {launchLabel}
@@ -406,7 +406,7 @@ export function NewTaskBar({
         <button
           type="button"
           onClick={toggleCollapsed}
-          class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 bg-white dark:bg-slate-800 px-2 py-2 text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
+          class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 bg-white dark:bg-slate-800 px-2.5 py-2.5 text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
           title="Collapse the task bar"
           aria-label="Collapse task bar"
           data-testid="new-task-collapse"

--- a/src/chat/SessionTabs.tsx
+++ b/src/chat/SessionTabs.tsx
@@ -22,7 +22,7 @@ export function SessionTabs({ tabs, active, onChange, children }: SessionTabsPro
       <div
         role="tablist"
         aria-label="Session views"
-        class="flex items-center gap-1 px-3 py-1.5 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0"
+        class="flex items-center gap-1.5 px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0"
         data-testid="session-tabs"
       >
         {visible.map((t) => {
@@ -37,7 +37,7 @@ export function SessionTabs({ tabs, active, onChange, children }: SessionTabsPro
               id={`session-tab-${t.id}`}
               onClick={() => onChange(t.id)}
               class={
-                'px-3 py-1 text-xs font-medium rounded-md transition-colors ' +
+                'px-3 py-1.5 text-xs font-medium rounded-md transition-colors ' +
                 (isActive
                   ? 'bg-indigo-50 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-800'
                   : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700/50 border border-transparent')

--- a/src/components/WorktreeHeader.tsx
+++ b/src/components/WorktreeHeader.tsx
@@ -73,7 +73,7 @@ export function WorktreeHeader({
 
   return (
     <div
-      class="flex items-center gap-3 px-4 py-1.5 border-b border-slate-100 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/40 text-xs shrink-0"
+      class="flex items-center gap-3 px-4 py-2 border-b border-slate-100 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/40 text-xs shrink-0"
       data-testid="worktree-header"
     >
       {session.branch && (


### PR DESCRIPTION
## Summary

- Replace bottom sheet debug text ("HALF", "FULL") with user-friendly labels ("Swipe up", "Swipe down")
- Increase spacing throughout mobile UI for better touch targets and visual breathing room
- Improve padding and gaps in NewTaskBar, headers, session tabs, and worktree info

## Changes by Component

**ChatPanel** (`src/chat/ChatPanel.tsx`)
- Replace debug snap indicators with user-friendly text

**NewTaskBar** (`src/chat/NewTaskBar.tsx`)
- Increase container gaps and padding: `gap-2` → `gap-3`, `py-2` → `py-3`
- Increase mode button spacing: `gap-1` → `gap-1.5`
- Enlarge button padding for better touch targets: `px-3 py-1` → `px-3.5 py-1.5`
- Improve input area spacing and button sizes

**App Header** (`src/App.tsx`)
- Increase mobile header spacing: `gap-1.5` → `gap-2`, `px-2` → `px-3`, `py-2` → `py-2.5`

**ChatPane** (`src/chat/ChatPane.tsx`)
- Improve session header spacing: `gap-2` → `gap-2.5`, `py-2` → `py-2.5`

**SessionTabs** (`src/chat/SessionTabs.tsx`)
- Increase tab bar spacing: `gap-1` → `gap-1.5`, `py-1.5` → `py-2`
- Enlarge tab button padding: `py-1` → `py-1.5`

**WorktreeHeader** (`src/components/WorktreeHeader.tsx`)
- Increase vertical padding: `py-1.5` → `py-2`

## Test Plan

- [x] Type checking passes (`npm run typecheck`)
- [x] Linting passes (`npm run lint`)
- [x] Unit tests pass (`npm run test`)
- [ ] Visual verification on mobile device
- [ ] Test bottom sheet interactions (peek/half/full states)
- [ ] Verify touch target sizes meet accessibility standards
