### PR TITLE
refactor(handlers): centralise completion handler priorities

### DIFF
--- a/server/handlers/ci-babysit-handler.ts
+++ b/server/handlers/ci-babysit-handler.ts
@@ -4,12 +4,13 @@ import { execFile as execFileCb } from 'node:child_process'
 import { promisify } from 'node:util'
 import path from 'node:path'
 import { loadDag } from '../dag/store'
+import { HANDLER_PRIORITIES } from './priorities'
 
 const execFileP = promisify(execFileCb)
 
 export const ciBabysitHandler: CompletionHandler = {
   name: 'ci-babysit',
-  priority: 0,
+  priority: HANDLER_PRIORITIES.OBSERVE,
 
   matches(): boolean {
     return true

--- a/server/handlers/digest-handler.ts
+++ b/server/handlers/digest-handler.ts
@@ -1,9 +1,11 @@
 import { spawnSync } from 'node:child_process'
 import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
+import { HANDLER_PRIORITIES } from './priorities'
+
 
 export const digestHandler: CompletionHandler = {
   name: 'digest',
-  priority: 0,
+  priority: HANDLER_PRIORITIES.OBSERVE,
 
   matches(): boolean {
     return true

--- a/server/handlers/loop-completion-handler.ts
+++ b/server/handlers/loop-completion-handler.ts
@@ -1,8 +1,10 @@
 import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent, SessionMetadata } from './types'
+import { HANDLER_PRIORITIES } from './priorities'
+
 
 export const loopCompletionHandler: CompletionHandler = {
   name: 'loop-completion',
-  priority: 50,
+  priority: HANDLER_PRIORITIES.LOOP,
 
   matches(): boolean {
     return true

--- a/server/handlers/mode-completion-handler.ts
+++ b/server/handlers/mode-completion-handler.ts
@@ -1,8 +1,10 @@
 import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
+import { HANDLER_PRIORITIES } from './priorities'
+
 
 export const modeCompletionHandler: CompletionHandler = {
   name: 'mode-completion',
-  priority: 40,
+  priority: HANDLER_PRIORITIES.EMIT_MODE,
 
   matches(): boolean {
     return true

--- a/server/handlers/parent-notify-handler.ts
+++ b/server/handlers/parent-notify-handler.ts
@@ -1,8 +1,10 @@
 import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent, SessionMetadata } from './types'
+import { HANDLER_PRIORITIES } from './priorities'
+
 
 export const parentNotifyHandler: CompletionHandler = {
   name: 'parent-notify',
-  priority: 0,
+  priority: HANDLER_PRIORITIES.OBSERVE,
 
   matches(): boolean {
     return true

--- a/server/handlers/pending-feedback-handler.ts
+++ b/server/handlers/pending-feedback-handler.ts
@@ -1,8 +1,10 @@
 import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent, SessionMetadata } from './types'
+import { HANDLER_PRIORITIES } from './priorities'
+
 
 export const pendingFeedbackHandler: CompletionHandler = {
   name: 'pending-feedback',
-  priority: 0,
+  priority: HANDLER_PRIORITIES.OBSERVE,
 
   matches(): boolean {
     return true

--- a/server/handlers/priorities.test.ts
+++ b/server/handlers/priorities.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect } from 'bun:test'
+import { HANDLER_PRIORITIES } from './priorities'
+import { pendingFeedbackHandler } from './pending-feedback-handler'
+import { parentNotifyHandler } from './parent-notify-handler'
+import { qualityGateHandler } from './quality-gate-handler'
+import { digestHandler } from './digest-handler'
+import { ciBabysitHandler } from './ci-babysit-handler'
+import { statsHandler } from './stats-handler'
+import { restackResolverHandler } from './restack-resolver-handler'
+import { quotaHandler } from './quota-handler'
+import { shipAdvanceHandler } from './ship-advance-handler'
+import { modeCompletionHandler } from './mode-completion-handler'
+import { loopCompletionHandler } from './loop-completion-handler'
+import { taskCompletionHandler } from './task-completion-handler'
+import type { CompletionHandler } from './types'
+
+describe('HANDLER_PRIORITIES', () => {
+  test('tier values follow the documented spacing', () => {
+    expect(HANDLER_PRIORITIES.OBSERVE).toBe(0)
+    expect(HANDLER_PRIORITIES.RECORD).toBe(10)
+    expect(HANDLER_PRIORITIES.RETRY).toBe(20)
+    expect(HANDLER_PRIORITIES.ADVANCE).toBe(30)
+    expect(HANDLER_PRIORITIES.EMIT_MODE).toBe(40)
+    expect(HANDLER_PRIORITIES.LOOP).toBe(50)
+    expect(HANDLER_PRIORITIES.TASK).toBe(60)
+  })
+
+  test('tiers are strictly ascending with 10 spacing', () => {
+    const tiers = [
+      HANDLER_PRIORITIES.OBSERVE,
+      HANDLER_PRIORITIES.RECORD,
+      HANDLER_PRIORITIES.RETRY,
+      HANDLER_PRIORITIES.ADVANCE,
+      HANDLER_PRIORITIES.EMIT_MODE,
+      HANDLER_PRIORITIES.LOOP,
+      HANDLER_PRIORITIES.TASK,
+    ]
+    for (let i = 1; i < tiers.length; i++) {
+      expect(tiers[i]).toBeGreaterThan(tiers[i - 1] as number)
+      expect((tiers[i] as number) - (tiers[i - 1] as number)).toBe(10)
+    }
+  })
+
+  test('OBSERVE < RECORD < RETRY < ADVANCE < EMIT_MODE < LOOP < TASK', () => {
+    expect(HANDLER_PRIORITIES.OBSERVE).toBeLessThan(HANDLER_PRIORITIES.RECORD)
+    expect(HANDLER_PRIORITIES.RECORD).toBeLessThan(HANDLER_PRIORITIES.RETRY)
+    expect(HANDLER_PRIORITIES.RETRY).toBeLessThan(HANDLER_PRIORITIES.ADVANCE)
+    expect(HANDLER_PRIORITIES.ADVANCE).toBeLessThan(HANDLER_PRIORITIES.EMIT_MODE)
+    expect(HANDLER_PRIORITIES.EMIT_MODE).toBeLessThan(HANDLER_PRIORITIES.LOOP)
+    expect(HANDLER_PRIORITIES.LOOP).toBeLessThan(HANDLER_PRIORITIES.TASK)
+  })
+})
+
+describe('handler priority assignments', () => {
+  test('OBSERVE-tier handlers use HANDLER_PRIORITIES.OBSERVE', () => {
+    expect(pendingFeedbackHandler.priority).toBe(HANDLER_PRIORITIES.OBSERVE)
+    expect(parentNotifyHandler.priority).toBe(HANDLER_PRIORITIES.OBSERVE)
+    expect(qualityGateHandler.priority).toBe(HANDLER_PRIORITIES.OBSERVE)
+    expect(digestHandler.priority).toBe(HANDLER_PRIORITIES.OBSERVE)
+    expect(ciBabysitHandler.priority).toBe(HANDLER_PRIORITIES.OBSERVE)
+  })
+
+  test('RECORD-tier handlers use HANDLER_PRIORITIES.RECORD', () => {
+    expect(statsHandler.priority).toBe(HANDLER_PRIORITIES.RECORD)
+    expect(restackResolverHandler.priority).toBe(HANDLER_PRIORITIES.RECORD)
+  })
+
+  test('quota uses RETRY tier', () => {
+    expect(quotaHandler.priority).toBe(HANDLER_PRIORITIES.RETRY)
+  })
+
+  test('ship-advance uses ADVANCE tier', () => {
+    expect(shipAdvanceHandler.priority).toBe(HANDLER_PRIORITIES.ADVANCE)
+  })
+
+  test('mode-completion uses EMIT_MODE tier', () => {
+    expect(modeCompletionHandler.priority).toBe(HANDLER_PRIORITIES.EMIT_MODE)
+  })
+
+  test('loop-completion uses LOOP tier', () => {
+    expect(loopCompletionHandler.priority).toBe(HANDLER_PRIORITIES.LOOP)
+  })
+
+  test('task-completion uses TASK tier', () => {
+    expect(taskCompletionHandler.priority).toBe(HANDLER_PRIORITIES.TASK)
+  })
+})
+
+describe('handler ordering invariants', () => {
+  test('parent-notify fires before quota retry and ship advance', () => {
+    expect(parentNotifyHandler.priority).toBeLessThan(quotaHandler.priority)
+    expect(parentNotifyHandler.priority).toBeLessThan(shipAdvanceHandler.priority)
+  })
+
+  test('quota retry fires before ship advance', () => {
+    expect(quotaHandler.priority).toBeLessThan(shipAdvanceHandler.priority)
+  })
+
+  test('ship advance fires before mode completion event emission', () => {
+    expect(shipAdvanceHandler.priority).toBeLessThan(modeCompletionHandler.priority)
+  })
+
+  test('mode completion fires before loop bookkeeping', () => {
+    expect(modeCompletionHandler.priority).toBeLessThan(loopCompletionHandler.priority)
+  })
+
+  test('all single-purpose handlers fire before task composite', () => {
+    const composite = taskCompletionHandler.priority
+    const singlePurpose: CompletionHandler[] = [
+      pendingFeedbackHandler,
+      parentNotifyHandler,
+      qualityGateHandler,
+      digestHandler,
+      ciBabysitHandler,
+      statsHandler,
+      restackResolverHandler,
+      quotaHandler,
+      shipAdvanceHandler,
+      modeCompletionHandler,
+      loopCompletionHandler,
+    ]
+    for (const h of singlePurpose) {
+      expect(h.priority).toBeLessThan(composite)
+    }
+  })
+
+  test('sorting registered handlers produces the expected execution order', () => {
+    const handlers: CompletionHandler[] = [
+      taskCompletionHandler,
+      shipAdvanceHandler,
+      pendingFeedbackHandler,
+      modeCompletionHandler,
+      quotaHandler,
+      statsHandler,
+      loopCompletionHandler,
+      parentNotifyHandler,
+    ]
+    const sorted = [...handlers].sort((a, b) => a.priority - b.priority)
+    const orderedNames = sorted.map((h) => h.name)
+    expect(orderedNames).toEqual([
+      'pending-feedback',
+      'parent-notify',
+      'stats',
+      'quota',
+      'ship-advance',
+      'mode-completion',
+      'loop-completion',
+      'task-completion',
+    ])
+  })
+})

--- a/server/handlers/priorities.ts
+++ b/server/handlers/priorities.ts
@@ -1,0 +1,61 @@
+/**
+ * Centralised execution-order constants for `session.completed` handlers.
+ *
+ * `CompletionDispatcher` invokes registered handlers in ASCENDING priority
+ * order (lower number runs earlier). Handlers must reference one of the
+ * constants below instead of inlining a magic number so the ordering contract
+ * is auditable in a single file.
+ *
+ * Tiers are spaced by 10 to leave room for new handlers without renumbering
+ * existing ones.
+ *
+ * Ordering invariants — read these before changing a value:
+ *
+ *  1. OBSERVE (0) runs first.
+ *     Handlers in this tier read or persist terminal session state, drain
+ *     in-memory queues, and emit derived events. They MUST NOT depend on
+ *     side effects from any later tier. `parent-notify` lives here so the
+ *     DAG scheduler observes the terminal state before any retry/advance
+ *     handler can mask it.
+ *
+ *  2. RECORD (10) runs after OBSERVE.
+ *     Append-only bookkeeping (e.g. `session_stats` rows) and post-hoc
+ *     status checks (`restack-resolver` validates rebase outcome and pushes).
+ *     Must run after OBSERVE because `restack-resolver` emits
+ *     `dag.node.pushed` based on the SHA captured by the observer.
+ *
+ *  3. RETRY (20) runs before any ADVANCE.
+ *     Reschedules the session on transient failure (e.g. `quota_exhausted`).
+ *     Must precede ADVANCE so a quota-blocked ship-think is not advanced to
+ *     ship-plan.
+ *
+ *  4. ADVANCE (30) runs after RETRY.
+ *     Pipeline progression (`ship-think` → `ship-plan` → `ship-do`). Only
+ *     fires on `state === 'completed'`, which makes it disjoint from RETRY
+ *     in practice, but the ordering is preserved as a safety net.
+ *
+ *  5. EMIT_MODE (40) runs after ADVANCE.
+ *     Emits `session.mode_completed`. Sequenced last among single-purpose
+ *     handlers so downstream listeners see post-advance state.
+ *
+ *  6. LOOP (50) runs after EMIT_MODE.
+ *     Records loop outcome and closes the session. Depends on EMIT_MODE so
+ *     loop scheduler subscribers see the mode-completed signal first.
+ *
+ *  7. TASK (60) runs last.
+ *     Composite that fans out to quality gates, digest, and CI babysit for
+ *     `mode === 'task'` sessions. Intentionally last because it triggers
+ *     side effects (PR comments, CI polling) that should not race with
+ *     OBSERVE-tier state capture.
+ */
+export const HANDLER_PRIORITIES = {
+  OBSERVE: 0,
+  RECORD: 10,
+  RETRY: 20,
+  ADVANCE: 30,
+  EMIT_MODE: 40,
+  LOOP: 50,
+  TASK: 60,
+} as const
+
+export type HandlerPriority = (typeof HANDLER_PRIORITIES)[keyof typeof HANDLER_PRIORITIES]

--- a/server/handlers/quality-gate-handler.ts
+++ b/server/handlers/quality-gate-handler.ts
@@ -1,8 +1,10 @@
 import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent, SessionMetadata } from './types'
+import { HANDLER_PRIORITIES } from './priorities'
+
 
 export const qualityGateHandler: CompletionHandler = {
   name: 'quality-gate',
-  priority: 0,
+  priority: HANDLER_PRIORITIES.OBSERVE,
 
   matches(): boolean {
     return true

--- a/server/handlers/quota-handler.ts
+++ b/server/handlers/quota-handler.ts
@@ -1,10 +1,12 @@
 import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
+import { HANDLER_PRIORITIES } from './priorities'
+
 
 const QUOTA_RETRY_MAX_DEFAULT = 3
 
 export const quotaHandler: CompletionHandler = {
   name: 'quota',
-  priority: 20,
+  priority: HANDLER_PRIORITIES.RETRY,
 
   matches(ev: SessionCompletedEvent): boolean {
     return ev.state === 'quota_exhausted'

--- a/server/handlers/restack-resolver-handler.ts
+++ b/server/handlers/restack-resolver-handler.ts
@@ -3,12 +3,13 @@ import { execFile as execFileCb } from 'node:child_process'
 import { promisify } from 'node:util'
 import path from 'node:path'
 import { loadDag } from '../dag/store'
+import { HANDLER_PRIORITIES } from './priorities'
 
 const execFileP = promisify(execFileCb)
 
 export const restackResolverHandler: CompletionHandler = {
   name: 'restack-resolver',
-  priority: 10,
+  priority: HANDLER_PRIORITIES.RECORD,
 
   matches(ev: SessionCompletedEvent): boolean {
     return ev.sessionId !== undefined

--- a/server/handlers/ship-advance-handler.ts
+++ b/server/handlers/ship-advance-handler.ts
@@ -1,11 +1,12 @@
 import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
 import { handleExecute } from '../commands/plan-actions'
+import { HANDLER_PRIORITIES } from './priorities'
 
 const SHIP_ADVANCE_MODES = new Set(['ship-think', 'ship-plan'])
 
 export const shipAdvanceHandler: CompletionHandler = {
   name: 'ship-advance',
-  priority: 30,
+  priority: HANDLER_PRIORITIES.ADVANCE,
 
   matches(ev: SessionCompletedEvent): boolean {
     return ev.state === 'completed'

--- a/server/handlers/stats-handler.ts
+++ b/server/handlers/stats-handler.ts
@@ -1,8 +1,10 @@
 import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
+import { HANDLER_PRIORITIES } from './priorities'
+
 
 export const statsHandler: CompletionHandler = {
   name: 'stats',
-  priority: 10,
+  priority: HANDLER_PRIORITIES.RECORD,
 
   matches(): boolean {
     return true

--- a/server/handlers/task-completion-handler.ts
+++ b/server/handlers/task-completion-handler.ts
@@ -2,10 +2,11 @@ import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEven
 import { qualityGateHandler } from './quality-gate-handler'
 import { digestHandler } from './digest-handler'
 import { ciBabysitHandler } from './ci-babysit-handler'
+import { HANDLER_PRIORITIES } from './priorities'
 
 export const taskCompletionHandler: CompletionHandler = {
   name: 'task-completion',
-  priority: 60,
+  priority: HANDLER_PRIORITIES.TASK,
 
   matches(): boolean {
     return true


### PR DESCRIPTION
## Summary

The twelve `session.completed` handlers each declared a magic priority
number (`0`, `10`, `20`, …) with no shared documentation explaining what
the spacing meant or which orderings were load-bearing. This PR replaces
those literals with a single `HANDLER_PRIORITIES` constant and documents
the ordering invariants in one place so future handler additions can
slot into the right tier without guesswork.

Tiers (ascending = earlier execution):

| Tier | Value | Handlers |
|------|------:|----------|
| `OBSERVE` | 0 | pending-feedback, parent-notify, quality-gate, digest, ci-babysit |
| `RECORD` | 10 | stats, restack-resolver |
| `RETRY` | 20 | quota |
| `ADVANCE` | 30 | ship-advance |
| `EMIT_MODE` | 40 | mode-completion |
| `LOOP` | 50 | loop-completion |
| `TASK` | 60 | task-completion |

`server/handlers/priorities.ts` carries the rationale for each tier
boundary (e.g. RETRY must precede ADVANCE so a quota-blocked ship-think
isn't advanced to ship-plan). Behaviour is unchanged — every handler
still resolves to the same numeric priority it had before.

## Test plan

- [x] `bun test server/handlers/priorities.test.ts` — 16 new tests cover
      the constant values, monotonicity, per-handler tier assignment, and
      the dispatcher's resulting execution order.
- [x] `bun test server/handlers/ server/events/` — handler + dispatcher
      suites still pass (one pre-existing failure unrelated to this PR:
      `restack-resolver-handler` test that performs a real `git push`).
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — full vitest suite (1083/1083).
