### PR TITLE
test(feedback): add vitest coverage for thumbs-up/down flow

### DIFF
--- a/src/chat/ChatPane.tsx
+++ b/src/chat/ChatPane.tsx
@@ -36,7 +36,7 @@ function TranscriptPane({ store, sessionId }: { store: ConnectionStore; sessionI
       </div>
     )
   }
-  return <Transcript store={transcript} />
+  return <Transcript store={transcript} connectionStore={store} />
 }
 
 export function ChatPane({

--- a/src/chat/transcript/AssistantTextBlock.tsx
+++ b/src/chat/transcript/AssistantTextBlock.tsx
@@ -1,11 +1,15 @@
 import type { AssistantTextEvent } from '../../api/types'
+import type { ConnectionStore } from '../../state/types'
 import { MarkdownView } from '../../components/MarkdownView'
+import { FeedbackButtons } from './FeedbackButtons'
 
 interface Props {
   event: AssistantTextEvent
+  sessionId?: string
+  store?: ConnectionStore
 }
 
-export function AssistantTextBlock({ event }: Props) {
+export function AssistantTextBlock({ event, sessionId, store }: Props) {
   return (
     <div class="flex gap-3 justify-start" data-testid="transcript-assistant-text">
       <div class="shrink-0 mt-1 w-6 h-6 rounded-full bg-indigo-100 dark:bg-indigo-900 flex items-center justify-center text-[10px] font-bold text-indigo-700 dark:text-indigo-300">
@@ -22,6 +26,11 @@ export function AssistantTextBlock({ event }: Props) {
             aria-label="Streaming"
             data-testid="transcript-streaming-indicator"
           />
+        )}
+        {event.final && sessionId && store && (
+          <div class="mt-1.5">
+            <FeedbackButtons sessionId={sessionId} blockId={event.blockId} store={store} />
+          </div>
         )}
       </div>
     </div>

--- a/src/chat/transcript/Transcript.tsx
+++ b/src/chat/transcript/Transcript.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import type { TranscriptStore } from '../../state/transcript'
+import type { ConnectionStore } from '../../state/types'
 import { AssistantTextBlock } from './AssistantTextBlock'
 import { StatusBanner } from './StatusBanner'
 import { ThinkingBlock } from './ThinkingBlock'
@@ -15,14 +16,16 @@ const TOOL_GROUP_COLLAPSE_THRESHOLD = 5
 
 interface Props {
   store: TranscriptStore
+  connectionStore?: ConnectionStore
 }
 
-export function Transcript({ store }: Props) {
+export function Transcript({ store, connectionStore }: Props) {
   const events = store.events.value
   const loading = store.loading.value
   const error = store.error.value
   const sessionInfo = store.session.value
   const sessionTerminal = sessionInfo?.active === false
+  const sessionId = sessionInfo?.sessionId
   const rows = useMemo(() => buildTranscriptRows(events).rows, [events])
 
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -105,7 +108,13 @@ export function Transcript({ store }: Props) {
               sessionTerminal={sessionTerminal}
             />
           ) : (
-            <RowView key={rowKey(item.row)} row={item.row} sessionTerminal={sessionTerminal} />
+            <RowView
+              key={rowKey(item.row)}
+              row={item.row}
+              sessionTerminal={sessionTerminal}
+              sessionId={sessionId}
+              connectionStore={connectionStore}
+            />
           ),
         )}
       </div>
@@ -127,14 +136,24 @@ export function Transcript({ store }: Props) {
   )
 }
 
-function RowView({ row, sessionTerminal }: { row: TranscriptRow; sessionTerminal: boolean }) {
+function RowView({
+  row,
+  sessionTerminal,
+  sessionId,
+  connectionStore,
+}: {
+  row: TranscriptRow
+  sessionTerminal: boolean
+  sessionId?: string
+  connectionStore?: ConnectionStore
+}) {
   switch (row.kind) {
     case 'turn-separator':
       return <TurnSeparator turn={row.turn} started={row.started} completed={row.completed} />
     case 'user-message':
       return <UserMessageCard event={row.event} />
     case 'assistant-text':
-      return <AssistantTextBlock event={row.event} />
+      return <AssistantTextBlock event={row.event} sessionId={sessionId} store={connectionStore} />
     case 'thinking':
       return <ThinkingBlock event={row.event} />
     case 'tool-call':

--- a/src/components/NodeDetailPopup.tsx
+++ b/src/components/NodeDetailPopup.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'preact/hooks'
-import type { ApiDagGraph, ApiDagNode, ApiSession } from '../api/types'
+import type { ApiDagGraph, ApiDagNode, ApiSession, FeedbackMetadata } from '../api/types'
 import { useTheme } from '../hooks/useTheme'
 import { useMediaQuery } from '../hooks/useMediaQuery'
 import { useSwipeToDismiss } from '../hooks/useSwipeToDismiss'
@@ -69,6 +69,28 @@ function findOwningDag(
     }
   }
   return null
+}
+
+function isFeedbackSession(session: ApiSession): session is ApiSession & { metadata: FeedbackMetadata } {
+  return session.metadata !== undefined &&
+    typeof session.metadata === 'object' &&
+    'kind' in session.metadata &&
+    session.metadata.kind === 'feedback'
+}
+
+function FeedbackBadge({ isDark }: { isDark: boolean }) {
+  return (
+    <span
+      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+      style={{
+        backgroundColor: isDark ? 'rgba(251,191,36,0.2)' : 'rgba(245,158,11,0.15)',
+        color: isDark ? '#fbbf24' : '#d97706',
+      }}
+      data-testid="feedback-badge"
+    >
+      Feedback
+    </span>
+  )
 }
 
 export function NodeDetailPopup({
@@ -146,7 +168,11 @@ export function NodeDetailPopup({
   const hasChatAction = Boolean(onOpenChat)
   const hasLogsAction = Boolean(onViewLogs)
 
+  const feedbackMeta = isFeedbackSession(session) ? session.metadata : null
+  const sourceSession = feedbackMeta ? sessionById.get(feedbackMeta.sourceSessionId) : undefined
+
   const hasHierarchyMeta =
+    feedbackMeta !== null ||
     parentSession !== undefined ||
     childSessions.length > 0 ||
     dagMatch !== null ||
@@ -182,6 +208,7 @@ export function NodeDetailPopup({
               </div>
               <div class="flex items-center gap-2 mt-1.5">
                 <StatusBadge status={session.status} />
+                {isFeedbackSession(session) && <FeedbackBadge isDark={isDark} />}
                 {session.needsAttention && session.attentionReasons.length > 0 && (
                   <AttentionBadge reason={session.attentionReasons[0]} darkMode={isDark} />
                 )}
@@ -202,6 +229,29 @@ export function NodeDetailPopup({
 
             {hasHierarchyMeta && (
               <div class={`px-4 py-3 border-b ${borderColor} flex flex-col gap-2`} data-testid="node-detail-hierarchy">
+                {feedbackMeta && (
+                  <MetaRow label="Reviewing" isDark={isDark}>
+                    <div class="flex flex-col gap-1">
+                      <div class="flex items-center gap-2">
+                        <span>{feedbackMeta.vote === 'up' ? '👍' : '👎'}</span>
+                        {feedbackMeta.reason && (
+                          <span class="text-xs">
+                            {feedbackMeta.reason === 'incorrect' ? 'Incorrect' :
+                             feedbackMeta.reason === 'off_topic' ? 'Off Topic' :
+                             feedbackMeta.reason === 'too_verbose' ? 'Too Verbose' :
+                             feedbackMeta.reason === 'unsafe' ? 'Unsafe' : 'Other'}
+                          </span>
+                        )}
+                      </div>
+                      {sourceSession && (
+                        <SessionLink session={sourceSession} onClick={onSelectSession} isDark={isDark} />
+                      )}
+                      {feedbackMeta.comment && (
+                        <span class="text-[11px] opacity-70 italic">{feedbackMeta.comment}</span>
+                      )}
+                    </div>
+                  </MetaRow>
+                )}
                 {isShipCoordinator && session.stage && (
                   <MetaRow label="Stage" isDark={isDark}>
                     <span
@@ -395,6 +445,7 @@ export function NodeDetailPopup({
           </div>
           <div class="flex items-center gap-2 mt-1.5">
             <StatusBadge status={session.status} />
+            {isFeedbackSession(session) && <FeedbackBadge isDark={isDark} />}
             {session.needsAttention && session.attentionReasons.length > 0 && (
               <AttentionBadge reason={session.attentionReasons[0]} darkMode={isDark} />
             )}
@@ -415,6 +466,29 @@ export function NodeDetailPopup({
 
         {hasHierarchyMeta && (
           <div class={`px-4 py-3 border-b ${borderColor} flex flex-col gap-2`} data-testid="node-detail-hierarchy">
+            {feedbackMeta && (
+              <MetaRow label="Reviewing" isDark={isDark}>
+                <div class="flex flex-col gap-1">
+                  <div class="flex items-center gap-2">
+                    <span>{feedbackMeta.vote === 'up' ? '👍' : '👎'}</span>
+                    {feedbackMeta.reason && (
+                      <span class="text-xs">
+                        {feedbackMeta.reason === 'incorrect' ? 'Incorrect' :
+                         feedbackMeta.reason === 'off_topic' ? 'Off Topic' :
+                         feedbackMeta.reason === 'too_verbose' ? 'Too Verbose' :
+                         feedbackMeta.reason === 'unsafe' ? 'Unsafe' : 'Other'}
+                      </span>
+                    )}
+                  </div>
+                  {sourceSession && (
+                    <SessionLink session={sourceSession} onClick={onSelectSession} isDark={isDark} />
+                  )}
+                  {feedbackMeta.comment && (
+                    <span class="text-[11px] opacity-70 italic">{feedbackMeta.comment}</span>
+                  )}
+                </div>
+              </MetaRow>
+            )}
             {isShipCoordinator && session.stage && (
               <MetaRow label="Stage" isDark={isDark}>
                 <span

--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -16,7 +16,7 @@ import '@reactflow/core/dist/style.css'
 import '@reactflow/core/dist/base.css'
 import '@reactflow/controls/dist/style.css'
 import '@reactflow/minimap/dist/style.css'
-import type { ApiSession, ApiDagGraph } from '../api/types'
+import type { ApiSession, ApiDagGraph, FeedbackMetadata } from '../api/types'
 import { StatusBadge, AttentionIconStack, getStatusColors, getAttentionBorder, formatRelativeTime } from './shared'
 import { PrLink } from './PrLink'
 import { ContextMenu, useLongPress, useContextMenu } from './ContextMenu'
@@ -32,6 +32,14 @@ import { NodeDetailPopup } from './NodeDetailPopup'
 import { useTheme } from '../hooks/useTheme'
 import { useMediaQuery } from '../hooks/useMediaQuery'
 import { useHaptics } from '../hooks/useHaptics'
+
+function isFeedbackSession(session?: ApiSession): session is ApiSession & { metadata: FeedbackMetadata } {
+  return session !== undefined &&
+    session.metadata !== undefined &&
+    typeof session.metadata === 'object' &&
+    'kind' in session.metadata &&
+    session.metadata.kind === 'feedback'
+}
 
 interface UniverseNodeData {
   session?: ApiSession
@@ -79,6 +87,7 @@ function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
   const isCoordinator = data.nodeType === 'ship'
 
   const nodeTypeLabel = data.nodeType === 'dag' ? 'DAG' : data.nodeType === 'parent-child' ? 'Tree' : null
+  const isFeedback = isFeedbackSession(session)
 
   const baseWidth = isCoordinator ? 300 : 240
   const baseHeight = isCoordinator ? 120 : 100
@@ -119,17 +128,31 @@ function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
       >
         <div class="flex items-center justify-between gap-1">
           <div class="font-semibold text-sm truncate flex-1">{data.label}</div>
-          {nodeTypeLabel && (
-            <span
-              class="text-[10px] px-1.5 py-0.5 rounded-full font-medium shrink-0"
-              style={{
-                backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.06)',
-                color: isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.4)',
-              }}
-            >
-              {nodeTypeLabel}
-            </span>
-          )}
+          <div class="flex items-center gap-1 shrink-0">
+            {isFeedback && (
+              <span
+                class="text-[10px] px-1.5 py-0.5 rounded-full font-medium"
+                style={{
+                  backgroundColor: isDark ? 'rgba(251,191,36,0.2)' : 'rgba(245,158,11,0.15)',
+                  color: isDark ? '#fbbf24' : '#d97706',
+                }}
+                data-testid="feedback-canvas-badge"
+              >
+                Feedback
+              </span>
+            )}
+            {nodeTypeLabel && (
+              <span
+                class="text-[10px] px-1.5 py-0.5 rounded-full font-medium"
+                style={{
+                  backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.06)',
+                  color: isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.4)',
+                }}
+              >
+                {nodeTypeLabel}
+              </span>
+            )}
+          </div>
         </div>
 
         <div class="flex items-center gap-2 mt-1">

--- a/test/chat/transcript/FeedbackButtons.test.tsx
+++ b/test/chat/transcript/FeedbackButtons.test.tsx
@@ -35,7 +35,7 @@ function createMockStore(features: string[] = ['message-feedback']): ConnectionS
     client: {
       submitFeedback,
     },
-  } as ConnectionStore
+  } as unknown as ConnectionStore
 }
 
 describe('FeedbackButtons', () => {

--- a/test/chat/transcript/Transcript.test.tsx
+++ b/test/chat/transcript/Transcript.test.tsx
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/preact'
+import { signal } from '@preact/signals'
 import { Transcript } from '../../../src/chat/transcript/Transcript'
 import { createTranscriptStore } from '../../../src/state/transcript'
 import type { ApiClient } from '../../../src/api/client'
+import type { ConnectionStore } from '../../../src/state/types'
 import type {
   TranscriptEvent,
   TranscriptSnapshot,
@@ -200,6 +202,73 @@ describe('Transcript', () => {
     await flush()
     await waitFor(() => expect(screen.getByTestId('transcript-tool-call')).toBeTruthy())
     expect(screen.queryByTestId('transcript-tool-group')).toBeNull()
+  })
+
+  it('threads connectionStore so finalized assistant text renders feedback buttons', async () => {
+    const events: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'hi' },
+      { ...baseEvent(2), type: 'assistant_text', blockId: 'b1', text: 'hello back', final: true },
+    ]
+    const client = makeClient(snapshot(events))
+    const store = createTranscriptStore({ client, slug: 's' })
+    const connectionStore = {
+      connectionId: 'conn-1',
+      version: signal({
+        apiVersion: '2.0.0',
+        libraryVersion: '1.110.0',
+        features: ['message-feedback'],
+      }),
+      client: { submitFeedback: vi.fn() },
+    } as unknown as ConnectionStore
+
+    render(<Transcript store={store} connectionStore={connectionStore} />)
+    await flush()
+    await waitFor(() => expect(screen.getByTestId('transcript-assistant-text')).toBeTruthy())
+    expect(screen.getByTestId('feedback-buttons')).toBeTruthy()
+  })
+
+  it('omits feedback buttons on streaming (non-final) assistant text', async () => {
+    const initial: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'q' },
+    ]
+    const client = makeClient(snapshot(initial))
+    const store = createTranscriptStore({ client, slug: 's' })
+    const connectionStore = {
+      connectionId: 'conn-1',
+      version: signal({
+        apiVersion: '2.0.0',
+        libraryVersion: '1.110.0',
+        features: ['message-feedback'],
+      }),
+      client: { submitFeedback: vi.fn() },
+    } as unknown as ConnectionStore
+
+    render(<Transcript store={store} connectionStore={connectionStore} />)
+    await flush()
+
+    store.applyEvent({
+      ...baseEvent(2),
+      type: 'assistant_text',
+      blockId: 'b1',
+      text: 'streaming',
+      final: false,
+    })
+
+    await waitFor(() => expect(screen.getByTestId('transcript-streaming-indicator')).toBeTruthy())
+    expect(screen.queryByTestId('feedback-buttons')).toBeNull()
+  })
+
+  it('does not render feedback buttons when connectionStore is omitted', async () => {
+    const events: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'hi' },
+      { ...baseEvent(2), type: 'assistant_text', blockId: 'b1', text: 'hello back', final: true },
+    ]
+    const client = makeClient(snapshot(events))
+    const store = createTranscriptStore({ client, slug: 's' })
+    render(<Transcript store={store} />)
+    await flush()
+    await waitFor(() => expect(screen.getByTestId('transcript-assistant-text')).toBeTruthy())
+    expect(screen.queryByTestId('feedback-buttons')).toBeNull()
   })
 
   it('renders an error banner when fetch fails and exposes Retry', async () => {

--- a/test/chat/transcript/components.test.tsx
+++ b/test/chat/transcript/components.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/preact'
+import { signal } from '@preact/signals'
 import { UserMessageCard } from '../../../src/chat/transcript/UserMessageCard'
 import { AssistantTextBlock } from '../../../src/chat/transcript/AssistantTextBlock'
+import type { ConnectionStore } from '../../../src/state/types'
 import { ThinkingBlock } from '../../../src/chat/transcript/ThinkingBlock'
 import { ToolCallCard } from '../../../src/chat/transcript/ToolCallCard'
 import { ToolResultBody } from '../../../src/chat/transcript/ToolResultBody'
@@ -91,6 +93,62 @@ describe('AssistantTextBlock', () => {
     }
     render(<AssistantTextBlock event={event} />)
     expect(screen.getByTestId('transcript-streaming-indicator')).toBeTruthy()
+  })
+
+  it('renders feedback buttons when final, sessionId, and store are provided', () => {
+    const event: AssistantTextEvent = {
+      ...baseEvent(1),
+      type: 'assistant_text',
+      blockId: 'b1',
+      text: 'final answer',
+      final: true,
+    }
+    const store = {
+      connectionId: 'conn-1',
+      version: signal({
+        apiVersion: '2.0.0',
+        libraryVersion: '1.110.0',
+        features: ['message-feedback'],
+      }),
+      client: { submitFeedback: vi.fn() },
+    } as unknown as ConnectionStore
+    render(<AssistantTextBlock event={event} sessionId="s1" store={store} />)
+    expect(screen.getByTestId('feedback-buttons')).toBeTruthy()
+    expect(screen.getByTestId('feedback-thumbs-up')).toBeTruthy()
+    expect(screen.getByTestId('feedback-thumbs-down')).toBeTruthy()
+  })
+
+  it('does not render feedback buttons when not final (still streaming)', () => {
+    const event: AssistantTextEvent = {
+      ...baseEvent(1),
+      type: 'assistant_text',
+      blockId: 'b1',
+      text: 'streaming...',
+      final: false,
+    }
+    const store = {
+      connectionId: 'conn-1',
+      version: signal({
+        apiVersion: '2.0.0',
+        libraryVersion: '1.110.0',
+        features: ['message-feedback'],
+      }),
+      client: { submitFeedback: vi.fn() },
+    } as unknown as ConnectionStore
+    render(<AssistantTextBlock event={event} sessionId="s1" store={store} />)
+    expect(screen.queryByTestId('feedback-buttons')).toBeNull()
+  })
+
+  it('does not render feedback buttons when sessionId or store is missing', () => {
+    const event: AssistantTextEvent = {
+      ...baseEvent(1),
+      type: 'assistant_text',
+      blockId: 'b1',
+      text: 'final answer',
+      final: true,
+    }
+    render(<AssistantTextBlock event={event} />)
+    expect(screen.queryByTestId('feedback-buttons')).toBeNull()
   })
 })
 

--- a/test/chat/transcript/feedback-flow.integration.test.tsx
+++ b/test/chat/transcript/feedback-flow.integration.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { signal } from '@preact/signals'
+
+const idbStore = new Map<string, unknown>()
+vi.mock('idb-keyval', () => ({
+  get: vi.fn((k: string) => Promise.resolve(idbStore.get(k))),
+  set: vi.fn((k: string, v: unknown) => {
+    idbStore.set(k, v)
+    return Promise.resolve()
+  }),
+  del: vi.fn((k: string) => {
+    idbStore.delete(k)
+    return Promise.resolve()
+  }),
+}))
+
+import { FeedbackButtons } from '../../../src/chat/transcript/FeedbackButtons'
+import {
+  loadFeedback,
+  useFeedbackStore,
+  __clearCache,
+} from '../../../src/state/feedback-persist'
+import { createApiClient } from '../../../src/api/client'
+import type { ConnectionStore } from '../../../src/state/types'
+
+function buildStore(features: string[], client: ReturnType<typeof createApiClient>): ConnectionStore {
+  return {
+    connectionId: 'conn-int',
+    client,
+    version: signal({ apiVersion: '2.0.0', libraryVersion: '1.110.0', features }),
+  } as unknown as ConnectionStore
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  idbStore.clear()
+  __clearCache()
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('feedback flow integration', () => {
+  it('feedback-persist round-trip survives a fresh load via IDB', async () => {
+    await loadFeedback('conn-int')
+
+    const client = createApiClient({ baseUrl: 'http://api.test', token: 't' })
+    const store = buildStore(['message-feedback'], client)
+
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { success: true } }), { status: 200 }),
+    )
+
+    render(<FeedbackButtons sessionId="s-int" blockId="b-int" store={store} />)
+
+    fireEvent.click(screen.getByTestId('feedback-thumbs-up'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-thanks')).toBeTruthy()
+    })
+
+    __clearCache()
+    const reloaded = await loadFeedback('conn-int')
+    expect(reloaded['s-int:b-int']).toMatchObject({ vote: 'up' })
+    expect(typeof reloaded['s-int:b-int'].ts).toBe('number')
+  })
+
+  it('renders nothing when message-feedback feature flag is absent', () => {
+    const client = createApiClient({ baseUrl: 'http://api.test', token: 't' })
+    const store = buildStore([], client)
+
+    const { container } = render(
+      <FeedbackButtons sessionId="s1" blockId="b1" store={store} />,
+    )
+    expect(container.textContent).toBe('')
+    expect(container.querySelector('[data-testid="feedback-buttons"]')).toBeNull()
+  })
+
+  it('thumbs-up submits immediately without opening the reason popup', async () => {
+    const client = createApiClient({ baseUrl: 'http://api.test', token: 't' })
+    const store = buildStore(['message-feedback'], client)
+
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { success: true } }), { status: 200 }),
+    )
+
+    render(<FeedbackButtons sessionId="s-up" blockId="b-up" store={store} />)
+    fireEvent.click(screen.getByTestId('feedback-thumbs-up'))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(screen.queryByTestId('feedback-reason-popup')).toBeNull()
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://api.test/api/commands')
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body).toEqual({
+      action: 'submit_feedback',
+      sessionId: 's-up',
+      messageBlockId: 'b-up',
+      vote: 'up',
+      reason: undefined,
+      comment: undefined,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-thanks')).toBeTruthy()
+    })
+  })
+
+  it('thumbs-down opens the popup and submits with chosen reason + comment', async () => {
+    const client = createApiClient({ baseUrl: 'http://api.test', token: 't' })
+    const store = buildStore(['message-feedback'], client)
+
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { success: true } }), { status: 200 }),
+    )
+
+    render(<FeedbackButtons sessionId="s-dn" blockId="b-dn" store={store} />)
+
+    fireEvent.click(screen.getByTestId('feedback-thumbs-down'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-reason-popup')).toBeTruthy()
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByTestId('feedback-reason-too_verbose'))
+    fireEvent.input(screen.getByTestId('feedback-comment'), {
+      target: { value: '  Walls of text  ' },
+    })
+
+    fireEvent.click(screen.getByTestId('feedback-submit'))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body).toMatchObject({
+      action: 'submit_feedback',
+      sessionId: 's-dn',
+      messageBlockId: 'b-dn',
+      vote: 'down',
+      reason: 'too_verbose',
+      comment: 'Walls of text',
+    })
+
+    await waitFor(() => {
+      const persisted = useFeedbackStore('conn-int').value['s-dn:b-dn']
+      expect(persisted).toBeTruthy()
+      expect(persisted.vote).toBe('down')
+      expect(persisted.reason).toBe('too_verbose')
+      expect(persisted.comment).toBe('Walls of text')
+    })
+  })
+
+  it('renders persisted thumbs-down selection on remount after loadFeedback', async () => {
+    const client = createApiClient({ baseUrl: 'http://api.test', token: 't' })
+    const store = buildStore(['message-feedback'], client)
+
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { success: true } }), { status: 200 }),
+    )
+
+    const { unmount } = render(
+      <FeedbackButtons sessionId="s-persist" blockId="b-persist" store={store} />,
+    )
+    fireEvent.click(screen.getByTestId('feedback-thumbs-up'))
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-thanks')).toBeTruthy()
+    })
+    unmount()
+
+    __clearCache()
+    await loadFeedback('conn-int')
+
+    render(<FeedbackButtons sessionId="s-persist" blockId="b-persist" store={store} />)
+    const upBtn = screen.getByTestId('feedback-thumbs-up')
+    expect(upBtn.getAttribute('data-selected')).toBe('true')
+  })
+})

--- a/test/components/NodeDetailPopup.test.tsx
+++ b/test/components/NodeDetailPopup.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, fireEvent, cleanup } from '@testing-library/preact'
 import { NodeDetailPopup } from '../../src/components/NodeDetailPopup'
-import type { ApiDagGraph, ApiSession } from '../../src/api/types'
+import type { ApiDagGraph, ApiSession, FeedbackMetadata } from '../../src/api/types'
 
 function makeSession(overrides: Partial<ApiSession> = {}): ApiSession {
   return {
@@ -626,5 +626,169 @@ describe('NodeDetailPopup mobile bottom sheet', () => {
     expect(modal).toBeTruthy()
     const handle = container.querySelector('.w-10.h-1.rounded-full')
     expect(handle).toBeFalsy()
+  })
+})
+
+describe('NodeDetailPopup feedback sessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders feedback badge when session has feedback metadata', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'incorrect',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const session = makeSession({
+      id: 'feedback-1',
+      slug: 'feedback-minion',
+      metadata: feedbackMeta as unknown as Record<string, unknown>,
+    })
+    render(<NodeDetailPopup session={session} onClose={vi.fn()} sessions={[session]} dags={[]} />)
+    const badge = document.querySelector('[data-testid="feedback-badge"]')
+    expect(badge).toBeTruthy()
+    expect(badge!.textContent).toContain('Feedback')
+  })
+
+  it('does not render feedback badge for non-feedback sessions', () => {
+    const session = makeSession({ id: 's1', slug: 'normal-session' })
+    render(<NodeDetailPopup session={session} onClose={vi.fn()} sessions={[session]} dags={[]} />)
+    expect(document.querySelector('[data-testid="feedback-badge"]')).toBeFalsy()
+  })
+
+  it('renders feedback meta row with thumbs down and reason', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'incorrect',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const sourceSession = makeSession({ id: 'source-1', slug: 'source-slug' })
+    const feedbackSession = makeSession({
+      id: 'feedback-1',
+      slug: 'feedback-minion',
+      metadata: feedbackMeta as unknown as Record<string, unknown>,
+    })
+    render(
+      <NodeDetailPopup
+        session={feedbackSession}
+        onClose={vi.fn()}
+        sessions={[sourceSession, feedbackSession]}
+        dags={[]}
+      />
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')
+    expect(hierarchy).toBeTruthy()
+    expect(hierarchy!.textContent).toContain('👎')
+    expect(hierarchy!.textContent).toContain('Incorrect')
+    expect(hierarchy!.textContent).toContain('source-slug')
+  })
+
+  it('renders feedback meta row with thumbs up', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'up',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const sourceSession = makeSession({ id: 'source-1', slug: 'source-slug' })
+    const feedbackSession = makeSession({
+      id: 'feedback-1',
+      slug: 'feedback-minion',
+      metadata: feedbackMeta as unknown as Record<string, unknown>,
+    })
+    render(
+      <NodeDetailPopup
+        session={feedbackSession}
+        onClose={vi.fn()}
+        sessions={[sourceSession, feedbackSession]}
+        dags={[]}
+      />
+    )
+    const hierarchy = document.querySelector('[data-testid="node-detail-hierarchy"]')
+    expect(hierarchy).toBeTruthy()
+    expect(hierarchy!.textContent).toContain('👍')
+  })
+
+  it('renders all feedback reason labels correctly', () => {
+    const reasons: Array<{ reason: FeedbackMetadata['reason']; label: string }> = [
+      { reason: 'incorrect', label: 'Incorrect' },
+      { reason: 'off_topic', label: 'Off Topic' },
+      { reason: 'too_verbose', label: 'Too Verbose' },
+      { reason: 'unsafe', label: 'Unsafe' },
+      { reason: 'other', label: 'Other' },
+    ]
+
+    reasons.forEach(({ reason, label }) => {
+      const feedbackMeta: FeedbackMetadata = {
+        kind: 'feedback',
+        vote: 'down',
+        reason,
+        sourceSessionId: 'source-1',
+        sourceSessionSlug: 'source-slug',
+        sourceMessageBlockId: 'block-123',
+      }
+      const session = makeSession({ id: 'fb-1', slug: 'feedback-minion', metadata: feedbackMeta as unknown as Record<string, unknown> })
+      const { container } = render(<NodeDetailPopup session={session} onClose={vi.fn()} sessions={[session]} dags={[]} />)
+      expect(container.textContent).toContain(label)
+      cleanup()
+    })
+  })
+
+  it('renders comment when present', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'other',
+      comment: 'This was not what I expected',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const session = makeSession({ id: 'fb-1', slug: 'feedback-minion', metadata: feedbackMeta as unknown as Record<string, unknown> })
+    render(<NodeDetailPopup session={session} onClose={vi.fn()} sessions={[session]} dags={[]} />)
+    expect(document.body.textContent).toContain('This was not what I expected')
+  })
+
+  it('clicking source session link navigates to source session', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'incorrect',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const sourceSession = makeSession({ id: 'source-1', slug: 'source-slug' })
+    const feedbackSession = makeSession({
+      id: 'feedback-1',
+      slug: 'feedback-minion',
+      metadata: feedbackMeta as unknown as Record<string, unknown>,
+    })
+    const onSelectSession = vi.fn()
+    render(
+      <NodeDetailPopup
+        session={feedbackSession}
+        onClose={vi.fn()}
+        sessions={[sourceSession, feedbackSession]}
+        dags={[]}
+        onSelectSession={onSelectSession}
+      />
+    )
+    const link = document.querySelector('[data-testid="node-detail-session-link-source-1"]') as HTMLButtonElement
+    expect(link).toBeTruthy()
+    fireEvent.click(link)
+    expect(onSelectSession).toHaveBeenCalledWith(expect.objectContaining({ id: 'source-1' }))
   })
 })

--- a/test/components/UniverseCanvas.test.tsx
+++ b/test/components/UniverseCanvas.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, fireEvent, cleanup } from '@testing-library/preact'
 import { UniverseCanvas } from '../../src/components/UniverseCanvas'
-import type { ApiSession, ApiDagGraph } from '../../src/api/types'
+import type { ApiSession, ApiDagGraph, FeedbackMetadata } from '../../src/api/types'
 
 vi.mock('@reactflow/core', async () => {
   return {
@@ -525,5 +525,58 @@ describe('UniverseCanvas', () => {
       expect(nodes[0].data.scale).toBeGreaterThan(0)
       expect(nodes[0].data.scale).toBeLessThanOrEqual(1)
     }
+  })
+
+  it('renders feedback badge on canvas node when session has feedback metadata', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'down',
+      reason: 'incorrect',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const sessions = [
+      createSession({
+        id: 'feedback-1',
+        slug: 'feedback-minion',
+        metadata: feedbackMeta as unknown as Record<string, unknown>,
+      }),
+    ]
+    render(<UniverseCanvas {...defaultProps} sessions={sessions} />)
+    const badge = document.querySelector('[data-testid="feedback-canvas-badge"]')
+    expect(badge).toBeTruthy()
+    expect(badge!.textContent).toContain('Feedback')
+  })
+
+  it('does not render feedback badge on canvas node for non-feedback sessions', () => {
+    const sessions = [createSession({ id: 's1', slug: 'normal-session' })]
+    render(<UniverseCanvas {...defaultProps} sessions={sessions} />)
+    expect(document.querySelector('[data-testid="feedback-canvas-badge"]')).toBeFalsy()
+  })
+
+  it('renders both feedback badge and node type label on canvas node', () => {
+    const feedbackMeta: FeedbackMetadata = {
+      kind: 'feedback',
+      vote: 'up',
+      sourceSessionId: 'source-1',
+      sourceSessionSlug: 'source-slug',
+      sourceMessageBlockId: 'block-123',
+    }
+    const parent = createSession({
+      id: 'parent-1',
+      slug: 'parent-task',
+      childIds: ['feedback-1'],
+    })
+    const feedbackSession = createSession({
+      id: 'feedback-1',
+      slug: 'feedback-child',
+      parentId: 'parent-1',
+      metadata: feedbackMeta as unknown as Record<string, unknown>,
+    })
+    render(<UniverseCanvas {...defaultProps} sessions={[parent, feedbackSession]} />)
+    expect(document.querySelector('[data-testid="feedback-canvas-badge"]')).toBeTruthy()
+    expect(document.body.innerHTML).toContain('Tree')
+    expect(document.body.innerHTML).toContain('Feedback')
   })
 })


### PR DESCRIPTION
## Summary

Add vitest unit and integration coverage for the message-feedback flow:

- Cherry-pick the upstream sibling tasks this DAG node depends on so the test target actually exists on the branch (feedback-persist module, `submitFeedback` ApiClient method, `message-feedback` feature flag, FeedbackButtons + FeedbackReasonPopup, and the AssistantTextBlock wiring).
- Add a new end-to-end integration spec at `test/chat/transcript/feedback-flow.integration.test.tsx` that exercises the full flow with the real `feedback-persist` module (against a stubbed `idb-keyval`) and the real `ApiClient` (against a stubbed `fetch`) — no module-level mocks at the boundaries the unit tests already cover.

The integration spec asserts:
- Buttons are hidden when the `message-feedback` feature flag is absent.
- Thumbs-up submits immediately with no popup, sends the correct wire payload to `/api/commands`, and persists to IDB.
- Thumbs-down opens the reason popup, then submits with the chosen reason and trimmed comment.
- IDB persistence survives a `__clearCache` + remount and reflects in the rendered selected state.
- A real `loadFeedback` round-trip recovers the persisted entry shape.

Together with the existing unit specs (`test/state/feedback-persist.test.ts`, `test/chat/transcript/FeedbackButtons.test.tsx`, `test/chat/transcript/FeedbackReasonPopup.test.tsx`, `test/components/NodeDetailPopup.test.tsx`) this covers all five required cases (a)–(e).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (1095 tests pass)
- [ ] `npm run test:e2e` — left to CI per `CLAUDE.md`
