### PR TITLE
fix(test): cast partial mock through unknown to satisfy ConnectionStore

### DIFF
--- a/test/chat/transcript/FeedbackButtons.test.tsx
+++ b/test/chat/transcript/FeedbackButtons.test.tsx
@@ -35,7 +35,7 @@ function createMockStore(features: string[] = ['message-feedback']): ConnectionS
     client: {
       submitFeedback,
     },
-  } as ConnectionStore
+  } as unknown as ConnectionStore
 }
 
 describe('FeedbackButtons', () => {


### PR DESCRIPTION
Main is currently red on typecheck because `createMockStore` in `test/chat/transcript/FeedbackButtons.test.tsx` casts a partial object directly to `ConnectionStore`. TypeScript reports insufficient overlap and recommends going through `unknown`, which is the convention used elsewhere (`ChatPane.test.tsx`, `MessageInput.test.tsx`, `touch-targets.test.tsx`).

This is the same pattern used by every other ConnectionStore mock in the test tree.