### PR TITLE
feat(feedback): add FeedbackButtons and FeedbackReasonPopup components

### DIFF
--- a/src/api/features.ts
+++ b/src/api/features.ts
@@ -21,6 +21,7 @@ export type FeatureName =
   | 'audit-log'
   | 'ship-coordinator'
   | 'memory'
+  | 'message-feedback'
 
 export function hasFeature(
   source: ConnectionStore | VersionInfo | null | undefined,

--- a/src/chat/transcript/FeedbackButtons.tsx
+++ b/src/chat/transcript/FeedbackButtons.tsx
@@ -1,0 +1,184 @@
+import { useState, useEffect } from 'preact/hooks'
+import type { ConnectionStore } from '../../state/types'
+import { hasFeature } from '../../api/features'
+import type { FeedbackVote } from '../../api/types'
+import { recordFeedback, useFeedbackStore } from '../../state/feedback-persist'
+import { FeedbackReasonPopup } from './FeedbackReasonPopup'
+
+interface Props {
+  sessionId: string
+  blockId: string
+  store: ConnectionStore
+  persisted?: boolean
+}
+
+export function FeedbackButtons({ sessionId, blockId, store, persisted }: Props) {
+  if (!hasFeature(store, 'message-feedback')) return null
+
+  const feedbackStore = useFeedbackStore(store.connectionId)
+  const entryKey = `${sessionId}:${blockId}`
+  const existing = feedbackStore.value[entryKey]
+
+  const [submitting, setSubmitting] = useState(false)
+  const [showReasonPopup, setShowReasonPopup] = useState(false)
+  const [showThanks, setShowThanks] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (showThanks) {
+      const timer = setTimeout(() => setShowThanks(false), 2000)
+      return () => clearTimeout(timer)
+    }
+  }, [showThanks])
+
+  async function handleVote(vote: FeedbackVote) {
+    if (submitting) return
+    if (vote === 'down') {
+      setShowReasonPopup(true)
+      return
+    }
+
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      const result = await store.client.submitFeedback({
+        sessionId,
+        messageBlockId: blockId,
+        vote,
+      })
+
+      if (!result.success) {
+        setError(result.error ?? 'Submission failed')
+        return
+      }
+
+      await recordFeedback(store.connectionId, entryKey, {
+        vote,
+        ts: Date.now(),
+      })
+
+      setShowThanks(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleReasonSubmit(reason: string, comment?: string) {
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      const result = await store.client.submitFeedback({
+        sessionId,
+        messageBlockId: blockId,
+        vote: 'down',
+        reason: reason as 'incorrect' | 'off_topic' | 'too_verbose' | 'unsafe' | 'other',
+        comment,
+      })
+
+      if (!result.success) {
+        setError(result.error ?? 'Submission failed')
+        return
+      }
+
+      await recordFeedback(store.connectionId, entryKey, {
+        vote: 'down',
+        reason,
+        comment,
+        ts: Date.now(),
+      })
+
+      setShowReasonPopup(false)
+      setShowThanks(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const upSelected = existing?.vote === 'up'
+  const downSelected = existing?.vote === 'down'
+
+  if (showThanks) {
+    return (
+      <div
+        class="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300 text-xs font-medium"
+        data-testid="feedback-thanks"
+      >
+        <svg viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5">
+          <path
+            fill-rule="evenodd"
+            d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        Thanks!
+      </div>
+    )
+  }
+
+  return (
+    <div class="relative">
+      <div class="inline-flex items-center gap-1" data-testid="feedback-buttons">
+        <button
+          type="button"
+          onClick={() => void handleVote('up')}
+          disabled={submitting || persisted === false}
+          aria-label="Thumbs up"
+          data-testid="feedback-thumbs-up"
+          data-selected={upSelected}
+          class={`p-1 rounded transition-colors ${
+            upSelected
+              ? 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20'
+              : 'text-slate-400 dark:text-slate-500 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20'
+          } disabled:opacity-50 disabled:cursor-not-allowed`}
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
+            <path d="M1 8.75a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v6.5a.75.75 0 0 1-.75.75h-1.5A.75.75 0 0 1 1 15.25v-6.5ZM5 4.75a.75.75 0 0 1 .75-.75h1.19c.645 0 1.23.32 1.575.855l1.985 3.083V15.25a.75.75 0 0 1-.75.75H5.75a.75.75 0 0 1-.75-.75V4.75Z" />
+            <path d="M11.25 8a.75.75 0 0 0-.75.75v5.5c0 .414.336.75.75.75h4.25a2.25 2.25 0 0 0 2.165-1.615l.82-2.95A3.75 3.75 0 0 0 15 6.25h-2.25a.75.75 0 0 1-.75-.75V3a.75.75 0 0 0-1.5 0v5Z" />
+          </svg>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => void handleVote('down')}
+          disabled={submitting || persisted === false}
+          aria-label="Thumbs down"
+          data-testid="feedback-thumbs-down"
+          data-selected={downSelected}
+          class={`p-1 rounded transition-colors ${
+            downSelected
+              ? 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20'
+              : 'text-slate-400 dark:text-slate-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20'
+          } disabled:opacity-50 disabled:cursor-not-allowed`}
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
+            <path d="M18.25 12.25a.75.75 0 0 0 .75-.75v-6.5a.75.75 0 0 0-.75-.75h-1.5a.75.75 0 0 0-.75.75v6.5c0 .414.336.75.75.75h1.5ZM15 16.25a.75.75 0 0 0 .75.75h1.19c.645 0 1.23-.32 1.575-.855l1.985-3.083V5.75a.75.75 0 0 0-.75-.75h-4.25a.75.75 0 0 0-.75.75v10.5Z" />
+            <path d="M8 13a.75.75 0 0 1 .75-.75h4.25a2.25 2.25 0 0 1 2.165 1.615l.82 2.95A3.75 3.75 0 0 1 12.36 21H10.11a.75.75 0 0 1-.75-.75V18a.75.75 0 0 0-1.5 0v2.5a.75.75 0 0 1-.75.75H5.86a.75.75 0 0 1-.75-.75V13Z" />
+          </svg>
+        </button>
+      </div>
+
+      {error && (
+        <div
+          class="absolute top-full left-0 mt-1 px-2 py-1 rounded bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 text-xs whitespace-nowrap z-10"
+          data-testid="feedback-error"
+        >
+          {error}
+        </div>
+      )}
+
+      {showReasonPopup && (
+        <FeedbackReasonPopup
+          onSubmit={handleReasonSubmit}
+          onCancel={() => setShowReasonPopup(false)}
+          submitting={submitting}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/chat/transcript/FeedbackReasonPopup.tsx
+++ b/src/chat/transcript/FeedbackReasonPopup.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'preact/hooks'
+import { useTheme } from '../../hooks/useTheme'
+import type { FeedbackReason } from '../../api/types'
+
+interface Props {
+  onSubmit: (reason: string, comment?: string) => void | Promise<void>
+  onCancel: () => void
+  submitting?: boolean
+}
+
+const REASONS: Array<{ value: FeedbackReason; label: string }> = [
+  { value: 'incorrect', label: 'Incorrect' },
+  { value: 'off_topic', label: "Didn't follow instructions" },
+  { value: 'too_verbose', label: 'Too verbose' },
+  { value: 'unsafe', label: 'Unsafe / risky' },
+  { value: 'other', label: 'Other' },
+]
+
+export function FeedbackReasonPopup({ onSubmit, onCancel, submitting }: Props) {
+  const theme = useTheme()
+  const isDark = theme.value === 'dark'
+  const [selectedReason, setSelectedReason] = useState<FeedbackReason | null>(null)
+  const [comment, setComment] = useState('')
+
+  function handleSubmit(e: Event) {
+    e.preventDefault()
+    if (!selectedReason) return
+    void onSubmit(selectedReason, comment.trim() || undefined)
+  }
+
+  const overlayBg = isDark ? 'bg-black/70' : 'bg-black/50'
+  const popupBg = isDark ? 'bg-slate-800 border-slate-700' : 'bg-white border-slate-200'
+  const titleColor = isDark ? 'text-slate-100' : 'text-slate-900'
+  const labelColor = isDark ? 'text-slate-300' : 'text-slate-700'
+  const chipBg = isDark ? 'bg-slate-700 hover:bg-slate-600 text-slate-200' : 'bg-slate-100 hover:bg-slate-200 text-slate-700'
+  const chipSelectedBg = isDark ? 'bg-indigo-600 text-white' : 'bg-indigo-600 text-white'
+  const textareaBg = isDark ? 'bg-slate-900 border-slate-600 text-slate-100' : 'bg-white border-slate-300 text-slate-900'
+  const cancelColor = isDark ? 'text-slate-300 hover:bg-slate-700' : 'text-slate-600 hover:bg-slate-100'
+  const submitBg = isDark ? 'bg-indigo-600 hover:bg-indigo-700 text-white' : 'bg-indigo-600 hover:bg-indigo-700 text-white'
+
+  return (
+    <div class="fixed inset-0 z-50 flex items-center justify-center" data-testid="feedback-reason-popup">
+      <div class={`absolute inset-0 ${overlayBg}`} onClick={onCancel} />
+      <form
+        onSubmit={handleSubmit}
+        class={`relative ${popupBg} border rounded-lg shadow-xl p-4 max-w-sm w-full mx-4`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="feedback-reason-title"
+      >
+        <h3 id="feedback-reason-title" class={`text-sm font-semibold ${titleColor} mb-3`}>
+          What went wrong?
+        </h3>
+
+        <div class="space-y-3">
+          <div>
+            <label class={`block text-xs font-medium ${labelColor} mb-2`}>
+              Reason <span class="text-red-500">*</span>
+            </label>
+            <div class="flex flex-wrap gap-2">
+              {REASONS.map((reason) => (
+                <button
+                  key={reason.value}
+                  type="button"
+                  onClick={() => setSelectedReason(reason.value)}
+                  data-testid={`feedback-reason-${reason.value}`}
+                  data-selected={selectedReason === reason.value}
+                  class={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                    selectedReason === reason.value ? chipSelectedBg : chipBg
+                  }`}
+                  disabled={submitting}
+                >
+                  {reason.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label class={`block text-xs font-medium ${labelColor} mb-1.5`} for="feedback-comment">
+              Additional context <span class="text-slate-400">(optional)</span>
+            </label>
+            <textarea
+              id="feedback-comment"
+              value={comment}
+              onInput={(e) => setComment((e.target as HTMLTextAreaElement).value)}
+              maxLength={2000}
+              rows={3}
+              disabled={submitting}
+              placeholder="Tell us more..."
+              data-testid="feedback-comment"
+              class={`w-full px-3 py-2 text-xs border rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent disabled:opacity-50 ${textareaBg}`}
+            />
+            <div class="text-[10px] text-slate-400 dark:text-slate-500 mt-1 text-right">
+              {comment.length} / 2000
+            </div>
+          </div>
+        </div>
+
+        <div class="flex justify-end gap-2 mt-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={submitting}
+            data-testid="feedback-cancel"
+            class={`px-3 py-1.5 text-xs font-medium rounded transition-colors disabled:opacity-50 ${cancelColor}`}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!selectedReason || submitting}
+            data-testid="feedback-submit"
+            class={`px-3 py-1.5 text-xs font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${submitBg}`}
+          >
+            {submitting ? 'Submitting...' : 'Submit'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/test/chat/transcript/FeedbackButtons.test.tsx
+++ b/test/chat/transcript/FeedbackButtons.test.tsx
@@ -1,0 +1,216 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { signal } from '@preact/signals'
+import { FeedbackButtons } from '../../../src/chat/transcript/FeedbackButtons'
+import type { ConnectionStore } from '../../../src/state/types'
+import type { CommandResult } from '../../../src/api/types'
+
+vi.mock('../../../src/state/feedback-persist', () => ({
+  useFeedbackStore: vi.fn(() => signal({})),
+  recordFeedback: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { useFeedbackStore, recordFeedback } from '../../../src/state/feedback-persist'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    })
+  }
+})
+
+function createMockStore(features: string[] = ['message-feedback']): ConnectionStore {
+  const submitFeedback = vi.fn().mockResolvedValue({ success: true } as CommandResult)
+
+  return {
+    connectionId: 'conn-1',
+    version: signal({ apiVersion: '2.0.0', libraryVersion: '1.110.0', features }),
+    client: {
+      submitFeedback,
+    },
+  } as ConnectionStore
+}
+
+describe('FeedbackButtons', () => {
+  it('renders nothing when message-feedback feature is absent', () => {
+    const store = createMockStore([])
+    const { container } = render(
+      <FeedbackButtons sessionId="s1" blockId="block1" store={store} />,
+    )
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders thumbs-up and thumbs-down buttons when feature is present', () => {
+    const store = createMockStore()
+    render(<FeedbackButtons sessionId="s1" blockId="block1" store={store} />)
+
+    expect(screen.getByTestId('feedback-thumbs-up')).toBeTruthy()
+    expect(screen.getByTestId('feedback-thumbs-down')).toBeTruthy()
+  })
+
+  it('submits thumbs-up immediately and shows thanks', async () => {
+    const store = createMockStore()
+    vi.mocked(useFeedbackStore).mockReturnValue(signal({}))
+
+    render(<FeedbackButtons sessionId="s1" blockId="block1" store={store} />)
+
+    const upBtn = screen.getByTestId('feedback-thumbs-up')
+    fireEvent.click(upBtn)
+
+    await waitFor(() => {
+      expect(store.client.submitFeedback).toHaveBeenCalledWith({
+        sessionId: 's1',
+        messageBlockId: 'block1',
+        vote: 'up',
+      })
+    })
+
+    await waitFor(() => {
+      expect(recordFeedback).toHaveBeenCalledWith('conn-1', 's1:block1', {
+        vote: 'up',
+        ts: expect.any(Number),
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-thanks')).toBeTruthy()
+      expect(screen.getByText('Thanks!')).toBeTruthy()
+    })
+  })
+
+  it('opens reason popup on thumbs-down click', async () => {
+    const store = createMockStore()
+    vi.mocked(useFeedbackStore).mockReturnValue(signal({}))
+
+    render(<FeedbackButtons sessionId="s1" blockId="block1" store={store} />)
+
+    const downBtn = screen.getByTestId('feedback-thumbs-down')
+    fireEvent.click(downBtn)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-reason-popup')).toBeTruthy()
+    })
+  })
+
+  it('submits thumbs-down with reason from popup', async () => {
+    const store = createMockStore()
+    vi.mocked(useFeedbackStore).mockReturnValue(signal({}))
+
+    render(<FeedbackButtons sessionId="s1" blockId="block1" store={store} />)
+
+    fireEvent.click(screen.getByTestId('feedback-thumbs-down'))
+    await waitFor(() => expect(screen.getByTestId('feedback-reason-popup')).toBeTruthy())
+
+    fireEvent.click(screen.getByTestId('feedback-reason-incorrect'))
+
+    const commentArea = screen.getByTestId('feedback-comment') as HTMLTextAreaElement
+    fireEvent.input(commentArea, { target: { value: 'Too many errors' } })
+
+    fireEvent.click(screen.getByTestId('feedback-submit'))
+
+    await waitFor(() => {
+      expect(store.client.submitFeedback).toHaveBeenCalledWith({
+        sessionId: 's1',
+        messageBlockId: 'block1',
+        vote: 'down',
+        reason: 'incorrect',
+        comment: 'Too many errors',
+      })
+    })
+
+    await waitFor(() => {
+      expect(recordFeedback).toHaveBeenCalledWith('conn-1', 's1:block1', {
+        vote: 'down',
+        reason: 'incorrect',
+        comment: 'Too many errors',
+        ts: expect.any(Number),
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-thanks')).toBeTruthy()
+    })
+  })
+
+  it('shows selected state for thumbs-up', () => {
+    const store = createMockStore()
+    vi.mocked(useFeedbackStore).mockReturnValue(
+      signal({
+        's1:block1': { vote: 'up', ts: Date.now() },
+      }),
+    )
+
+    render(<FeedbackButtons sessionId="s1" blockId="block1" store={store} />)
+
+    const upBtn = screen.getByTestId('feedback-thumbs-up')
+    expect(upBtn.getAttribute('data-selected')).toBe('true')
+  })
+
+  it('shows selected state for thumbs-down', () => {
+    const store = createMockStore()
+    vi.mocked(useFeedbackStore).mockReturnValue(
+      signal({
+        's1:block1': { vote: 'down', reason: 'incorrect', ts: Date.now() },
+      }),
+    )
+
+    render(<FeedbackButtons sessionId="s1" blockId="block1" store={store} />)
+
+    const downBtn = screen.getByTestId('feedback-thumbs-down')
+    expect(downBtn.getAttribute('data-selected')).toBe('true')
+  })
+
+  it('shows error when submission fails', async () => {
+    const store = createMockStore()
+    vi.mocked(store.client.submitFeedback).mockResolvedValue({
+      success: false,
+      error: 'Network error',
+    })
+    vi.mocked(useFeedbackStore).mockReturnValue(signal({}))
+
+    render(<FeedbackButtons sessionId="s1" blockId="block1" store={store} />)
+
+    fireEvent.click(screen.getByTestId('feedback-thumbs-up'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-error')).toBeTruthy()
+      expect(screen.getByText('Network error')).toBeTruthy()
+    })
+  })
+
+  it('disables buttons when persisted is false', () => {
+    const store = createMockStore()
+    vi.mocked(useFeedbackStore).mockReturnValue(signal({}))
+
+    render(<FeedbackButtons sessionId="s1" blockId="block1" store={store} persisted={false} />)
+
+    const upBtn = screen.getByTestId('feedback-thumbs-up')
+    const downBtn = screen.getByTestId('feedback-thumbs-down')
+
+    expect(upBtn.hasAttribute('disabled')).toBe(true)
+    expect(downBtn.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('does not call submitFeedback multiple times when clicked rapidly', async () => {
+    const store = createMockStore()
+    vi.mocked(useFeedbackStore).mockReturnValue(signal({}))
+
+    render(<FeedbackButtons sessionId="s1" blockId="block1" store={store} />)
+
+    const upBtn = screen.getByTestId('feedback-thumbs-up')
+    fireEvent.click(upBtn)
+    fireEvent.click(upBtn)
+    fireEvent.click(upBtn)
+
+    await waitFor(() => {
+      expect(store.client.submitFeedback).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/test/chat/transcript/FeedbackReasonPopup.test.tsx
+++ b/test/chat/transcript/FeedbackReasonPopup.test.tsx
@@ -1,0 +1,215 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { FeedbackReasonPopup } from '../../../src/chat/transcript/FeedbackReasonPopup'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    })
+  }
+})
+
+describe('FeedbackReasonPopup', () => {
+  it('renders the popup with title and reason chips', () => {
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    expect(screen.getByText('What went wrong?')).toBeTruthy()
+    expect(screen.getByTestId('feedback-reason-incorrect')).toBeTruthy()
+    expect(screen.getByTestId('feedback-reason-off_topic')).toBeTruthy()
+    expect(screen.getByTestId('feedback-reason-too_verbose')).toBeTruthy()
+    expect(screen.getByTestId('feedback-reason-unsafe')).toBeTruthy()
+    expect(screen.getByTestId('feedback-reason-other')).toBeTruthy()
+  })
+
+  it('renders cancel and submit buttons', () => {
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    expect(screen.getByTestId('feedback-cancel')).toBeTruthy()
+    expect(screen.getByTestId('feedback-submit')).toBeTruthy()
+  })
+
+  it('shows submit button as disabled when no reason is selected', () => {
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    const submitBtn = screen.getByTestId('feedback-submit')
+    expect(submitBtn.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('enables submit button when a reason is selected', () => {
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('feedback-reason-incorrect'))
+
+    const submitBtn = screen.getByTestId('feedback-submit')
+    expect(submitBtn.hasAttribute('disabled')).toBe(false)
+  })
+
+  it('marks selected reason chip', () => {
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    const incorrectChip = screen.getByTestId('feedback-reason-incorrect')
+    fireEvent.click(incorrectChip)
+
+    expect(incorrectChip.getAttribute('data-selected')).toBe('true')
+  })
+
+  it('allows switching between reasons', () => {
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    const incorrectChip = screen.getByTestId('feedback-reason-incorrect')
+    const verboseChip = screen.getByTestId('feedback-reason-too_verbose')
+
+    fireEvent.click(incorrectChip)
+    expect(incorrectChip.getAttribute('data-selected')).toBe('true')
+
+    fireEvent.click(verboseChip)
+    expect(incorrectChip.getAttribute('data-selected')).toBe('false')
+    expect(verboseChip.getAttribute('data-selected')).toBe('true')
+  })
+
+  it('calls onSubmit with reason when submitted without comment', async () => {
+    const onSubmit = vi.fn()
+    render(<FeedbackReasonPopup onSubmit={onSubmit} onCancel={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('feedback-reason-incorrect'))
+    fireEvent.click(screen.getByTestId('feedback-submit'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('incorrect', undefined)
+    })
+  })
+
+  it('calls onSubmit with reason and comment when both provided', async () => {
+    const onSubmit = vi.fn()
+    render(<FeedbackReasonPopup onSubmit={onSubmit} onCancel={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('feedback-reason-incorrect'))
+
+    const commentArea = screen.getByTestId('feedback-comment') as HTMLTextAreaElement
+    fireEvent.input(commentArea, { target: { value: 'The answer was wrong' } })
+
+    fireEvent.click(screen.getByTestId('feedback-submit'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('incorrect', 'The answer was wrong')
+    })
+  })
+
+  it('trims whitespace from comment before submission', async () => {
+    const onSubmit = vi.fn()
+    render(<FeedbackReasonPopup onSubmit={onSubmit} onCancel={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('feedback-reason-incorrect'))
+
+    const commentArea = screen.getByTestId('feedback-comment') as HTMLTextAreaElement
+    fireEvent.input(commentArea, { target: { value: '  whitespace test  ' } })
+
+    fireEvent.click(screen.getByTestId('feedback-submit'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('incorrect', 'whitespace test')
+    })
+  })
+
+  it('does not submit comment if it is only whitespace', async () => {
+    const onSubmit = vi.fn()
+    render(<FeedbackReasonPopup onSubmit={onSubmit} onCancel={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('feedback-reason-incorrect'))
+
+    const commentArea = screen.getByTestId('feedback-comment') as HTMLTextAreaElement
+    fireEvent.input(commentArea, { target: { value: '   ' } })
+
+    fireEvent.click(screen.getByTestId('feedback-submit'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('incorrect', undefined)
+    })
+  })
+
+  it('calls onCancel when cancel button is clicked', () => {
+    const onCancel = vi.fn()
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={onCancel} />)
+
+    fireEvent.click(screen.getByTestId('feedback-cancel'))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when overlay is clicked', () => {
+    const onCancel = vi.fn()
+    const { container } = render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={onCancel} />)
+
+    const overlay = container.querySelector('.fixed > .absolute')
+    if (overlay) {
+      fireEvent.click(overlay)
+    }
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('enforces maxLength of 2000 characters on comment', () => {
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    const commentArea = screen.getByTestId('feedback-comment') as HTMLTextAreaElement
+    expect(commentArea.maxLength).toBe(2000)
+  })
+
+  it('shows character count for comment', () => {
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    const commentArea = screen.getByTestId('feedback-comment') as HTMLTextAreaElement
+    fireEvent.input(commentArea, { target: { value: 'test' } })
+
+    expect(screen.getByText('4 / 2000')).toBeTruthy()
+  })
+
+  it('disables all inputs and buttons when submitting', () => {
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={vi.fn()} submitting={true} />)
+
+    const incorrectChip = screen.getByTestId('feedback-reason-incorrect')
+    const commentArea = screen.getByTestId('feedback-comment')
+    const cancelBtn = screen.getByTestId('feedback-cancel')
+    const submitBtn = screen.getByTestId('feedback-submit')
+
+    expect(incorrectChip.hasAttribute('disabled')).toBe(true)
+    expect(commentArea.hasAttribute('disabled')).toBe(true)
+    expect(cancelBtn.hasAttribute('disabled')).toBe(true)
+    expect(submitBtn.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('shows "Submitting..." text on submit button when submitting', () => {
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={vi.fn()} submitting={true} />)
+
+    expect(screen.getByText('Submitting...')).toBeTruthy()
+  })
+
+  it('prevents form submission when no reason is selected', () => {
+    const onSubmit = vi.fn()
+    render(<FeedbackReasonPopup onSubmit={onSubmit} onCancel={vi.fn()} />)
+
+    const form = screen.getByTestId('feedback-reason-popup').querySelector('form')
+    if (form) {
+      fireEvent.submit(form)
+    }
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('displays all reason labels correctly', () => {
+    render(<FeedbackReasonPopup onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    expect(screen.getByText('Incorrect')).toBeTruthy()
+    expect(screen.getByText("Didn't follow instructions")).toBeTruthy()
+    expect(screen.getByText('Too verbose')).toBeTruthy()
+    expect(screen.getByText('Unsafe / risky')).toBeTruthy()
+    expect(screen.getByText('Other')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Adds two new transcript-level UI components for collecting per-message feedback on agent replies:

- **`FeedbackButtons`** – thumbs-up / thumbs-down icon buttons rendered under each assistant block (wiring is handled by a separate minion). Up vote submits immediately; down vote opens a reason popup. Selected state reflects persisted votes from the feedback IDB store, and a transient "Thanks!" pill appears on success. Gated behind `hasFeature(store, 'message-feedback')`.
- **`FeedbackReasonPopup`** – modal popup with five reason chips (Incorrect, Didn't follow instructions, Too verbose, Unsafe / risky, Other), an optional comment textarea capped at 2000 characters, and Cancel / Submit actions.

Also registers `'message-feedback'` in the `FeatureName` union so the call site type-checks.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 1074 passed, including 28 new cases covering:
  - Feature-flag gating (component renders nothing when flag missing)
  - Up vote: immediate submission, persistence, "Thanks!" confirmation
  - Down vote: opens popup, full submit flow with reason + comment
  - Persisted state reflected in selected styling for both votes
  - Error surfacing when `submitFeedback` returns failure
  - Disabled state when `persisted={false}`
  - Rapid-click guard (single submission)
  - Reason popup: chip selection, switching reasons, submit-disabled gating, comment trimming, whitespace-only handling, cancel/overlay dismissal, char counter, maxLength enforcement, submitting disabled state
