### PR TITLE
feat(api): add feedback types to shared API types

### DIFF
--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -15,6 +15,18 @@ export type PlanActionType = 'execute' | 'split' | 'stack' | 'dag'
 export interface ConversationMessage { role: 'user' | 'assistant'; text: string }
 export type ShipStage = 'think' | 'plan' | 'dag' | 'verify' | 'done'
 
+export type FeedbackVote = 'up' | 'down'
+export type FeedbackReason = 'incorrect' | 'off_topic' | 'too_verbose' | 'unsafe' | 'other'
+export interface FeedbackMetadata {
+  kind: 'feedback'
+  vote: FeedbackVote
+  reason?: FeedbackReason
+  comment?: string
+  sourceSessionId: string
+  sourceSessionSlug: string
+  sourceMessageBlockId: string
+}
+
 export interface ApiSession {
   id: string
   slug: string
@@ -37,6 +49,7 @@ export interface ApiSession {
   conversation: ConversationMessage[]
   variantGroupId?: string
   transcriptUrl?: string
+  metadata?: Record<string, unknown>
 }
 
 export interface ApiDagNode {
@@ -338,6 +351,14 @@ export type MinionCommand =
   | { action: 'ship_advance'; sessionId: string; to?: ShipStage }
   | { action: 'land'; dagId: string; nodeId: string }
   | { action: 'retry_rebase'; dagId: string; nodeId: string }
+  | {
+      action: 'submit_feedback'
+      sessionId: string
+      messageBlockId: string
+      vote: FeedbackVote
+      reason?: FeedbackReason
+      comment?: string
+    }
 
 export interface RepoEntry {
   alias: string

--- a/test/shared/api-types.test.ts
+++ b/test/shared/api-types.test.ts
@@ -1,5 +1,13 @@
 import { describe, test, expect } from 'vitest'
-import type { ShipStage, ApiSession, MinionCommand, CreateSessionMode } from '../../shared/api-types'
+import type {
+  ShipStage,
+  ApiSession,
+  MinionCommand,
+  CreateSessionMode,
+  FeedbackVote,
+  FeedbackReason,
+  FeedbackMetadata,
+} from '../../shared/api-types'
 
 describe('api-types', () => {
   test('ShipStage type has correct values', () => {
@@ -43,5 +51,115 @@ describe('api-types', () => {
       const m: CreateSessionMode = mode
       expect(m).toBe(mode)
     })
+  })
+
+  test('ApiSession includes optional metadata field', () => {
+    const sessionWithMeta: ApiSession = {
+      id: 'test-id',
+      slug: 'test-slug',
+      status: 'running',
+      command: 'test command',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      childIds: [],
+      needsAttention: false,
+      attentionReasons: [],
+      quickActions: [],
+      mode: 'task',
+      conversation: [],
+      metadata: { kind: 'feedback', vote: 'up' },
+    }
+    expect(sessionWithMeta.metadata).toEqual({ kind: 'feedback', vote: 'up' })
+
+    const sessionWithoutMeta: ApiSession = {
+      id: 'test-id-2',
+      slug: 'test-slug-2',
+      status: 'pending',
+      command: 'another command',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      childIds: [],
+      needsAttention: false,
+      attentionReasons: [],
+      quickActions: [],
+      mode: 'task',
+      conversation: [],
+    }
+    expect(sessionWithoutMeta.metadata).toBeUndefined()
+  })
+
+  test('FeedbackVote type has correct values', () => {
+    const validVotes: FeedbackVote[] = ['up', 'down']
+    validVotes.forEach((vote) => {
+      const v: FeedbackVote = vote
+      expect(v).toBe(vote)
+    })
+  })
+
+  test('FeedbackReason type has correct values', () => {
+    const validReasons: FeedbackReason[] = ['incorrect', 'off_topic', 'too_verbose', 'unsafe', 'other']
+    validReasons.forEach((reason) => {
+      const r: FeedbackReason = reason
+      expect(r).toBe(reason)
+    })
+  })
+
+  test('FeedbackMetadata interface structure', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'incorrect',
+      comment: 'The response was wrong',
+      sourceSessionId: 'session-123',
+      sourceSessionSlug: 'sharp-wood-0472',
+      sourceMessageBlockId: 'block-456',
+    }
+    expect(feedbackMeta.kind).toBe('feedback')
+    expect(feedbackMeta.vote).toBe('down')
+    expect(feedbackMeta.reason).toBe('incorrect')
+    expect(feedbackMeta.comment).toBe('The response was wrong')
+    expect(feedbackMeta.sourceSessionId).toBe('session-123')
+    expect(feedbackMeta.sourceSessionSlug).toBe('sharp-wood-0472')
+    expect(feedbackMeta.sourceMessageBlockId).toBe('block-456')
+
+    const minimalFeedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'up',
+      sourceSessionId: 'session-789',
+      sourceSessionSlug: 'quiet-dune-1132',
+      sourceMessageBlockId: 'block-101',
+    }
+    expect(minimalFeedbackMeta.reason).toBeUndefined()
+    expect(minimalFeedbackMeta.comment).toBeUndefined()
+  })
+
+  test('MinionCommand includes submit_feedback action', () => {
+    const feedbackCmdFull: MinionCommand = {
+      action: 'submit_feedback',
+      sessionId: 'test-session',
+      messageBlockId: 'block-123',
+      vote: 'down',
+      reason: 'too_verbose',
+      comment: 'Too long',
+    }
+    expect(feedbackCmdFull.action).toBe('submit_feedback')
+    expect(feedbackCmdFull.vote).toBe('down')
+    expect(feedbackCmdFull.reason).toBe('too_verbose')
+    expect(feedbackCmdFull.comment).toBe('Too long')
+
+    const feedbackCmdMinimal: MinionCommand = {
+      action: 'submit_feedback',
+      sessionId: 'test-session',
+      messageBlockId: 'block-456',
+      vote: 'up',
+    }
+    expect(feedbackCmdMinimal.action).toBe('submit_feedback')
+    expect(feedbackCmdMinimal.vote).toBe('up')
+    if ('reason' in feedbackCmdMinimal) {
+      expect(feedbackCmdMinimal.reason).toBeUndefined()
+    }
+    if ('comment' in feedbackCmdMinimal) {
+      expect(feedbackCmdMinimal.comment).toBeUndefined()
+    }
   })
 })


### PR DESCRIPTION
## Summary

- Add optional `metadata?: Record<string, unknown>` field to `ApiSession`
- Add `FeedbackVote` ('up'|'down') and `FeedbackReason` (incorrect|off_topic|too_verbose|unsafe|other) types
- Add `FeedbackMetadata` interface with kind, vote, reason, comment, and source tracking fields
- Add `submit_feedback` command arm to `MinionCommand` discriminated union
- Add comprehensive unit tests covering all feedback types and structures

## Test plan

- ✅ TypeScript compilation passes (`npm run typecheck`)
- ✅ ESLint validation passes (`npm run lint`)
- ✅ All unit tests pass including new feedback type tests (`npm run test`)
- ✅ Verified FeedbackMetadata interface structure with required and optional fields
- ✅ Verified submit_feedback command with both full and minimal payloads
- ✅ Verified ApiSession.metadata field is optional and type-safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)