### PR TITLE
feat(ui): visually mark feedback minion sessions

### DIFF
--- a/src/components/NodeDetailPopup.tsx
+++ b/src/components/NodeDetailPopup.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'preact/hooks'
-import type { ApiDagGraph, ApiDagNode, ApiSession } from '../api/types'
+import type { ApiDagGraph, ApiDagNode, ApiSession, FeedbackMetadata } from '../api/types'
 import { useTheme } from '../hooks/useTheme'
 import { useMediaQuery } from '../hooks/useMediaQuery'
 import { useSwipeToDismiss } from '../hooks/useSwipeToDismiss'
@@ -69,6 +69,28 @@ function findOwningDag(
     }
   }
   return null
+}
+
+function isFeedbackSession(session: ApiSession): session is ApiSession & { metadata: FeedbackMetadata } {
+  return session.metadata !== undefined &&
+    typeof session.metadata === 'object' &&
+    'kind' in session.metadata &&
+    session.metadata.kind === 'feedback'
+}
+
+function FeedbackBadge({ isDark }: { isDark: boolean }) {
+  return (
+    <span
+      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+      style={{
+        backgroundColor: isDark ? 'rgba(251,191,36,0.2)' : 'rgba(245,158,11,0.15)',
+        color: isDark ? '#fbbf24' : '#d97706',
+      }}
+      data-testid="feedback-badge"
+    >
+      Feedback
+    </span>
+  )
 }
 
 export function NodeDetailPopup({
@@ -146,7 +168,11 @@ export function NodeDetailPopup({
   const hasChatAction = Boolean(onOpenChat)
   const hasLogsAction = Boolean(onViewLogs)
 
+  const feedbackMeta = isFeedbackSession(session) ? session.metadata : null
+  const sourceSession = feedbackMeta ? sessionById.get(feedbackMeta.sourceSessionId) : undefined
+
   const hasHierarchyMeta =
+    feedbackMeta !== null ||
     parentSession !== undefined ||
     childSessions.length > 0 ||
     dagMatch !== null ||
@@ -182,6 +208,7 @@ export function NodeDetailPopup({
               </div>
               <div class="flex items-center gap-2 mt-1.5">
                 <StatusBadge status={session.status} />
+                {isFeedbackSession(session) && <FeedbackBadge isDark={isDark} />}
                 {session.needsAttention && session.attentionReasons.length > 0 && (
                   <AttentionBadge reason={session.attentionReasons[0]} darkMode={isDark} />
                 )}
@@ -202,6 +229,29 @@ export function NodeDetailPopup({
 
             {hasHierarchyMeta && (
               <div class={`px-4 py-3 border-b ${borderColor} flex flex-col gap-2`} data-testid="node-detail-hierarchy">
+                {feedbackMeta && (
+                  <MetaRow label="Reviewing" isDark={isDark}>
+                    <div class="flex flex-col gap-1">
+                      <div class="flex items-center gap-2">
+                        <span>{feedbackMeta.vote === 'up' ? '👍' : '👎'}</span>
+                        {feedbackMeta.reason && (
+                          <span class="text-xs">
+                            {feedbackMeta.reason === 'incorrect' ? 'Incorrect' :
+                             feedbackMeta.reason === 'off_topic' ? 'Off Topic' :
+                             feedbackMeta.reason === 'too_verbose' ? 'Too Verbose' :
+                             feedbackMeta.reason === 'unsafe' ? 'Unsafe' : 'Other'}
+                          </span>
+                        )}
+                      </div>
+                      {sourceSession && (
+                        <SessionLink session={sourceSession} onClick={onSelectSession} isDark={isDark} />
+                      )}
+                      {feedbackMeta.comment && (
+                        <span class="text-[11px] opacity-70 italic">{feedbackMeta.comment}</span>
+                      )}
+                    </div>
+                  </MetaRow>
+                )}
                 {isShipCoordinator && session.stage && (
                   <MetaRow label="Stage" isDark={isDark}>
                     <span
@@ -395,6 +445,7 @@ export function NodeDetailPopup({
           </div>
           <div class="flex items-center gap-2 mt-1.5">
             <StatusBadge status={session.status} />
+            {isFeedbackSession(session) && <FeedbackBadge isDark={isDark} />}
             {session.needsAttention && session.attentionReasons.length > 0 && (
               <AttentionBadge reason={session.attentionReasons[0]} darkMode={isDark} />
             )}
@@ -415,6 +466,29 @@ export function NodeDetailPopup({
 
         {hasHierarchyMeta && (
           <div class={`px-4 py-3 border-b ${borderColor} flex flex-col gap-2`} data-testid="node-detail-hierarchy">
+            {feedbackMeta && (
+              <MetaRow label="Reviewing" isDark={isDark}>
+                <div class="flex flex-col gap-1">
+                  <div class="flex items-center gap-2">
+                    <span>{feedbackMeta.vote === 'up' ? '👍' : '👎'}</span>
+                    {feedbackMeta.reason && (
+                      <span class="text-xs">
+                        {feedbackMeta.reason === 'incorrect' ? 'Incorrect' :
+                         feedbackMeta.reason === 'off_topic' ? 'Off Topic' :
+                         feedbackMeta.reason === 'too_verbose' ? 'Too Verbose' :
+                         feedbackMeta.reason === 'unsafe' ? 'Unsafe' : 'Other'}
+                      </span>
+                    )}
+                  </div>
+                  {sourceSession && (
+                    <SessionLink session={sourceSession} onClick={onSelectSession} isDark={isDark} />
+                  )}
+                  {feedbackMeta.comment && (
+                    <span class="text-[11px] opacity-70 italic">{feedbackMeta.comment}</span>
+                  )}
+                </div>
+              </MetaRow>
+            )}
             {isShipCoordinator && session.stage && (
               <MetaRow label="Stage" isDark={isDark}>
                 <span

--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -16,7 +16,7 @@ import '@reactflow/core/dist/style.css'
 import '@reactflow/core/dist/base.css'
 import '@reactflow/controls/dist/style.css'
 import '@reactflow/minimap/dist/style.css'
-import type { ApiSession, ApiDagGraph } from '../api/types'
+import type { ApiSession, ApiDagGraph, FeedbackMetadata } from '../api/types'
 import { StatusBadge, AttentionIconStack, getStatusColors, getAttentionBorder, formatRelativeTime } from './shared'
 import { PrLink } from './PrLink'
 import { ContextMenu, useLongPress, useContextMenu } from './ContextMenu'
@@ -32,6 +32,14 @@ import { NodeDetailPopup } from './NodeDetailPopup'
 import { useTheme } from '../hooks/useTheme'
 import { useMediaQuery } from '../hooks/useMediaQuery'
 import { useHaptics } from '../hooks/useHaptics'
+
+function isFeedbackSession(session?: ApiSession): session is ApiSession & { metadata: FeedbackMetadata } {
+  return session !== undefined &&
+    session.metadata !== undefined &&
+    typeof session.metadata === 'object' &&
+    'kind' in session.metadata &&
+    session.metadata.kind === 'feedback'
+}
 
 interface UniverseNodeData {
   session?: ApiSession
@@ -79,6 +87,7 @@ function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
   const isCoordinator = data.nodeType === 'ship'
 
   const nodeTypeLabel = data.nodeType === 'dag' ? 'DAG' : data.nodeType === 'parent-child' ? 'Tree' : null
+  const isFeedback = isFeedbackSession(session)
 
   const baseWidth = isCoordinator ? 300 : 240
   const baseHeight = isCoordinator ? 120 : 100
@@ -119,17 +128,31 @@ function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
       >
         <div class="flex items-center justify-between gap-1">
           <div class="font-semibold text-sm truncate flex-1">{data.label}</div>
-          {nodeTypeLabel && (
-            <span
-              class="text-[10px] px-1.5 py-0.5 rounded-full font-medium shrink-0"
-              style={{
-                backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.06)',
-                color: isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.4)',
-              }}
-            >
-              {nodeTypeLabel}
-            </span>
-          )}
+          <div class="flex items-center gap-1 shrink-0">
+            {isFeedback && (
+              <span
+                class="text-[10px] px-1.5 py-0.5 rounded-full font-medium"
+                style={{
+                  backgroundColor: isDark ? 'rgba(251,191,36,0.2)' : 'rgba(245,158,11,0.15)',
+                  color: isDark ? '#fbbf24' : '#d97706',
+                }}
+                data-testid="feedback-canvas-badge"
+              >
+                Feedback
+              </span>
+            )}
+            {nodeTypeLabel && (
+              <span
+                class="text-[10px] px-1.5 py-0.5 rounded-full font-medium"
+                style={{
+                  backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.06)',
+                  color: isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.4)',
+                }}
+              >
+                {nodeTypeLabel}
+              </span>
+            )}
+          </div>
         </div>
 
         <div class="flex items-center gap-2 mt-1">

--- a/test/components/NodeDetailPopup.test.tsx
+++ b/test/components/NodeDetailPopup.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, fireEvent, cleanup } from '@testing-library/preact'
 import { NodeDetailPopup } from '../../src/components/NodeDetailPopup'
-import type { ApiDagGraph, ApiSession } from '../../src/api/types'
+import type { ApiDagGraph, ApiSession, FeedbackMetadata } from '../../src/api/types'
 
 function makeSession(overrides: Partial<ApiSession> = {}): ApiSession {
   return {
@@ -626,5 +626,169 @@ describe('NodeDetailPopup mobile bottom sheet', () => {
     expect(modal).toBeTruthy()
     const handle = container.querySelector('.w-10.h-1.rounded-full')
     expect(handle).toBeFalsy()
+  })
+})
+
+describe('NodeDetailPopup feedback sessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders feedback badge when session has feedback metadata', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'incorrect',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const session = makeSession({
+      id: 'feedback-1',
+      slug: 'feedback-minion',
+      metadata: feedbackMeta as unknown as Record<string, unknown>,
+    })
+    render(<NodeDetailPopup session={session} onClose={vi.fn()} sessions={[session]} dags={[]} />)
+    const badge = document.querySelector('[data-testid="feedback-badge"]')
+    expect(badge).toBeTruthy()
+    expect(badge!.textContent).toContain('Feedback')
+  })
+
+  it('does not render feedback badge for non-feedback sessions', () => {
+    const session = makeSession({ id: 's1', slug: 'normal-session' })
+    render(<NodeDetailPopup session={session} onClose={vi.fn()} sessions={[session]} dags={[]} />)
+    expect(document.querySelector('[data-testid="feedback-badge"]')).toBeFalsy()
+  })
+
+  it('renders feedback meta row with thumbs down and reason', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'incorrect',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const sourceSession = makeSession({ id: 'source-1', slug: 'source-slug' })
+    const feedbackSession = makeSession({
+      id: 'feedback-1',
+      slug: 'feedback-minion',
+      metadata: feedbackMeta as unknown as Record<string, unknown>,
+    })
+    render(
+      <NodeDetailPopup
+        session={feedbackSession}
+        onClose={vi.fn()}
+        sessions={[sourceSession, feedbackSession]}
+        dags={[]}
+      />
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')
+    expect(hierarchy).toBeTruthy()
+    expect(hierarchy!.textContent).toContain('👎')
+    expect(hierarchy!.textContent).toContain('Incorrect')
+    expect(hierarchy!.textContent).toContain('source-slug')
+  })
+
+  it('renders feedback meta row with thumbs up', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'up',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const sourceSession = makeSession({ id: 'source-1', slug: 'source-slug' })
+    const feedbackSession = makeSession({
+      id: 'feedback-1',
+      slug: 'feedback-minion',
+      metadata: feedbackMeta as unknown as Record<string, unknown>,
+    })
+    render(
+      <NodeDetailPopup
+        session={feedbackSession}
+        onClose={vi.fn()}
+        sessions={[sourceSession, feedbackSession]}
+        dags={[]}
+      />
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')
+    expect(hierarchy).toBeTruthy()
+    expect(hierarchy!.textContent).toContain('👍')
+  })
+
+  it('renders all feedback reason labels correctly', () => {
+    const reasons: Array<{ reason: FeedbackMetadata['reason']; label: string }> = [
+      { reason: 'incorrect', label: 'Incorrect' },
+      { reason: 'off_topic', label: 'Off Topic' },
+      { reason: 'too_verbose', label: 'Too Verbose' },
+      { reason: 'unsafe', label: 'Unsafe' },
+      { reason: 'other', label: 'Other' },
+    ]
+
+    reasons.forEach(({ reason, label }) => {
+      const feedbackMeta: FeedbackMetadata = {
+        kind: 'feedback',
+        vote: 'down',
+        reason,
+        sourceSessionId: 'source-1',
+        sourceSessionSlug: 'source-slug',
+        sourceMessageBlockId: 'block-123',
+      }
+      const session = makeSession({ id: 'fb-1', slug: 'feedback-minion', metadata: feedbackMeta as unknown as Record<string, unknown> })
+      const { container } = render(<NodeDetailPopup session={session} onClose={vi.fn()} sessions={[session]} dags={[]} />)
+      expect(container.textContent).toContain(label)
+      cleanup()
+    })
+  })
+
+  it('renders comment when present', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'other',
+      comment: 'This was not what I expected',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const session = makeSession({ id: 'fb-1', slug: 'feedback-minion', metadata: feedbackMeta as unknown as Record<string, unknown> })
+    render(<NodeDetailPopup session={session} onClose={vi.fn()} sessions={[session]} dags={[]} />)
+    expect(document.body.textContent).toContain('This was not what I expected')
+  })
+
+  it('clicking source session link navigates to source session', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'incorrect',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const sourceSession = makeSession({ id: 'source-1', slug: 'source-slug' })
+    const feedbackSession = makeSession({
+      id: 'feedback-1',
+      slug: 'feedback-minion',
+      metadata: feedbackMeta as unknown as Record<string, unknown>,
+    })
+    const onSelectSession = vi.fn()
+    render(
+      <NodeDetailPopup
+        session={feedbackSession}
+        onClose={vi.fn()}
+        sessions={[sourceSession, feedbackSession]}
+        dags={[]}
+        onSelectSession={onSelectSession}
+      />
+    )
+    const link = document.querySelector('[data-testid="node-detail-session-link-source-1"]') as HTMLButtonElement
+    expect(link).toBeTruthy()
+    fireEvent.click(link)
+    expect(onSelectSession).toHaveBeenCalledWith(expect.objectContaining({ id: 'source-1' }))
   })
 })

--- a/test/components/UniverseCanvas.test.tsx
+++ b/test/components/UniverseCanvas.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, fireEvent, cleanup } from '@testing-library/preact'
 import { UniverseCanvas } from '../../src/components/UniverseCanvas'
-import type { ApiSession, ApiDagGraph } from '../../src/api/types'
+import type { ApiSession, ApiDagGraph, FeedbackMetadata } from '../../src/api/types'
 
 vi.mock('@reactflow/core', async () => {
   return {
@@ -525,5 +525,58 @@ describe('UniverseCanvas', () => {
       expect(nodes[0].data.scale).toBeGreaterThan(0)
       expect(nodes[0].data.scale).toBeLessThanOrEqual(1)
     }
+  })
+
+  it('renders feedback badge on canvas node when session has feedback metadata', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'incorrect',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const sessions = [
+      createSession({
+        id: 'feedback-1',
+        slug: 'feedback-minion',
+        metadata: feedbackMeta as unknown as Record<string, unknown>,
+      }),
+    ]
+    render(<UniverseCanvas {...defaultProps} sessions={sessions} />)
+    const badge = document.querySelector('[data-testid="feedback-canvas-badge"]')
+    expect(badge).toBeTruthy()
+    expect(badge!.textContent).toContain('Feedback')
+  })
+
+  it('does not render feedback badge on canvas node for non-feedback sessions', () => {
+    const sessions = [createSession({ id: 's1', slug: 'normal-session' })]
+    render(<UniverseCanvas {...defaultProps} sessions={sessions} />)
+    expect(document.querySelector('[data-testid="feedback-canvas-badge"]')).toBeFalsy()
+  })
+
+  it('renders both feedback badge and node type label on canvas node', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'up',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const parent = createSession({
+      id: 'parent-1',
+      slug: 'parent-task',
+      childIds: ['feedback-1'],
+    })
+    const feedbackSession = createSession({
+      id: 'feedback-1',
+      slug: 'feedback-child',
+      parentId: 'parent-1',
+      metadata: feedbackMeta as unknown as Record<string, unknown>,
+    })
+    render(<UniverseCanvas {...defaultProps} sessions={[parent, feedbackSession]} />)
+    expect(document.querySelector('[data-testid="feedback-canvas-badge"]')).toBeTruthy()
+    expect(document.body.innerHTML).toContain('Tree')
+    expect(document.body.innerHTML).toContain('Feedback')
   })
 })


### PR DESCRIPTION
## Summary

- Render a 'Feedback' pill next to StatusBadge in NodeDetailPopup (mobile + desktop) when `session.metadata?.kind === 'feedback'`
- Add a 'Reviewing' meta row showing vote (👍/👎), reason label, source-session link, and optional comment
- Show a small 'Feedback' tag on UniverseCanvas session nodes for feedback minions, mirroring the existing 'Tree'/'DAG' pill placement

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run test\` passes (1042 tests)
- [x] New unit tests cover: badge rendering on feedback sessions, no badge on regular sessions, all reason labels (Incorrect/Off Topic/Too Verbose/Unsafe/Other), thumbs-up vs thumbs-down rendering, comment rendering, source-session link click, canvas badge alongside Tree label