### PR TITLE
fix(mobile): increase bottom sheet peek height

### DIFF
--- a/src/hooks/useBottomSheetSnap.ts
+++ b/src/hooks/useBottomSheetSnap.ts
@@ -17,8 +17,8 @@ interface TouchState {
 }
 
 const SNAP_HEIGHTS = {
-  peek: 0.25,
-  half: 0.5,
+  peek: 0.45,
+  half: 0.65,
   full: 0.9,
 }
 

--- a/test/hooks/useBottomSheetSnap.test.ts
+++ b/test/hooks/useBottomSheetSnap.test.ts
@@ -66,7 +66,7 @@ describe('useBottomSheetSnap', () => {
       result.current.snapTo('half')
     })
 
-    expect(mockElement.style.height).toBe('500px')
+    expect(mockElement.style.height).toBe('650px')
   })
 
   it('calculates correct heights for snap points', () => {
@@ -78,12 +78,12 @@ describe('useBottomSheetSnap', () => {
     act(() => {
       result.current.snapTo('peek')
     })
-    expect(mockElement.style.height).toBe('250px')
+    expect(mockElement.style.height).toBe('450px')
 
     act(() => {
       result.current.snapTo('half')
     })
-    expect(mockElement.style.height).toBe('500px')
+    expect(mockElement.style.height).toBe('650px')
 
     act(() => {
       result.current.snapTo('full')


### PR DESCRIPTION
## Summary
- Increases bottom sheet peek snap from 25% to 45% of viewport height
- Adjusts half snap from 50% to 65% for better spacing
- Eliminates large empty space between task list and chat panel on mobile

## Test plan
- [x] Unit tests updated and passing
- [ ] Manual test on mobile: verify bottom sheet shows more content in peek mode
- [ ] Manual test: verify swipe gestures still work smoothly between snap points
- [ ] Manual test: verify no layout issues on different screen sizes