### PR TITLE
feat(feedback): add IndexedDB persistence layer for vote state

### DIFF
--- a/src/state/feedback-persist.ts
+++ b/src/state/feedback-persist.ts
@@ -1,0 +1,65 @@
+import { get, set, del } from 'idb-keyval'
+import { signal, computed } from '@preact/signals'
+
+export interface FeedbackEntry {
+  vote: 'up' | 'down'
+  reason?: string
+  comment?: string
+  ts: number
+}
+
+type FeedbackMap = Record<string, FeedbackEntry>
+
+interface FeedbackStore {
+  v: 1
+  entries: FeedbackMap
+}
+
+function key(connectionId: string): string {
+  return `minions-ui:feedback:${connectionId}`
+}
+
+const cacheByConnection = signal<Map<string, FeedbackMap>>(new Map())
+
+export function loadFeedback(connectionId: string): Promise<FeedbackMap> {
+  const cached = cacheByConnection.value.get(connectionId)
+  if (cached) return Promise.resolve(cached)
+
+  return get<FeedbackStore>(key(connectionId)).then((raw) => {
+    const entries = raw?.v === 1 ? raw.entries : {}
+    const next = new Map(cacheByConnection.value)
+    next.set(connectionId, entries)
+    cacheByConnection.value = next
+    return entries
+  })
+}
+
+export async function recordFeedback(
+  connectionId: string,
+  entryKey: string,
+  entry: FeedbackEntry
+): Promise<void> {
+  const current = cacheByConnection.value.get(connectionId) || {}
+  const updated = { ...current, [entryKey]: entry }
+
+  const next = new Map(cacheByConnection.value)
+  next.set(connectionId, updated)
+  cacheByConnection.value = next
+
+  await set(key(connectionId), { v: 1, entries: updated } as FeedbackStore)
+}
+
+export async function clearFeedback(connectionId: string): Promise<void> {
+  const next = new Map(cacheByConnection.value)
+  next.delete(connectionId)
+  cacheByConnection.value = next
+  await del(key(connectionId))
+}
+
+export function useFeedbackStore(connectionId: string) {
+  return computed(() => cacheByConnection.value.get(connectionId) || {})
+}
+
+export function __clearCache(): void {
+  cacheByConnection.value = new Map()
+}

--- a/test/state/feedback-persist.test.ts
+++ b/test/state/feedback-persist.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const store = new Map<string, unknown>()
+
+vi.mock('idb-keyval', () => ({
+  get: vi.fn((k: string) => Promise.resolve(store.get(k))),
+  set: vi.fn((k: string, v: unknown) => { store.set(k, v); return Promise.resolve() }),
+  del: vi.fn((k: string) => { store.delete(k); return Promise.resolve() }),
+}))
+
+import { loadFeedback, recordFeedback, clearFeedback, useFeedbackStore, __clearCache } from '../../src/state/feedback-persist'
+import type { FeedbackEntry } from '../../src/state/feedback-persist'
+
+describe('feedback-persist', () => {
+  beforeEach(() => {
+    store.clear()
+    __clearCache()
+  })
+
+  it('loadFeedback returns empty object when no entry exists', async () => {
+    const entries = await loadFeedback('conn-1')
+    expect(entries).toEqual({})
+  })
+
+  it('recordFeedback stores entry and updates cache', async () => {
+    const entry: FeedbackEntry = { vote: 'up', ts: Date.now() }
+    await recordFeedback('conn-1', 's1:block1', entry)
+
+    const entries = await loadFeedback('conn-1')
+    expect(entries['s1:block1']).toEqual(entry)
+  })
+
+  it('recordFeedback merges with existing entries', async () => {
+    const entry1: FeedbackEntry = { vote: 'up', ts: Date.now() }
+    const entry2: FeedbackEntry = { vote: 'down', reason: 'Incorrect', ts: Date.now() + 1 }
+
+    await recordFeedback('conn-1', 's1:block1', entry1)
+    await recordFeedback('conn-1', 's1:block2', entry2)
+
+    const entries = await loadFeedback('conn-1')
+    expect(entries['s1:block1']).toEqual(entry1)
+    expect(entries['s1:block2']).toEqual(entry2)
+  })
+
+  it('recordFeedback overwrites existing entry with same key', async () => {
+    const entry1: FeedbackEntry = { vote: 'up', ts: Date.now() }
+    const entry2: FeedbackEntry = { vote: 'down', reason: 'Incorrect', ts: Date.now() + 1 }
+
+    await recordFeedback('conn-1', 's1:block1', entry1)
+    await recordFeedback('conn-1', 's1:block1', entry2)
+
+    const entries = await loadFeedback('conn-1')
+    expect(entries['s1:block1']).toEqual(entry2)
+  })
+
+  it('clearFeedback removes all entries', async () => {
+    const entry: FeedbackEntry = { vote: 'up', ts: Date.now() }
+    await recordFeedback('conn-1', 's1:block1', entry)
+    await clearFeedback('conn-1')
+
+    const entries = await loadFeedback('conn-1')
+    expect(entries).toEqual({})
+  })
+
+  it('isolates feedback across connections', async () => {
+    const entry1: FeedbackEntry = { vote: 'up', ts: Date.now() }
+    const entry2: FeedbackEntry = { vote: 'down', reason: 'Wrong', ts: Date.now() }
+
+    await recordFeedback('conn-1', 's1:block1', entry1)
+    await recordFeedback('conn-2', 's1:block1', entry2)
+
+    const entries1 = await loadFeedback('conn-1')
+    const entries2 = await loadFeedback('conn-2')
+
+    expect(entries1['s1:block1']).toEqual(entry1)
+    expect(entries2['s1:block1']).toEqual(entry2)
+  })
+
+  it('loadFeedback returns from cache on subsequent calls', async () => {
+    const entry: FeedbackEntry = { vote: 'up', ts: Date.now() }
+    await recordFeedback('conn-1', 's1:block1', entry)
+
+    const entries1 = await loadFeedback('conn-1')
+    const entries2 = await loadFeedback('conn-1')
+
+    expect(entries1).toBe(entries2)
+  })
+
+  it('useFeedbackStore returns computed signal with entries', async () => {
+    const entry: FeedbackEntry = { vote: 'up', ts: Date.now() }
+    await recordFeedback('conn-1', 's1:block1', entry)
+
+    const store = useFeedbackStore('conn-1')
+    expect(store.value['s1:block1']).toEqual(entry)
+  })
+
+  it('useFeedbackStore returns empty object for unknown connection', () => {
+    const store = useFeedbackStore('unknown')
+    expect(store.value).toEqual({})
+  })
+
+  it('useFeedbackStore reactively updates when recordFeedback is called', async () => {
+    await loadFeedback('conn-1')
+
+    const store = useFeedbackStore('conn-1')
+    expect(store.value).toEqual({})
+
+    const entry: FeedbackEntry = { vote: 'up', ts: Date.now() }
+    await recordFeedback('conn-1', 's1:block1', entry)
+
+    expect(store.value['s1:block1']).toEqual(entry)
+  })
+
+  it('stores feedback with reason and comment', async () => {
+    const entry: FeedbackEntry = {
+      vote: 'down',
+      reason: 'Incorrect',
+      comment: 'The response was factually wrong',
+      ts: Date.now(),
+    }
+    await recordFeedback('conn-1', 's1:block1', entry)
+
+    const entries = await loadFeedback('conn-1')
+    expect(entries['s1:block1']).toEqual(entry)
+  })
+
+  it('persists to IDB with correct structure', async () => {
+    const entry: FeedbackEntry = { vote: 'up', ts: Date.now() }
+    await recordFeedback('conn-1', 's1:block1', entry)
+
+    const raw = store.get('minions-ui:feedback:conn-1')
+    expect(raw).toEqual({
+      v: 1,
+      entries: {
+        's1:block1': entry,
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- New `src/state/feedback-persist.ts` module with IDB-backed vote storage
- Key shape: `minions-ui:feedback:${connectionId}` → `Record<sessionId:blockId, FeedbackEntry>`
- Export `loadFeedback`, `recordFeedback`, `clearFeedback` + `useFeedbackStore` computed signal
- In-memory cache with Preact signals for reactive subscriptions
- Add `__clearCache` for test isolation

## Test plan

- [x] 12 vitest unit tests covering round-trip persistence, cache behavior, signal reactivity
- [x] Full test suite passes (1039 tests)
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
