### PR TITLE
refactor(dag): decouple ship advance via dag.completed event

### DIFF
--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -3,6 +3,7 @@ import { Database } from "bun:sqlite"
 import { buildDag } from "./dag"
 import { saveDag, loadDag } from "./store"
 import { createDagScheduler } from "./scheduler"
+import { registerDagCompletionHandler } from "../handlers/dag-completion-handler"
 import { EngineEventBus } from "../events/bus"
 import { openDatabase, prepared, runMigrations } from "../db/sqlite"
 import { buildVerifyDirective } from "../ship/verification"
@@ -346,8 +347,20 @@ describe("DagScheduler", () => {
     }
 
     const scheduler = makeScheduler(registry)
+    registerDagCompletionHandler(bus, { db, registry, scheduler: { start: scheduler.start } })
+
+    const dagCompletedEvents: Array<{ dagId: string; rootSessionId: string; status: string }> = []
+    bus.onKind("dag.completed", (e) => {
+      dagCompletedEvents.push({ dagId: e.dagId, rootSessionId: e.rootSessionId, status: e.status })
+    })
+
     await scheduler.start("dag-ship-complete")
     await scheduler.onSessionCompleted("ship-child", "completed")
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(dagCompletedEvents).toEqual([
+      { dagId: "dag-ship-complete", rootSessionId: rootId, status: "completed" },
+    ])
 
     const row = prepared.getSession(db, rootId)
     expect(row?.stage).toBe("verify")
@@ -355,6 +368,56 @@ describe("DagScheduler", () => {
       { title: "Task A", description: "A", branch: "minion/test-ship-child", prUrl: null },
     ])
     expect(replies).toEqual([{ sessionId: rootId, text: expected }])
+  })
+
+  it("emits dag.completed without advancing ship for non-ship root sessions", async () => {
+    const graph = buildDag("dag-non-ship", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session-non-ship", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const dagCompletedEvents: Array<{ dagId: string; status: string }> = []
+    bus.onKind("dag.completed", (e) => {
+      dagCompletedEvents.push({ dagId: e.dagId, status: e.status })
+    })
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-non-ship")
+    await scheduler.onSessionCompleted(sessions[0]!, "completed")
+
+    expect(dagCompletedEvents).toEqual([{ dagId: "dag-non-ship", status: "completed" }])
+  })
+
+  it("emits dag.completed with status=failed when DAG terminates with failed nodes", async () => {
+    const graph = buildDag("dag-failed", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session-failed", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const dagCompletedEvents: Array<{ dagId: string; status: string }> = []
+    bus.onKind("dag.completed", (e) => {
+      dagCompletedEvents.push({ dagId: e.dagId, status: e.status })
+    })
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-failed")
+    await scheduler.onSessionCompleted(sessions[0]!, "errored")
+
+    expect(dagCompletedEvents).toEqual([{ dagId: "dag-failed", status: "failed" }])
   })
 
   it("cancel stops running sessions and marks them cancelled", async () => {

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -10,7 +10,6 @@ import type { SessionRegistry } from "../session/registry"
 import type { EngineEventBus } from "../events/bus"
 import type { SessionRunState } from "../events/types"
 import type { ApiDagNode, ApiDagGraph } from "../../shared/api-types"
-import { advanceShip } from "../ship/coordinator"
 import type { CIBabysitter } from "../handlers/types"
 import { createRestackManager } from "./restack"
 import type { RestackManager } from "./restack"
@@ -244,13 +243,14 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
       persist(graph)
       if (!completedDags.has(graph.id)) {
         completedDags.add(graph.id)
+        const status = dagGraphStatus(graph)
         bus.emit({
           kind: "dag.completed",
           dagId: graph.id,
-          status: dagGraphStatus(graph) === "failed" ? "failed" : "completed",
+          rootSessionId: graph.rootSessionId,
+          status: status === "failed" ? "failed" : "completed",
         })
       }
-      await advanceShip(graph.rootSessionId, "verify", { db, registry, scheduler: { start } })
     }
   }
 

--- a/server/events/types.ts
+++ b/server/events/types.ts
@@ -32,7 +32,12 @@ export type EngineEvent =
     }
   | { kind: 'dag.snapshot'; dag: ApiDagGraph }
   | { kind: 'dag.deleted'; dagId: string }
-  | { kind: 'dag.completed'; dagId: string; status: 'completed' | 'failed' }
+  | {
+      kind: 'dag.completed'
+      dagId: string
+      rootSessionId: string
+      status: 'completed' | 'failed'
+    }
   | { kind: 'dag.cancelled'; dagId: string }
   | { kind: 'dag.node.landed'; dagId: string; nodeId: string }
   | { kind: 'dag.node.land_reverted'; dagId: string; nodeId: string }

--- a/server/handlers/dag-completion-handler.test.ts
+++ b/server/handlers/dag-completion-handler.test.ts
@@ -1,0 +1,237 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test'
+import type { Database } from 'bun:sqlite'
+import { openDatabase, prepared, runMigrations } from '../db/sqlite'
+import { EngineEventBus, resetEventBus } from '../events/bus'
+import {
+  handleDagCompletion,
+  registerDagCompletionHandler,
+  type DagCompletedEvent,
+} from './dag-completion-handler'
+import type { SessionRegistry } from '../session/registry'
+
+function createTestDb(): Database {
+  const db = openDatabase(':memory:')
+  runMigrations(db)
+  return db
+}
+
+function createMockRegistry(): SessionRegistry {
+  return {
+    reply: mock(async () => true),
+    create: mock(async () => ({ session: {} as never, runtime: {} as never })),
+    get: mock(() => undefined),
+    getBySlug: mock(() => undefined),
+    list: mock(() => []),
+    snapshot: mock(() => undefined),
+    stop: mock(async () => {}),
+    close: mock(async () => {}),
+    reconcileOnBoot: mock(async () => {}),
+    scheduleQuotaResume: mock(async () => {}),
+  }
+}
+
+function insertShipRoot(db: Database, id: string, stage: 'think' | 'plan' | 'dag' | 'verify' | 'done'): void {
+  const now = Date.now()
+  prepared.insertSession(db, {
+    id,
+    slug: id,
+    status: 'running',
+    command: 'ship',
+    mode: 'ship',
+    repo: 'https://github.com/org/repo',
+    branch: 'minion/ship-root',
+    bare_dir: null,
+    pr_url: null,
+    parent_id: null,
+    variant_group_id: null,
+    claude_session_id: 'claude-ship',
+    workspace_root: '/tmp/workspace',
+    created_at: now,
+    updated_at: now,
+    needs_attention: false,
+    attention_reasons: [],
+    quick_actions: [],
+    conversation: [],
+    quota_sleep_until: null,
+    quota_retry_count: 0,
+    metadata: {},
+    pipeline_advancing: false,
+    stage,
+    coordinator_children: [],
+  })
+}
+
+describe('dag-completion-handler', () => {
+  let db: Database
+  let registry: SessionRegistry
+  let scheduler: { start: (id: string) => Promise<void> }
+
+  beforeEach(() => {
+    resetEventBus()
+    db = createTestDb()
+    registry = createMockRegistry()
+    scheduler = { start: mock(async () => {}) }
+  })
+
+  test('advances a ship-root session from dag to verify', async () => {
+    const rootId = 'ship-handler-root'
+    insertShipRoot(db, rootId, 'dag')
+
+    const event: DagCompletedEvent = {
+      kind: 'dag.completed',
+      dagId: 'dag-1',
+      rootSessionId: rootId,
+      status: 'completed',
+    }
+
+    await handleDagCompletion(event, { db, registry, scheduler })
+
+    const row = prepared.getSession(db, rootId)
+    expect(row?.stage).toBe('verify')
+    expect(registry.reply).toHaveBeenCalledTimes(1)
+  })
+
+  test('also advances when DAG status is failed (preserves prior behavior)', async () => {
+    const rootId = 'ship-handler-failed'
+    insertShipRoot(db, rootId, 'dag')
+
+    const event: DagCompletedEvent = {
+      kind: 'dag.completed',
+      dagId: 'dag-2',
+      rootSessionId: rootId,
+      status: 'failed',
+    }
+
+    await handleDagCompletion(event, { db, registry, scheduler })
+
+    const row = prepared.getSession(db, rootId)
+    expect(row?.stage).toBe('verify')
+  })
+
+  test('is a no-op for non-ship root sessions', async () => {
+    const rootId = 'task-root'
+    const now = Date.now()
+    prepared.insertSession(db, {
+      id: rootId,
+      slug: rootId,
+      status: 'running',
+      command: 'task',
+      mode: 'task',
+      repo: 'https://github.com/org/repo',
+      branch: null,
+      bare_dir: null,
+      pr_url: null,
+      parent_id: null,
+      variant_group_id: null,
+      claude_session_id: null,
+      workspace_root: null,
+      created_at: now,
+      updated_at: now,
+      needs_attention: false,
+      attention_reasons: [],
+      quick_actions: [],
+      conversation: [],
+      quota_sleep_until: null,
+      quota_retry_count: 0,
+      metadata: {},
+      pipeline_advancing: false,
+      stage: null,
+      coordinator_children: [],
+    })
+
+    const event: DagCompletedEvent = {
+      kind: 'dag.completed',
+      dagId: 'dag-3',
+      rootSessionId: rootId,
+      status: 'completed',
+    }
+
+    await handleDagCompletion(event, { db, registry, scheduler })
+
+    const row = prepared.getSession(db, rootId)
+    expect(row?.stage).toBeFalsy()
+    expect(registry.reply).toHaveBeenCalledTimes(0)
+  })
+
+  test('is a no-op when ship root is not in dag stage', async () => {
+    const rootId = 'ship-handler-think'
+    insertShipRoot(db, rootId, 'think')
+
+    const event: DagCompletedEvent = {
+      kind: 'dag.completed',
+      dagId: 'dag-4',
+      rootSessionId: rootId,
+      status: 'completed',
+    }
+
+    await handleDagCompletion(event, { db, registry, scheduler })
+
+    const row = prepared.getSession(db, rootId)
+    expect(row?.stage).toBe('think')
+    expect(registry.reply).toHaveBeenCalledTimes(0)
+  })
+
+  test('swallows errors thrown by advanceShip so the bus listener does not break', async () => {
+    const rootId = 'ship-handler-errors'
+    insertShipRoot(db, rootId, 'dag')
+
+    const throwingRegistry = createMockRegistry()
+    throwingRegistry.reply = mock(async () => {
+      throw new Error('boom')
+    })
+
+    const event: DagCompletedEvent = {
+      kind: 'dag.completed',
+      dagId: 'dag-5',
+      rootSessionId: rootId,
+      status: 'completed',
+    }
+
+    await expect(
+      handleDagCompletion(event, { db, registry: throwingRegistry, scheduler }),
+    ).resolves.toBeUndefined()
+  })
+
+  test('registerDagCompletionHandler subscribes to dag.completed events on the bus', async () => {
+    const rootId = 'ship-handler-bus'
+    insertShipRoot(db, rootId, 'dag')
+
+    const bus = new EngineEventBus()
+    const off = registerDagCompletionHandler(bus, { db, registry, scheduler })
+
+    bus.emit({
+      kind: 'dag.completed',
+      dagId: 'dag-bus',
+      rootSessionId: rootId,
+      status: 'completed',
+    })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    const row = prepared.getSession(db, rootId)
+    expect(row?.stage).toBe('verify')
+
+    off()
+  })
+
+  test('returned unsubscribe stops the handler from reacting', async () => {
+    const rootId = 'ship-handler-unsub'
+    insertShipRoot(db, rootId, 'dag')
+
+    const bus = new EngineEventBus()
+    const off = registerDagCompletionHandler(bus, { db, registry, scheduler })
+    off()
+
+    bus.emit({
+      kind: 'dag.completed',
+      dagId: 'dag-bus-unsub',
+      rootSessionId: rootId,
+      status: 'completed',
+    })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    const row = prepared.getSession(db, rootId)
+    expect(row?.stage).toBe('dag')
+  })
+})

--- a/server/handlers/dag-completion-handler.ts
+++ b/server/handlers/dag-completion-handler.ts
@@ -1,0 +1,33 @@
+import type { Database } from 'bun:sqlite'
+import type { EngineEventBus } from '../events/bus'
+import type { EngineEventOfKind } from '../events/types'
+import type { SessionRegistry } from '../session/registry'
+import { advanceShip } from '../ship/coordinator'
+
+export interface DagCompletionHandlerCtx {
+  db: Database
+  registry: SessionRegistry
+  scheduler: { start(dagId: string): Promise<void> }
+}
+
+export type DagCompletedEvent = EngineEventOfKind<'dag.completed'>
+
+export async function handleDagCompletion(
+  event: DagCompletedEvent,
+  ctx: DagCompletionHandlerCtx,
+): Promise<void> {
+  try {
+    await advanceShip(event.rootSessionId, 'verify', ctx)
+  } catch (err) {
+    console.error(`[dag-completion] failed to advance ship for dag ${event.dagId}:`, err)
+  }
+}
+
+export function registerDagCompletionHandler(
+  bus: EngineEventBus,
+  ctx: DagCompletionHandlerCtx,
+): () => void {
+  return bus.onKind('dag.completed', (event) => {
+    void handleDagCompletion(event, ctx)
+  })
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,6 +19,7 @@ import { digestHandler } from './handlers/digest-handler'
 import { ciBabysitHandler } from './handlers/ci-babysit-handler'
 import { parentNotifyHandler } from './handlers/parent-notify-handler'
 import { restackResolverHandler } from './handlers/restack-resolver-handler'
+import { registerDagCompletionHandler } from './handlers/dag-completion-handler'
 import {
   createRealCIBabysitter,
   createRealQualityGates,
@@ -151,6 +152,8 @@ dispatcher.register(digestHandler)
 dispatcher.register(restackResolverHandler)
 dispatcher.register(ciBabysitHandler)
 dispatcher.register(parentNotifyHandler)
+
+registerDagCompletionHandler(bus, { db, registry, scheduler })
 
 wirePrLifecycle({
   bus,


### PR DESCRIPTION
## Summary

The DAG scheduler previously called `advanceShip(rootSessionId, "verify", ...)` directly when an active DAG reached a terminal state, creating a circular dependency between `server/dag/scheduler.ts` and `server/ship/coordinator.ts`.

This PR breaks that coupling:

- Adds a new `dag.completed` engine event with `{ dagId, rootSessionId, status: 'completed' | 'failed' }`.
- `tickGraph` in `server/dag/scheduler.ts` now emits `dag.completed` instead of calling `advanceShip` directly. The `advanceShip` import is removed.
- New `server/handlers/dag-completion-handler.ts` subscribes to the bus and invokes `advanceShip(rootSessionId, 'verify', ctx)`. `advanceShip` already gates on `mode === 'ship'` and the current stage, so non-ship roots and ship sessions in other stages stay no-ops — preserving the prior behavior verbatim.
- Wired in `server/index.ts` alongside the other completion-dispatcher handlers via `registerDagCompletionHandler(bus, { db, registry, scheduler })`.

This is consistent with how `shipAdvanceHandler` already handles `session.completed` and removes the layering inversion called out in the orchestration audit.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `bun test server/handlers/dag-completion-handler.test.ts server/dag/scheduler.test.ts server/handlers/ship-advance-handler.test.ts` — all 34 tests pass
- New tests cover: handler advances ship-root from `dag` → `verify`; handles `status=failed`; no-op for non-ship sessions; no-op for ship sessions not in `dag` stage; swallows downstream errors so the bus listener stays alive; `registerDagCompletionHandler` correctly subscribes / unsubscribes
- Updated scheduler integration test now wires the handler explicitly and asserts the new `dag.completed` event is emitted with the right payload (including `status: 'failed'` when nodes fail)
- Pre-existing failures in `server/db/sqlite.test.ts` (FTS5) and `server/session/registry.test.ts` (sandbox lacks `git`) reproduce on `main` and are unrelated
