### PR TITLE
feat(dag): emit dag.completed and dag.cancelled events

### DIFF
--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -747,6 +747,143 @@ describe("DagScheduler", () => {
     const after = scheduler.status("dag-resume-noop")
     expect(after.nodes[0]?.status).toBe("running")
   })
+
+  it("emits dag.completed when all nodes finish successfully", async () => {
+    const graph = buildDag("dag-emit-complete", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const events: Array<{ dagId: string; status: string }> = []
+    bus.onKind("dag.completed", (e) => events.push({ dagId: e.dagId, status: e.status }))
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-emit-complete")
+
+    expect(events).toHaveLength(0)
+
+    await scheduler.onSessionCompleted(sessions[0]!, "completed")
+    expect(events).toHaveLength(0)
+
+    await scheduler.onSessionCompleted(sessions[1]!, "completed")
+    expect(events).toEqual([{ dagId: "dag-emit-complete", status: "completed" }])
+  })
+
+  it("emits dag.completed with status 'failed' when a node fails", async () => {
+    const graph = buildDag("dag-emit-failed", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const events: Array<{ dagId: string; status: string }> = []
+    bus.onKind("dag.completed", (e) => events.push({ dagId: e.dagId, status: e.status }))
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-emit-failed")
+
+    await scheduler.onSessionCompleted(sessions[0]!, "errored")
+
+    expect(events).toEqual([{ dagId: "dag-emit-failed", status: "failed" }])
+  })
+
+  it("emits dag.completed only once per terminal transition", async () => {
+    const graph = buildDag("dag-emit-once", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const events: Array<{ dagId: string }> = []
+    bus.onKind("dag.completed", (e) => events.push({ dagId: e.dagId }))
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-emit-once")
+    await scheduler.onSessionCompleted(sessions[0]!, "completed")
+    expect(events).toHaveLength(1)
+
+    await scheduler.forceNodeLanded("a", "dag-emit-once")
+    expect(events).toHaveLength(1)
+  })
+
+  it("emits dag.completed again after retry resurrects a failed DAG", async () => {
+    const graph = buildDag("dag-emit-retry", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const events: Array<{ status: string }> = []
+    bus.onKind("dag.completed", (e) => events.push({ status: e.status }))
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-emit-retry")
+    await scheduler.onSessionCompleted(sessions[0]!, "errored")
+
+    expect(events).toEqual([{ status: "failed" }])
+
+    await scheduler.retryNode("a", "dag-emit-retry")
+    await scheduler.onSessionCompleted(sessions[1]!, "completed")
+
+    expect(events).toEqual([{ status: "failed" }, { status: "completed" }])
+  })
+
+  it("emits dag.cancelled when cancel is called on an active DAG", async () => {
+    const graph = buildDag("dag-emit-cancel", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const cancelled: Array<{ dagId: string }> = []
+    const completed: Array<{ dagId: string }> = []
+    bus.onKind("dag.cancelled", (e) => cancelled.push({ dagId: e.dagId }))
+    bus.onKind("dag.completed", (e) => completed.push({ dagId: e.dagId }))
+
+    const registry = makeRegistry(db, async () => ({ session: makeSession("ss", db), runtime: {} as never }))
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-emit-cancel")
+    await scheduler.cancel("dag-emit-cancel")
+
+    expect(cancelled).toEqual([{ dagId: "dag-emit-cancel" }])
+    expect(completed).toHaveLength(0)
+  })
+
+  it("does not emit dag.cancelled when cancelling an unknown DAG", async () => {
+    const cancelled: Array<{ dagId: string }> = []
+    bus.onKind("dag.cancelled", (e) => cancelled.push({ dagId: e.dagId }))
+
+    const scheduler = makeScheduler(makeRegistry(db))
+    await scheduler.cancel("never-started")
+
+    expect(cancelled).toHaveLength(0)
+  })
 })
 
 describe("DagScheduler restack integration", () => {

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -128,6 +128,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
   const nodeToSession = new Map<string, string>()
   const nodeToGraph = new Map<string, string>()
   const cancelledDags = new Set<string>()
+  const completedDags = new Set<string>()
 
   const restackManager: RestackManager = createRestackManager({
     bus,
@@ -241,6 +242,14 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     if (isDagComplete(graph)) {
       activeGraphs.delete(graph.id)
       persist(graph)
+      if (!completedDags.has(graph.id)) {
+        completedDags.add(graph.id)
+        bus.emit({
+          kind: "dag.completed",
+          dagId: graph.id,
+          status: dagGraphStatus(graph) === "failed" ? "failed" : "completed",
+        })
+      }
       await advanceShip(graph.rootSessionId, "verify", { db, registry, scheduler: { start } })
     }
   }
@@ -251,6 +260,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
 
     activeGraphs.set(dagId, existing)
     cancelledDags.delete(dagId)
+    completedDags.delete(dagId)
 
     await tickGraph(existing)
   }
@@ -398,6 +408,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
         console.error(`[scheduler] failed to stop session ${sessionId} during cancel:`, err)
       }
     }
+    bus.emit({ kind: "dag.cancelled", dagId })
   }
 
   function status(dagId: string): DagStatusSnapshot {
@@ -426,6 +437,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
       activeGraphs.set(dagId, graph)
       cancelledDags.delete(dagId)
     }
+    completedDags.delete(dagId)
 
     resetFailedNode(graph, nodeId)
     persist(graph)

--- a/server/events/types.ts
+++ b/server/events/types.ts
@@ -32,6 +32,8 @@ export type EngineEvent =
     }
   | { kind: 'dag.snapshot'; dag: ApiDagGraph }
   | { kind: 'dag.deleted'; dagId: string }
+  | { kind: 'dag.completed'; dagId: string; status: 'completed' | 'failed' }
+  | { kind: 'dag.cancelled'; dagId: string }
   | { kind: 'dag.node.landed'; dagId: string; nodeId: string }
   | { kind: 'dag.node.land_reverted'; dagId: string; nodeId: string }
   | { kind: 'dag.node.pushed'; dagId: string; nodeId: string; parentSha: string; newSha: string }


### PR DESCRIPTION
## Summary

Adds two new engine events so handlers can react to whole-DAG terminality without diffing `dag.snapshot` or tracking per-node `dag.node.completed` events:

- `dag.completed { dagId, status: 'completed' | 'failed' }` — fires once when the DAG enters a terminal state. `status` is `'failed'` if any node ended in `failed`/`skipped`/`ci-failed`, `'completed'` otherwise.
- `dag.cancelled { dagId }` — fires when `cancel()` tears down a running DAG.

Emission happens in `tickGraph()` after `persist(graph)`, so consumers can rely on having the latest snapshot when they receive the event. A small in-process set dedups `dag.completed` so terminal-state mutations like `forceNodeLanded` don't re-fire it; `start()` and `retryNode()` clear the dedup so legitimate re-runs can emit again.

No SSE projection — these are backend-only events. The UI continues to receive `dag.snapshot` updates as before.

## Test plan

- [x] `bun test server/dag/scheduler.test.ts` — six new tests covering: emission on success, emission on failure, dedup across `forceNodeLanded`, re-emission after `retryNode`, cancellation, and no-op cancel for unknown DAG.
- [x] `npm run typecheck`
- [x] `npm run lint`
