### PR TITLE
fix(github): parse checks from stdout when gh pr checks exits code 8

### DIFF
--- a/server/github/pr-preview.test.ts
+++ b/server/github/pr-preview.test.ts
@@ -49,7 +49,7 @@ describe("fetchPrPreview", () => {
     expect(result.checks[0]!.status).toBe("success")
   })
 
-  test("checks result is empty array when gh pr checks fails", async () => {
+  test("checks result is empty array when gh pr checks fails without stdout", async () => {
     const viewPayload = JSON.stringify({
       number: 1002,
       url: "https://github.com/org/repo/pull/1002",
@@ -69,6 +69,34 @@ describe("fetchPrPreview", () => {
 
     expect(result.title).toBe("My PR")
     expect(result.checks).toHaveLength(0)
+  })
+
+  test("parses checks from error.stdout when gh pr checks exits code 8", async () => {
+    const viewPayload = JSON.stringify({
+      number: 1004,
+      url: "https://github.com/org/repo/pull/1004",
+      title: "PR with failing checks",
+      body: "",
+      state: "OPEN",
+      isDraft: false,
+      mergeable: "MERGEABLE",
+      headRefName: "feature",
+      baseRefName: "main",
+      author: { login: "octocat" },
+      updatedAt: "2024-01-01T00:00:00Z",
+    })
+    const checksPayload = JSON.stringify([
+      { name: "ci/test", status: "completed", conclusion: "failure", link: "https://ci.example.com/1" },
+    ])
+
+    const errorWithStdout = Object.assign(new Error("exit code 8"), { stdout: checksPayload })
+    const exec = makeExec([{ stdout: viewPayload }, errorWithStdout])
+    const result = await fetchPrPreview("https://github.com/org/repo/pull/1004", exec)
+
+    expect(result.title).toBe("PR with failing checks")
+    expect(result.checks).toHaveLength(1)
+    expect(result.checks[0]!.name).toBe("ci/test")
+    expect(result.checks[0]!.status).toBe("failure")
   })
 
   test("throws when gh pr view fails", async () => {

--- a/server/github/pr-preview.ts
+++ b/server/github/pr-preview.ts
@@ -117,7 +117,12 @@ export async function fetchPrPreview(
       cmd: "gh",
       args: ["pr", "checks", prUrl, "--json", "name,status,conclusion,link"],
       opts: { timeout: TIMEOUT_MS, encoding: "utf-8" },
-    }).catch(() => ({ stdout: "[]", stderr: "" })),
+    }).catch((err: unknown) => {
+      if (err && typeof err === "object" && "stdout" in err && typeof err.stdout === "string") {
+        return { stdout: err.stdout, stderr: "" }
+      }
+      return { stdout: "[]", stderr: "" }
+    }),
   ])
 
   let viewData: Record<string, unknown>


### PR DESCRIPTION
## Summary
- Fixed `gh pr checks` error handling to capture stdout when command exits with code 8
- `gh pr checks` exits non-zero when checks are pending/failing but still writes valid JSON to stdout
- Error handler now extracts stdout from error object before falling back to empty array
- Added test coverage for the code 8 scenario with failing checks

## Test plan
- [x] All pr-preview tests pass (5/5)
- [x] New test verifies checks parsing from error.stdout
- [x] Existing test confirms backward compatibility (errors without stdout)
- [x] `npm run typecheck && npm run lint` passes
