### PR TITLE
feat(dag): deadline + zero-progress watchdog with retry/fail-forward

### DIFF
--- a/server/commands/force.test.ts
+++ b/server/commands/force.test.ts
@@ -15,6 +15,8 @@ function makeScheduler(shouldFail = false): DagScheduler {
     },
     async reconcileOnBoot() {},
     persistDag() {},
+    async watchdogTick() {},
+    shutdown() {},
   }
 }
 

--- a/server/commands/retry.test.ts
+++ b/server/commands/retry.test.ts
@@ -15,6 +15,8 @@ function makeScheduler(shouldFail = false): DagScheduler {
     async forceNodeLanded() {},
     async reconcileOnBoot() {},
     persistDag() {},
+    async watchdogTick() {},
+    shutdown() {},
   }
 }
 

--- a/server/dag/dag.test.ts
+++ b/server/dag/dag.test.ts
@@ -39,6 +39,19 @@ describe("buildDag", () => {
     expect(graph.nodes[2]!.status).toBe("pending")
   })
 
+  it("propagates deadlineMs option onto the graph", () => {
+    const graph = buildDag(
+      "deadline-dag",
+      [{ id: "a", title: "Step A", description: "", dependsOn: [] }],
+      "root-session",
+      "myrepo",
+      undefined,
+      { deadlineMs: 1234567 },
+    )
+
+    expect(graph.deadlineMs).toBe(1234567)
+  })
+
   it("builds a diamond DAG", () => {
     const items: DagInput[] = [
       { id: "a", title: "Base", description: "Foundation", dependsOn: [] },

--- a/server/dag/dag.ts
+++ b/server/dag/dag.ts
@@ -70,6 +70,7 @@ export interface DagGraph {
   repoUrl?: string
   repo: string
   createdAt: number
+  deadlineMs?: number
 }
 
 export interface DagInput {
@@ -125,6 +126,7 @@ export function buildDag(
   rootSessionId: string,
   repo: string,
   repoUrl?: string,
+  opts?: { deadlineMs?: number },
 ): DagGraph {
   const ids = new Set(items.map((i) => i.id))
 
@@ -154,6 +156,7 @@ export function buildDag(
     repo,
     repoUrl,
     createdAt: Date.now(),
+    deadlineMs: opts?.deadlineMs,
   }
 
   const sorted = topologicalSort(graph)

--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -780,6 +780,278 @@ describe("DagScheduler", () => {
     await expect(scheduler.onSessionResumed(session.id)).resolves.toBeUndefined()
   })
 
+  it("watchdog retries running nodes on first no-progress stall", async () => {
+    let now = 1_000
+    const graph = buildDag("dag-stall-retry", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const stoppedSessions: string[] = []
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+    registry.stop = async (id) => { stoppedSessions.push(id) }
+
+    const stallEvents: Array<{ reason: string; action: string; stallCount: number }> = []
+    bus.onKind("dag.stalled", (e) => stallEvents.push({ reason: e.reason, action: e.action, stallCount: e.stallCount }))
+
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+      updateStackComment: async () => {},
+      watchdog: {
+        stallThresholdMs: 1000,
+        checkIntervalMs: 1_000_000,
+        maxRetries: 1,
+        now: () => now,
+        setIntervalFn: (() => 0) as unknown as typeof setInterval,
+        clearIntervalFn: (() => {}) as unknown as typeof clearInterval,
+      },
+    })
+
+    await scheduler.start("dag-stall-retry")
+    expect(sessions).toHaveLength(1)
+    const firstSession = sessions[0]!
+
+    now = 5_000
+    await scheduler.watchdogTick(now)
+
+    expect(stallEvents).toHaveLength(1)
+    expect(stallEvents[0]).toMatchObject({ reason: "no-progress", action: "retry", stallCount: 1 })
+    expect(stoppedSessions).toEqual([firstSession])
+    expect(sessions).toHaveLength(2)
+
+    const status = scheduler.status("dag-stall-retry")
+    expect(status.nodes[0]?.status).toBe("running")
+
+    scheduler.shutdown()
+  })
+
+  it("watchdog fail-forwards after retry budget is exhausted", async () => {
+    let now = 1_000
+    const graph = buildDag("dag-stall-fwd", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+    registry.stop = async () => {}
+
+    const stallEvents: Array<{ action: string }> = []
+    bus.onKind("dag.stalled", (e) => stallEvents.push({ action: e.action }))
+
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+      updateStackComment: async () => {},
+      watchdog: {
+        stallThresholdMs: 1000,
+        checkIntervalMs: 1_000_000,
+        maxRetries: 1,
+        now: () => now,
+        setIntervalFn: (() => 0) as unknown as typeof setInterval,
+        clearIntervalFn: (() => {}) as unknown as typeof clearInterval,
+      },
+    })
+
+    await scheduler.start("dag-stall-fwd")
+
+    now = 5_000
+    await scheduler.watchdogTick(now)
+    expect(stallEvents.at(-1)?.action).toBe("retry")
+
+    now = 10_000
+    await scheduler.watchdogTick(now)
+    expect(stallEvents.at(-1)?.action).toBe("fail-forward")
+
+    const status = scheduler.status("dag-stall-fwd")
+    const nodeA = status.nodes.find((n) => n.id === "a")
+    const nodeB = status.nodes.find((n) => n.id === "b")
+    expect(nodeA?.status).toBe("failed")
+    expect(nodeA?.error).toContain("dag stalled")
+    expect(nodeB?.status).toBe("skipped")
+
+    scheduler.shutdown()
+  })
+
+  it("watchdog deadline immediately fail-forwards even on first stall", async () => {
+    let now = 1_000
+    const graph = buildDag("dag-stall-deadline", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo", undefined, { deadlineMs: 5_000 })
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+    registry.stop = async () => {}
+
+    const stallEvents: Array<{ reason: string; action: string }> = []
+    bus.onKind("dag.stalled", (e) => stallEvents.push({ reason: e.reason, action: e.action }))
+
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+      updateStackComment: async () => {},
+      watchdog: {
+        stallThresholdMs: 1_000_000,
+        checkIntervalMs: 1_000_000,
+        maxRetries: 5,
+        now: () => now,
+        setIntervalFn: (() => 0) as unknown as typeof setInterval,
+        clearIntervalFn: (() => {}) as unknown as typeof clearInterval,
+      },
+    })
+
+    await scheduler.start("dag-stall-deadline")
+
+    now = 6_000
+    await scheduler.watchdogTick(now)
+
+    expect(stallEvents).toHaveLength(1)
+    expect(stallEvents[0]).toEqual({ reason: "deadline", action: "fail-forward" })
+
+    const status = scheduler.status("dag-stall-deadline")
+    expect(status.nodes[0]?.status).toBe("failed")
+
+    scheduler.shutdown()
+  })
+
+  it("watchdog notifyResolved keeps the dag alive across node completion", async () => {
+    let now = 1_000
+    const graph = buildDag("dag-stall-progress", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const stallEvents: unknown[] = []
+    bus.onKind("dag.stalled", (e) => stallEvents.push(e))
+
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+      updateStackComment: async () => {},
+      watchdog: {
+        stallThresholdMs: 1000,
+        checkIntervalMs: 1_000_000,
+        maxRetries: 1,
+        now: () => now,
+        setIntervalFn: (() => 0) as unknown as typeof setInterval,
+        clearIntervalFn: (() => {}) as unknown as typeof clearInterval,
+      },
+    })
+
+    await scheduler.start("dag-stall-progress")
+
+    now = 1_500
+    await scheduler.onSessionCompleted(sessions[0]!, "completed")
+
+    now = 2_200
+    await scheduler.watchdogTick(now)
+
+    expect(stallEvents).toHaveLength(0)
+
+    scheduler.shutdown()
+  })
+
+  it("watchdog disarms when the dag completes", async () => {
+    let now = 1_000
+    const graph = buildDag("dag-stall-disarm", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const stallEvents: unknown[] = []
+    bus.onKind("dag.stalled", (e) => stallEvents.push(e))
+
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+      updateStackComment: async () => {},
+      watchdog: {
+        stallThresholdMs: 1000,
+        checkIntervalMs: 1_000_000,
+        maxRetries: 1,
+        now: () => now,
+        setIntervalFn: (() => 0) as unknown as typeof setInterval,
+        clearIntervalFn: (() => {}) as unknown as typeof clearInterval,
+      },
+    })
+
+    await scheduler.start("dag-stall-disarm")
+    await scheduler.onSessionCompleted(sessions[0]!, "completed")
+
+    now = 1_000_000
+    await scheduler.watchdogTick(now)
+
+    expect(stallEvents).toHaveLength(0)
+
+    scheduler.shutdown()
+  })
+
   it("onSessionResumed is a no-op when node is not in failed state", async () => {
     const graph = buildDag("dag-resume-noop", [
       { id: "a", title: "Task A", description: "A", dependsOn: [] },

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -13,6 +13,8 @@ import type { ApiDagNode, ApiDagGraph } from "../../shared/api-types"
 import type { CIBabysitter } from "../handlers/types"
 import { createRestackManager } from "./restack"
 import type { RestackManager } from "./restack"
+import { createDagWatchdog } from "./watchdog"
+import type { DagWatchdog, DagWatchdogOpts, StallEvent, StallAction } from "./watchdog"
 
 function fetchRootConversation(db: Database, rootSessionId: string): TopicMessage[] {
   const rows = db
@@ -105,6 +107,7 @@ export interface DagSchedulerOpts {
   workspace: string
   ciBabysitter: CIBabysitter
   updateStackComment?: (graph: DagGraph) => Promise<void>
+  watchdog?: Pick<DagWatchdogOpts, "stallThresholdMs" | "checkIntervalMs" | "maxRetries" | "now" | "setIntervalFn" | "clearIntervalFn">
 }
 
 export interface DagScheduler {
@@ -117,6 +120,8 @@ export interface DagScheduler {
   forceNodeLanded(nodeId: string, dagId: string): Promise<void>
   reconcileOnBoot(): Promise<void>
   persistDag(graph: DagGraph): void
+  watchdogTick(at?: number): Promise<void>
+  shutdown(): void
 }
 
 export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
@@ -136,6 +141,62 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
   })
 
   const deferredRestacks = new Map<string, Array<{ dagId: string; nodeId: string; parentSha: string; newSha: string; cascadeDepth: number }>>()
+
+  const watchdog: DagWatchdog = createDagWatchdog({
+    bus,
+    stallThresholdMs: opts.watchdog?.stallThresholdMs,
+    checkIntervalMs: opts.watchdog?.checkIntervalMs,
+    maxRetries: opts.watchdog?.maxRetries,
+    now: opts.watchdog?.now,
+    setIntervalFn: opts.watchdog?.setIntervalFn,
+    clearIntervalFn: opts.watchdog?.clearIntervalFn,
+    onStall: (event, action) => handleStall(event, action),
+  })
+
+  async function handleStall(event: StallEvent, action: StallAction): Promise<void> {
+    const graph = activeGraphs.get(event.graph.id)
+    if (!graph) return
+
+    if (action === "retry") {
+      for (const nodeId of event.runningNodeIds) {
+        const sessionId = nodeToSession.get(nodeId)
+        if (sessionId) {
+          await registry.stop(sessionId, `dag stalled (${event.reason})`).catch(() => {})
+          nodeToSession.delete(nodeId)
+          nodeToGraph.delete(sessionId)
+        }
+        const node = nodeIndex(graph).get(nodeId)
+        if (!node) continue
+        if (node.status === "running") {
+          node.status = "ready"
+          node.error = undefined
+          node.sessionId = undefined
+        }
+      }
+      persist(graph)
+      await commentUpdater(graph).catch(() => {})
+      await tickGraph(graph)
+      return
+    }
+
+    for (const nodeId of event.runningNodeIds) {
+      const sessionId = nodeToSession.get(nodeId)
+      if (sessionId) {
+        await registry.stop(sessionId, `dag stalled (${event.reason})`).catch(() => {})
+        nodeToSession.delete(nodeId)
+        nodeToGraph.delete(sessionId)
+      }
+      const node = nodeIndex(graph).get(nodeId)
+      if (!node) continue
+      node.status = "failed"
+      node.error = `dag stalled: ${event.reason}`
+      failNode(graph, nodeId)
+    }
+
+    persist(graph)
+    await commentUpdater(graph).catch(() => {})
+    await tickGraph(graph)
+  }
 
   function runningCount(graph: DagGraph): number {
     return graph.nodes.filter((n) => n.status === "running").length
@@ -215,6 +276,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
         sessionId: session.id,
       })
 
+      watchdog.notifyProgress(graph.id)
       persist(graph)
       await commentUpdater(graph)
     } catch (err) {
@@ -222,6 +284,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
       node.status = "failed"
       node.error = msg
       failNode(graph, node.id)
+      watchdog.notifyProgress(graph.id)
       persist(graph)
       await commentUpdater(graph)
     }
@@ -240,6 +303,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
 
     if (isDagComplete(graph)) {
       activeGraphs.delete(graph.id)
+      watchdog.disarm(graph.id)
       persist(graph)
       if (!completedDags.has(graph.id)) {
         completedDags.add(graph.id)
@@ -261,6 +325,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     activeGraphs.set(dagId, existing)
     cancelledDags.delete(dagId)
     completedDags.delete(dagId)
+    watchdog.arm(existing)
 
     await tickGraph(existing)
   }
@@ -337,6 +402,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
         sessionId,
         state: "completed",
       })
+      watchdog.notifyResolved(dagId)
     } else {
       node.status = "failed"
       node.error = `session ended with state: ${state}`
@@ -349,6 +415,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
         sessionId,
         state: state === "quota_exhausted" ? "quota_exhausted" : "errored",
       })
+      watchdog.notifyProgress(dagId)
     }
 
     persist(graph)
@@ -371,6 +438,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
 
   async function cancel(dagId: string): Promise<void> {
     cancelledDags.add(dagId)
+    watchdog.disarm(dagId)
 
     let graph = activeGraphs.get(dagId)
     if (!graph) {
@@ -440,6 +508,8 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     completedDags.delete(dagId)
 
     resetFailedNode(graph, nodeId)
+    watchdog.arm(graph)
+    watchdog.notifyResolved(graph.id)
     persist(graph)
     await commentUpdater(graph)
     await tickGraph(graph)
@@ -469,6 +539,8 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     nodeToSession.set(node.id, sessionId)
     nodeToGraph.set(sessionId, graph.id)
 
+    watchdog.arm(graph)
+    watchdog.notifyResolved(graph.id)
     persist(graph)
     await commentUpdater(graph).catch(() => {})
   }
@@ -482,6 +554,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
       if (!nonTerminal) continue
 
       activeGraphs.set(graph.id, graph)
+      watchdog.arm(graph)
 
       for (const node of graph.nodes) {
         if (node.status !== "running") continue
@@ -548,6 +621,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
       nodeId,
     })
 
+    watchdog.notifyResolved(dagId)
     persist(graph)
     await commentUpdater(graph)
     await tickGraph(graph)
@@ -593,5 +667,17 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     })
   })
 
-  return { start, onSessionCompleted, onSessionResumed, cancel, status, retryNode, forceNodeLanded, reconcileOnBoot, persistDag: persist }
+  return {
+    start,
+    onSessionCompleted,
+    onSessionResumed,
+    cancel,
+    status,
+    retryNode,
+    forceNodeLanded,
+    reconcileOnBoot,
+    persistDag: persist,
+    watchdogTick: (at) => watchdog.tick(at),
+    shutdown: () => watchdog.shutdown(),
+  }
 }

--- a/server/dag/store.ts
+++ b/server/dag/store.ts
@@ -10,6 +10,7 @@ function graphToRows(graph: DagGraph): { dagRow: Parameters<typeof prepared.inse
     root_task_id: graph.rootSessionId,
     status: dagGraphStatus(graph),
     repo: repo && repo.length > 0 ? repo : null,
+    deadline_ms: graph.deadlineMs ?? null,
     created_at: graph.createdAt,
     updated_at: Date.now(),
   }
@@ -121,6 +122,7 @@ export function loadDag(id: string, db?: Database): DagGraph | null {
     rootSessionId: dagRow.root_task_id,
     repo: dagRow.repo ?? "",
     createdAt: dagRow.created_at,
+    deadlineMs: dagRow.deadline_ms ?? undefined,
   }
 }
 
@@ -135,6 +137,7 @@ export function saveDag(graph: DagGraph, db?: Database): void {
       root_task_id: dagRow.root_task_id,
       status: dagRow.status,
       repo: dagRow.repo,
+      deadline_ms: dagRow.deadline_ms,
       updated_at: dagRow.updated_at,
     })
   } else {

--- a/server/dag/watchdog.test.ts
+++ b/server/dag/watchdog.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach } from "bun:test"
+import { createDagWatchdog } from "./watchdog"
+import type { StallAction, StallEvent } from "./watchdog"
+import { buildDag } from "./dag"
+import { EngineEventBus } from "../events/bus"
+import type { EngineEventOfKind } from "../events/types"
+
+type StalledEvent = EngineEventOfKind<"dag.stalled">
+
+function makeGraph(deadlineMs?: number) {
+  const graph = buildDag(
+    "dag-test",
+    [{ id: "a", title: "Task A", description: "A", dependsOn: [] }],
+    "root-session",
+    "https://github.com/org/repo",
+    undefined,
+    deadlineMs != null ? { deadlineMs } : undefined,
+  )
+  graph.nodes[0]!.status = "running"
+  graph.nodes[0]!.sessionId = "session-a"
+  return graph
+}
+
+describe("DagWatchdog", () => {
+  let bus: EngineEventBus
+  let stallEvents: StalledEvent[]
+  let onStallCalls: Array<{ event: StallEvent; action: StallAction }>
+
+  beforeEach(() => {
+    bus = new EngineEventBus()
+    stallEvents = []
+    onStallCalls = []
+    bus.onKind("dag.stalled", (e) => stallEvents.push(e))
+  })
+
+  function makeWatchdog(overrides: { now?: () => number; stallThresholdMs?: number; maxRetries?: number; onStall?: (event: StallEvent, action: StallAction) => Promise<void> } = {}) {
+    return createDagWatchdog({
+      bus,
+      stallThresholdMs: overrides.stallThresholdMs ?? 1000,
+      checkIntervalMs: 1_000_000,
+      maxRetries: overrides.maxRetries ?? 1,
+      now: overrides.now,
+      setIntervalFn: (() => 0) as unknown as typeof setInterval,
+      clearIntervalFn: (() => {}) as unknown as typeof clearInterval,
+      onStall: overrides.onStall ?? (async (event, action) => {
+        onStallCalls.push({ event, action })
+      }),
+    })
+  }
+
+  it("does not fire before stall threshold is reached", async () => {
+    let t = 0
+    const dog = makeWatchdog({ now: () => t })
+    dog.arm(makeGraph())
+
+    t = 500
+    await dog.tick()
+
+    expect(stallEvents).toHaveLength(0)
+    expect(onStallCalls).toHaveLength(0)
+  })
+
+  it("fires no-progress stall after threshold elapses with retry action on first stall", async () => {
+    let t = 0
+    const dog = makeWatchdog({ now: () => t, stallThresholdMs: 1000, maxRetries: 1 })
+    dog.arm(makeGraph())
+
+    t = 1500
+    await dog.tick()
+
+    expect(stallEvents).toHaveLength(1)
+    const ev = stallEvents[0]!
+    expect(ev.reason).toBe("no-progress")
+    expect(ev.action).toBe("retry")
+    expect(ev.runningNodeIds).toEqual(["a"])
+    expect(ev.stallCount).toBe(1)
+  })
+
+  it("escalates to fail-forward after retry budget exhausted", async () => {
+    let t = 0
+    const dog = makeWatchdog({ now: () => t, stallThresholdMs: 1000, maxRetries: 1 })
+    dog.arm(makeGraph())
+
+    t = 1500
+    await dog.tick()
+    t = 3000
+    await dog.tick()
+
+    expect(stallEvents).toHaveLength(2)
+    expect(stallEvents[0]!.action).toBe("retry")
+    expect(stallEvents[1]!.action).toBe("fail-forward")
+    expect(stallEvents[1]!.stallCount).toBe(2)
+  })
+
+  it("fires deadline stall when graph deadlineMs is reached, regardless of progress", async () => {
+    let t = 0
+    const dog = makeWatchdog({ now: () => t, stallThresholdMs: 1_000_000_000 })
+    dog.arm(makeGraph(2000))
+
+    t = 1500
+    await dog.tick()
+    expect(stallEvents).toHaveLength(0)
+
+    dog.notifyProgress("dag-test", 1900)
+
+    t = 2500
+    await dog.tick()
+
+    expect(stallEvents).toHaveLength(1)
+    expect(stallEvents[0]!.reason).toBe("deadline")
+    expect(stallEvents[0]!.action).toBe("fail-forward")
+  })
+
+  it("notifyProgress shifts the stall timer but keeps stallCount", async () => {
+    let t = 0
+    const dog = makeWatchdog({ now: () => t, stallThresholdMs: 1000, maxRetries: 1 })
+    dog.arm(makeGraph())
+
+    t = 800
+    dog.notifyProgress("dag-test", t)
+
+    t = 1500
+    await dog.tick()
+    expect(stallEvents).toHaveLength(0)
+
+    t = 1900
+    await dog.tick()
+    expect(stallEvents).toHaveLength(1)
+    expect(stallEvents[0]!.stallCount).toBe(1)
+
+    dog.notifyProgress("dag-test", 1900)
+
+    t = 3000
+    await dog.tick()
+    expect(stallEvents).toHaveLength(2)
+    expect(stallEvents[1]!.stallCount).toBe(2)
+    expect(stallEvents[1]!.action).toBe("fail-forward")
+  })
+
+  it("notifyResolved resets stallCount so retries are budgeted again", async () => {
+    let t = 0
+    const dog = makeWatchdog({ now: () => t, stallThresholdMs: 1000, maxRetries: 1 })
+    dog.arm(makeGraph())
+
+    t = 1500
+    await dog.tick()
+    expect(stallEvents.at(-1)!.action).toBe("retry")
+
+    dog.notifyResolved("dag-test", 1500)
+
+    t = 3000
+    await dog.tick()
+    expect(stallEvents.at(-1)!.action).toBe("retry")
+    expect(stallEvents.at(-1)!.stallCount).toBe(1)
+  })
+
+  it("disarm stops further stall events for that DAG", async () => {
+    let t = 0
+    const dog = makeWatchdog({ now: () => t })
+    dog.arm(makeGraph())
+
+    dog.disarm("dag-test")
+
+    t = 5000
+    await dog.tick()
+
+    expect(stallEvents).toHaveLength(0)
+  })
+
+  it("calls onStall handler with the stall event and action", async () => {
+    let t = 0
+    const dog = makeWatchdog({ now: () => t, stallThresholdMs: 1000 })
+    dog.arm(makeGraph())
+
+    t = 1500
+    await dog.tick()
+
+    expect(onStallCalls).toHaveLength(1)
+    expect(onStallCalls[0]!.event.reason).toBe("no-progress")
+    expect(onStallCalls[0]!.action).toBe("retry")
+    expect(onStallCalls[0]!.event.graph.id).toBe("dag-test")
+  })
+
+  it("does not double-fire while a stall handler is in flight", async () => {
+    let t = 0
+    let release: (() => void) | undefined
+    const dog = makeWatchdog({
+      now: () => t,
+      stallThresholdMs: 1000,
+      onStall: () => new Promise<void>((resolve) => { release = resolve }),
+    })
+    dog.arm(makeGraph())
+
+    t = 1500
+    void dog.tick()
+    t = 3000
+    await dog.tick()
+
+    expect(stallEvents).toHaveLength(1)
+    release?.()
+  })
+})

--- a/server/dag/watchdog.ts
+++ b/server/dag/watchdog.ts
@@ -1,0 +1,174 @@
+import type { DagGraph } from "./dag"
+import type { EngineEventBus } from "../events/bus"
+
+export type StallReason = "deadline" | "no-progress"
+export type StallAction = "retry" | "fail-forward"
+
+export interface StallEvent {
+  graph: DagGraph
+  reason: StallReason
+  sinceMs: number
+  runningNodeIds: string[]
+  stallCount: number
+}
+
+export interface DagWatchdogOpts {
+  bus: EngineEventBus
+  stallThresholdMs?: number
+  checkIntervalMs?: number
+  maxRetries?: number
+  onStall: (event: StallEvent, action: StallAction) => Promise<void>
+  now?: () => number
+  setIntervalFn?: typeof setInterval
+  clearIntervalFn?: typeof clearInterval
+}
+
+export interface DagWatchdog {
+  arm(graph: DagGraph): void
+  notifyProgress(dagId: string, at?: number): void
+  notifyResolved(dagId: string, at?: number): void
+  disarm(dagId: string): void
+  tick(at?: number): Promise<void>
+  shutdown(): void
+}
+
+interface WatchEntry {
+  graph: DagGraph
+  lastProgressAt: number
+  stallCount: number
+  inFlight: boolean
+}
+
+const DEFAULT_STALL_THRESHOLD_MS = 30 * 60 * 1000
+const DEFAULT_CHECK_INTERVAL_MS = 60 * 1000
+const DEFAULT_MAX_RETRIES = 1
+
+export function createDagWatchdog(opts: DagWatchdogOpts): DagWatchdog {
+  const stallThresholdMs = opts.stallThresholdMs ?? DEFAULT_STALL_THRESHOLD_MS
+  const checkIntervalMs = opts.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES
+  const now = opts.now ?? (() => Date.now())
+  const setIntervalImpl = opts.setIntervalFn ?? setInterval
+  const clearIntervalImpl = opts.clearIntervalFn ?? clearInterval
+
+  const entries = new Map<string, WatchEntry>()
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  function ensureTimer(): void {
+    if (timer != null) return
+    if (entries.size === 0) return
+    timer = setIntervalImpl(() => {
+      void tick()
+    }, checkIntervalMs)
+    if (typeof timer === "object" && timer && "unref" in timer && typeof (timer as { unref?: () => void }).unref === "function") {
+      ;(timer as { unref: () => void }).unref()
+    }
+  }
+
+  function maybeClearTimer(): void {
+    if (entries.size === 0 && timer != null) {
+      clearIntervalImpl(timer)
+      timer = null
+    }
+  }
+
+  function arm(graph: DagGraph): void {
+    const existing = entries.get(graph.id)
+    entries.set(graph.id, {
+      graph,
+      lastProgressAt: existing?.lastProgressAt ?? now(),
+      stallCount: existing?.stallCount ?? 0,
+      inFlight: false,
+    })
+    ensureTimer()
+  }
+
+  function notifyProgress(dagId: string, at?: number): void {
+    const entry = entries.get(dagId)
+    if (!entry) return
+    entry.lastProgressAt = at ?? now()
+  }
+
+  function notifyResolved(dagId: string, at?: number): void {
+    const entry = entries.get(dagId)
+    if (!entry) return
+    entry.lastProgressAt = at ?? now()
+    entry.stallCount = 0
+  }
+
+  function disarm(dagId: string): void {
+    entries.delete(dagId)
+    maybeClearTimer()
+  }
+
+  async function tick(at?: number): Promise<void> {
+    const t = at ?? now()
+    const work: Array<Promise<void>> = []
+    for (const entry of entries.values()) {
+      if (entry.inFlight) continue
+      const elapsed = t - entry.lastProgressAt
+      const deadlineHit = entry.graph.deadlineMs != null && t >= entry.graph.deadlineMs
+      const stalled = elapsed >= stallThresholdMs
+
+      if (!deadlineHit && !stalled) continue
+
+      const reason: StallReason = deadlineHit ? "deadline" : "no-progress"
+      const sinceMs = deadlineHit
+        ? Math.max(0, t - (entry.graph.deadlineMs ?? t))
+        : elapsed
+
+      entry.stallCount += 1
+      const action: StallAction =
+        reason === "deadline" || entry.stallCount > maxRetries
+          ? "fail-forward"
+          : "retry"
+
+      const runningNodeIds = entry.graph.nodes
+        .filter((n) => n.status === "running")
+        .map((n) => n.id)
+
+      opts.bus.emit({
+        kind: "dag.stalled",
+        dagId: entry.graph.id,
+        reason,
+        sinceMs,
+        runningNodeIds,
+        action,
+        stallCount: entry.stallCount,
+      })
+
+      entry.inFlight = true
+      entry.lastProgressAt = t
+
+      const stallEvent: StallEvent = {
+        graph: entry.graph,
+        reason,
+        sinceMs,
+        runningNodeIds,
+        stallCount: entry.stallCount,
+      }
+
+      work.push(
+        Promise.resolve()
+          .then(() => opts.onStall(stallEvent, action))
+          .catch((err) => {
+            console.error(`[watchdog] onStall handler failed for dag ${entry.graph.id}:`, err)
+          })
+          .finally(() => {
+            entry.inFlight = false
+          }),
+      )
+    }
+    await Promise.all(work)
+  }
+
+  function shutdown(): void {
+    entries.clear()
+    if (timer != null) {
+      clearIntervalImpl(timer)
+      timer = null
+    }
+  }
+
+  return { arm, notifyProgress, notifyResolved, disarm, tick, shutdown }
+}

--- a/server/db/migrations/0013_dag_deadline.sql
+++ b/server/db/migrations/0013_dag_deadline.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dags ADD COLUMN deadline_ms INTEGER;

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -102,6 +102,7 @@ CREATE TABLE IF NOT EXISTS dags (
   root_task_id TEXT NOT NULL,
   status TEXT NOT NULL CHECK (status IN ('pending','running','completed','failed','cancelled')),
   repo TEXT,
+  deadline_ms INTEGER,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );

--- a/server/db/sqlite.test.ts
+++ b/server/db/sqlite.test.ts
@@ -404,6 +404,7 @@ test('getDagNodeBySessionId returns dag_id, node_id, and status for linked node'
     root_task_id: 'root-1',
     status: 'running',
     repo: 'org/repo',
+    deadline_ms: null,
     created_at: now,
     updated_at: now,
   })
@@ -498,6 +499,7 @@ test('getDagNodeBySessionId tracks updates after upsertDagNode replaces session_
     root_task_id: 'root-r',
     status: 'running',
     repo: null,
+    deadline_ms: null,
     created_at: now,
     updated_at: now,
   })
@@ -566,6 +568,7 @@ test('memories table has all expected columns and constraints', () => {
     root_task_id: 'task-1',
     status: 'completed',
     repo: 'test/repo',
+    deadline_ms: null,
     created_at: now,
     updated_at: now,
   })

--- a/server/db/sqlite.ts
+++ b/server/db/sqlite.ts
@@ -155,6 +155,7 @@ interface DagRow {
   root_task_id: string
   status: DagStatus
   repo: string | null
+  deadline_ms: number | null
   created_at: number
   updated_at: number
 }
@@ -627,8 +628,8 @@ export const prepared = {
     const c = stmts(db)
     if (!c.insertDag) {
       c.insertDag = db.prepare(
-        `INSERT INTO dags (id, root_task_id, status, repo, created_at, updated_at)
-         VALUES ($id, $root_task_id, $status, $repo, $created_at, $updated_at)`,
+        `INSERT INTO dags (id, root_task_id, status, repo, deadline_ms, created_at, updated_at)
+         VALUES ($id, $root_task_id, $status, $repo, $deadline_ms, $created_at, $updated_at)`,
       )
     }
     c.insertDag.run({
@@ -636,6 +637,7 @@ export const prepared = {
       $root_task_id: row.root_task_id,
       $status: row.status,
       $repo: row.repo,
+      $deadline_ms: row.deadline_ms,
       $created_at: row.created_at,
       $updated_at: row.updated_at,
     })
@@ -649,6 +651,7 @@ export const prepared = {
           root_task_id = COALESCE($root_task_id, root_task_id),
           status = COALESCE($status, status),
           repo = COALESCE($repo, repo),
+          deadline_ms = COALESCE($deadline_ms, deadline_ms),
           updated_at = $updated_at
         WHERE id = $id`,
       )
@@ -658,6 +661,7 @@ export const prepared = {
       $root_task_id: row.root_task_id ?? null,
       $status: row.status ?? null,
       $repo: row.repo ?? null,
+      $deadline_ms: row.deadline_ms ?? null,
       $updated_at: row.updated_at,
     })
   },

--- a/server/events/types.ts
+++ b/server/events/types.ts
@@ -39,6 +39,15 @@ export type EngineEvent =
       status: 'completed' | 'failed'
     }
   | { kind: 'dag.cancelled'; dagId: string }
+  | {
+      kind: 'dag.stalled'
+      dagId: string
+      reason: 'deadline' | 'no-progress'
+      sinceMs: number
+      runningNodeIds: string[]
+      action: 'retry' | 'fail-forward'
+      stallCount: number
+    }
   | { kind: 'dag.node.landed'; dagId: string; nodeId: string }
   | { kind: 'dag.node.land_reverted'; dagId: string; nodeId: string }
   | { kind: 'dag.node.pushed'; dagId: string; nodeId: string; parentSha: string; newSha: string }


### PR DESCRIPTION
## Summary

- Adds `DagGraph.deadlineMs` (persisted via new `0012_dag_deadline.sql`) so DAGs can carry a hard wall-clock cap.
- New `DagWatchdog` (`server/dag/watchdog.ts`) detects two stall conditions per DAG:
  - **No progress** for a configurable threshold → emits `dag.stalled` with `action: 'retry'` first, escalates to `'fail-forward'` once the retry budget is exhausted.
  - **Deadline reached** → always emits `dag.stalled` with `action: 'fail-forward'`.
- Scheduler arms the watchdog on `start`/`onSessionResumed`/`retryNode`/`reconcileOnBoot`, disarms it on `cancel` and on DAG completion, and distinguishes `notifyProgress` (any state shift) from `notifyResolved` (real node done/landed) so a retried attempt doesn't silently reset the stall budget.
- `dag.stalled` is now part of `EngineEvent` so other components / observability can react.

This prevents hung child sessions from holding scheduler concurrency slots forever — exactly the failure mode flagged in the orchestration audit.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (vitest, 1083 passed)
- [x] `bun test server/dag server/db/sqlite.test.ts server/commands/force.test.ts server/commands/retry.test.ts` — 204 passed; 2 pre-existing FTS5 memory test failures untouched on `main`.
- [x] Watchdog unit tests cover threshold gating, no-progress vs. deadline detection, retry-then-fail-forward escalation, `notifyProgress` shift vs. `notifyResolved` reset, and inflight de-duplication.
- [x] Scheduler integration tests cover the full retry → fail-forward path, deadline-triggered fail-forward, progress-driven survival, and disarm-on-completion.