### PR TITLE
feat(api): register message-feedback feature flag and validation schema

### DIFF
--- a/server/api/routes.test.ts
+++ b/server/api/routes.test.ts
@@ -130,6 +130,7 @@ describe('GET /api/version', () => {
     expect(features).toContain('transcript')
     expect(features).toContain('auth')
     expect(features).toContain('cors-allowlist')
+    expect(features).toContain('message-feedback')
     expect(body.data.provider).toBe('claude')
   })
 })
@@ -937,5 +938,204 @@ describe('DELETE /api/push-subscribe', () => {
       body: JSON.stringify({}),
     }))
     expect(res.status).toBe(400)
+  })
+})
+
+describe('POST /api/commands - submit_feedback', () => {
+  test('accepts valid submit_feedback command with minimal fields', async () => {
+    const app = makeApp(testDb)
+    const res = await app.fetch(
+      new Request('http://localhost/api/commands', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'submit_feedback',
+          sessionId: 'test-session-id',
+          messageBlockId: 'block-123',
+          vote: 'up',
+        }),
+      }),
+    )
+    expect(res.status).toBe(200)
+    const body = await json<{ data: { success: boolean } }>(res)
+    expect(body.data.success).toBe(true)
+  })
+
+  test('accepts submit_feedback with all optional fields', async () => {
+    const app = makeApp(testDb)
+    const res = await app.fetch(
+      new Request('http://localhost/api/commands', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'submit_feedback',
+          sessionId: 'test-session-id',
+          messageBlockId: 'block-456',
+          vote: 'down',
+          reason: 'incorrect',
+          comment: 'This response was not accurate.',
+        }),
+      }),
+    )
+    expect(res.status).toBe(200)
+    const body = await json<{ data: { success: boolean } }>(res)
+    expect(body.data.success).toBe(true)
+  })
+
+  test('accepts all valid feedback reasons', async () => {
+    const app = makeApp(testDb)
+    const reasons = ['incorrect', 'off_topic', 'too_verbose', 'unsafe', 'other']
+    for (const reason of reasons) {
+      const res = await app.fetch(
+        new Request('http://localhost/api/commands', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            action: 'submit_feedback',
+            sessionId: 'test-session-id',
+            messageBlockId: 'block-123',
+            vote: 'down',
+            reason,
+          }),
+        }),
+      )
+      expect(res.status).toBe(200)
+    }
+  })
+
+  test('rejects submit_feedback with missing sessionId', async () => {
+    const app = makeApp(testDb)
+    const res = await app.fetch(
+      new Request('http://localhost/api/commands', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'submit_feedback',
+          messageBlockId: 'block-123',
+          vote: 'up',
+        }),
+      }),
+    )
+    expect(res.status).toBe(400)
+    const body = await json<{ error: string }>(res)
+    expect(body.error).toContain('sessionId')
+  })
+
+  test('rejects submit_feedback with empty sessionId', async () => {
+    const app = makeApp(testDb)
+    const res = await app.fetch(
+      new Request('http://localhost/api/commands', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'submit_feedback',
+          sessionId: '',
+          messageBlockId: 'block-123',
+          vote: 'up',
+        }),
+      }),
+    )
+    expect(res.status).toBe(400)
+    const body = await json<{ error: string }>(res)
+    expect(body.error).toContain('sessionId')
+  })
+
+  test('rejects submit_feedback with missing messageBlockId', async () => {
+    const app = makeApp(testDb)
+    const res = await app.fetch(
+      new Request('http://localhost/api/commands', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'submit_feedback',
+          sessionId: 'test-session-id',
+          vote: 'up',
+        }),
+      }),
+    )
+    expect(res.status).toBe(400)
+    const body = await json<{ error: string }>(res)
+    expect(body.error).toContain('messageBlockId')
+  })
+
+  test('rejects submit_feedback with invalid vote', async () => {
+    const app = makeApp(testDb)
+    const res = await app.fetch(
+      new Request('http://localhost/api/commands', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'submit_feedback',
+          sessionId: 'test-session-id',
+          messageBlockId: 'block-123',
+          vote: 'invalid',
+        }),
+      }),
+    )
+    expect(res.status).toBe(400)
+    const body = await json<{ error: string }>(res)
+    expect(body.error).toContain('vote')
+  })
+
+  test('rejects submit_feedback with invalid reason', async () => {
+    const app = makeApp(testDb)
+    const res = await app.fetch(
+      new Request('http://localhost/api/commands', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'submit_feedback',
+          sessionId: 'test-session-id',
+          messageBlockId: 'block-123',
+          vote: 'down',
+          reason: 'invalid-reason',
+        }),
+      }),
+    )
+    expect(res.status).toBe(400)
+    const body = await json<{ error: string }>(res)
+    expect(body.error).toContain('reason')
+  })
+
+  test('rejects submit_feedback with comment exceeding 2000 chars', async () => {
+    const app = makeApp(testDb)
+    const longComment = 'x'.repeat(2001)
+    const res = await app.fetch(
+      new Request('http://localhost/api/commands', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'submit_feedback',
+          sessionId: 'test-session-id',
+          messageBlockId: 'block-123',
+          vote: 'down',
+          comment: longComment,
+        }),
+      }),
+    )
+    expect(res.status).toBe(400)
+    const body = await json<{ error: string }>(res)
+    expect(body.error).toContain('comment')
+  })
+
+  test('accepts submit_feedback with comment at 2000 chars', async () => {
+    const app = makeApp(testDb)
+    const maxComment = 'x'.repeat(2000)
+    const res = await app.fetch(
+      new Request('http://localhost/api/commands', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'submit_feedback',
+          sessionId: 'test-session-id',
+          messageBlockId: 'block-123',
+          vote: 'down',
+          comment: maxComment,
+        }),
+      }),
+    )
+    expect(res.status).toBe(200)
+    const body = await json<{ data: { success: boolean } }>(res)
+    expect(body.data.success).toBe(true)
   })
 })

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -106,6 +106,7 @@ const FEATURES = [
   'external-entrypoints',
   'audit-log',
   'memory',
+  'message-feedback',
 ]
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
@@ -150,6 +151,14 @@ const CommandSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('land'), dagId: z.string(), nodeId: z.string() }),
   z.object({ action: z.literal('retry_rebase'), dagId: z.string(), nodeId: z.string() }),
   z.object({ action: z.literal('ship_advance'), sessionId: z.string(), to: z.enum(['think', 'plan', 'dag', 'verify', 'done']).optional() }),
+  z.object({
+    action: z.literal('submit_feedback'),
+    sessionId: z.string().min(1),
+    messageBlockId: z.string().min(1),
+    vote: z.enum(['up', 'down']),
+    reason: z.enum(['incorrect', 'off_topic', 'too_verbose', 'unsafe', 'other']).optional(),
+    comment: z.string().max(2000).optional(),
+  }),
 ])
 
 const MessageSchema = z.object({


### PR DESCRIPTION
## Summary
- Register `message-feedback` feature flag in `/api/version` response
- Add Zod validation schema for `submit_feedback` command in `/api/commands` endpoint
- Required fields: `sessionId`, `messageBlockId`, `vote` (enum: 'up' | 'down')
- Optional fields: `reason` (enum: 'incorrect' | 'off_topic' | 'too_verbose' | 'unsafe' | 'other'), `comment` (max 2000 chars)

## Test plan
- [x] Feature flag appears in GET /api/version response
- [x] Valid minimal submit_feedback command (vote only) passes validation
- [x] Valid full submit_feedback command (with reason & comment) passes validation
- [x] All valid feedback reasons accepted: incorrect, off_topic, too_verbose, unsafe, other
- [x] Missing required fields (sessionId, messageBlockId) rejected with 400
- [x] Empty sessionId rejected
- [x] Invalid vote value rejected
- [x] Invalid reason value rejected
- [x] Comment exceeding 2000 chars rejected
- [x] Comment at exactly 2000 chars accepted
- [x] All 56 route tests pass including 11 new feedback validation tests
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)