### PR TITLE
feat(api): add submitFeedback method to ApiClient

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -10,6 +10,8 @@ import type {
   CreateSessionRequest,
   CreateSessionVariantsRequest,
   CreateSessionVariantsResult,
+  FeedbackReason,
+  FeedbackVote,
   MemoryEntry,
   MergeReadiness,
   MinionCommand,
@@ -51,6 +53,13 @@ export interface ApiClient {
   getDags(): Promise<ApiDagGraph[]>
   sendCommand(cmd: MinionCommand): Promise<CommandResult>
   sendMessage(text: string, sessionId?: string, images?: Array<{ mediaType: string; dataBase64: string }>): Promise<{ ok: true; sessionId: string | null }>
+  submitFeedback(input: {
+    sessionId: string
+    messageBlockId: string
+    vote: FeedbackVote
+    reason?: FeedbackReason
+    comment?: string
+  }): Promise<CommandResult>
   createSession(req: CreateSessionRequest): Promise<ApiSession>
   createSessionVariants(req: CreateSessionVariantsRequest): Promise<CreateSessionVariantsResult>
   createExternalTask(req: CreateExternalTaskRequest): Promise<ExternalTaskResult>
@@ -172,6 +181,23 @@ export function createApiClient(opts: { baseUrl: string; token: string }): ApiCl
 
     sendMessage(text: string, sessionId?: string, images?: Array<{ mediaType: string; dataBase64: string }>) {
       return post<{ ok: true; sessionId: string | null }>('/api/messages', { text, sessionId, images })
+    },
+
+    submitFeedback(input: {
+      sessionId: string
+      messageBlockId: string
+      vote: FeedbackVote
+      reason?: FeedbackReason
+      comment?: string
+    }) {
+      return this.sendCommand({
+        action: 'submit_feedback',
+        sessionId: input.sessionId,
+        messageBlockId: input.messageBlockId,
+        vote: input.vote,
+        reason: input.reason,
+        comment: input.comment,
+      })
     },
 
     createSession(req: CreateSessionRequest) {

--- a/test/api/client-extended.test.ts
+++ b/test/api/client-extended.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createApiClient, ApiError } from '../../src/api/client'
 import type {
   ApiSession,
+  CommandResult,
   CreateSessionRequest,
   CreateSessionVariantsRequest,
   CreateSessionVariantsResult,
+  MinionCommand,
   PrPreview,
   PushSubscriptionJSON,
   ScreenshotList,
@@ -292,5 +294,62 @@ describe('ApiClient — sendMessage with images', () => {
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     const body = JSON.parse(init.body as string) as { images?: unknown }
     expect(body.images).toBeUndefined()
+  })
+})
+
+describe('ApiClient — submitFeedback', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('delegates to sendCommand with submit_feedback action and all fields', async () => {
+    const result: CommandResult = { success: true }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: result }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const out = await client.submitFeedback({
+      sessionId: 's-1',
+      messageBlockId: 'b-42',
+      vote: 'down',
+      reason: 'incorrect',
+      comment: 'This was wrong',
+    })
+
+    expect(out).toEqual(result)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/api/commands`)
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string) as MinionCommand
+    expect(body).toEqual({
+      action: 'submit_feedback',
+      sessionId: 's-1',
+      messageBlockId: 'b-42',
+      vote: 'down',
+      reason: 'incorrect',
+      comment: 'This was wrong',
+    })
+  })
+
+  it('omits optional reason and comment when not provided', async () => {
+    const result: CommandResult = { success: true }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: result }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    await client.submitFeedback({
+      sessionId: 's-1',
+      messageBlockId: 'b-42',
+      vote: 'up',
+    })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string) as MinionCommand
+    expect(body).toEqual({
+      action: 'submit_feedback',
+      sessionId: 's-1',
+      messageBlockId: 'b-42',
+      vote: 'up',
+      reason: undefined,
+      comment: undefined,
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Add `submitFeedback()` method to `ApiClient` interface
- Implementation delegates to existing `sendCommand()` with `submit_feedback` action
- Full type safety with `FeedbackVote` and `FeedbackReason` types
- Includes comprehensive test coverage for both full and minimal payloads

## Test plan
- ✅ `npm run typecheck` — TypeScript validates all types
- ✅ `npm run lint` — ESLint passes
- ✅ `npm run test` — All 1034 tests pass, including new `submitFeedback` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)