### PR TITLE
test(e2e): feedback flow mock-minion + spec

### DIFF
--- a/e2e/fixtures/mock-minion.ts
+++ b/e2e/fixtures/mock-minion.ts
@@ -14,6 +14,7 @@ import type {
   ScreenshotEntry,
   VapidPublicKey,
   PushSubscriptionJSON,
+  FeedbackMetadata,
 } from '../../src/api/types'
 
 export type {
@@ -305,6 +306,49 @@ export async function createMockMinion(opts?: {
       const body = await readBody(req)
       const cmd = JSON.parse(body) as MinionCommand
       lastCommands.push(cmd)
+      if (cmd.action === 'submit_feedback') {
+        const parent = sessions.find((s) => s.id === cmd.sessionId)
+        sessionCounter += 1
+        const id = `mock-feedback-${sessionCounter}`
+        const now = new Date().toISOString()
+        const metadata: Record<string, unknown> = {
+          kind: 'feedback',
+          vote: cmd.vote,
+          reason: cmd.reason,
+          comment: cmd.comment,
+          sourceSessionId: cmd.sessionId,
+          sourceSessionSlug: parent?.slug ?? '',
+          sourceMessageBlockId: cmd.messageBlockId,
+        } satisfies FeedbackMetadata
+        const child: ApiSession = {
+          id,
+          slug: `feedback-${sessionCounter}`,
+          status: 'pending',
+          command: `/feedback ${cmd.vote}${cmd.reason ? ` (${cmd.reason})` : ''}`,
+          parentId: cmd.sessionId,
+          childIds: [],
+          needsAttention: false,
+          attentionReasons: [],
+          quickActions: [],
+          mode: 'feedback',
+          createdAt: now,
+          updatedAt: now,
+          conversation: [],
+          metadata,
+        }
+        if (parent) {
+          const updatedParent: ApiSession = {
+            ...parent,
+            childIds: [...parent.childIds, child.id],
+            updatedAt: now,
+          }
+          sessions = sessions.map((s) => (s.id === parent.id ? updatedParent : s)).concat(child)
+          if (activeSseRes) writeSse(activeSseRes, { type: 'session_updated', session: updatedParent })
+        } else {
+          sessions = [...sessions, child]
+        }
+        if (activeSseRes) writeSse(activeSseRes, { type: 'session_created', session: child })
+      }
       sendJson(res, 200, { data: { success: true } })
       return
     }

--- a/e2e/tests/feedback.spec.ts
+++ b/e2e/tests/feedback.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from '@playwright/test'
+import { createMockMinion } from '../fixtures/mock-minion'
+import { connectToMinion } from '../helpers/connect'
+import type { ApiSession, MinionCommand } from '../../src/api/types'
+
+const SESSION_ID = 'feedback-source-1'
+const BLOCK_ID = 'block-abc'
+
+function makeSourceSession(): ApiSession {
+  const now = new Date().toISOString()
+  return {
+    id: SESSION_ID,
+    slug: 'source-task',
+    status: 'running',
+    command: '/task explain something',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [{ role: 'user', text: 'explain something' }],
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+test.describe('feedback flow', () => {
+  test('thumbs-down opens reason popup, submits, and spawns a feedback minion', async ({ page }) => {
+    const mock = await createMockMinion({ token: 'tok' })
+    mock.setVersion({ features: ['messages', 'feedback'] })
+    mock.setSessions([makeSourceSession()])
+
+    try {
+      await connectToMinion(page, mock, 'Feedback Minion')
+
+      await expect(page.getByTestId(`session-item-${SESSION_ID}`)).toBeVisible({ timeout: 8_000 })
+      await page.getByTestId(`session-item-${SESSION_ID}`).click()
+      await expect(page.getByTestId('message-textarea')).toBeVisible({ timeout: 5_000 })
+
+      mock.emit({
+        type: 'transcript_event',
+        sessionId: SESSION_ID,
+        event: {
+          seq: 1,
+          id: 'evt-1',
+          sessionId: SESSION_ID,
+          turn: 1,
+          timestamp: Date.now(),
+          type: 'assistant_text',
+          blockId: BLOCK_ID,
+          text: 'Here is a confidently incorrect answer.',
+          final: true,
+        },
+      })
+
+      await expect(page.getByTestId('transcript-assistant-text').first()).toBeVisible({ timeout: 5_000 })
+
+      const downBtn = page.getByTestId(`feedback-thumbs-down-${BLOCK_ID}`)
+      await expect(downBtn).toBeVisible({ timeout: 5_000 })
+      await downBtn.click()
+
+      const popup = page.getByTestId('feedback-reason-popup')
+      await expect(popup).toBeVisible({ timeout: 5_000 })
+
+      await popup.getByTestId('feedback-reason-incorrect').click()
+      await popup.getByTestId('feedback-submit-btn').click()
+
+      await expect
+        .poll(
+          () =>
+            mock.lastCommands.find(
+              (c): c is Extract<MinionCommand, { action: 'submit_feedback' }> =>
+                c.action === 'submit_feedback',
+            ),
+          { timeout: 5_000 },
+        )
+        .toMatchObject({
+          action: 'submit_feedback',
+          sessionId: SESSION_ID,
+          messageBlockId: BLOCK_ID,
+          vote: 'down',
+          reason: 'incorrect',
+        })
+
+      const feedbackSession = await page.evaluate(async (url) => {
+        const res = await fetch(`${url}/api/sessions`, { headers: { Authorization: 'Bearer tok' } })
+        const json = (await res.json()) as { data: Array<{ id: string; parentId?: string; mode: string }> }
+        return json.data.find((s) => s.parentId && s.mode === 'feedback')
+      }, mock.url)
+      expect(feedbackSession?.id).toBeTruthy()
+
+      const feedbackId = feedbackSession!.id
+      await expect(page.getByTestId(`session-item-${feedbackId}`)).toBeVisible({ timeout: 8_000 })
+
+      const universeNode = page.getByTestId(`universe-node-${feedbackId}`)
+      await expect(universeNode).toBeVisible()
+      await expect(universeNode.getByTestId('feedback-badge')).toBeVisible()
+    } finally {
+      await mock.close()
+    }
+  })
+
+  test('thumbs-up submits immediately without a popup', async ({ page }) => {
+    const mock = await createMockMinion({ token: 'tok' })
+    mock.setVersion({ features: ['messages', 'feedback'] })
+    mock.setSessions([makeSourceSession()])
+
+    try {
+      await connectToMinion(page, mock, 'Feedback Minion')
+
+      await page.getByTestId(`session-item-${SESSION_ID}`).click()
+      await expect(page.getByTestId('message-textarea')).toBeVisible({ timeout: 5_000 })
+
+      mock.emit({
+        type: 'transcript_event',
+        sessionId: SESSION_ID,
+        event: {
+          seq: 1,
+          id: 'evt-1',
+          sessionId: SESSION_ID,
+          turn: 1,
+          timestamp: Date.now(),
+          type: 'assistant_text',
+          blockId: BLOCK_ID,
+          text: 'A great answer.',
+          final: true,
+        },
+      })
+
+      await expect(page.getByTestId('transcript-assistant-text').first()).toBeVisible({ timeout: 5_000 })
+
+      await page.getByTestId(`feedback-thumbs-up-${BLOCK_ID}`).click()
+
+      await expect(page.getByTestId('feedback-reason-popup')).not.toBeVisible()
+
+      await expect
+        .poll(
+          () =>
+            mock.lastCommands.find(
+              (c): c is Extract<MinionCommand, { action: 'submit_feedback' }> =>
+                c.action === 'submit_feedback',
+            ),
+          { timeout: 5_000 },
+        )
+        .toMatchObject({
+          action: 'submit_feedback',
+          sessionId: SESSION_ID,
+          messageBlockId: BLOCK_ID,
+          vote: 'up',
+        })
+    } finally {
+      await mock.close()
+    }
+  })
+})

--- a/test/api/mock-minion-integration.test.ts
+++ b/test/api/mock-minion-integration.test.ts
@@ -2,7 +2,12 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { createApiClient, ApiError } from '../../src/api/client'
 import { createMockMinion, type MockMinion } from '../../e2e/fixtures/mock-minion'
-import type { PrPreview, PushSubscriptionJSON, WorkspaceDiff } from '../../src/api/types'
+import type {
+  ApiSession,
+  PrPreview,
+  PushSubscriptionJSON,
+  WorkspaceDiff,
+} from '../../src/api/types'
 
 describe('mock-minion integration', () => {
   let minion: MockMinion
@@ -110,6 +115,97 @@ describe('mock-minion integration', () => {
     const blob = await client.fetchScreenshotBlob(entry!.url)
     const buf = Buffer.from(await blob.arrayBuffer())
     expect(buf.equals(png)).toBe(true)
+  })
+
+  it('submit_feedback records the command and spawns a feedback child session', async () => {
+    const parent: ApiSession = {
+      id: 'parent-1',
+      slug: 'parent-task',
+      status: 'running',
+      command: '/task do thing',
+      createdAt: '2026-04-19T00:00:00Z',
+      updatedAt: '2026-04-19T00:00:00Z',
+      childIds: [],
+      needsAttention: false,
+      attentionReasons: [],
+      quickActions: [],
+      mode: 'task',
+      conversation: [],
+    }
+    minion.setSessions([parent])
+
+    const before = minion.lastCommands.length
+    const result = await client.sendCommand({
+      action: 'submit_feedback',
+      sessionId: 'parent-1',
+      messageBlockId: 'block-7',
+      vote: 'down',
+      reason: 'incorrect',
+      comment: 'wrong answer',
+    })
+    expect(result.success).toBe(true)
+
+    expect(minion.lastCommands.length).toBe(before + 1)
+    const recorded = minion.lastCommands[minion.lastCommands.length - 1]
+    expect(recorded).toEqual({
+      action: 'submit_feedback',
+      sessionId: 'parent-1',
+      messageBlockId: 'block-7',
+      vote: 'down',
+      reason: 'incorrect',
+      comment: 'wrong answer',
+    })
+
+    const sessions = await client.getSessions()
+    const feedback = sessions.find((s) => s.parentId === 'parent-1')
+    expect(feedback).toBeDefined()
+    expect(feedback!.mode).toBe('feedback')
+    expect(feedback!.metadata).toMatchObject({
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'incorrect',
+      comment: 'wrong answer',
+      sourceSessionId: 'parent-1',
+      sourceSessionSlug: 'parent-task',
+      sourceMessageBlockId: 'block-7',
+    })
+
+    const updatedParent = sessions.find((s) => s.id === 'parent-1')
+    expect(updatedParent?.childIds).toContain(feedback!.id)
+  })
+
+  it('submit_feedback (upvote without reason) still spawns a feedback child', async () => {
+    const parent: ApiSession = {
+      id: 'parent-2',
+      slug: 'good-task',
+      status: 'running',
+      command: '/task something',
+      createdAt: '2026-04-19T00:00:00Z',
+      updatedAt: '2026-04-19T00:00:00Z',
+      childIds: [],
+      needsAttention: false,
+      attentionReasons: [],
+      quickActions: [],
+      mode: 'task',
+      conversation: [],
+    }
+    minion.setSessions([parent])
+
+    await client.sendCommand({
+      action: 'submit_feedback',
+      sessionId: 'parent-2',
+      messageBlockId: 'block-9',
+      vote: 'up',
+    })
+
+    const sessions = await client.getSessions()
+    const feedback = sessions.find((s) => s.parentId === 'parent-2')
+    expect(feedback).toBeDefined()
+    expect(feedback!.metadata).toMatchObject({
+      kind: 'feedback',
+      vote: 'up',
+      sourceMessageBlockId: 'block-9',
+    })
   })
 
   it('web push flow: getVapidKey → subscribe → unsubscribe', async () => {


### PR DESCRIPTION
## Summary
- Extends `e2e/fixtures/mock-minion.ts` to detect `submit_feedback` commands, auto-spawn a child session (`parentId=sourceSessionId`, `mode='feedback'`, `metadata` matching `FeedbackMetadata`), update the parent's `childIds`, and emit both `session_created` (child) and `session_updated` (parent) SSE events.
- Adds `e2e/tests/feedback.spec.ts` that drives the thumbs-down → reason popup → submit flow end-to-end, asserts the mock-minion received the command, and verifies the spawned feedback session shows up in the universe with the badge. A second test covers thumbs-up submitting immediately without a popup.
- Adds vitest integration coverage in `test/api/mock-minion-integration.test.ts` for the new handler — both downvote-with-reason and upvote-without-reason paths.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (1036 passing)
- [ ] CI runs the new `e2e/tests/feedback.spec.ts` against the merged DAG once the FeedbackButtons / FeedbackReasonPopup UI work lands