### PR TITLE
feat(server): expose session metadata in API responses

### DIFF
--- a/server/api/wire-mappers.test.ts
+++ b/server/api/wire-mappers.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from 'bun:test'
+import { sessionRowToApi } from './wire-mappers'
+import type { SessionRow } from '../db/sqlite'
+
+function makeRow(overrides: Partial<SessionRow> = {}): SessionRow {
+  const now = Date.now()
+  return {
+    id: 'sess-1',
+    slug: 'test-slug',
+    status: 'running',
+    command: 'do the thing',
+    mode: 'task',
+    repo: null,
+    branch: null,
+    bare_dir: null,
+    pr_url: null,
+    parent_id: null,
+    variant_group_id: null,
+    claude_session_id: null,
+    workspace_root: null,
+    created_at: now - 1000,
+    updated_at: now - 1000,
+    needs_attention: false,
+    attention_reasons: [],
+    quick_actions: [],
+    conversation: [],
+    quota_sleep_until: null,
+    quota_retry_count: 0,
+    metadata: {},
+    pipeline_advancing: false,
+    stage: null,
+    coordinator_children: [],
+    ...overrides,
+  }
+}
+
+describe('sessionRowToApi', () => {
+  describe('metadata field', () => {
+    test('excludes metadata when empty object', () => {
+      const row = makeRow({ metadata: {} })
+      const api = sessionRowToApi(row)
+      expect(api.metadata).toBeUndefined()
+    })
+
+    test('includes metadata when non-empty', () => {
+      const row = makeRow({ metadata: { kind: 'feedback', vote: 'up' } })
+      const api = sessionRowToApi(row)
+      expect(api.metadata).toEqual({ kind: 'feedback', vote: 'up' })
+    })
+
+    test('includes metadata with feedback details', () => {
+      const row = makeRow({
+        metadata: {
+          kind: 'feedback',
+          vote: 'down',
+          reason: 'incorrect',
+          comment: 'wrong approach',
+          sourceSessionId: 'sess-parent',
+          sourceSessionSlug: 'parent-slug',
+          sourceMessageBlockId: 'block-123',
+        },
+      })
+      const api = sessionRowToApi(row)
+      expect(api.metadata).toEqual({
+        kind: 'feedback',
+        vote: 'down',
+        reason: 'incorrect',
+        comment: 'wrong approach',
+        sourceSessionId: 'sess-parent',
+        sourceSessionSlug: 'parent-slug',
+        sourceMessageBlockId: 'block-123',
+      })
+    })
+
+    test('preserves metadata structure for other kinds', () => {
+      const row = makeRow({ metadata: { customKey: 'customValue', nested: { deep: true } } })
+      const api = sessionRowToApi(row)
+      expect(api.metadata).toEqual({ customKey: 'customValue', nested: { deep: true } })
+    })
+  })
+})

--- a/server/api/wire-mappers.ts
+++ b/server/api/wire-mappers.ts
@@ -45,6 +45,7 @@ export function sessionRowToApi(row: SessionRow): ApiSession {
     quickActions,
     conversation: row.conversation as ConversationMessage[],
     variantGroupId: row.variant_group_id ?? undefined,
+    metadata: Object.keys(row.metadata).length > 0 ? row.metadata : undefined,
   }
 
   // Include stage only when mode is 'ship' and stage is present

--- a/server/session/registry.test.ts
+++ b/server/session/registry.test.ts
@@ -558,6 +558,91 @@ describe('SessionRegistry', () => {
     }, 30_000)
   })
 
+  describe('metadata exposure', () => {
+    test('excludes metadata when empty object', async () => {
+      const bare = trackedDir('bare-empty-meta')
+      const work = trackedDir('work-empty-meta')
+      const workspaceRoot = trackedDir('ws-empty-meta')
+      await initLocalBareRepo(bare, work)
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn() })
+      const { session } = await registry.create({
+        mode: 'task',
+        prompt: 'test',
+        repo: bare,
+        workspaceRoot,
+        metadata: {},
+      })
+
+      const snap = registry.snapshot(session.id)
+      expect(snap).toBeDefined()
+      expect(snap!.metadata).toBeUndefined()
+    }, 30_000)
+
+    test('includes metadata when non-empty', async () => {
+      const bare = trackedDir('bare-with-meta')
+      const work = trackedDir('work-with-meta')
+      const workspaceRoot = trackedDir('ws-with-meta')
+      await initLocalBareRepo(bare, work)
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn() })
+      const { session } = await registry.create({
+        mode: 'task',
+        prompt: 'feedback task',
+        repo: bare,
+        workspaceRoot,
+        metadata: {
+          kind: 'feedback',
+          vote: 'up',
+          sourceSessionId: 'parent-123',
+          sourceSessionSlug: 'parent-slug',
+          sourceMessageBlockId: 'msg-block-1',
+        },
+      })
+
+      const snap = registry.snapshot(session.id)
+      expect(snap).toBeDefined()
+      expect(snap!.metadata).toEqual({
+        kind: 'feedback',
+        vote: 'up',
+        sourceSessionId: 'parent-123',
+        sourceSessionSlug: 'parent-slug',
+        sourceMessageBlockId: 'msg-block-1',
+      })
+    }, 30_000)
+
+    test('includes metadata in list() results', async () => {
+      const bare = trackedDir('bare-list-meta')
+      const work = trackedDir('work-list-meta')
+      const workspaceRoot = trackedDir('ws-list-meta')
+      await initLocalBareRepo(bare, work)
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn() })
+      await registry.create({
+        mode: 'task',
+        prompt: 'no metadata',
+        repo: bare,
+        workspaceRoot,
+      })
+      await registry.create({
+        mode: 'task',
+        prompt: 'with metadata',
+        repo: bare,
+        workspaceRoot,
+        metadata: { kind: 'feedback', vote: 'down' },
+      })
+
+      const sessions = registry.list()
+      expect(sessions).toHaveLength(2)
+
+      const withoutMeta = sessions.find((s) => s.command === 'no metadata')
+      const withMeta = sessions.find((s) => s.command === 'with metadata')
+
+      expect(withoutMeta?.metadata).toBeUndefined()
+      expect(withMeta?.metadata).toEqual({ kind: 'feedback', vote: 'down' })
+    }, 60_000)
+  })
+
   describe('childIds and stage propagation', () => {
     test('populates childIds in ApiSession ordered by created_at', async () => {
       const bare = trackedDir('bare-children')

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -56,6 +56,7 @@ function rowToApi(row: SessionRow, db?: Database): ApiSession {
     mode: row.mode,
     conversation: [],
     transcriptUrl: `/api/sessions/${row.slug}/transcript`,
+    metadata: Object.keys(row.metadata).length > 0 ? row.metadata : undefined,
   }
 
   if (row.mode === 'ship' && row.stage) {


### PR DESCRIPTION
## Summary

- Updated `sessionRowToApi` in `server/api/wire-mappers.ts` to expose `metadata` field when non-empty
- Updated `rowToApi` in `server/session/registry.ts` to expose `metadata` field when non-empty  
- Both mappers return `undefined` (not `{}`) when metadata is empty to preserve existing JSON shape
- Added comprehensive unit tests covering empty and populated metadata scenarios

This enables the UI to detect and render feedback minion sessions by checking `session.metadata.kind === 'feedback'`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] New wire-mappers tests pass (4 tests covering metadata field)
- [x] CI will validate full server test suite including registry integration tests