### PR TITLE
fix(land): persist landed status, close sessions, continue past failures

### DIFF
--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -703,23 +703,41 @@ export function registerApiRoutes(
           return c.json({ error: 'no nodes with a PR URL are ready to land' }, 422)
         }
 
-        const landed: Array<{ nodeId: string; prUrl?: string }> = []
+        console.log(
+          `[land] dag=${graph.id} attempting ${landable.length} node(s):`,
+          landable.map((n) => `${n.id}@${n.prUrl}`).join(', '),
+        )
+        const landed: Array<{ nodeId: string; prUrl?: string; closedSessionId?: string }> = []
         const failed: Array<{ nodeId: string; error: string }> = []
         for (const node of landable) {
+          console.log(`[land] dag=${graph.id} node=${node.id} pr=${node.prUrl} -> attempting merge`)
           const result = await landingManager.landNode(node.id, graph)
           if (result.ok) {
-            landed.push({ nodeId: node.id, prUrl: result.prUrl })
+            console.log(
+              `[land] dag=${graph.id} node=${node.id} merged${
+                result.closedSessionId ? ` (closed session ${result.closedSessionId})` : ''
+              }`,
+            )
+            landed.push({
+              nodeId: node.id,
+              prUrl: result.prUrl,
+              closedSessionId: result.closedSessionId,
+            })
           } else {
+            console.error(`[land] dag=${graph.id} node=${node.id} failed: ${result.error}`)
             failed.push({ nodeId: node.id, error: result.error ?? 'unknown error' })
-            break
           }
         }
+        console.log(
+          `[land] dag=${graph.id} done: landed=${landed.length} failed=${failed.length}`,
+        )
 
         return c.json({
           data: {
             ok: failed.length === 0,
             sessionId,
             dagId: graph.id,
+            attempted: landable.length,
             landed: landed.length,
             failed: failed.length,
             details: { landed, failed },

--- a/server/commands/force.test.ts
+++ b/server/commands/force.test.ts
@@ -14,6 +14,7 @@ function makeScheduler(shouldFail = false): DagScheduler {
       if (shouldFail) throw new Error(`cannot force ${nodeId} in ${dagId}`)
     },
     async reconcileOnBoot() {},
+    persistDag() {},
   }
 }
 

--- a/server/commands/retry.test.ts
+++ b/server/commands/retry.test.ts
@@ -14,6 +14,7 @@ function makeScheduler(shouldFail = false): DagScheduler {
     },
     async forceNodeLanded() {},
     async reconcileOnBoot() {},
+    persistDag() {},
   }
 }
 

--- a/server/dag/landing.ts
+++ b/server/dag/landing.ts
@@ -6,6 +6,7 @@ import { nodeIndex, getDownstreamNodes } from "./dag"
 import type { DagGraph } from "./dag"
 import type { EngineEventBus } from "../events/bus"
 import type { ExecCall, ExecFn } from "./preflight"
+import type { SessionRegistry } from "../session/registry"
 
 const execFileP = promisify(execFileCb)
 
@@ -17,12 +18,15 @@ export interface LandNodeResult {
   ok: boolean
   prUrl?: string
   error?: string
+  closedSessionId?: string
 }
 
 export interface LandingManagerOpts {
   bus: EngineEventBus
   workspaceRoot: string
   execFile?: ExecFn
+  registry?: SessionRegistry
+  persistDag?: (graph: DagGraph) => void
 }
 
 export interface LandingManager {
@@ -47,7 +51,7 @@ function worktreeDir(workspaceRoot: string, branch: string): string {
 }
 
 export function createLandingManager(opts: LandingManagerOpts): LandingManager {
-  const { bus, workspaceRoot } = opts
+  const { bus, workspaceRoot, registry, persistDag } = opts
   const run = opts.execFile ?? defaultExec
 
   async function retargetAllStackedPRs(graph: DagGraph): Promise<void> {
@@ -134,6 +138,24 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
 
     node.status = "landed"
 
+    if (persistDag) {
+      try {
+        persistDag(graph)
+      } catch (err) {
+        console.error(`[landing] persistDag failed for ${nodeId}:`, err)
+      }
+    }
+
+    let closedSessionId: string | undefined
+    if (registry && node.sessionId) {
+      try {
+        await registry.close(node.sessionId)
+        closedSessionId = node.sessionId
+      } catch (err) {
+        console.error(`[landing] failed to close session ${node.sessionId} for node ${nodeId}:`, err)
+      }
+    }
+
     bus.emit({
       kind: "dag.node.landed",
       dagId: graph.id,
@@ -142,7 +164,7 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
 
     await rebaseDownstream(nodeId, graph)
 
-    return { ok: true, prUrl: node.prUrl }
+    return { ok: true, prUrl: node.prUrl, closedSessionId }
   }
 
   return { landNode }

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -117,6 +117,7 @@ export interface DagScheduler {
   retryNode(nodeId: string, dagId: string): Promise<void>
   forceNodeLanded(nodeId: string, dagId: string): Promise<void>
   reconcileOnBoot(): Promise<void>
+  persistDag(graph: DagGraph): void
 }
 
 export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
@@ -548,5 +549,5 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     })
   })
 
-  return { start, onSessionCompleted, onSessionResumed, cancel, status, retryNode, forceNodeLanded, reconcileOnBoot }
+  return { start, onSessionCompleted, onSessionResumed, cancel, status, retryNode, forceNodeLanded, reconcileOnBoot, persistDag: persist }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -177,7 +177,12 @@ try {
 
 startPushNotifier(bus)
 
-const landingManager = createLandingManager({ bus, workspaceRoot: WORKSPACE_ROOT })
+const landingManager = createLandingManager({
+  bus,
+  workspaceRoot: WORKSPACE_ROOT,
+  registry,
+  persistDag: (graph) => scheduler.persistDag(graph),
+})
 registerApiRoutes(app, registry, () => db, scheduler, landingManager, {
   loopRuntime: loopScheduler,
   resourceMonitor,


### PR DESCRIPTION
## Summary

The `/land` command (and the per-node Land button) had three issues exposed during the recent feedback DAG landing run:

- **Landed status not persisted.** `landNode` mutated `node.status = 'landed'` on its in-memory `DagGraph` but never wrote the change back. The next `loadDag` returned the same node still in `done`, so the UI never reflected that landing happened.
- **Session was not closed.** Each DAG node has a session associated with it. After landing, that session stayed in the active pool with no surface signal that its work shipped.
- **Slash command stopped at the first failure.** `routes.ts /land` had `break` on the first failed merge, leaving every later landable PR untouched. We saw this with the feedback DAG: 7 of 14 PRs merged, the 8th hit a conflict, and the rest silently stayed open.

## Changes

- `server/dag/landing.ts` — accept optional `registry` and `persistDag` callbacks. After a successful `gh pr merge`, call `persistDag(graph)` (which `saveDag`s and emits `dag.snapshot`) and `registry.close(node.sessionId)`. Emit log lines so the engine container shows progress.
- `server/dag/scheduler.ts` — expose the existing internal `persist` as `persistDag` on the `DagScheduler` interface.
- `server/index.ts` — wire `registry` and `scheduler.persistDag` into `createLandingManager`.
- `server/api/routes.ts` — `/land` no longer breaks on first failure; collects per-node `{ landed, failed }` and includes `closedSessionId` in the per-node detail. Adds `[land]` engine logs.
- `server/commands/{retry,force}.test.ts` — extend the `DagScheduler` stub with the new `persistDag()` member.

## Test plan

- [x] `tsc -b --noEmit` passes for the server tree
- [ ] CI: server unit tests (`server/dag/landing.test.ts`, `routes.test.ts`)
- [ ] After deploy: re-run `/land` against a stuck DAG and confirm:
  - landed nodes flip to `landed` in the UI snapshot
  - their sessions disappear from the active list
  - failures don't abort remaining merges
