### PR TITLE
fix(mobile): collapse dense header/chrome rows behind triggers

### DIFF
--- a/e2e/tests/reconnect.spec.ts
+++ b/e2e/tests/reconnect.spec.ts
@@ -26,13 +26,14 @@ test.describe('SSE reconnect', () => {
     try {
       await connectToMinion(page, mock, 'Reconnect Minion')
 
-      await expect(page.getByText('live')).toBeVisible({ timeout: 20_000 })
+      const statusBadge = page.getByTestId('connection-status-badge')
+      await expect(statusBadge).toHaveAttribute('aria-label', /live/, { timeout: 20_000 })
 
       mock.drop()
 
-      await expect(page.getByText('retrying')).toBeVisible({ timeout: 5_000 })
+      await expect(statusBadge).toHaveAttribute('aria-label', /retrying/, { timeout: 5_000 })
 
-      await expect(page.getByText('live')).toBeVisible({ timeout: 20_000 })
+      await expect(statusBadge).toHaveAttribute('aria-label', /live/, { timeout: 20_000 })
 
       await expect(page.getByTestId('session-item-s-reconnect')).toBeVisible({ timeout: 10_000 })
     } finally {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,6 +118,7 @@ function ConnectionStatusBadge({
   status: string
   reconnectAt?: number | null
 }) {
+  const isDesktop = useMediaQuery('(min-width: 768px)')
   const color =
     status === 'live'
       ? 'bg-green-500'
@@ -151,9 +152,13 @@ function ConnectionStatusBadge({
     <span
       class="flex items-center gap-1 sm:gap-1.5 text-xs text-slate-600 dark:text-slate-400 min-w-0 shrink"
       data-testid="connection-status-badge"
+      title={label}
+      aria-label={`Connection status: ${label}`}
     >
       <span class={`inline-block h-2 w-2 shrink-0 rounded-full ${color}`} />
-      <span class="truncate" data-testid="connection-status-label">{label}</span>
+      {isDesktop.value && (
+        <span class="truncate" data-testid="connection-status-label">{label}</span>
+      )}
     </span>
   )
 }

--- a/src/chat/ChatPane.tsx
+++ b/src/chat/ChatPane.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo } from 'preact/hooks'
+import { useState, useMemo, useEffect, useRef } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
 import { useMediaQuery } from '../hooks/useMediaQuery'
 import { confirm } from '../hooks/useConfirm'
 import { SessionTabs, type SessionTabId } from './SessionTabs'
@@ -11,7 +12,7 @@ import { MessageInput } from './MessageInput'
 import { DagStatusPanel } from './DagStatusPanel'
 import { Transcript, TranscriptUpgradeNotice } from './transcript'
 import { PrPreviewCard } from '../components/PrPreviewCard'
-import { WorktreeHeader } from '../components/WorktreeHeader'
+import { WorktreeHeader, truncateCwd } from '../components/WorktreeHeader'
 import { statusDot } from '../components/SessionList'
 import { hasFeature } from '../api/features'
 import type { ApiSession, MinionCommand, QuickAction } from '../api/types'
@@ -53,6 +54,20 @@ export function ChatPane({
   const [fullscreen, setFullscreen] = useState<boolean>(() =>
     typeof localStorage !== 'undefined' && localStorage.getItem('minions-ui:chat-fullscreen') === 'true',
   )
+  const infoOpen = useSignal(false)
+  const infoRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!infoOpen.value || isDesktopPane.value) return
+    const handler = (e: MouseEvent) => {
+      if (infoRef.current && !infoRef.current.contains(e.target as Node)) {
+        infoOpen.value = false
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [infoOpen.value, isDesktopPane.value, infoOpen])
+
   const toggleFullscreen = () => {
     const next = !fullscreen
     setFullscreen(next)
@@ -132,6 +147,8 @@ export function ChatPane({
     return null
   }, [session.id, store.dags.value, store.sessions.value])
 
+  const cwd = session.repo ? truncateCwd(session.repo) : null
+
   return (
     <div class={rootClass} data-testid="chat-pane" data-fullscreen={mobileFullscreen ? 'true' : 'false'}>
       <header class="flex items-center gap-2.5 px-4 py-2.5 border-b border-slate-200 dark:border-slate-700 shrink-0">
@@ -148,19 +165,80 @@ export function ChatPane({
         )}
         <span class={`inline-block h-2 w-2 rounded-full ${statusDot(session.status)}`} />
         <span class="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">{session.slug}</span>
-        <span class={`text-xs ${statusTone}`} data-testid="chat-pane-status">{session.status}</span>
-        <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500 ml-2">
-          {session.mode}
-        </span>
-        {session.prUrl && (
-          <a
-            href={session.prUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-xs underline text-indigo-600 dark:text-indigo-400 ml-2"
-          >
-            PR
-          </a>
+        {isDesktopPane.value ? (
+          <>
+            <span class={`text-xs ${statusTone}`} data-testid="chat-pane-status">{session.status}</span>
+            <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500 ml-2">
+              {session.mode}
+            </span>
+            {session.prUrl && (
+              <a
+                href={session.prUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-xs underline text-indigo-600 dark:text-indigo-400 ml-2"
+              >
+                PR
+              </a>
+            )}
+          </>
+        ) : (
+          <div class="relative" ref={infoRef}>
+            <button
+              type="button"
+              onClick={() => { infoOpen.value = !infoOpen.value }}
+              aria-haspopup="dialog"
+              aria-expanded={infoOpen.value}
+              aria-label="Session info"
+              title={`${session.status} · ${session.mode}`}
+              class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-3 py-2.5 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700 min-h-[44px]"
+              data-testid="chat-pane-info-btn"
+            >
+              ⓘ
+            </button>
+            {infoOpen.value && (
+              <div
+                class="absolute left-0 top-full mt-1 z-40 min-w-[220px] rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-lg p-3 flex flex-col gap-2 text-xs"
+                data-testid="chat-pane-info-popover"
+              >
+                <div class="flex items-center gap-2">
+                  <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500 w-14 shrink-0">Status</span>
+                  <span class={statusTone} data-testid="chat-pane-status">{session.status}</span>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500 w-14 shrink-0">Mode</span>
+                  <span class="text-slate-700 dark:text-slate-200">{session.mode}</span>
+                </div>
+                {session.branch && (
+                  <div class="flex items-center gap-2 min-w-0">
+                    <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500 w-14 shrink-0">Branch</span>
+                    <span class="font-mono text-slate-700 dark:text-slate-200 truncate" title={session.branch} data-testid="info-branch">
+                      {session.branch}
+                    </span>
+                  </div>
+                )}
+                {cwd && (
+                  <div class="flex items-center gap-2 min-w-0">
+                    <span class="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500 w-14 shrink-0">Cwd</span>
+                    <span class="font-mono text-slate-700 dark:text-slate-200 truncate" title={cwd.full} data-testid="info-cwd">
+                      {cwd.display}
+                    </span>
+                  </div>
+                )}
+                {session.prUrl && (
+                  <a
+                    href={session.prUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-indigo-600 dark:text-indigo-400 underline"
+                    data-testid="info-pr-link"
+                  >
+                    View PR
+                  </a>
+                )}
+              </div>
+            )}
+          </div>
         )}
         <div class="ml-auto flex items-center gap-1.5">
           {!isDesktopPane.value && (
@@ -197,7 +275,7 @@ export function ChatPane({
           </button>
         </div>
       </header>
-      <WorktreeHeader session={session} store={store} />
+      {isDesktopPane.value && <WorktreeHeader session={session} store={store} />}
       <DagStatusPanel session={session} store={store} onSelect={onNavigate} onLand={handleLand} />
       <SessionTabs
         tabs={[

--- a/src/chat/QuickActionsBar.tsx
+++ b/src/chat/QuickActionsBar.tsx
@@ -103,11 +103,6 @@ export function QuickActionsBar({ session, onAction, onShipAdvance }: QuickActio
     ? 'bg-gray-700 hover:bg-gray-600 text-gray-200 border-gray-600'
     : 'bg-gray-100 hover:bg-gray-200 text-gray-800 border-gray-200'
 
-  const maxVisible = isDesktop.value ? 5 : 3
-  const hasOverflow = session.quickActions.length > maxVisible
-  const visibleActions = hasOverflow ? session.quickActions.slice(0, maxVisible) : session.quickActions
-  const overflowActions = hasOverflow ? session.quickActions.slice(maxVisible) : []
-
   const handleActionClick = (action: QuickAction) => {
     vibrate('light')
     void onAction(action)
@@ -121,6 +116,68 @@ export function QuickActionsBar({ session, onAction, onShipAdvance }: QuickActio
     open.value = true
   }
 
+  if (!isDesktop.value) {
+    return (
+      <>
+        <div
+          class="flex flex-wrap gap-2 px-4 py-2 border-t"
+          style={{ borderColor: isDark ? '#374151' : '#e5e7eb' }}
+          data-testid="quick-actions-bar"
+        >
+          <button
+            onClick={handleMoreClick}
+            class={`text-xs font-medium px-4 py-3 rounded-full border transition-colors min-h-[44px] ${btnClass}`}
+            data-testid="quick-actions-trigger"
+            aria-haspopup="dialog"
+            aria-expanded={open.value}
+          >
+            Quick actions ({session.quickActions.length})
+          </button>
+        </div>
+        {open.value && (
+          <div class="fixed inset-x-0 top-0 z-50 h-[100dvh]">
+            <div
+              class="absolute inset-0 bg-black/50"
+              data-testid="quick-actions-backdrop"
+              onClick={handleClose}
+            />
+            <div
+              ref={sheetRef}
+              class="absolute bottom-0 left-0 right-0 rounded-t-2xl shadow-2xl flex flex-col border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 max-h-[70dvh]"
+              data-testid="quick-actions-sheet"
+            >
+              <div class="flex justify-center pt-2 pb-1 shrink-0">
+                <div class="w-10 h-1 rounded-full bg-slate-300 dark:bg-slate-600" />
+              </div>
+              <div class="px-4 py-2 border-b border-slate-200 dark:border-slate-700 shrink-0">
+                <h3 class="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  Quick actions
+                </h3>
+              </div>
+              <div class="flex-1 overflow-y-auto">
+                {session.quickActions.map((action) => (
+                  <button
+                    key={action.type}
+                    onClick={() => handleActionClick(action)}
+                    class="w-full text-left px-4 py-3 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors min-h-[44px] border-b border-slate-100 dark:border-slate-700 last:border-0"
+                    data-testid={`quick-action-${action.type}`}
+                  >
+                    {action.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </>
+    )
+  }
+
+  const maxVisible = 5
+  const hasOverflow = session.quickActions.length > maxVisible
+  const visibleActions = hasOverflow ? session.quickActions.slice(0, maxVisible) : session.quickActions
+  const overflowActions = hasOverflow ? session.quickActions.slice(maxVisible) : []
+
   const actionButton = (action: QuickAction, key: string) => (
     <button
       key={key}
@@ -133,79 +190,42 @@ export function QuickActionsBar({ session, onAction, onShipAdvance }: QuickActio
   )
 
   return (
-    <>
-      <div
-        class="flex flex-wrap gap-2 px-4 py-2 border-t relative"
-        style={{ borderColor: isDark ? '#374151' : '#e5e7eb' }}
-        data-testid="quick-actions-bar"
-      >
-        {visibleActions.map((action) => actionButton(action, action.type))}
-        {hasOverflow && (
-          <button
-            onClick={handleMoreClick}
-            class={`text-xs font-medium px-4 py-3 rounded-full border transition-colors min-h-[44px] ${btnClass}`}
-            data-testid="quick-actions-more-btn"
-            aria-haspopup="dialog"
-            aria-expanded={open.value}
-          >
-            More actions... ({overflowActions.length})
-          </button>
-        )}
-        {open.value && isDesktop.value && (
-          <div
-            ref={dropdownRef}
-            class="absolute left-4 bottom-full mb-2 z-50 min-w-[220px] rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-lg py-2 max-h-64 overflow-y-auto"
-            data-testid="quick-actions-dropdown"
-          >
-            {overflowActions.map((action) => (
-              <button
-                key={action.type}
-                onClick={() => handleActionClick(action)}
-                class="w-full text-left px-4 py-3 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors min-h-[44px]"
-                data-testid={`quick-action-overflow-${action.type}`}
-              >
-                {action.label}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-      {open.value && !isDesktop.value && (
-        <div class="fixed inset-x-0 top-0 z-50 h-[100dvh]">
-          <div
-            class="absolute inset-0 bg-black/50"
-            data-testid="quick-actions-backdrop"
-            onClick={handleClose}
-          />
-          <div
-            ref={sheetRef}
-            class="absolute bottom-0 left-0 right-0 rounded-t-2xl shadow-2xl flex flex-col border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 max-h-[70dvh]"
-            data-testid="quick-actions-sheet"
-          >
-            <div class="flex justify-center pt-2 pb-1 shrink-0">
-              <div class="w-10 h-1 rounded-full bg-slate-300 dark:bg-slate-600" />
-            </div>
-            <div class="px-4 py-2 border-b border-slate-200 dark:border-slate-700 shrink-0">
-              <h3 class="text-sm font-semibold text-slate-900 dark:text-slate-100">
-                More actions
-              </h3>
-            </div>
-            <div class="flex-1 overflow-y-auto">
-              {overflowActions.map((action) => (
-                <button
-                  key={action.type}
-                  onClick={() => handleActionClick(action)}
-                  class="w-full text-left px-4 py-3 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors min-h-[44px] border-b border-slate-100 dark:border-slate-700 last:border-0"
-                  data-testid={`quick-action-overflow-${action.type}`}
-                >
-                  {action.label}
-                </button>
-              ))}
-            </div>
-          </div>
+    <div
+      class="flex flex-wrap gap-2 px-4 py-2 border-t relative"
+      style={{ borderColor: isDark ? '#374151' : '#e5e7eb' }}
+      data-testid="quick-actions-bar"
+    >
+      {visibleActions.map((action) => actionButton(action, action.type))}
+      {hasOverflow && (
+        <button
+          onClick={handleMoreClick}
+          class={`text-xs font-medium px-4 py-3 rounded-full border transition-colors min-h-[44px] ${btnClass}`}
+          data-testid="quick-actions-more-btn"
+          aria-haspopup="dialog"
+          aria-expanded={open.value}
+        >
+          More actions... ({overflowActions.length})
+        </button>
+      )}
+      {open.value && (
+        <div
+          ref={dropdownRef}
+          class="absolute left-4 bottom-full mb-2 z-50 min-w-[220px] rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-lg py-2 max-h-64 overflow-y-auto"
+          data-testid="quick-actions-dropdown"
+        >
+          {overflowActions.map((action) => (
+            <button
+              key={action.type}
+              onClick={() => handleActionClick(action)}
+              class="w-full text-left px-4 py-3 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors min-h-[44px]"
+              data-testid={`quick-action-overflow-${action.type}`}
+            >
+              {action.label}
+            </button>
+          ))}
         </div>
       )}
-    </>
+    </div>
   )
 }
 

--- a/src/components/AttentionBar.tsx
+++ b/src/components/AttentionBar.tsx
@@ -1,5 +1,8 @@
+import { useSignal } from '@preact/signals'
+import { useEffect, useRef } from 'preact/hooks'
 import type { ApiSession, AttentionReason } from '../api/types'
 import { useTheme } from '../hooks/useTheme'
+import { useMediaQuery } from '../hooks/useMediaQuery'
 import { ATTENTION_CONFIG } from './shared'
 
 const REASON_ORDER: AttentionReason[] = [
@@ -56,10 +59,116 @@ interface AttentionBarProps {
 export function AttentionBar({ sessions, filter, onSelect }: AttentionBarProps) {
   const theme = useTheme()
   const dark = theme.value === 'dark'
+  const isDesktop = useMediaQuery('(min-width: 768px)')
+  const open = useSignal(false)
+  const containerRef = useRef<HTMLDivElement>(null)
   const counts = countByAttentionReason(sessions)
   const total = REASON_ORDER.reduce((t, r) => t + counts[r], 0)
 
+  useEffect(() => {
+    if (!open.value || isDesktop.value) return
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        open.value = false
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open.value, isDesktop.value, open])
+
   if (total === 0) return null
+
+  const renderPill = (reason: AttentionReason, closeOnSelect: boolean) => {
+    const count = counts[reason]
+    if (count === 0) return null
+    const config = ATTENTION_CONFIG[reason]
+    const tone = dark ? config.darkClassName : config.className
+    const isActive = filter === reason
+    const ring = isActive
+      ? 'ring-2 ring-indigo-500 dark:ring-indigo-400 shadow-sm'
+      : 'ring-0 opacity-80 hover:opacity-100'
+    const handleClick = () => {
+      if (isActive) {
+        onSelect(null, null)
+        if (closeOnSelect) open.value = false
+        return
+      }
+      const first = firstSessionWithReason(sessions, reason)
+      onSelect(reason, first?.id ?? null)
+      if (closeOnSelect) open.value = false
+    }
+    return (
+      <button
+        key={reason}
+        type="button"
+        onClick={handleClick}
+        aria-pressed={isActive}
+        title={`${count} ${count === 1 ? 'session' : 'sessions'} — ${config.label}`}
+        data-testid={`attention-pill-${reason}`}
+        class={`shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-all ${tone} ${ring}`}
+      >
+        <span aria-hidden>{config.emoji}</span>
+        <span>{config.label}</span>
+        <span class="ml-0.5 tabular-nums font-semibold">{count}</span>
+      </button>
+    )
+  }
+
+  const renderClearButton = (closeOnSelect: boolean) => (
+    <button
+      type="button"
+      onClick={() => {
+        onSelect(null, null)
+        if (closeOnSelect) open.value = false
+      }}
+      class="shrink-0 ml-auto text-xs font-medium text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 underline"
+      data-testid="attention-clear"
+    >
+      Clear filter
+    </button>
+  )
+
+  if (!isDesktop.value) {
+    const triggerRing = filter !== null
+      ? 'ring-2 ring-indigo-500 dark:ring-indigo-400'
+      : ''
+    return (
+      <div
+        ref={containerRef}
+        class="relative px-3 py-1.5 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
+        data-testid="attention-bar"
+        role="toolbar"
+        aria-label="Sessions needing attention"
+      >
+        <button
+          type="button"
+          onClick={() => { open.value = !open.value }}
+          aria-haspopup="dialog"
+          aria-expanded={open.value}
+          data-testid="attention-toggle"
+          class={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 text-amber-800 dark:text-amber-200 ${triggerRing}`}
+        >
+          <span aria-hidden>⚠️</span>
+          <span>Needs attention</span>
+          <span class="tabular-nums font-semibold">{total}</span>
+          {filter !== null && (
+            <span class="ml-1 text-[10px] uppercase tracking-wide text-indigo-700 dark:text-indigo-300">
+              filtered
+            </span>
+          )}
+        </button>
+        {open.value && (
+          <div
+            class="absolute left-3 right-3 top-full mt-1 z-40 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-lg p-2 flex flex-wrap items-center gap-1.5"
+            data-testid="attention-popover"
+          >
+            {REASON_ORDER.map((reason) => renderPill(reason, true))}
+            {filter !== null && renderClearButton(true)}
+          </div>
+        )}
+      </div>
+    )
+  }
 
   return (
     <div
@@ -71,49 +180,8 @@ export function AttentionBar({ sessions, filter, onSelect }: AttentionBarProps) 
       <span class="shrink-0 text-[11px] uppercase tracking-wide font-medium text-slate-500 dark:text-slate-400 mr-1">
         Needs attention
       </span>
-      {REASON_ORDER.map((reason) => {
-        const count = counts[reason]
-        if (count === 0) return null
-        const config = ATTENTION_CONFIG[reason]
-        const tone = dark ? config.darkClassName : config.className
-        const isActive = filter === reason
-        const ring = isActive
-          ? 'ring-2 ring-indigo-500 dark:ring-indigo-400 shadow-sm'
-          : 'ring-0 opacity-80 hover:opacity-100'
-        const handleClick = () => {
-          if (isActive) {
-            onSelect(null, null)
-            return
-          }
-          const first = firstSessionWithReason(sessions, reason)
-          onSelect(reason, first?.id ?? null)
-        }
-        return (
-          <button
-            key={reason}
-            type="button"
-            onClick={handleClick}
-            aria-pressed={isActive}
-            title={`${count} ${count === 1 ? 'session' : 'sessions'} — ${config.label}`}
-            data-testid={`attention-pill-${reason}`}
-            class={`shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-all ${tone} ${ring}`}
-          >
-            <span aria-hidden>{config.emoji}</span>
-            <span>{config.label}</span>
-            <span class="ml-0.5 tabular-nums font-semibold">{count}</span>
-          </button>
-        )
-      })}
-      {filter !== null && (
-        <button
-          type="button"
-          onClick={() => onSelect(null, null)}
-          class="shrink-0 ml-auto text-xs font-medium text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 underline"
-          data-testid="attention-clear"
-        >
-          Clear filter
-        </button>
-      )}
+      {REASON_ORDER.map((reason) => renderPill(reason, false))}
+      {filter !== null && renderClearButton(false)}
     </div>
   )
 }

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -183,6 +183,7 @@ describe('App', () => {
     render(<App />)
 
     await screen.findByTestId('attention-bar')
+    fireEvent.click(screen.getByTestId('attention-toggle'))
     expect(screen.getByTestId('attention-pill-failed').textContent).toContain('1')
     expect(screen.getByTestId('attention-pill-waiting_for_feedback').textContent).toContain('1')
 
@@ -193,6 +194,7 @@ describe('App', () => {
     expect(screen.queryByTestId('session-item-s2')).toBeNull()
     expect(screen.queryByTestId('session-item-s3')).toBeNull()
 
+    fireEvent.click(screen.getByTestId('attention-toggle'))
     fireEvent.click(screen.getByTestId('attention-clear'))
     expect(screen.getByTestId('session-item-s3')).toBeTruthy()
   })

--- a/test/chat/QuickActionsBar.test.tsx
+++ b/test/chat/QuickActionsBar.test.tsx
@@ -6,6 +6,7 @@ import type { QuickAction, ApiSession } from '../../src/api/types'
 function mockMatchMedia(matches: boolean) {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
+    configurable: true,
     value: vi.fn((query: string) => ({
       matches,
       media: query,
@@ -60,14 +61,9 @@ function createSession(overrides: Partial<ApiSession> = {}): ApiSession {
 }
 
 describe('QuickActionsBar', () => {
-  describe('non-ship modes', () => {
-    it('renders N buttons for N actions when count is below threshold', () => {
-      const session = createSession()
-      render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
-      expect(screen.getByText('Make PR')).toBeTruthy()
-      expect(screen.getByText('Retry')).toBeTruthy()
-      expect(screen.getByText('Resume')).toBeTruthy()
-      expect(screen.queryByTestId('quick-actions-more-btn')).toBeNull()
+  describe('non-ship modes (mobile)', () => {
+    beforeEach(() => {
+      mockMatchMedia(false)
     })
 
     it('renders nothing when actions is empty', () => {
@@ -78,7 +74,82 @@ describe('QuickActionsBar', () => {
       expect(container.firstChild).toBeNull()
     })
 
-    it('calls onAction with the matching QuickAction when button is clicked', async () => {
+    it('renders a single trigger button labeled with the action count', () => {
+      const session = createSession()
+      render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
+      const trigger = screen.getByTestId('quick-actions-trigger')
+      expect(trigger).toBeTruthy()
+      expect(trigger.textContent).toContain('3')
+      expect(screen.queryByText('Make PR')).toBeNull()
+      expect(screen.queryByText('Retry')).toBeNull()
+      expect(screen.queryByText('Resume')).toBeNull()
+    })
+
+    it('opens the bottom sheet showing all actions when the trigger is clicked', () => {
+      const session = createSession()
+      render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
+
+      fireEvent.click(screen.getByTestId('quick-actions-trigger'))
+      const sheet = screen.getByTestId('quick-actions-sheet')
+      expect(sheet).toBeTruthy()
+      expect(sheet.textContent).toContain('Make PR')
+      expect(sheet.textContent).toContain('Retry')
+      expect(sheet.textContent).toContain('Resume')
+    })
+
+    it('calls onAction when an action in the sheet is clicked and closes the sheet', () => {
+      const session = createSession()
+      const onAction = vi.fn().mockResolvedValue(undefined)
+      render(<QuickActionsBar session={session} onAction={onAction} />)
+
+      fireEvent.click(screen.getByTestId('quick-actions-trigger'))
+      const sheet = screen.getByTestId('quick-actions-sheet')
+      const makePrBtn = Array.from(sheet.querySelectorAll('button')).find(b => b.textContent?.includes('Make PR'))!
+      fireEvent.click(makePrBtn)
+
+      expect(onAction).toHaveBeenCalledWith(actions[0])
+      expect(screen.queryByTestId('quick-actions-sheet')).toBeNull()
+    })
+
+    it('closes the bottom sheet when the backdrop is clicked', () => {
+      const session = createSession()
+      render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
+
+      fireEvent.click(screen.getByTestId('quick-actions-trigger'))
+      expect(screen.getByTestId('quick-actions-sheet')).toBeTruthy()
+      fireEvent.click(screen.getByTestId('quick-actions-backdrop'))
+      expect(screen.queryByTestId('quick-actions-sheet')).toBeNull()
+    })
+
+    it('lists all 7 actions in the sheet regardless of count', () => {
+      const session = createSession({ quickActions: manyActions })
+      render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
+      const trigger = screen.getByTestId('quick-actions-trigger')
+      expect(trigger.textContent).toContain('7')
+
+      fireEvent.click(trigger)
+      const sheet = screen.getByTestId('quick-actions-sheet')
+      for (const action of manyActions) {
+        expect(sheet.textContent).toContain(action.label)
+      }
+    })
+  })
+
+  describe('non-ship modes (desktop)', () => {
+    beforeEach(() => {
+      mockMatchMedia(true)
+    })
+
+    it('renders all actions inline when count is below threshold', () => {
+      const session = createSession()
+      render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
+      expect(screen.getByText('Make PR')).toBeTruthy()
+      expect(screen.getByText('Retry')).toBeTruthy()
+      expect(screen.getByText('Resume')).toBeTruthy()
+      expect(screen.queryByTestId('quick-actions-more-btn')).toBeNull()
+    })
+
+    it('calls onAction with the matching QuickAction when an inline button is clicked', () => {
       const session = createSession()
       const onAction = vi.fn().mockResolvedValue(undefined)
       render(<QuickActionsBar session={session} onAction={onAction} />)
@@ -86,127 +157,49 @@ describe('QuickActionsBar', () => {
       expect(onAction).toHaveBeenCalledWith(actions[0])
     })
 
-    it('calls onAction with the correct action for each button', async () => {
-      const session = createSession()
+    it('shows "More actions..." button when actions exceed desktop threshold', () => {
+      const session = createSession({ quickActions: manyActions })
+      render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
+      expect(screen.getByTestId('quick-actions-more-btn')).toBeTruthy()
+      expect(screen.getByText(/More actions\.\.\. \(2\)/)).toBeTruthy()
+    })
+
+    it('shows first 5 actions directly on desktop', () => {
+      const session = createSession({ quickActions: manyActions })
+      render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
+      expect(screen.getByText('Action 1')).toBeTruthy()
+      expect(screen.getByText('Action 2')).toBeTruthy()
+      expect(screen.getByText('Action 3')).toBeTruthy()
+      expect(screen.getByText('Action 4')).toBeTruthy()
+      expect(screen.getByText('Action 5')).toBeTruthy()
+      expect(screen.queryByText('Action 6')).toBeNull()
+    })
+
+    it('opens dropdown when "More actions..." is clicked on desktop', () => {
+      const session = createSession({ quickActions: manyActions })
+      render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
+      fireEvent.click(screen.getByTestId('quick-actions-more-btn'))
+      expect(screen.getByTestId('quick-actions-dropdown')).toBeTruthy()
+    })
+
+    it('shows overflow actions in dropdown', () => {
+      const session = createSession({ quickActions: manyActions })
+      render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
+      fireEvent.click(screen.getByTestId('quick-actions-more-btn'))
+      const dropdown = screen.getByTestId('quick-actions-dropdown')
+      expect(dropdown.textContent).toContain('Action 6')
+      expect(dropdown.textContent).toContain('Action 7')
+    })
+
+    it('calls onAction when overflow action is clicked in dropdown', () => {
+      const session = createSession({ quickActions: manyActions })
       const onAction = vi.fn().mockResolvedValue(undefined)
       render(<QuickActionsBar session={session} onAction={onAction} />)
-      fireEvent.click(screen.getByText('Retry'))
-      expect(onAction).toHaveBeenCalledWith(actions[1])
-      fireEvent.click(screen.getByText('Resume'))
-      expect(onAction).toHaveBeenCalledWith(actions[2])
-    })
-
-    describe('overflow handling on mobile', () => {
-      beforeEach(() => {
-        mockMatchMedia(false)
-      })
-
-      it('shows "More actions..." button when actions exceed mobile threshold', () => {
-        const session = createSession({ quickActions: manyActions })
-        render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
-        expect(screen.getByTestId('quick-actions-more-btn')).toBeTruthy()
-        expect(screen.getByText(/More actions\.\.\. \(4\)/)).toBeTruthy()
-      })
-
-      it('shows first 3 actions directly on mobile', () => {
-        const session = createSession({ quickActions: manyActions })
-        render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
-        expect(screen.getByText('Action 1')).toBeTruthy()
-        expect(screen.getByText('Action 2')).toBeTruthy()
-        expect(screen.getByText('Action 3')).toBeTruthy()
-        expect(screen.queryByText('Action 4')).toBeNull()
-      })
-
-      it('opens bottom sheet when "More actions..." is clicked on mobile', () => {
-        const session = createSession({ quickActions: manyActions })
-        render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
-        fireEvent.click(screen.getByTestId('quick-actions-more-btn'))
-        expect(screen.getByTestId('quick-actions-sheet')).toBeTruthy()
-        expect(screen.getByTestId('quick-actions-backdrop')).toBeTruthy()
-      })
-
-      it('shows overflow actions in bottom sheet', () => {
-        const session = createSession({ quickActions: manyActions })
-        render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
-        fireEvent.click(screen.getByTestId('quick-actions-more-btn'))
-        const sheet = screen.getByTestId('quick-actions-sheet')
-        expect(sheet.textContent).toContain('Action 4')
-        expect(sheet.textContent).toContain('Action 5')
-        expect(sheet.textContent).toContain('Action 6')
-        expect(sheet.textContent).toContain('Action 7')
-      })
-
-      it('calls onAction when overflow action is clicked and closes sheet', () => {
-        const session = createSession({ quickActions: manyActions })
-        const onAction = vi.fn().mockResolvedValue(undefined)
-        render(<QuickActionsBar session={session} onAction={onAction} />)
-        fireEvent.click(screen.getByTestId('quick-actions-more-btn'))
-        const sheet = screen.getByTestId('quick-actions-sheet')
-        const action4 = Array.from(sheet.querySelectorAll('button')).find(b => b.textContent?.includes('Action 4'))!
-        fireEvent.click(action4)
-        expect(onAction).toHaveBeenCalledWith(manyActions[3])
-        expect(screen.queryByTestId('quick-actions-sheet')).toBeNull()
-      })
-
-      it('closes bottom sheet when backdrop is clicked', () => {
-        const session = createSession({ quickActions: manyActions })
-        render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
-        fireEvent.click(screen.getByTestId('quick-actions-more-btn'))
-        expect(screen.getByTestId('quick-actions-sheet')).toBeTruthy()
-        fireEvent.click(screen.getByTestId('quick-actions-backdrop'))
-        expect(screen.queryByTestId('quick-actions-sheet')).toBeNull()
-      })
-    })
-
-    describe('overflow handling on desktop', () => {
-      beforeEach(() => {
-        mockMatchMedia(true)
-      })
-
-      it('shows "More actions..." button when actions exceed desktop threshold', () => {
-        const session = createSession({ quickActions: manyActions })
-        render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
-        expect(screen.getByTestId('quick-actions-more-btn')).toBeTruthy()
-        expect(screen.getByText(/More actions\.\.\. \(2\)/)).toBeTruthy()
-      })
-
-      it('shows first 5 actions directly on desktop', () => {
-        const session = createSession({ quickActions: manyActions })
-        render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
-        expect(screen.getByText('Action 1')).toBeTruthy()
-        expect(screen.getByText('Action 2')).toBeTruthy()
-        expect(screen.getByText('Action 3')).toBeTruthy()
-        expect(screen.getByText('Action 4')).toBeTruthy()
-        expect(screen.getByText('Action 5')).toBeTruthy()
-        expect(screen.queryByText('Action 6')).toBeNull()
-      })
-
-      it('opens dropdown when "More actions..." is clicked on desktop', () => {
-        const session = createSession({ quickActions: manyActions })
-        render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
-        fireEvent.click(screen.getByTestId('quick-actions-more-btn'))
-        expect(screen.getByTestId('quick-actions-dropdown')).toBeTruthy()
-      })
-
-      it('shows overflow actions in dropdown', () => {
-        const session = createSession({ quickActions: manyActions })
-        render(<QuickActionsBar session={session} onAction={vi.fn().mockResolvedValue(undefined)} />)
-        fireEvent.click(screen.getByTestId('quick-actions-more-btn'))
-        const dropdown = screen.getByTestId('quick-actions-dropdown')
-        expect(dropdown.textContent).toContain('Action 6')
-        expect(dropdown.textContent).toContain('Action 7')
-      })
-
-      it('calls onAction when overflow action is clicked in dropdown', () => {
-        const session = createSession({ quickActions: manyActions })
-        const onAction = vi.fn().mockResolvedValue(undefined)
-        render(<QuickActionsBar session={session} onAction={onAction} />)
-        fireEvent.click(screen.getByTestId('quick-actions-more-btn'))
-        const dropdown = screen.getByTestId('quick-actions-dropdown')
-        const action6 = Array.from(dropdown.querySelectorAll('button')).find(b => b.textContent?.includes('Action 6'))!
-        fireEvent.click(action6)
-        expect(onAction).toHaveBeenCalledWith(manyActions[5])
-      })
+      fireEvent.click(screen.getByTestId('quick-actions-more-btn'))
+      const dropdown = screen.getByTestId('quick-actions-dropdown')
+      const action6 = Array.from(dropdown.querySelectorAll('button')).find(b => b.textContent?.includes('Action 6'))!
+      fireEvent.click(action6)
+      expect(onAction).toHaveBeenCalledWith(manyActions[5])
     })
   })
 

--- a/test/chat/transcript/FeedbackButtons.test.tsx
+++ b/test/chat/transcript/FeedbackButtons.test.tsx
@@ -35,7 +35,7 @@ function createMockStore(features: string[] = ['message-feedback']): ConnectionS
     client: {
       submitFeedback,
     },
-  } as ConnectionStore
+  } as unknown as ConnectionStore
 }
 
 describe('FeedbackButtons', () => {

--- a/test/components/AttentionBar.test.tsx
+++ b/test/components/AttentionBar.test.tsx
@@ -8,6 +8,19 @@ import {
 } from '../../src/components/AttentionBar'
 import type { ApiSession, AttentionReason } from '../../src/api/types'
 
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      matches,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  })
+}
+
 function makeSession(overrides: Partial<ApiSession> = {}): ApiSession {
   return {
     id: 'session-1',
@@ -136,9 +149,10 @@ describe('firstSessionWithReason', () => {
   })
 })
 
-describe('AttentionBar', () => {
+describe('AttentionBar (desktop)', () => {
   beforeEach(() => {
     cleanup()
+    mockMatchMedia(true)
   })
 
   it('renders nothing when no sessions need attention', () => {
@@ -263,5 +277,62 @@ describe('AttentionBar', () => {
 
     fireEvent.click(screen.getByTestId('attention-pill-failed'))
     expect(onSelect).toHaveBeenCalledWith('failed', 's1')
+  })
+})
+
+describe('AttentionBar (mobile)', () => {
+  beforeEach(() => {
+    cleanup()
+    mockMatchMedia(false)
+  })
+
+  it('renders a collapsed toggle showing the total attention count', () => {
+    const sessions = [
+      makeSession({ id: 's1', needsAttention: true, attentionReasons: ['failed', 'waiting_for_feedback'] }),
+      makeSession({ id: 's2', slug: 's2', needsAttention: true, attentionReasons: ['interrupted'] }),
+    ]
+    render(<AttentionBar sessions={sessions} filter={null} onSelect={() => {}} />)
+
+    const toggle = screen.getByTestId('attention-toggle')
+    expect(toggle).toBeTruthy()
+    expect(toggle.textContent).toContain('3')
+    expect(screen.queryByTestId('attention-popover')).toBeNull()
+    expect(screen.queryByTestId('attention-pill-failed')).toBeNull()
+  })
+
+  it('opens a popover with pills when the toggle is clicked', () => {
+    const sessions = [
+      makeSession({ id: 's1', needsAttention: true, attentionReasons: ['failed'] }),
+      makeSession({ id: 's2', slug: 's2', needsAttention: true, attentionReasons: ['waiting_for_feedback'] }),
+    ]
+    render(<AttentionBar sessions={sessions} filter={null} onSelect={() => {}} />)
+
+    fireEvent.click(screen.getByTestId('attention-toggle'))
+    expect(screen.getByTestId('attention-popover')).toBeTruthy()
+    expect(screen.getByTestId('attention-pill-failed')).toBeTruthy()
+    expect(screen.getByTestId('attention-pill-waiting_for_feedback')).toBeTruthy()
+  })
+
+  it('clicking a pill in the popover invokes onSelect and closes the popover', () => {
+    const onSelect = vi.fn()
+    const sessions = [
+      makeSession({ id: 's1', needsAttention: true, attentionReasons: ['failed'] }),
+    ]
+    render(<AttentionBar sessions={sessions} filter={null} onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByTestId('attention-toggle'))
+    fireEvent.click(screen.getByTestId('attention-pill-failed'))
+
+    expect(onSelect).toHaveBeenCalledWith('failed', 's1')
+    expect(screen.queryByTestId('attention-popover')).toBeNull()
+  })
+
+  it('shows "filtered" indicator on the toggle when a filter is active', () => {
+    const sessions = [
+      makeSession({ id: 's1', needsAttention: true, attentionReasons: ['failed'] }),
+    ]
+    render(<AttentionBar sessions={sessions} filter="failed" onSelect={() => {}} />)
+    const toggle = screen.getByTestId('attention-toggle')
+    expect(toggle.textContent?.toLowerCase()).toContain('filtered')
   })
 })


### PR DESCRIPTION
## Summary

Frees up vertical and horizontal space on mobile by collapsing four dense UI regions behind mobile-only triggers. Desktop behavior is unchanged.

- **AttentionBar**: replaces the inline `Needs attention` label + N pills with a single `⚠️ Needs attention N` toggle. Tapping opens a popover with the same pills + clear-filter button.
- **QuickActionsBar**: replaces the inline 3-button row + overflow modal with a single `Quick actions (N)` trigger that opens the existing bottom sheet listing **all** actions. (Ship-mode advance button is unchanged.)
- **ConnectionStatusBadge** (header): hides the textual status word on mobile, leaving only the colored dot. The label is kept as `title` / `aria-label` for accessibility.
- **ChatPane header**: collapses the inline status text + mode tag + PR link into a single `ⓘ` info button that opens a popover with status, mode, branch, cwd, and a `View PR` link. The separate `WorktreeHeader` row is hidden on mobile since its content now lives in that popover.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (1013 passing)
- [ ] CI runs Playwright (`e2e` job) — verify mobile-chromium snapshots still pass
- [ ] Manually verify on a phone-width browser:
  - AttentionBar shows count badge and popover toggles correctly; clicking a pill applies the filter and closes the popover
  - QuickActionsBar shows single trigger; sheet lists every action; selecting one fires it and closes the sheet
  - Header shows only the connection-status dot (no `live`/`retrying` text)
  - ChatPane header shows slug + ⓘ; popover shows status / mode / branch / cwd / PR; WorktreeHeader is not rendered
  - Desktop view at ≥768px is unchanged in all four regions
