### PR TITLE
feat(ui): paste clipboard images in new task prompt

### DIFF
--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -114,6 +114,27 @@ export function NewTaskBar({
     [addFiles],
   )
 
+  const handlePaste = useCallback(
+    (e: ClipboardEvent) => {
+      const items = e.clipboardData?.items
+      if (!items) return
+      const imageItems: File[] = []
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i]
+        if (!item) continue
+        if (item.kind === 'file' && VALID_IMAGE_TYPES.has(item.type)) {
+          const file = item.getAsFile()
+          if (file) imageItems.push(file)
+        }
+      }
+      if (imageItems.length > 0) {
+        e.preventDefault()
+        void addFiles(imageItems)
+      }
+    },
+    [addFiles],
+  )
+
   const removeAttachment = useCallback((idx: number) => {
     setAttachments((prev) => {
       const next = [...prev]
@@ -382,6 +403,7 @@ export function NewTaskBar({
         <textarea
           value={prompt.value}
           onInput={(e) => { prompt.value = (e.currentTarget as HTMLTextAreaElement).value }}
+          onPaste={handlePaste}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
               e.preventDefault()

--- a/test/chat/NewTaskBar.test.tsx
+++ b/test/chat/NewTaskBar.test.tsx
@@ -295,6 +295,48 @@ describe('NewTaskBar', () => {
     expect(recorded?.variantSessionIds).toEqual(['sv-1', 'sv-2'])
   })
 
+  it('paste event with image file queues attachment and shows thumbnail strip', async () => {
+    vi.stubGlobal('FileReader', class {
+      result: string | ArrayBuffer | null = null
+      onload: ((ev: ProgressEvent) => void) | null = null
+      onerror: ((ev: ProgressEvent) => void) | null = null
+      readAsDataURL = vi.fn().mockImplementation(function (this: { result: string | null; onload: ((ev: ProgressEvent) => void) | null }) {
+        Promise.resolve().then(() => {
+          this.result = 'data:image/png;base64,dGVzdA=='
+          this.onload?.call(this, new ProgressEvent('load'))
+        })
+      })
+    })
+
+    const { store } = makeStore({ features: ['sessions-create', 'sessions-create-images'] })
+    render(<NewTaskBar store={store} />)
+
+    const fakeFile = new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], 'paste.png', { type: 'image/png' })
+    const dt = {
+      items: [{ kind: 'file', type: 'image/png', getAsFile: () => fakeFile }],
+    }
+    const textarea = screen.getByTestId('new-task-prompt')
+    fireEvent(textarea, Object.assign(new Event('paste', { bubbles: true }), { clipboardData: dt }))
+
+    await waitFor(() => expect(screen.getByTestId('new-task-attachments')).toBeTruthy())
+    expect(screen.getByTestId('remove-attachment-0')).toBeTruthy()
+  })
+
+  it('paste ignores non-image clipboard items', async () => {
+    const { store } = makeStore({ features: ['sessions-create', 'sessions-create-images'] })
+    render(<NewTaskBar store={store} />)
+
+    const textFile = new File(['hello'], 'doc.txt', { type: 'text/plain' })
+    const dt = {
+      items: [{ kind: 'file', type: 'text/plain', getAsFile: () => textFile }],
+    }
+    const textarea = screen.getByTestId('new-task-prompt')
+    fireEvent(textarea, Object.assign(new Event('paste', { bubbles: true }), { clipboardData: dt }))
+
+    await waitFor(() => new Promise((r) => setTimeout(r, 50)))
+    expect(screen.queryByTestId('new-task-attachments')).toBeNull()
+  })
+
   it('Launch button label reflects variant count', async () => {
     const { store } = makeStore({
       features: ['sessions-create', 'sessions-variants'],


### PR DESCRIPTION
## Summary
- The new-task prompt textarea (`NewTaskBar`) now accepts pasted clipboard images (Cmd/Ctrl+V), matching the existing behavior in the per-session `MessageInput`. Previously the only way to attach an image was the paperclip file picker.
- Added an `onPaste` handler that filters `clipboardData.items` to valid image types (`png`, `jpeg`, `gif`, `webp`) and routes them through the existing `addFiles` path; non-image paste falls through to default textarea behavior.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — added two `NewTaskBar` tests covering image paste and non-image paste rejection
- [ ] Manual: in desktop, take a screenshot, focus the new-task prompt, Cmd/Ctrl+V — thumbnail appears in the attachments strip
