### PR TITLE
feat(server): add submit_feedback command handler

### DIFF
--- a/server/commands/feedback.test.ts
+++ b/server/commands/feedback.test.ts
@@ -1,0 +1,239 @@
+import { describe, test, expect } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { readFileSync } from 'node:fs'
+import { runMigrations, prepared } from '../db/sqlite'
+import { handleSubmitFeedback, type SubmitFeedbackInput } from './feedback'
+import type { SessionRegistry } from '../session/registry'
+import type { ApiSession } from '../../shared/api-types'
+
+function makeDb(): Database {
+  const db = new Database(':memory:')
+  const schemaPath = new URL('../db/schema.sql', import.meta.url).pathname
+  db.exec(readFileSync(schemaPath, 'utf8'))
+  runMigrations(db)
+  return db
+}
+
+function seedSession(db: Database, id: string, repo: string | null): void {
+  const now = Date.now()
+  db.run(
+    `INSERT INTO sessions (id, slug, status, command, mode, repo, created_at, updated_at, needs_attention, attention_reasons, quick_actions, conversation, quota_retry_count, metadata, pipeline_advancing)
+     VALUES (?, ?, 'completed', 'test task', 'task', ?, ?, ?, 0, '[]', '[]', '[]', 0, '{}', 0)`,
+    [id, `slug-${id}`, repo, now, now],
+  )
+}
+
+function seedEvents(db: Database, sessionId: string): void {
+  db.run(
+    `INSERT INTO session_events (session_id, seq, turn, type, timestamp, payload)
+     VALUES (?, 1, 1, 'user_message', ?, ?)`,
+    [sessionId, Date.now(), JSON.stringify({ text: 'Please help me with X' })],
+  )
+  db.run(
+    `INSERT INTO session_events (session_id, seq, turn, type, timestamp, payload)
+     VALUES (?, 2, 1, 'assistant_text', ?, ?)`,
+    [sessionId, Date.now(), JSON.stringify({ blockId: 'block-1', text: 'Here is my answer', final: true })],
+  )
+}
+
+function makeRegistry(onCreateCalled?: (opts: { mode: string; prompt: string; repo: string; parentId?: string; metadata?: Record<string, unknown> }) => void): SessionRegistry {
+  return {
+    async create(opts) {
+      onCreateCalled?.(opts)
+      return {
+        session: { id: 'child-session-id' } as ApiSession,
+        runtime: {} as never,
+      }
+    },
+    get() { return undefined },
+    getBySlug() { return undefined },
+    list() { return [] },
+    snapshot() { return undefined },
+    async stop() {},
+    async close() {},
+    async reply() { return true },
+    async reconcileOnBoot() {},
+    async scheduleQuotaResume() {},
+  }
+}
+
+describe('handleSubmitFeedback', () => {
+  test('missing sourceSessionId returns error', async () => {
+    const db = makeDb()
+    const input: SubmitFeedbackInput = {
+      sourceSessionId: '',
+      sourceSessionSlug: 'test-slug',
+      sourceMessageBlockId: 'block-1',
+      vote: 'up',
+    }
+    const result = await handleSubmitFeedback(input, { registry: makeRegistry(), db })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('sourceSessionId required')
+    db.close()
+  })
+
+  test('missing vote returns error', async () => {
+    const db = makeDb()
+    const input: SubmitFeedbackInput = {
+      sourceSessionId: 's1',
+      sourceSessionSlug: 'test-slug',
+      sourceMessageBlockId: 'block-1',
+      vote: '' as never,
+    }
+    const result = await handleSubmitFeedback(input, { registry: makeRegistry(), db })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('vote required')
+    db.close()
+  })
+
+  test('session not found returns error', async () => {
+    const db = makeDb()
+    const input: SubmitFeedbackInput = {
+      sourceSessionId: 'nonexistent',
+      sourceSessionSlug: 'test-slug',
+      sourceMessageBlockId: 'block-1',
+      vote: 'up',
+    }
+    const result = await handleSubmitFeedback(input, { registry: makeRegistry(), db })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('not found')
+    db.close()
+  })
+
+  test('upvote with repo spawns feedback minion', async () => {
+    const db = makeDb()
+    seedSession(db, 's1', 'https://github.com/owner/repo')
+    seedEvents(db, 's1')
+
+    let createCalled = false
+    let capturedOpts: { mode: string; prompt: string; repo: string; parentId?: string; metadata?: Record<string, unknown> } | undefined
+
+    const result = await handleSubmitFeedback(
+      {
+        sourceSessionId: 's1',
+        sourceSessionSlug: 'slug-s1',
+        sourceMessageBlockId: 'block-1',
+        vote: 'up',
+      },
+      {
+        registry: makeRegistry((opts) => {
+          createCalled = true
+          capturedOpts = opts
+        }),
+        db,
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.childSessionId).toBe('child-session-id')
+    expect(createCalled).toBe(true)
+    expect(capturedOpts?.mode).toBe('task')
+    expect(capturedOpts?.repo).toBe('https://github.com/owner/repo')
+    expect(capturedOpts?.parentId).toBe('s1')
+    expect(capturedOpts?.metadata?.kind).toBe('feedback')
+    expect(capturedOpts?.metadata?.vote).toBe('up')
+    expect(capturedOpts?.prompt).toContain('Positive feedback')
+    expect(capturedOpts?.prompt).toContain('Identify what worked well')
+
+    const auditRows = db.query('SELECT * FROM audit_events WHERE action = ?').all('message_feedback')
+    expect(auditRows.length).toBe(1)
+
+    db.close()
+  })
+
+  test('downvote with reason and comment spawns feedback minion', async () => {
+    const db = makeDb()
+    seedSession(db, 's2', 'https://github.com/owner/repo')
+    seedEvents(db, 's2')
+
+    let capturedOpts: { mode: string; prompt: string; repo: string; parentId?: string; metadata?: Record<string, unknown> } | undefined
+
+    const result = await handleSubmitFeedback(
+      {
+        sourceSessionId: 's2',
+        sourceSessionSlug: 'slug-s2',
+        sourceMessageBlockId: 'block-1',
+        vote: 'down',
+        reason: 'incorrect',
+        comment: 'This approach was wrong',
+      },
+      {
+        registry: makeRegistry((opts) => {
+          capturedOpts = opts
+        }),
+        db,
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.childSessionId).toBe('child-session-id')
+    expect(capturedOpts?.metadata?.vote).toBe('down')
+    expect(capturedOpts?.metadata?.reason).toBe('incorrect')
+    expect(capturedOpts?.metadata?.comment).toBe('This approach was wrong')
+    expect(capturedOpts?.prompt).toContain('Negative feedback')
+    expect(capturedOpts?.prompt).toContain('Reason:** Incorrect')
+    expect(capturedOpts?.prompt).toContain('This approach was wrong')
+    expect(capturedOpts?.prompt).toContain('Diagnose what went wrong')
+
+    db.close()
+  })
+
+  test('feedback without repo records audit but does not spawn', async () => {
+    const db = makeDb()
+    seedSession(db, 's3', null)
+    seedEvents(db, 's3')
+
+    let createCalled = false
+
+    const result = await handleSubmitFeedback(
+      {
+        sourceSessionId: 's3',
+        sourceSessionSlug: 'slug-s3',
+        sourceMessageBlockId: 'block-1',
+        vote: 'up',
+      },
+      {
+        registry: makeRegistry(() => {
+          createCalled = true
+        }),
+        db,
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.childSessionId).toBeUndefined()
+    expect(createCalled).toBe(false)
+
+    const auditRows = db.query('SELECT * FROM audit_events WHERE action = ?').all('message_feedback')
+    expect(auditRows.length).toBe(1)
+
+    db.close()
+  })
+
+  test('audit event is always recorded', async () => {
+    const db = makeDb()
+    seedSession(db, 's4', 'https://github.com/owner/repo')
+    seedEvents(db, 's4')
+
+    await handleSubmitFeedback(
+      {
+        sourceSessionId: 's4',
+        sourceSessionSlug: 'slug-s4',
+        sourceMessageBlockId: 'block-1',
+        vote: 'down',
+        reason: 'too_verbose',
+        comment: 'Too long',
+      },
+      { registry: makeRegistry(), db },
+    )
+
+    const auditRow = prepared.listAuditEvents(db).find(r => r.action === 'message_feedback')
+    expect(auditRow).toBeDefined()
+    expect(auditRow?.session_id).toBe('s4')
+    expect(auditRow?.metadata.vote).toBe('down')
+    expect(auditRow?.metadata.reason).toBe('too_verbose')
+    expect(auditRow?.metadata.comment).toBe('Too long')
+
+    db.close()
+  })
+})

--- a/server/commands/feedback.ts
+++ b/server/commands/feedback.ts
@@ -1,0 +1,180 @@
+import type { SessionRegistry } from '../session/registry'
+import type { Database } from 'bun:sqlite'
+import { prepared } from '../db/sqlite'
+import { recordAuditEvent } from '../audit/audit-log'
+import { eventRowToTranscript } from '../api/wire-mappers'
+import type { FeedbackVote, FeedbackReason, TranscriptEvent } from '../../shared/api-types'
+
+export interface SubmitFeedbackInput {
+  sourceSessionId: string
+  sourceSessionSlug: string
+  sourceMessageBlockId: string
+  vote: FeedbackVote
+  reason?: FeedbackReason
+  comment?: string
+}
+
+export interface FeedbackCommandCtx {
+  registry: SessionRegistry
+  db: Database
+}
+
+export interface FeedbackCommandResult {
+  ok: boolean
+  childSessionId?: string
+  error?: string
+}
+
+function renderTranscript(events: TranscriptEvent[]): string {
+  const lines: string[] = []
+
+  for (const event of events) {
+    if (event.type === 'user_message') {
+      lines.push(`## User`)
+      lines.push(``)
+      lines.push(event.text)
+      lines.push(``)
+    } else if (event.type === 'assistant_text' && event.final) {
+      lines.push(`## Assistant`)
+      lines.push(``)
+      lines.push(event.text)
+      lines.push(``)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function buildFeedbackPrompt(
+  input: SubmitFeedbackInput,
+  transcript: string,
+  ratedReply: string,
+): string {
+  const lines: string[] = []
+
+  if (input.vote === 'up') {
+    lines.push(`# Positive feedback received`)
+    lines.push(``)
+    lines.push(`A user upvoted an assistant reply in session ${input.sourceSessionSlug}.`)
+    lines.push(``)
+    lines.push(`## Your task`)
+    lines.push(``)
+    lines.push(`1. Analyze the rated reply and the full conversation context`)
+    lines.push(`2. Identify what worked well — was it the approach, the tone, the level of detail, the technical accuracy, or something else?`)
+    lines.push(`3. Propose a concrete feedback memory entry that captures this success pattern for future reference`)
+    lines.push(``)
+    lines.push(`The memory should help future agents repeat this success. Focus on the WHY — what made this response valuable?`)
+    lines.push(``)
+  } else {
+    lines.push(`# Negative feedback received`)
+    lines.push(``)
+    lines.push(`A user downvoted an assistant reply in session ${input.sourceSessionSlug}.`)
+    lines.push(``)
+    if (input.reason) {
+      const reasonLabels: Record<FeedbackReason, string> = {
+        incorrect: 'Incorrect',
+        off_topic: 'Off topic',
+        too_verbose: 'Too verbose',
+        unsafe: 'Unsafe',
+        other: 'Other',
+      }
+      lines.push(`**Reason:** ${reasonLabels[input.reason]}`)
+      lines.push(``)
+    }
+    if (input.comment) {
+      lines.push(`**User comment:**`)
+      lines.push(``)
+      lines.push(`> ${input.comment}`)
+      lines.push(``)
+    }
+    lines.push(`## Your task`)
+    lines.push(``)
+    lines.push(`1. Diagnose what went wrong in the rated reply`)
+    lines.push(`2. Locate the root cause — was it a misunderstanding, missing context, wrong approach, or something else?`)
+    lines.push(`3. Propose a feedback memory entry to avoid this failure pattern in the future`)
+    lines.push(`4. If applicable, identify the specific fix or change that would prevent recurrence`)
+    lines.push(``)
+    lines.push(`The memory should help future agents avoid this mistake. Focus on the WHY and HOW TO APPLY.`)
+    lines.push(``)
+  }
+
+  lines.push(`## Rated reply`)
+  lines.push(``)
+  lines.push(`\`\`\``)
+  lines.push(ratedReply)
+  lines.push(`\`\`\``)
+  lines.push(``)
+  lines.push(`## Full conversation transcript`)
+  lines.push(``)
+  lines.push(transcript)
+
+  return lines.join('\n')
+}
+
+export async function handleSubmitFeedback(
+  input: SubmitFeedbackInput,
+  ctx: FeedbackCommandCtx,
+): Promise<FeedbackCommandResult> {
+  if (!input.sourceSessionId) {
+    return { ok: false, error: 'sourceSessionId required' }
+  }
+  if (!input.vote) {
+    return { ok: false, error: 'vote required' }
+  }
+
+  const sourceRow = prepared.getSession(ctx.db, input.sourceSessionId)
+  if (!sourceRow) {
+    return { ok: false, error: `session ${input.sourceSessionId} not found` }
+  }
+
+  const eventRows = prepared.listEvents(ctx.db, input.sourceSessionId, -1)
+  const events = eventRows.map((row) => eventRowToTranscript({
+    session_id: row.session_id,
+    seq: row.seq,
+    turn: row.turn,
+    type: row.type,
+    timestamp: row.timestamp,
+    payload: JSON.stringify(row.payload)
+  }))
+
+  recordAuditEvent(ctx.db, {
+    action: 'message_feedback',
+    sessionId: input.sourceSessionId,
+    metadata: {
+      vote: input.vote,
+      reason: input.reason,
+      comment: input.comment,
+      sourceMessageBlockId: input.sourceMessageBlockId,
+    },
+  })
+
+  if (!sourceRow.repo) {
+    return { ok: true }
+  }
+
+  const ratedReply = events
+    .filter((e) => e.type === 'assistant_text' && e.final && e.blockId === input.sourceMessageBlockId)
+    .map((e) => (e as Extract<TranscriptEvent, { type: 'assistant_text' }>).text)
+    .join('\n\n')
+
+  const transcript = renderTranscript(events)
+  const prompt = buildFeedbackPrompt(input, transcript, ratedReply)
+
+  const { session } = await ctx.registry.create({
+    mode: 'task',
+    prompt,
+    repo: sourceRow.repo,
+    parentId: sourceRow.id,
+    metadata: {
+      kind: 'feedback',
+      vote: input.vote,
+      reason: input.reason,
+      comment: input.comment,
+      sourceSessionId: input.sourceSessionId,
+      sourceSessionSlug: input.sourceSessionSlug,
+      sourceMessageBlockId: input.sourceMessageBlockId,
+    },
+  })
+
+  return { ok: true, childSessionId: session.id }
+}


### PR DESCRIPTION
## Summary

- Implements `handleSubmitFeedback` command in `server/commands/feedback.ts`
- Validates input (sourceSessionId, vote required) and returns 4xx-shaped errors for missing fields
- Loads source session and full transcript using `prepared.getSession` + `prepared.listEvents`
- Records audit event (`message_feedback`) for every vote regardless of spawn
- Spawns feedback minion (task mode) with full conversation context when source session has a repo
- Builds context-aware prompt based on vote type:
  - **Upvote**: "identify what worked well, propose feedback memory entry"
  - **Downvote**: "diagnose failure, propose corrective memory, locate fix if applicable"
- Returns `{ ok: true, childSessionId }` on successful spawn, `{ ok: true }` for audit-only

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (1032 UI tests)
- [x] `bun test server/commands/feedback.test.ts` passes (7 tests covering validation, audit, spawn logic)
- [ ] CI will run full E2E suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)