### PR TITLE
Wire FeedbackButtons under finalized assistant replies

### DIFF
--- a/src/chat/ChatPane.tsx
+++ b/src/chat/ChatPane.tsx
@@ -36,7 +36,7 @@ function TranscriptPane({ store, sessionId }: { store: ConnectionStore; sessionI
       </div>
     )
   }
-  return <Transcript store={transcript} />
+  return <Transcript store={transcript} connectionStore={store} />
 }
 
 export function ChatPane({

--- a/src/chat/transcript/AssistantTextBlock.tsx
+++ b/src/chat/transcript/AssistantTextBlock.tsx
@@ -1,11 +1,15 @@
 import type { AssistantTextEvent } from '../../api/types'
+import type { ConnectionStore } from '../../state/types'
 import { MarkdownView } from '../../components/MarkdownView'
+import { FeedbackButtons } from './FeedbackButtons'
 
 interface Props {
   event: AssistantTextEvent
+  sessionId?: string
+  store?: ConnectionStore
 }
 
-export function AssistantTextBlock({ event }: Props) {
+export function AssistantTextBlock({ event, sessionId, store }: Props) {
   return (
     <div class="flex gap-3 justify-start" data-testid="transcript-assistant-text">
       <div class="shrink-0 mt-1 w-6 h-6 rounded-full bg-indigo-100 dark:bg-indigo-900 flex items-center justify-center text-[10px] font-bold text-indigo-700 dark:text-indigo-300">
@@ -22,6 +26,11 @@ export function AssistantTextBlock({ event }: Props) {
             aria-label="Streaming"
             data-testid="transcript-streaming-indicator"
           />
+        )}
+        {event.final && sessionId && store && (
+          <div class="mt-1.5">
+            <FeedbackButtons sessionId={sessionId} blockId={event.blockId} store={store} />
+          </div>
         )}
       </div>
     </div>

--- a/src/chat/transcript/Transcript.tsx
+++ b/src/chat/transcript/Transcript.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import type { TranscriptStore } from '../../state/transcript'
+import type { ConnectionStore } from '../../state/types'
 import { AssistantTextBlock } from './AssistantTextBlock'
 import { StatusBanner } from './StatusBanner'
 import { ThinkingBlock } from './ThinkingBlock'
@@ -15,14 +16,16 @@ const TOOL_GROUP_COLLAPSE_THRESHOLD = 5
 
 interface Props {
   store: TranscriptStore
+  connectionStore?: ConnectionStore
 }
 
-export function Transcript({ store }: Props) {
+export function Transcript({ store, connectionStore }: Props) {
   const events = store.events.value
   const loading = store.loading.value
   const error = store.error.value
   const sessionInfo = store.session.value
   const sessionTerminal = sessionInfo?.active === false
+  const sessionId = sessionInfo?.sessionId
   const rows = useMemo(() => buildTranscriptRows(events).rows, [events])
 
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -105,7 +108,13 @@ export function Transcript({ store }: Props) {
               sessionTerminal={sessionTerminal}
             />
           ) : (
-            <RowView key={rowKey(item.row)} row={item.row} sessionTerminal={sessionTerminal} />
+            <RowView
+              key={rowKey(item.row)}
+              row={item.row}
+              sessionTerminal={sessionTerminal}
+              sessionId={sessionId}
+              connectionStore={connectionStore}
+            />
           ),
         )}
       </div>
@@ -127,14 +136,24 @@ export function Transcript({ store }: Props) {
   )
 }
 
-function RowView({ row, sessionTerminal }: { row: TranscriptRow; sessionTerminal: boolean }) {
+function RowView({
+  row,
+  sessionTerminal,
+  sessionId,
+  connectionStore,
+}: {
+  row: TranscriptRow
+  sessionTerminal: boolean
+  sessionId?: string
+  connectionStore?: ConnectionStore
+}) {
   switch (row.kind) {
     case 'turn-separator':
       return <TurnSeparator turn={row.turn} started={row.started} completed={row.completed} />
     case 'user-message':
       return <UserMessageCard event={row.event} />
     case 'assistant-text':
-      return <AssistantTextBlock event={row.event} />
+      return <AssistantTextBlock event={row.event} sessionId={sessionId} store={connectionStore} />
     case 'thinking':
       return <ThinkingBlock event={row.event} />
     case 'tool-call':

--- a/test/chat/transcript/FeedbackButtons.test.tsx
+++ b/test/chat/transcript/FeedbackButtons.test.tsx
@@ -35,7 +35,7 @@ function createMockStore(features: string[] = ['message-feedback']): ConnectionS
     client: {
       submitFeedback,
     },
-  } as ConnectionStore
+  } as unknown as ConnectionStore
 }
 
 describe('FeedbackButtons', () => {

--- a/test/chat/transcript/Transcript.test.tsx
+++ b/test/chat/transcript/Transcript.test.tsx
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/preact'
+import { signal } from '@preact/signals'
 import { Transcript } from '../../../src/chat/transcript/Transcript'
 import { createTranscriptStore } from '../../../src/state/transcript'
 import type { ApiClient } from '../../../src/api/client'
+import type { ConnectionStore } from '../../../src/state/types'
 import type {
   TranscriptEvent,
   TranscriptSnapshot,
@@ -200,6 +202,73 @@ describe('Transcript', () => {
     await flush()
     await waitFor(() => expect(screen.getByTestId('transcript-tool-call')).toBeTruthy())
     expect(screen.queryByTestId('transcript-tool-group')).toBeNull()
+  })
+
+  it('threads connectionStore so finalized assistant text renders feedback buttons', async () => {
+    const events: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'hi' },
+      { ...baseEvent(2), type: 'assistant_text', blockId: 'b1', text: 'hello back', final: true },
+    ]
+    const client = makeClient(snapshot(events))
+    const store = createTranscriptStore({ client, slug: 's' })
+    const connectionStore = {
+      connectionId: 'conn-1',
+      version: signal({
+        apiVersion: '2.0.0',
+        libraryVersion: '1.110.0',
+        features: ['message-feedback'],
+      }),
+      client: { submitFeedback: vi.fn() },
+    } as unknown as ConnectionStore
+
+    render(<Transcript store={store} connectionStore={connectionStore} />)
+    await flush()
+    await waitFor(() => expect(screen.getByTestId('transcript-assistant-text')).toBeTruthy())
+    expect(screen.getByTestId('feedback-buttons')).toBeTruthy()
+  })
+
+  it('omits feedback buttons on streaming (non-final) assistant text', async () => {
+    const initial: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'q' },
+    ]
+    const client = makeClient(snapshot(initial))
+    const store = createTranscriptStore({ client, slug: 's' })
+    const connectionStore = {
+      connectionId: 'conn-1',
+      version: signal({
+        apiVersion: '2.0.0',
+        libraryVersion: '1.110.0',
+        features: ['message-feedback'],
+      }),
+      client: { submitFeedback: vi.fn() },
+    } as unknown as ConnectionStore
+
+    render(<Transcript store={store} connectionStore={connectionStore} />)
+    await flush()
+
+    store.applyEvent({
+      ...baseEvent(2),
+      type: 'assistant_text',
+      blockId: 'b1',
+      text: 'streaming',
+      final: false,
+    })
+
+    await waitFor(() => expect(screen.getByTestId('transcript-streaming-indicator')).toBeTruthy())
+    expect(screen.queryByTestId('feedback-buttons')).toBeNull()
+  })
+
+  it('does not render feedback buttons when connectionStore is omitted', async () => {
+    const events: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'hi' },
+      { ...baseEvent(2), type: 'assistant_text', blockId: 'b1', text: 'hello back', final: true },
+    ]
+    const client = makeClient(snapshot(events))
+    const store = createTranscriptStore({ client, slug: 's' })
+    render(<Transcript store={store} />)
+    await flush()
+    await waitFor(() => expect(screen.getByTestId('transcript-assistant-text')).toBeTruthy())
+    expect(screen.queryByTestId('feedback-buttons')).toBeNull()
   })
 
   it('renders an error banner when fetch fails and exposes Retry', async () => {

--- a/test/chat/transcript/components.test.tsx
+++ b/test/chat/transcript/components.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/preact'
+import { signal } from '@preact/signals'
 import { UserMessageCard } from '../../../src/chat/transcript/UserMessageCard'
 import { AssistantTextBlock } from '../../../src/chat/transcript/AssistantTextBlock'
+import type { ConnectionStore } from '../../../src/state/types'
 import { ThinkingBlock } from '../../../src/chat/transcript/ThinkingBlock'
 import { ToolCallCard } from '../../../src/chat/transcript/ToolCallCard'
 import { ToolResultBody } from '../../../src/chat/transcript/ToolResultBody'
@@ -91,6 +93,62 @@ describe('AssistantTextBlock', () => {
     }
     render(<AssistantTextBlock event={event} />)
     expect(screen.getByTestId('transcript-streaming-indicator')).toBeTruthy()
+  })
+
+  it('renders feedback buttons when final, sessionId, and store are provided', () => {
+    const event: AssistantTextEvent = {
+      ...baseEvent(1),
+      type: 'assistant_text',
+      blockId: 'b1',
+      text: 'final answer',
+      final: true,
+    }
+    const store = {
+      connectionId: 'conn-1',
+      version: signal({
+        apiVersion: '2.0.0',
+        libraryVersion: '1.110.0',
+        features: ['message-feedback'],
+      }),
+      client: { submitFeedback: vi.fn() },
+    } as unknown as ConnectionStore
+    render(<AssistantTextBlock event={event} sessionId="s1" store={store} />)
+    expect(screen.getByTestId('feedback-buttons')).toBeTruthy()
+    expect(screen.getByTestId('feedback-thumbs-up')).toBeTruthy()
+    expect(screen.getByTestId('feedback-thumbs-down')).toBeTruthy()
+  })
+
+  it('does not render feedback buttons when not final (still streaming)', () => {
+    const event: AssistantTextEvent = {
+      ...baseEvent(1),
+      type: 'assistant_text',
+      blockId: 'b1',
+      text: 'streaming...',
+      final: false,
+    }
+    const store = {
+      connectionId: 'conn-1',
+      version: signal({
+        apiVersion: '2.0.0',
+        libraryVersion: '1.110.0',
+        features: ['message-feedback'],
+      }),
+      client: { submitFeedback: vi.fn() },
+    } as unknown as ConnectionStore
+    render(<AssistantTextBlock event={event} sessionId="s1" store={store} />)
+    expect(screen.queryByTestId('feedback-buttons')).toBeNull()
+  })
+
+  it('does not render feedback buttons when sessionId or store is missing', () => {
+    const event: AssistantTextEvent = {
+      ...baseEvent(1),
+      type: 'assistant_text',
+      blockId: 'b1',
+      text: 'final answer',
+      final: true,
+    }
+    render(<AssistantTextBlock event={event} />)
+    expect(screen.queryByTestId('feedback-buttons')).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary

Renders thumbs up/down feedback controls beneath each finalized assistant text block in the transcript. The buttons leverage the existing `FeedbackButtons` component (built upstream); this PR threads the required `sessionId` + `ConnectionStore` through the transcript rendering pipeline.

- `AssistantTextBlock` accepts optional `sessionId` and `store` props; renders `FeedbackButtons` only when `event.final` is true and both props are supplied.
- `Transcript` accepts an optional `connectionStore` prop; `RowView` propagates `sessionId` (from `store.session.value?.sessionId`) and `connectionStore` into `AssistantTextBlock`.
- `ChatPane`'s `TranscriptPane` passes the active `ConnectionStore` to `Transcript`.

`FeedbackButtons` itself already gates on the `message-feedback` feature flag, so missing-flag deployments stay silent.

Streaming partials and `ThinkingBlock` are intentionally untouched — feedback only attaches to finalized assistant replies.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (1080 passed)
- [x] New unit tests cover: feedback buttons rendered when final + sessionId + store; hidden while streaming; hidden when connectionStore is omitted; `Transcript` threading verified end-to-end.
