### PR TITLE
fix(ship): include per-child branches and PRs in verify directive

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    serviceWorkers: 'block',
   },
   webServer: {
     command: 'npm run build && npm run preview -- --port 4173 --strictPort',

--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -5,7 +5,7 @@ import { saveDag } from "./store"
 import { createDagScheduler } from "./scheduler"
 import { EngineEventBus } from "../events/bus"
 import { openDatabase, prepared, runMigrations } from "../db/sqlite"
-import { DIRECTIVE_VERIFY } from "../ship/coordinator"
+import { buildVerifyDirective } from "../ship/verification"
 import type { SessionRegistry, CreateSessionOpts } from "../session/registry"
 import type { SessionRuntime } from "../session/runtime"
 import type { ApiSession } from "../../shared/api-types"
@@ -351,7 +351,10 @@ describe("DagScheduler", () => {
 
     const row = prepared.getSession(db, rootId)
     expect(row?.stage).toBe("verify")
-    expect(replies).toEqual([{ sessionId: rootId, text: DIRECTIVE_VERIFY }])
+    const expected = buildVerifyDirective([
+      { title: "Task A", description: "A", branch: "minion/test-ship-child", prUrl: null },
+    ])
+    expect(replies).toEqual([{ sessionId: rootId, text: expected }])
   })
 
   it("cancel stops running sessions and marks them failed", async () => {

--- a/server/ship/coordinator.ts
+++ b/server/ship/coordinator.ts
@@ -2,6 +2,8 @@ import type { ShipStage, AttentionReason, QuickAction } from '../../shared/api-t
 import { prepared } from '../db/sqlite'
 import { getEventBus } from '../events/bus'
 import { handleDag, type PlanActionCtx } from '../commands/plan-actions'
+import { listDags } from '../dag/store'
+import { buildVerifyDirective, type VerifyTask } from './verification'
 
 // Stage directive constants
 export const DIRECTIVE_PLAN = [
@@ -22,16 +24,32 @@ export const DIRECTIVE_PLAN = [
   'Output at least one task object covering all the work identified during thinking.',
 ].join('\n')
 
-export const DIRECTIVE_VERIFY = [
-  'All implementation tasks have completed. Review the work and verify quality.',
-  '',
-  '1. Check that all planned changes were made correctly.',
-  '2. Review test coverage and results.',
-  '3. Verify no regressions or breaking changes.',
-  '4. Confirm the solution addresses the original request.',
-  '',
-  'If issues are found, describe what needs fixing. Otherwise confirm the work is complete.',
-].join('\n')
+export const DIRECTIVE_VERIFY = buildVerifyDirective([])
+
+function buildVerifyDirectiveForSession(sessionId: string, ctx: PlanActionCtx): string {
+  const dag = listDags(ctx.db).find((g) => g.rootSessionId === sessionId)
+  if (!dag) return DIRECTIVE_VERIFY
+
+  const tasks: VerifyTask[] = dag.nodes.map((node) => {
+    let branch: string | null = node.branch ?? null
+    let prUrl: string | null = node.prUrl ?? null
+    if ((!branch || !prUrl) && node.sessionId) {
+      const childRow = prepared.getSession(ctx.db, node.sessionId)
+      if (childRow) {
+        if (!branch) branch = childRow.branch ?? null
+        if (!prUrl) prUrl = childRow.pr_url ?? null
+      }
+    }
+    return {
+      title: node.title || node.id,
+      description: node.description ?? '',
+      branch,
+      prUrl,
+    }
+  })
+
+  return buildVerifyDirective(tasks)
+}
 
 // State transition matrix
 const TRANSITIONS: Record<ShipStage, ShipStage[]> = {
@@ -204,7 +222,8 @@ export async function advanceShip(
     if (currentStage === 'think' && nextStage === 'plan') {
       await ctx.registry.reply(sessionId, DIRECTIVE_PLAN)
     } else if (currentStage === 'dag' && nextStage === 'verify') {
-      await ctx.registry.reply(sessionId, DIRECTIVE_VERIFY)
+      const directive = buildVerifyDirectiveForSession(sessionId, ctx)
+      await ctx.registry.reply(sessionId, directive)
     }
 
     return { ok: true, from: currentStage, to: nextStage, dagId }

--- a/server/ship/verification.ts
+++ b/server/ship/verification.ts
@@ -14,6 +14,43 @@ export function buildCompletenessReviewPrompt(
   ].join("\n")
 }
 
+export interface VerifyTask {
+  title: string
+  description: string
+  branch: string | null
+  prUrl: string | null
+}
+
+export function buildVerifyDirective(tasks: VerifyTask[]): string {
+  const header = [
+    'All implementation tasks have completed. Review the work and verify quality.',
+    '',
+    'Each task ran in its own isolated worktree on its own branch and was pushed as a separate PR — the changes are NOT present in your current working directory. Use `git` and `gh` to inspect each branch/PR remotely (e.g. `gh pr view <url>`, `gh pr diff <url>`, `git fetch origin <branch> && git log origin/<branch>`).',
+    '',
+  ]
+
+  const taskBlocks = tasks.length === 0
+    ? ['No child tasks were recorded for this ship — verify based on the original request alone.']
+    : tasks.map((t, i) => {
+        const lines = [`### Task ${i + 1}: ${t.title}`]
+        if (t.description) lines.push('', t.description)
+        lines.push('', `Branch: ${t.branch ?? '(none recorded)'}`, `PR: ${t.prUrl ?? '(none recorded)'}`)
+        return lines.join('\n')
+      })
+
+  const footer = [
+    '',
+    'For each task above:',
+    '1. Check that the changes on the branch/PR match the task description.',
+    '2. Review test coverage and CI results on the PR.',
+    '3. Note any regressions, gaps, or breaking changes.',
+    '',
+    'Then confirm whether the overall solution addresses the original request, or describe what still needs fixing.',
+  ]
+
+  return [...header, ...taskBlocks, ...footer].join('\n')
+}
+
 export function parseCompletenessResult(output: string): { passed: boolean; details: string } {
   const lower = output.toLowerCase()
   const passed = lower.includes("passed") || lower.includes("complete") || lower.includes("success")

--- a/test/chat/transcript/FeedbackButtons.test.tsx
+++ b/test/chat/transcript/FeedbackButtons.test.tsx
@@ -35,7 +35,7 @@ function createMockStore(features: string[] = ['message-feedback']): ConnectionS
     client: {
       submitFeedback,
     },
-  } as ConnectionStore
+  } as unknown as ConnectionStore
 }
 
 describe('FeedbackButtons', () => {


### PR DESCRIPTION
## Summary

When the ship DAG completes, the parent coordinator session is told to verify the work — but the parent's worktree contains none of the children's edits. Each child runs on its own branch in its own worktree and is pushed as a separate PR; the parent only sees its own (untouched) cwd. The static DIRECTIVE_VERIFY told the agent to "check that all planned changes were made correctly", which made it look locally and correctly conclude the changes weren't there.

This change builds the verify directive dynamically from the saved DAG so the parent agent gets the per-task branch and PR URL for each child, and is explicitly told to inspect them via git/gh (e.g. gh pr diff, git fetch origin <branch>) rather than the local working tree. When branch/prUrl are missing on a DAG node payload we fall back to the child session row, and when no DAG is found we keep the original generic directive as a fallback.

Two additional CI fixes are bundled in:

- test/chat/transcript/FeedbackButtons.test.tsx: the partial mock omits ~15 ConnectionStore members; the cast now uses "as unknown as" to match the established pattern in MessageInput.test.tsx and touch-targets.test.tsx. Was breaking npm run typecheck (and npm run build, which runs in the E2E job).
- playwright.config.ts: block service workers in tests. The PwaController offline-ready banner was firing mid-test in Firefox CI and overlapping the connections drawer close button, deterministically failing multi-connection.spec.ts. No e2e test exercises the PWA banner, so blocking SW is the minimal root-cause fix.

## Test plan

- [x] npm run typecheck
- [x] npm run lint
- [x] npm run test (vitest, 1058 passing)
- [x] bun test server/ship/ (59 passing)
- [x] bun test server/dag/scheduler.test.ts — updated the "advances ship roots to verification when their DAG becomes terminal" assertion to match the new directive payload
- [ ] CI green