### PR TITLE
fix(execute): forward /execute trailing args as user direction

### DIFF
--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -146,7 +146,7 @@ const CommandSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('reply'), sessionId: z.string(), message: z.string() }),
   z.object({ action: z.literal('stop'), sessionId: z.string() }),
   z.object({ action: z.literal('close'), sessionId: z.string() }),
-  z.object({ action: z.literal('plan_action'), sessionId: z.string(), planAction: z.enum(['execute', 'split', 'stack', 'dag']), markdown: z.string().optional() }),
+  z.object({ action: z.literal('plan_action'), sessionId: z.string(), planAction: z.enum(['execute', 'split', 'stack', 'dag']), markdown: z.string().optional(), message: z.string().optional() }),
   z.object({ action: z.literal('land'), dagId: z.string(), nodeId: z.string() }),
   z.object({ action: z.literal('retry_rebase'), dagId: z.string(), nodeId: z.string() }),
   z.object({ action: z.literal('ship_advance'), sessionId: z.string(), to: z.enum(['think', 'plan', 'dag', 'verify', 'done']).optional() }),
@@ -458,7 +458,7 @@ export function registerApiRoutes(
       try {
         let result
         if (command.planAction === 'execute') {
-          result = await handleExecute(command.sessionId, planCtx)
+          result = await handleExecute(command.sessionId, planCtx, command.message)
         } else if (command.planAction === 'split') {
           result = await handleSplit(command.sessionId, planCtx)
         } else if (command.planAction === 'stack') {
@@ -599,7 +599,7 @@ export function registerApiRoutes(
         try {
           let result
           if (command === 'execute') {
-            result = await handleExecute(sessionId, planCtx)
+            result = await handleExecute(sessionId, planCtx, rest)
           } else if (command === 'split') {
             result = await handleSplit(sessionId, planCtx)
           } else if (command === 'stack') {

--- a/server/commands/help.ts
+++ b/server/commands/help.ts
@@ -17,7 +17,7 @@ const HELP_TEXT = `**Task / Plan / Think / Review**
   /dag [markdown]      Build and run a DAG from markdown or last assistant message
   /split               Split plan into parallel tasks and run them
   /stack               Stack plan into sequential tasks and run them
-  /execute             Extract and execute plan from current session
+  /execute [direction] Execute plan from session; optional direction overrides default item-picking
   /judge [markdown]    Run judge orchestrator on the session conversation
   /retry <nodeId> <dagId>       Retry a failed DAG node
   /force <nodeId> <dagId>       Force a DAG node to landed state

--- a/server/commands/plan-actions.test.ts
+++ b/server/commands/plan-actions.test.ts
@@ -208,6 +208,156 @@ describe("plan-actions gating", () => {
     expect(createCalls[0]?.prompt).toContain("research/analysis, not a concrete implementation plan")
   })
 
+  it("uses the guided directive when userContext is provided in think mode (overrides item-picking)", async () => {
+    const sessionId = insertSession(db, { mode: "think" })
+    prepared.insertEvent(db, {
+      session_id: sessionId,
+      seq: 1,
+      turn: 1,
+      type: "assistant_text",
+      timestamp: Date.now(),
+      payload: { text: "Option 1: Foo. Option 2: Bar.", final: true, blockId: "block-1" },
+    })
+    const createCalls: Array<{ mode: string; prompt: string }> = []
+    const mockRuntime: Partial<SessionRuntime> = {
+      running: false,
+      currentProviderSessionId: undefined,
+      start: async () => {},
+      injectInput: async () => false,
+      stop: async () => {},
+    }
+    const registry: SessionRegistry = {
+      ...makeRegistry([]),
+      create: async (opts) => {
+        createCalls.push({ mode: opts.mode, prompt: opts.prompt })
+        return {
+          session: { id: "child-guided" } as ApiSession,
+          runtime: mockRuntime as SessionRuntime,
+        }
+      },
+    }
+    const ctx: PlanActionCtx = {
+      db,
+      registry,
+      scheduler: makeScheduler([]),
+    }
+
+    const result = await handleExecute(sessionId, ctx, "do option 1")
+
+    expect(result.ok).toBe(true)
+    expect(createCalls[0]?.prompt).toContain("Option 1: Foo. Option 2: Bar.")
+    expect(createCalls[0]?.prompt).toContain("<user_direction>")
+    expect(createCalls[0]?.prompt).toContain("do option 1")
+    expect(createCalls[0]?.prompt).toContain("</user_direction>")
+    expect(createCalls[0]?.prompt).not.toContain("Pick the SINGLE highest-leverage item")
+    expect(createCalls[0]?.prompt).not.toContain("research/analysis, not a concrete implementation plan")
+  })
+
+  it("uses the guided directive when userContext is provided in plan mode", async () => {
+    const sessionId = insertSession(db, { mode: "plan" })
+    prepared.insertEvent(db, {
+      session_id: sessionId,
+      seq: 1,
+      turn: 1,
+      type: "assistant_text",
+      timestamp: Date.now(),
+      payload: { text: "Plan steps here.", final: true, blockId: "block-1" },
+    })
+    const createCalls: Array<{ prompt: string }> = []
+    const mockRuntime: Partial<SessionRuntime> = {
+      running: false,
+      currentProviderSessionId: undefined,
+      start: async () => {},
+      injectInput: async () => false,
+      stop: async () => {},
+    }
+    const registry: SessionRegistry = {
+      ...makeRegistry([]),
+      create: async (opts) => {
+        createCalls.push({ prompt: opts.prompt })
+        return {
+          session: { id: "child" } as ApiSession,
+          runtime: mockRuntime as SessionRuntime,
+        }
+      },
+    }
+    const ctx: PlanActionCtx = {
+      db,
+      registry,
+      scheduler: makeScheduler([]),
+    }
+
+    await handleExecute(sessionId, ctx, "skip step 3")
+
+    expect(createCalls[0]?.prompt).toContain("<user_direction>")
+    expect(createCalls[0]?.prompt).toContain("skip step 3")
+    expect(createCalls[0]?.prompt).not.toContain("Implement your plan now")
+  })
+
+  it("ignores empty/whitespace userContext and falls back to default directive", async () => {
+    const sessionId = insertSession(db, { mode: "think" })
+    prepared.insertEvent(db, {
+      session_id: sessionId,
+      seq: 1,
+      turn: 1,
+      type: "assistant_text",
+      timestamp: Date.now(),
+      payload: { text: "Analysis here.", final: true, blockId: "block-1" },
+    })
+    const createCalls: Array<{ prompt: string }> = []
+    const mockRuntime: Partial<SessionRuntime> = {
+      running: false,
+      currentProviderSessionId: undefined,
+      start: async () => {},
+      injectInput: async () => false,
+      stop: async () => {},
+    }
+    const registry: SessionRegistry = {
+      ...makeRegistry([]),
+      create: async (opts) => {
+        createCalls.push({ prompt: opts.prompt })
+        return {
+          session: { id: "child" } as ApiSession,
+          runtime: mockRuntime as SessionRuntime,
+        }
+      },
+    }
+    const ctx: PlanActionCtx = {
+      db,
+      registry,
+      scheduler: makeScheduler([]),
+    }
+
+    await handleExecute(sessionId, ctx, "   ")
+
+    expect(createCalls[0]?.prompt).toContain("Pick the SINGLE highest-leverage item")
+    expect(createCalls[0]?.prompt).not.toContain("<user_direction>")
+  })
+
+  it("injects guided directive (not default) into task-mode session when userContext is provided", async () => {
+    const sessionId = insertSession(db, { mode: "task" })
+    const replyCalls: Array<{ sessionId: string; text: string }> = []
+    const registry = {
+      ...makeRegistry([]),
+      reply: async (sid: string, text: string) => {
+        replyCalls.push({ sessionId: sid, text })
+        return true
+      },
+    }
+    const ctx: PlanActionCtx = {
+      db,
+      registry,
+      scheduler: makeScheduler([]),
+    }
+
+    const result = await handleExecute(sessionId, ctx, "focus on auth refactor")
+
+    expect(result.ok).toBe(true)
+    expect(replyCalls[0]?.text).toContain("<user_direction>")
+    expect(replyCalls[0]?.text).toContain("focus on auth refactor")
+    expect(replyCalls[0]?.text).not.toContain("Implement your plan now")
+  })
+
   it("uses the plain implementation directive for plan/review modes (not the think variant)", async () => {
     const sessionId = insertSession(db, { mode: "plan" })
     prepared.insertEvent(db, {

--- a/server/commands/plan-actions.ts
+++ b/server/commands/plan-actions.ts
@@ -155,12 +155,39 @@ const EXECUTE_DIRECTIVE_THINK = [
   "If blocked, end with `BLOCKED: <one-line reason>` instead of stopping silently.",
 ].join("\n")
 
-export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Promise<PlanActionResult> {
+function buildGuidedDirective(userContext: string): string {
+  return [
+    "The user has given explicit direction for this execution. Their guidance OVERRIDES any default \"pick the highest-leverage item\" instinct — follow exactly what they said:",
+    "",
+    "<user_direction>",
+    userContext,
+    "</user_direction>",
+    "",
+    "Implement the user's direction now, in this session — do NOT wait for another turn, do NOT ask for clarification, and do NOT substitute a different item from the analysis above.",
+    "",
+    "1. State in one sentence what you are implementing based on the user's direction.",
+    "2. Write the code.",
+    "3. Run the unit/integration tests (NOT e2e or browser tests — too expensive).",
+    "4. `git add -A && git commit -m \"<descriptive message>\"`.",
+    "5. `git push -u origin HEAD`. Auth is preconfigured via GIT_ASKPASS.",
+    "6. `gh pr create` targeting `main` (no --draft, no --no-verify). Include a short summary and a test plan.",
+    "7. End your turn with a single trailing line: `PR: <url>` — so the orchestrator can link the PR.",
+    "",
+    "If blocked, end with `BLOCKED: <one-line reason>` instead of stopping silently.",
+  ].join("\n")
+}
+
+export async function handleExecute(
+  sessionId: string,
+  ctx: PlanActionCtx,
+  userContext?: string,
+): Promise<PlanActionResult> {
   const rejection = await gate(sessionId, ctx)
   if (rejection) return { ok: false, reason: rejection }
 
   const row = prepared.getSession(ctx.db, sessionId)
   const mode = row?.mode
+  const trimmedContext = userContext?.trim() ?? ""
 
   if (mode === "ship") {
     return { ok: false, reason: "use /dag to schedule a ship plan" }
@@ -176,7 +203,11 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
         return { ok: false, reason: "no plan/analysis to execute" }
       }
 
-      const directive = mode === "think" ? EXECUTE_DIRECTIVE_THINK : EXECUTE_DIRECTIVE_PLAN
+      const directive = trimmedContext
+        ? buildGuidedDirective(trimmedContext)
+        : mode === "think"
+          ? EXECUTE_DIRECTIVE_THINK
+          : EXECUTE_DIRECTIVE_PLAN
       const prompt = [plan, "", directive].join("\n")
 
       const { session } = await ctx.registry.create({
@@ -196,7 +227,10 @@ export async function handleExecute(sessionId: string, ctx: PlanActionCtx): Prom
 
   if (mode === "task" || mode === "dag-task" || mode === "ship-verify") {
     try {
-      const ok = await ctx.registry.reply(sessionId, EXECUTE_DIRECTIVE_PLAN)
+      const directive = trimmedContext
+        ? buildGuidedDirective(trimmedContext)
+        : EXECUTE_DIRECTIVE_PLAN
+      const ok = await ctx.registry.reply(sessionId, directive)
       if (!ok) return { ok: false, reason: "could not inject execute directive into session" }
       return { ok: true }
     } catch (err) {

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -334,7 +334,7 @@ export type MinionCommand =
   | { action: 'reply'; sessionId: string; message: string }
   | { action: 'stop'; sessionId: string }
   | { action: 'close'; sessionId: string }
-  | { action: 'plan_action'; sessionId: string; planAction: PlanActionType; markdown?: string }
+  | { action: 'plan_action'; sessionId: string; planAction: PlanActionType; markdown?: string; message?: string }
   | { action: 'ship_advance'; sessionId: string; to?: ShipStage }
   | { action: 'land'; dagId: string; nodeId: string }
   | { action: 'retry_rebase'; dagId: string; nodeId: string }

--- a/test/chat/transcript/FeedbackButtons.test.tsx
+++ b/test/chat/transcript/FeedbackButtons.test.tsx
@@ -35,7 +35,7 @@ function createMockStore(features: string[] = ['message-feedback']): ConnectionS
     client: {
       submitFeedback,
     },
-  } as ConnectionStore
+  } as unknown as ConnectionStore
 }
 
 describe('FeedbackButtons', () => {


### PR DESCRIPTION
## Summary

When users typed `/execute do option 1`, the trailing context ("do option 1") was being discarded. The spawned session received only the default `EXECUTE_DIRECTIVE_THINK`/`EXECUTE_DIRECTIVE_PLAN`, which told it to pick the highest-leverage item itself — overriding what the user just said.

The `/api/messages` slash router parsed `rest` from the input, but `handleExecute` had no parameter to receive it. Same for the JSON `plan_action` route.

## Changes

- `handleExecute(sessionId, ctx, userContext?)` — new optional param.
- `buildGuidedDirective(userContext)` — wraps the user's text in `<user_direction>` tags and explicitly overrides the default item-picking instinct. Used for `think`/`plan`/`review` (new spawned session) and `task`/`dag-task`/`ship-verify` (injected reply).
- `/api/messages` forwards parsed `rest` as `userContext`.
- `/api/commands` `plan_action` schema adds optional `message` field; route forwards it.
- `MinionCommand.plan_action` shared type updated with `message?: string`.
- `/help` text updated: `/execute [direction]`.

Empty/whitespace user context is treated as no context (falls back to default directives).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 1011 vitest tests pass
- [x] `bun test server/commands/plan-actions.test.ts` — 20/20 pass, includes 4 new tests:
  - guided directive in think mode overrides item-picking
  - guided directive in plan mode overrides default
  - empty/whitespace context falls back to default
  - guided directive injected into task-mode session
- [x] `bun test server/api/routes.test.ts` — 46/46 pass
