### PR TITLE
feat(handlers): typed HandlerResult and handler.invoked traceability

### DIFF
--- a/server/events/completion-dispatcher.test.ts
+++ b/server/events/completion-dispatcher.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect, beforeEach } from 'bun:test'
 import { EngineEventBus, resetEventBus } from './bus'
 import { CompletionDispatcher } from './completion-dispatcher'
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent } from '../handlers/types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from '../handlers/types'
+import type { EngineEvent, EngineEventOfKind } from './types'
 import { Database } from 'bun:sqlite'
 import { openDatabase, runMigrations } from '../db/sqlite'
 import { createSessionRegistry } from '../session/registry'
@@ -42,13 +43,20 @@ function makeEvent(sessionId = 'sess-1'): SessionCompletedEvent {
   return { kind: 'session.completed', sessionId, state: 'completed', durationMs: 100 }
 }
 
-function makeHandler(name: string, priority: number, callList: string[], matchResult = true): CompletionHandler {
+function makeHandler(
+  name: string,
+  priority: number,
+  callList: string[],
+  matchResult = true,
+  result: HandlerResult = { handled: true },
+): CompletionHandler {
   return {
     name,
     priority,
     matches: () => matchResult,
     handle: async () => {
       callList.push(name)
+      return result
     },
   }
 }
@@ -100,7 +108,7 @@ describe('CompletionDispatcher', () => {
       name: 'fail',
       priority: 10,
       matches: () => true,
-      handle: async () => {
+      handle: async (): Promise<HandlerResult> => {
         throw new Error('intentional failure')
       },
     }
@@ -133,8 +141,9 @@ describe('CompletionDispatcher', () => {
       name: 'recorder',
       priority: 10,
       matches: () => true,
-      handle: async (ev) => {
+      handle: async (ev): Promise<HandlerResult> => {
         calls.push(ev.sessionId)
+        return { handled: true }
       },
     }
     dispatcher.register(handler)
@@ -159,5 +168,155 @@ describe('CompletionDispatcher', () => {
     await new Promise<void>((r) => setTimeout(r, 20))
 
     expect(calls).toEqual(['a', 'm', 'z'])
+  })
+
+  test('emits handler.invoked for each handler that matches', async () => {
+    const calls: string[] = []
+    const dispatcher = new CompletionDispatcher(bus, ctx)
+
+    dispatcher.register(makeHandler('a', 10, calls, true, { handled: true, reason: 'ok' }))
+    dispatcher.register(makeHandler('b', 20, calls, true, { handled: false, reason: 'skipped' }))
+    dispatcher.register(makeHandler('c', 30, calls, false))
+
+    const invoked: EngineEventOfKind<'handler.invoked'>[] = []
+    bus.onKind('handler.invoked', (e) => invoked.push(e))
+
+    bus.emit(makeEvent('sess-x'))
+    await new Promise<void>((r) => setTimeout(r, 30))
+
+    expect(invoked).toHaveLength(2)
+    expect(invoked.map((e) => e.handlerName)).toEqual(['a', 'b'])
+
+    expect(invoked[0]!.sessionId).toBe('sess-x')
+    expect(invoked[0]!.priority).toBe(10)
+    expect(invoked[0]!.handled).toBe(true)
+    expect(invoked[0]!.stopPropagation).toBe(false)
+    expect(invoked[0]!.reason).toBe('ok')
+    expect(invoked[0]!.error).toBeUndefined()
+    expect(typeof invoked[0]!.durationMs).toBe('number')
+    expect(invoked[0]!.durationMs).toBeGreaterThanOrEqual(0)
+
+    expect(invoked[1]!.handlerName).toBe('b')
+    expect(invoked[1]!.handled).toBe(false)
+    expect(invoked[1]!.reason).toBe('skipped')
+  })
+
+  test('stopPropagation halts subsequent handlers and is recorded', async () => {
+    const calls: string[] = []
+    const dispatcher = new CompletionDispatcher(bus, ctx)
+
+    dispatcher.register(makeHandler('a', 10, calls, true, { handled: true }))
+    dispatcher.register(
+      makeHandler('stop', 20, calls, true, { handled: true, stopPropagation: true, reason: 'claimed' }),
+    )
+    dispatcher.register(makeHandler('after', 30, calls, true, { handled: true }))
+
+    const invoked: EngineEventOfKind<'handler.invoked'>[] = []
+    bus.onKind('handler.invoked', (e) => invoked.push(e))
+
+    bus.emit(makeEvent())
+    await new Promise<void>((r) => setTimeout(r, 30))
+
+    expect(calls).toEqual(['a', 'stop'])
+    expect(invoked.map((e) => e.handlerName)).toEqual(['a', 'stop'])
+    expect(invoked[1]!.stopPropagation).toBe(true)
+    expect(invoked[1]!.reason).toBe('claimed')
+  })
+
+  test('emits handler.invoked with error field when handler throws', async () => {
+    const dispatcher = new CompletionDispatcher(bus, ctx)
+
+    const failingHandler: CompletionHandler = {
+      name: 'fail',
+      priority: 10,
+      matches: () => true,
+      handle: async (): Promise<HandlerResult> => {
+        throw new Error('boom')
+      },
+    }
+    dispatcher.register(failingHandler)
+    dispatcher.register(makeHandler('after', 20, [], true, { handled: true }))
+
+    const invoked: EngineEventOfKind<'handler.invoked'>[] = []
+    bus.onKind('handler.invoked', (e) => invoked.push(e))
+
+    bus.emit(makeEvent('sess-err'))
+    await new Promise<void>((r) => setTimeout(r, 30))
+
+    expect(invoked).toHaveLength(2)
+    const failEv = invoked.find((e) => e.handlerName === 'fail')!
+    expect(failEv.handled).toBe(false)
+    expect(failEv.stopPropagation).toBe(false)
+    expect(failEv.error).toBe('boom')
+    expect(failEv.sessionId).toBe('sess-err')
+
+    const afterEv = invoked.find((e) => e.handlerName === 'after')!
+    expect(afterEv.handled).toBe(true)
+    expect(afterEv.error).toBeUndefined()
+  })
+
+  test('does not emit handler.invoked when matches() is false', async () => {
+    const dispatcher = new CompletionDispatcher(bus, ctx)
+
+    dispatcher.register(makeHandler('nomatch', 10, [], false))
+    dispatcher.register(makeHandler('match', 20, [], true, { handled: true }))
+
+    const invoked: EngineEventOfKind<'handler.invoked'>[] = []
+    bus.onKind('handler.invoked', (e) => invoked.push(e))
+
+    bus.emit(makeEvent())
+    await new Promise<void>((r) => setTimeout(r, 30))
+
+    expect(invoked.map((e) => e.handlerName)).toEqual(['match'])
+  })
+
+  test('handler.invoked events are session.completed-correlated', async () => {
+    const dispatcher = new CompletionDispatcher(bus, ctx)
+    dispatcher.register(makeHandler('one', 10, [], true, { handled: true }))
+
+    const invoked: EngineEventOfKind<'handler.invoked'>[] = []
+    bus.onKind('handler.invoked', (e) => invoked.push(e))
+
+    bus.emit(makeEvent('sess-a'))
+    bus.emit(makeEvent('sess-b'))
+    await new Promise<void>((r) => setTimeout(r, 30))
+
+    const sessionIds = invoked.map((e) => e.sessionId).sort()
+    expect(sessionIds).toEqual(['sess-a', 'sess-b'])
+  })
+
+  test('integration: real handler chain emits a handler.invoked per match (no handler claimed scenario)', async () => {
+    const calls: string[] = []
+    const dispatcher = new CompletionDispatcher(bus, ctx)
+
+    dispatcher.register(makeHandler('one', 10, calls, true, { handled: false, reason: 'session_not_found' }))
+    dispatcher.register(makeHandler('two', 20, calls, true, { handled: false, reason: 'mode_mismatch' }))
+
+    const invoked: EngineEventOfKind<'handler.invoked'>[] = []
+    bus.onKind('handler.invoked', (e) => invoked.push(e))
+
+    bus.emit(makeEvent('orphan-session'))
+    await new Promise<void>((r) => setTimeout(r, 30))
+
+    expect(invoked).toHaveLength(2)
+    expect(invoked.every((e) => e.handled === false)).toBe(true)
+    const reasons = invoked.map((e) => e.reason)
+    expect(reasons).toEqual(['session_not_found', 'mode_mismatch'])
+  })
+
+  test('does not double-emit handler.invoked back into the dispatcher', async () => {
+    const dispatcher = new CompletionDispatcher(bus, ctx)
+    const calls: string[] = []
+    dispatcher.register(makeHandler('one', 10, calls, true, { handled: true }))
+
+    const allEvents: EngineEvent[] = []
+    bus.on((e) => allEvents.push(e))
+
+    bus.emit(makeEvent())
+    await new Promise<void>((r) => setTimeout(r, 30))
+
+    expect(calls).toEqual(['one'])
+    const invokedCount = allEvents.filter((e) => e.kind === 'handler.invoked').length
+    expect(invokedCount).toBe(1)
   })
 })

--- a/server/events/completion-dispatcher.ts
+++ b/server/events/completion-dispatcher.ts
@@ -1,5 +1,5 @@
 import type { EngineEventBus } from './bus'
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent } from '../handlers/types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from '../handlers/types'
 
 export class CompletionDispatcher {
   private readonly handlers: CompletionHandler[] = []
@@ -20,11 +20,34 @@ export class CompletionDispatcher {
   private async dispatch(ev: SessionCompletedEvent): Promise<void> {
     for (const handler of this.handlers) {
       if (!handler.matches(ev)) continue
+
+      const startedAt = Date.now()
+      let result: HandlerResult = { handled: false }
+      let error: string | undefined
+
       try {
-        await handler.handle(ev, this.ctx)
+        result = await handler.handle(ev, this.ctx)
       } catch (err) {
+        error = err instanceof Error ? err.message : String(err)
         console.error(`[completion-dispatcher] handler "${handler.name}" failed for session ${ev.sessionId}:`, err)
       }
+
+      const durationMs = Date.now() - startedAt
+      const stopPropagation = result.stopPropagation === true
+
+      this.ctx.bus.emit({
+        kind: 'handler.invoked',
+        sessionId: ev.sessionId,
+        handlerName: handler.name,
+        priority: handler.priority,
+        handled: result.handled === true,
+        stopPropagation,
+        durationMs,
+        ...(result.reason !== undefined ? { reason: result.reason } : {}),
+        ...(error !== undefined ? { error } : {}),
+      })
+
+      if (stopPropagation) break
     }
   }
 }

--- a/server/events/types.ts
+++ b/server/events/types.ts
@@ -63,6 +63,17 @@ export type EngineEvent =
   | { kind: 'memory.updated'; memory: MemoryEntry }
   | { kind: 'memory.reviewed'; memory: MemoryEntry }
   | { kind: 'memory.deleted'; memoryId: number }
+  | {
+      kind: 'handler.invoked'
+      sessionId: string
+      handlerName: string
+      priority: number
+      handled: boolean
+      stopPropagation: boolean
+      durationMs: number
+      reason?: string
+      error?: string
+    }
 
 export type EngineEventKind = EngineEvent['kind']
 export type EngineEventOfKind<K extends EngineEventKind> = Extract<EngineEvent, { kind: K }>

--- a/server/handlers/ci-babysit-handler.ts
+++ b/server/handlers/ci-babysit-handler.ts
@@ -1,4 +1,4 @@
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent, SessionMetadata } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent, SessionMetadata } from './types'
 import { prepared } from '../db/sqlite'
 import { execFile as execFileCb } from 'node:child_process'
 import { promisify } from 'node:util'
@@ -15,14 +15,14 @@ export const ciBabysitHandler: CompletionHandler = {
     return true
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const row = ctx.db
       .query<{ pr_url: string | null; metadata: string; workspace_root: string | null }, [string]>(
         'SELECT pr_url, metadata, workspace_root FROM sessions WHERE id = ?',
       )
       .get(ev.sessionId)
 
-    if (!row?.pr_url) return
+    if (!row?.pr_url) return { handled: false, reason: 'no_pr_url' }
 
     let meta: SessionMetadata
     try {
@@ -37,7 +37,7 @@ export const ciBabysitHandler: CompletionHandler = {
       })
     }
 
-    if (meta.ciBabysitStartedAt) return
+    if (meta.ciBabysitStartedAt) return { handled: false, reason: 'already_babysat' }
 
     const now = Date.now()
     meta.ciBabysitStartedAt = now
@@ -50,9 +50,10 @@ export const ciBabysitHandler: CompletionHandler = {
 
     if (meta.parentThreadId) {
       await ctx.ciBabysitter.queueDeferredBabysit(ev.sessionId, meta.parentThreadId)
-    } else {
-      await ctx.ciBabysitter.babysitPR(ev.sessionId, row.pr_url)
+      return { handled: true, reason: 'deferred_babysit_queued' }
     }
+    await ctx.ciBabysitter.babysitPR(ev.sessionId, row.pr_url)
+    return { handled: true, reason: 'babysit_started' }
   },
 }
 

--- a/server/handlers/digest-handler.ts
+++ b/server/handlers/digest-handler.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
 
 export const digestHandler: CompletionHandler = {
   name: 'digest',
@@ -9,17 +9,17 @@ export const digestHandler: CompletionHandler = {
     return true
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const row = ctx.db
       .query<{ pr_url: string | null; workspace_root: string | null; slug: string }, [string]>(
         'SELECT pr_url, workspace_root, slug FROM sessions WHERE id = ?',
       )
       .get(ev.sessionId)
 
-    if (!row?.pr_url || !row.workspace_root) return
+    if (!row?.pr_url || !row.workspace_root) return { handled: false, reason: 'no_pr_or_workspace' }
 
     const body = await ctx.digest.build(ev.sessionId, ctx.db)
-    if (!body) return
+    if (!body) return { handled: false, reason: 'empty_digest' }
 
     const cwd = `${row.workspace_root}/${row.slug}`
 
@@ -31,5 +31,6 @@ export const digestHandler: CompletionHandler = {
     if (result.status !== 0) {
       throw new Error(`gh pr comment failed: ${result.stderr}`)
     }
+    return { handled: true }
   },
 }

--- a/server/handlers/loop-completion-handler.ts
+++ b/server/handlers/loop-completion-handler.ts
@@ -1,4 +1,4 @@
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent, SessionMetadata } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent, SessionMetadata } from './types'
 
 export const loopCompletionHandler: CompletionHandler = {
   name: 'loop-completion',
@@ -8,17 +8,18 @@ export const loopCompletionHandler: CompletionHandler = {
     return true
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const row = ctx.db
       .query<{ metadata: string }, [string]>('SELECT metadata FROM sessions WHERE id = ?')
       .get(ev.sessionId)
 
-    if (!row) return
+    if (!row) return { handled: false, reason: 'session_not_found' }
 
     const meta = JSON.parse(row.metadata) as SessionMetadata
-    if (!meta.loopId) return
+    if (!meta.loopId) return { handled: false, reason: 'not_a_loop_session' }
 
     await ctx.loopScheduler.recordOutcome(meta.loopId, ev.state)
     await ctx.registry.close(ev.sessionId)
+    return { handled: true }
   },
 }

--- a/server/handlers/mode-completion-handler.test.ts
+++ b/server/handlers/mode-completion-handler.test.ts
@@ -75,7 +75,7 @@ describe('modeCompletionHandler', () => {
       state: 'completed',
       durationMs: 500,
     }
-    await modeCompletionHandler.handle(ev, ctx)
+    const result = await modeCompletionHandler.handle(ev, ctx)
 
     const modeEv = emitted.find((e) => e.kind === 'session.mode_completed')
     expect(modeEv).toBeDefined()
@@ -85,6 +85,7 @@ describe('modeCompletionHandler', () => {
       expect(modeEv.state).toBe('completed')
       expect(modeEv.durationMs).toBe(500)
     }
+    expect(result.handled).toBe(true)
   })
 
   test('does nothing when session does not exist', async () => {
@@ -93,8 +94,10 @@ describe('modeCompletionHandler', () => {
     bus.on((e) => emitted.push(e))
 
     const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'ghost', state: 'completed', durationMs: 0 }
-    await modeCompletionHandler.handle(ev, ctx)
+    const result = await modeCompletionHandler.handle(ev, ctx)
 
     expect(emitted.filter((e) => e.kind === 'session.mode_completed')).toHaveLength(0)
+    expect(result.handled).toBe(false)
+    expect(result.reason).toBe('session_not_found')
   })
 })

--- a/server/handlers/mode-completion-handler.ts
+++ b/server/handlers/mode-completion-handler.ts
@@ -1,4 +1,4 @@
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
 
 export const modeCompletionHandler: CompletionHandler = {
   name: 'mode-completion',
@@ -8,12 +8,12 @@ export const modeCompletionHandler: CompletionHandler = {
     return true
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const row = ctx.db
       .query<{ mode: string }, [string]>('SELECT mode FROM sessions WHERE id = ?')
       .get(ev.sessionId)
 
-    if (!row) return
+    if (!row) return { handled: false, reason: 'session_not_found' }
 
     ctx.bus.emit({
       kind: 'session.mode_completed',
@@ -22,5 +22,6 @@ export const modeCompletionHandler: CompletionHandler = {
       state: ev.state,
       durationMs: ev.durationMs,
     })
+    return { handled: true }
   },
 }

--- a/server/handlers/parent-notify-handler.ts
+++ b/server/handlers/parent-notify-handler.ts
@@ -1,4 +1,4 @@
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent, SessionMetadata } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent, SessionMetadata } from './types'
 
 export const parentNotifyHandler: CompletionHandler = {
   name: 'parent-notify',
@@ -8,16 +8,17 @@ export const parentNotifyHandler: CompletionHandler = {
     return true
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const row = ctx.db
       .query<{ metadata: string }, [string]>('SELECT metadata FROM sessions WHERE id = ?')
       .get(ev.sessionId)
 
-    if (!row) return
+    if (!row) return { handled: false, reason: 'session_not_found' }
 
     const meta = JSON.parse(row.metadata) as SessionMetadata
-    if (!meta.dagNodeId) return
+    if (!meta.dagNodeId) return { handled: false, reason: 'not_a_dag_node' }
 
     await ctx.scheduler.onSessionCompleted(ev.sessionId, ev.state)
+    return { handled: true }
   },
 }

--- a/server/handlers/pending-feedback-handler.ts
+++ b/server/handlers/pending-feedback-handler.ts
@@ -1,4 +1,4 @@
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent, SessionMetadata } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent, SessionMetadata } from './types'
 
 export const pendingFeedbackHandler: CompletionHandler = {
   name: 'pending-feedback',
@@ -8,18 +8,18 @@ export const pendingFeedbackHandler: CompletionHandler = {
     return true
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const row = ctx.db
       .query<{ metadata: string }, [string]>('SELECT metadata FROM sessions WHERE id = ?')
       .get(ev.sessionId)
 
-    if (!row) return
+    if (!row) return { handled: false, reason: 'session_not_found' }
 
     const meta = JSON.parse(row.metadata) as SessionMetadata
     const queue = ctx.replyQueue.forSession(ev.sessionId)
     const pending = await queue.drain()
 
-    if (pending.length === 0) return
+    if (pending.length === 0) return { handled: false, reason: 'no_pending_feedback' }
 
     const existing: string[] = Array.isArray(meta.pendingFeedback) ? meta.pendingFeedback : []
     const updatedMeta: SessionMetadata = { ...meta, pendingFeedback: [...existing, ...pending] }
@@ -28,5 +28,6 @@ export const pendingFeedbackHandler: CompletionHandler = {
       'UPDATE sessions SET metadata = ?, updated_at = ? WHERE id = ?',
       [JSON.stringify(updatedMeta), Date.now(), ev.sessionId],
     )
+    return { handled: true }
   },
 }

--- a/server/handlers/quality-gate-handler.ts
+++ b/server/handlers/quality-gate-handler.ts
@@ -1,4 +1,4 @@
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent, SessionMetadata } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent, SessionMetadata } from './types'
 
 export const qualityGateHandler: CompletionHandler = {
   name: 'quality-gate',
@@ -8,14 +8,15 @@ export const qualityGateHandler: CompletionHandler = {
     return true
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const row = ctx.db
       .query<{ metadata: string; workspace_root: string | null; slug: string }, [string]>(
         'SELECT metadata, workspace_root, slug FROM sessions WHERE id = ?',
       )
       .get(ev.sessionId)
 
-    if (!row || !row.workspace_root) return
+    if (!row) return { handled: false, reason: 'session_not_found' }
+    if (!row.workspace_root) return { handled: false, reason: 'no_workspace_root' }
 
     const cwd = `${row.workspace_root}/${row.slug}`
     const report = await ctx.qualityGates.run(cwd)
@@ -51,5 +52,6 @@ export const qualityGateHandler: CompletionHandler = {
         [JSON.stringify(failedMeta), Date.now(), ev.sessionId],
       )
     }
+    return { handled: true, reason: report.allPassed ? 'gates_passed' : 'gates_failed' }
   },
 }

--- a/server/handlers/quota-handler.test.ts
+++ b/server/handlers/quota-handler.test.ts
@@ -90,7 +90,7 @@ describe('quotaHandler', () => {
     const ctx = makeCtx(db, resumeCalls, 3)
 
     const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-quota', state: 'quota_exhausted', durationMs: 0 }
-    await quotaHandler.handle(ev, ctx)
+    const result = await quotaHandler.handle(ev, ctx)
 
     expect(resumeCalls).toHaveLength(1)
     expect(resumeCalls[0]!.sessionId).toBe('sess-quota')
@@ -98,6 +98,8 @@ describe('quotaHandler', () => {
 
     const row = db.query<{ quota_retry_count: number }, [string]>('SELECT quota_retry_count FROM sessions WHERE id = ?').get('sess-quota')
     expect(row!.quota_retry_count).toBe(1)
+    expect(result.handled).toBe(true)
+    expect(result.reason).toBe('quota_resume_scheduled')
   })
 
   test('does not schedule resume when retry count exceeds max', async () => {
@@ -106,9 +108,11 @@ describe('quotaHandler', () => {
     const ctx = makeCtx(db, resumeCalls, 3)
 
     const ev: SessionCompletedEvent = { kind: 'session.completed', sessionId: 'sess-max', state: 'quota_exhausted', durationMs: 0 }
-    await quotaHandler.handle(ev, ctx)
+    const result = await quotaHandler.handle(ev, ctx)
 
     expect(resumeCalls).toHaveLength(0)
+    expect(result.handled).toBe(false)
+    expect(result.reason).toBe('retry_count_exceeded')
   })
 
   test('increments retry count on each exhaustion up to max', async () => {

--- a/server/handlers/quota-handler.ts
+++ b/server/handlers/quota-handler.ts
@@ -1,4 +1,4 @@
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
 
 const QUOTA_RETRY_MAX_DEFAULT = 3
 
@@ -10,7 +10,7 @@ export const quotaHandler: CompletionHandler = {
     return ev.state === 'quota_exhausted'
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const maxRetries = ctx.config.quotaRetryMax ?? QUOTA_RETRY_MAX_DEFAULT
 
     const row = ctx.db
@@ -22,7 +22,7 @@ export const quotaHandler: CompletionHandler = {
     const retryCount = (row?.quota_retry_count ?? 0) + 1
 
     if (retryCount > maxRetries) {
-      return
+      return { handled: false, reason: 'retry_count_exceeded' }
     }
 
     const resetAt = Date.now() + 60_000
@@ -33,5 +33,6 @@ export const quotaHandler: CompletionHandler = {
     )
 
     await ctx.registry.scheduleQuotaResume(ev.sessionId, resetAt)
+    return { handled: true, reason: 'quota_resume_scheduled' }
   },
 }

--- a/server/handlers/restack-resolver-handler.ts
+++ b/server/handlers/restack-resolver-handler.ts
@@ -1,4 +1,4 @@
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent, SessionMetadata } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent, SessionMetadata } from './types'
 import { execFile as execFileCb } from 'node:child_process'
 import { promisify } from 'node:util'
 import path from 'node:path'
@@ -14,14 +14,16 @@ export const restackResolverHandler: CompletionHandler = {
     return ev.sessionId !== undefined
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const row = ctx.db
       .query<{ mode: string; metadata: string; workspace_root: string | null; slug: string }, [string]>(
         'SELECT mode, metadata, workspace_root, slug FROM sessions WHERE id = ?',
       )
       .get(ev.sessionId)
 
-    if (!row || row.mode !== 'rebase-resolver' || !row.workspace_root) return
+    if (!row) return { handled: false, reason: 'session_not_found' }
+    if (row.mode !== 'rebase-resolver') return { handled: false, reason: 'mode_mismatch' }
+    if (!row.workspace_root) return { handled: false, reason: 'no_workspace_root' }
 
     let meta: SessionMetadata
     try {
@@ -33,19 +35,19 @@ export const restackResolverHandler: CompletionHandler = {
     const { dagId, dagNodeId, parentBranch, parentSha } = meta
     if (!dagId || !dagNodeId || !parentBranch || !parentSha) {
       console.error(`[restack-resolver-handler] missing metadata for session ${ev.sessionId}`)
-      return
+      return { handled: false, reason: 'missing_metadata' }
     }
 
     const graph = loadDag(dagId, ctx.db)
     if (!graph) {
       console.error(`[restack-resolver-handler] DAG ${dagId} not found`)
-      return
+      return { handled: false, reason: 'dag_not_found' }
     }
 
     const node = graph.nodes.find((n) => n.id === dagNodeId)
     if (!node) {
       console.error(`[restack-resolver-handler] node ${dagNodeId} not found in DAG ${dagId}`)
-      return
+      return { handled: false, reason: 'node_not_found' }
     }
 
     const cwd = path.join(row.workspace_root, row.slug)
@@ -63,7 +65,7 @@ export const restackResolverHandler: CompletionHandler = {
         result: 'conflict',
         error: node.error,
       })
-      return
+      return { handled: true, reason: 'rebase_in_progress' }
     }
 
     if (rebaseStatus === 'dirty') {
@@ -77,7 +79,7 @@ export const restackResolverHandler: CompletionHandler = {
         result: 'conflict',
         error: node.error,
       })
-      return
+      return { handled: true, reason: 'workspace_dirty' }
     }
 
     let currentSha: string
@@ -99,7 +101,7 @@ export const restackResolverHandler: CompletionHandler = {
         result: 'conflict',
         error: node.error,
       })
-      return
+      return { handled: true, reason: 'head_sha_failed' }
     }
 
     try {
@@ -119,7 +121,7 @@ export const restackResolverHandler: CompletionHandler = {
         result: 'conflict',
         error: node.error,
       })
-      return
+      return { handled: true, reason: 'push_failed' }
     }
 
     console.log(`[restack-resolver-handler] successfully resolved and pushed node ${dagNodeId}`)
@@ -140,6 +142,7 @@ export const restackResolverHandler: CompletionHandler = {
       parentSha: typeof parentSha === 'string' ? parentSha : '',
       newSha: currentSha,
     })
+    return { handled: true, reason: 'restack_resolved' }
   },
 }
 

--- a/server/handlers/ship-advance-handler.ts
+++ b/server/handlers/ship-advance-handler.ts
@@ -1,4 +1,4 @@
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
 import { handleExecute } from '../commands/plan-actions'
 
 const SHIP_ADVANCE_MODES = new Set(['ship-think', 'ship-plan'])
@@ -11,15 +11,17 @@ export const shipAdvanceHandler: CompletionHandler = {
     return ev.state === 'completed'
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const row = ctx.db
       .query<{ mode: string; pipeline_advancing: number }, [string]>(
         'SELECT mode, pipeline_advancing FROM sessions WHERE id = ?',
       )
       .get(ev.sessionId)
 
-    if (!row || !SHIP_ADVANCE_MODES.has(row.mode)) return
-    if (row.pipeline_advancing !== 0) return
+    if (!row || !SHIP_ADVANCE_MODES.has(row.mode)) {
+      return { handled: false, reason: row ? 'mode_mismatch' : 'session_not_found' }
+    }
+    if (row.pipeline_advancing !== 0) return { handled: false, reason: 'already_advancing' }
 
     try {
       await handleExecute(ev.sessionId, {
@@ -31,5 +33,6 @@ export const shipAdvanceHandler: CompletionHandler = {
       console.error(`[ship-advance] failed to advance session ${ev.sessionId} (mode=${row.mode}):`, err)
       throw err
     }
+    return { handled: true }
   },
 }

--- a/server/handlers/stats-handler.ts
+++ b/server/handlers/stats-handler.ts
@@ -1,4 +1,4 @@
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
 
 export const statsHandler: CompletionHandler = {
   name: 'stats',
@@ -8,14 +8,14 @@ export const statsHandler: CompletionHandler = {
     return true
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const row = ctx.db
       .query<{ slug: string; mode: string; repo: string | null }, [string]>(
         'SELECT slug, mode, repo FROM sessions WHERE id = ?',
       )
       .get(ev.sessionId)
 
-    if (!row) return
+    if (!row) return { handled: false, reason: 'session_not_found' }
 
     ctx.db.run(
       `INSERT INTO session_stats (session_id, slug, repo, mode, state, duration_ms, total_tokens, recorded_at)
@@ -31,5 +31,6 @@ export const statsHandler: CompletionHandler = {
         Date.now(),
       ],
     )
+    return { handled: true }
   },
 }

--- a/server/handlers/task-completion-handler.ts
+++ b/server/handlers/task-completion-handler.ts
@@ -1,4 +1,4 @@
-import type { CompletionHandler, HandlerCtx, SessionCompletedEvent } from './types'
+import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
 import { qualityGateHandler } from './quality-gate-handler'
 import { digestHandler } from './digest-handler'
 import { ciBabysitHandler } from './ci-babysit-handler'
@@ -11,15 +11,17 @@ export const taskCompletionHandler: CompletionHandler = {
     return true
   },
 
-  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void> {
+  async handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult> {
     const row = ctx.db
       .query<{ mode: string }, [string]>('SELECT mode FROM sessions WHERE id = ?')
       .get(ev.sessionId)
 
-    if (!row || row.mode !== 'task') return
+    if (!row) return { handled: false, reason: 'session_not_found' }
+    if (row.mode !== 'task') return { handled: false, reason: 'mode_mismatch' }
 
     await qualityGateHandler.handle(ev, ctx)
     await digestHandler.handle(ev, ctx)
     await ciBabysitHandler.handle(ev, ctx)
+    return { handled: true }
   },
 }

--- a/server/handlers/types.ts
+++ b/server/handlers/types.ts
@@ -8,11 +8,17 @@ export type QualityReport = ApiQualityReport
 export type SessionCompletedEvent = EngineEventOfKind<'session.completed'>
 export type { SessionRunState } from '../events/types'
 
+export interface HandlerResult {
+  handled: boolean
+  stopPropagation?: boolean
+  reason?: string
+}
+
 export interface CompletionHandler {
   readonly name: string
   readonly priority: number
   matches(ev: SessionCompletedEvent): boolean
-  handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<void>
+  handle(ev: SessionCompletedEvent, ctx: HandlerCtx): Promise<HandlerResult>
 }
 
 export interface DagScheduler {


### PR DESCRIPTION
## Summary

Adds typed `HandlerResult` return values to the completion-handler chain and a `handler.invoked` engine event so we can see, per `session.completed`, which handlers ran, which one claimed it, how long they took, and why each skipped or failed. This is the traceability primitive that recent fixes like `7eafc7b` (state divergence between memory and DB) had to be reverse-engineered from logs to find.

- `CompletionHandler.handle` now returns `Promise<HandlerResult>` where `HandlerResult = { handled, stopPropagation?, reason? }`. All eleven existing handlers updated to return explicit results.
- `CompletionDispatcher` times each invocation and emits a `handler.invoked` event with `{ sessionId, handlerName, priority, handled, stopPropagation, durationMs, reason?, error? }`. Errors are caught and reported in the event instead of being silent in `console.error`.
- `stopPropagation` is opt-in plumbing — no existing handler sets it, so behavior is unchanged. Future PRs can use it to make a single handler claim a completion (e.g. quota-resume).
- `handler.invoked` events are not re-dispatched (the dispatcher only listens to `session.completed`), so there's no feedback loop.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 1083 pass
- [x] `bun test server/events/completion-dispatcher.test.ts` — 13 pass (6 new test cases for the new behavior)
- [x] `bun test server/handlers/quota-handler.test.ts server/handlers/mode-completion-handler.test.ts` — pass with new return-value assertions
- [x] `bun test server/events server/handlers` — 70 pass; the one pre-existing `restackResolverHandler` push test failure was confirmed against `main` and is unrelated to this change
