### PR TITLE
feat(dag): indexed session→node reverse lookup

### DIFF
--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -503,6 +503,88 @@ describe("DagScheduler", () => {
     expect(afterResume.nodes.find((n) => n.id === "a")?.sessionId).toBe(sessionId)
   })
 
+  it("onSessionCompleted recovers from DB when in-memory cache is empty", async () => {
+    const graph = buildDag("dag-recover", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`session-${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const firstScheduler = makeScheduler(registry)
+    await firstScheduler.start("dag-recover")
+    expect(sessions).toHaveLength(1)
+    const sessionId = sessions[0]!
+
+    const secondScheduler = makeScheduler(registry)
+
+    await secondScheduler.onSessionCompleted(sessionId, "completed")
+
+    const after = secondScheduler.status("dag-recover")
+    const nodeA = after.nodes.find((n) => n.id === "a")
+    expect(nodeA?.status).toBe("done")
+    expect(sessions).toHaveLength(2)
+  })
+
+  it("onSessionCompleted ignores DB-discovered nodes that are not running", async () => {
+    const graph = buildDag("dag-stale", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const registry = makeRegistry(db, async () => ({ session: makeSession("stale-sess", db), runtime: {} as never }))
+    const firstScheduler = makeScheduler(registry)
+    await firstScheduler.start("dag-stale")
+
+    await firstScheduler.onSessionCompleted("stale-sess", "completed")
+
+    const secondScheduler = makeScheduler(registry)
+    await secondScheduler.onSessionCompleted("stale-sess", "completed")
+
+    const after = secondScheduler.status("dag-stale")
+    const nodeA = after.nodes.find((n) => n.id === "a")
+    expect(nodeA?.status).toBe("done")
+  })
+
+  it("onSessionResumed uses indexed dag_nodes.session_id lookup, not session metadata", async () => {
+    const graph = buildDag("dag-resume-indexed", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const id = `session-${sessions.length}`
+      const session = makeSession(id, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-resume-indexed")
+
+    const sessionId = sessions[0]!
+    await scheduler.onSessionCompleted(sessionId, "errored")
+
+    prepared.updateSession(db, {
+      id: sessionId,
+      updated_at: Date.now(),
+      metadata: {},
+    })
+
+    await scheduler.onSessionResumed(sessionId)
+
+    const after = scheduler.status("dag-resume-indexed")
+    expect(after.nodes.find((n) => n.id === "a")?.status).toBe("running")
+  })
+
   it("onSessionResumed is a no-op when session is not part of a DAG", async () => {
     const scheduler = makeScheduler(makeRegistry(db))
     const session = makeSession("loner", db)

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -256,19 +256,33 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
   }
 
   async function onSessionCompleted(sessionId: string, state: SessionRunState): Promise<void> {
-    const dagId = nodeToGraph.get(sessionId)
-    if (!dagId) return
+    let dagId = nodeToGraph.get(sessionId)
+    let nodeId: string | undefined
 
-    const graph = activeGraphs.get(dagId)
-    if (!graph) return
+    if (dagId) {
+      const nodeEntry = Array.from(nodeToSession.entries()).find(([, sid]) => sid === sessionId)
+      if (nodeEntry) nodeId = nodeEntry[0]
+    }
 
-    const nodeEntry = Array.from(nodeToSession.entries()).find(([, sid]) => sid === sessionId)
-    if (!nodeEntry) return
-    const [nodeId] = nodeEntry
+    if (!dagId || !nodeId) {
+      const lookup = prepared.getDagNodeBySessionId(db, sessionId)
+      if (!lookup) return
+      dagId = lookup.dag_id
+      nodeId = lookup.node_id
+    }
+
+    let graph = activeGraphs.get(dagId)
+    if (!graph) {
+      const stored = loadDag(dagId, db)
+      if (!stored) return
+      graph = stored
+      activeGraphs.set(dagId, graph)
+    }
 
     const idx = nodeIndex(graph)
     const node = idx.get(nodeId)
     if (!node) return
+    if (node.status !== "running") return
 
     nodeToSession.delete(nodeId)
     nodeToGraph.delete(sessionId)
@@ -400,22 +414,20 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
   }
 
   async function onSessionResumed(sessionId: string): Promise<void> {
-    const row = prepared.getSession(db, sessionId)
-    if (!row) return
-    const meta = row.metadata as { dagId?: string; dagNodeId?: string }
-    if (!meta.dagId || !meta.dagNodeId) return
+    const lookup = prepared.getDagNodeBySessionId(db, sessionId)
+    if (!lookup) return
 
-    let graph = activeGraphs.get(meta.dagId)
+    let graph = activeGraphs.get(lookup.dag_id)
     if (!graph) {
-      const stored = loadDag(meta.dagId, db)
+      const stored = loadDag(lookup.dag_id, db)
       if (!stored) return
       graph = stored
-      activeGraphs.set(meta.dagId, graph)
-      cancelledDags.delete(meta.dagId)
+      activeGraphs.set(lookup.dag_id, graph)
+      cancelledDags.delete(lookup.dag_id)
     }
 
     const idx = nodeIndex(graph)
-    const node = idx.get(meta.dagNodeId)
+    const node = idx.get(lookup.node_id)
     if (!node) return
     if (node.status !== "failed" && node.status !== "ci-failed") return
 

--- a/server/db/sqlite.test.ts
+++ b/server/db/sqlite.test.ts
@@ -368,6 +368,168 @@ test('migration 0007 migrates legacy ship modes to ship with stage', () => {
   }
 })
 
+test('getDagNodeBySessionId returns dag_id, node_id, and status for linked node', () => {
+  const now = Date.now()
+
+  prepared.insertSession(db, {
+    id: 'sess-dag-link',
+    slug: 'dag-link',
+    status: 'running',
+    command: 'cmd',
+    mode: 'dag-task',
+    repo: 'org/repo',
+    branch: null,
+    bare_dir: null,
+    pr_url: null,
+    parent_id: null,
+    variant_group_id: null,
+    claude_session_id: null,
+    workspace_root: null,
+    created_at: now,
+    updated_at: now,
+    needs_attention: false,
+    attention_reasons: [],
+    quick_actions: [],
+    conversation: [],
+    quota_sleep_until: null,
+    quota_retry_count: 0,
+    metadata: { dagId: 'dag-1', dagNodeId: 'node-a' },
+    pipeline_advancing: false,
+    stage: null,
+    coordinator_children: [],
+  })
+
+  prepared.insertDag(db, {
+    id: 'dag-1',
+    root_task_id: 'root-1',
+    status: 'running',
+    repo: 'org/repo',
+    created_at: now,
+    updated_at: now,
+  })
+
+  prepared.upsertDagNode(db, {
+    dag_id: 'dag-1',
+    id: 'node-a',
+    slug: 'node-a',
+    status: 'running',
+    session_id: 'sess-dag-link',
+    dependencies: [],
+    dependents: [],
+    payload: { title: 'Node A', description: 'first' },
+  })
+
+  const lookup = prepared.getDagNodeBySessionId(db, 'sess-dag-link')
+  expect(lookup).not.toBeNull()
+  expect(lookup!.dag_id).toBe('dag-1')
+  expect(lookup!.node_id).toBe('node-a')
+  expect(lookup!.status).toBe('running')
+})
+
+test('getDagNodeBySessionId returns null for unlinked session', () => {
+  const now = Date.now()
+  prepared.insertSession(db, {
+    id: 'sess-loner',
+    slug: 'loner',
+    status: 'running',
+    command: 'cmd',
+    mode: 'task',
+    repo: null,
+    branch: null,
+    bare_dir: null,
+    pr_url: null,
+    parent_id: null,
+    variant_group_id: null,
+    claude_session_id: null,
+    workspace_root: null,
+    created_at: now,
+    updated_at: now,
+    needs_attention: false,
+    attention_reasons: [],
+    quick_actions: [],
+    conversation: [],
+    quota_sleep_until: null,
+    quota_retry_count: 0,
+    metadata: {},
+    pipeline_advancing: false,
+    stage: null,
+    coordinator_children: [],
+  })
+
+  expect(prepared.getDagNodeBySessionId(db, 'sess-loner')).toBeNull()
+  expect(prepared.getDagNodeBySessionId(db, 'sess-nonexistent')).toBeNull()
+})
+
+test('getDagNodeBySessionId tracks updates after upsertDagNode replaces session_id', () => {
+  const now = Date.now()
+
+  for (const id of ['old-session', 'new-session']) {
+    prepared.insertSession(db, {
+      id,
+      slug: id,
+      status: 'running',
+      command: 'cmd',
+      mode: 'dag-task',
+      repo: null,
+      branch: null,
+      bare_dir: null,
+      pr_url: null,
+      parent_id: null,
+      variant_group_id: null,
+      claude_session_id: null,
+      workspace_root: null,
+      created_at: now,
+      updated_at: now,
+      needs_attention: false,
+      attention_reasons: [],
+      quick_actions: [],
+      conversation: [],
+      quota_sleep_until: null,
+      quota_retry_count: 0,
+      metadata: {},
+      pipeline_advancing: false,
+      stage: null,
+      coordinator_children: [],
+    })
+  }
+
+  prepared.insertDag(db, {
+    id: 'dag-retry',
+    root_task_id: 'root-r',
+    status: 'running',
+    repo: null,
+    created_at: now,
+    updated_at: now,
+  })
+
+  prepared.upsertDagNode(db, {
+    dag_id: 'dag-retry',
+    id: 'node-r',
+    slug: 'node-r',
+    status: 'running',
+    session_id: 'old-session',
+    dependencies: [],
+    dependents: [],
+    payload: { title: 'r', description: 'r' },
+  })
+
+  expect(prepared.getDagNodeBySessionId(db, 'old-session')!.node_id).toBe('node-r')
+
+  prepared.upsertDagNode(db, {
+    dag_id: 'dag-retry',
+    id: 'node-r',
+    slug: 'node-r',
+    status: 'running',
+    session_id: 'new-session',
+    dependencies: [],
+    dependents: [],
+    payload: { title: 'r', description: 'r' },
+  })
+
+  expect(prepared.getDagNodeBySessionId(db, 'old-session')).toBeNull()
+  expect(prepared.getDagNodeBySessionId(db, 'new-session')!.node_id).toBe('node-r')
+})
+
 test('memories table has all expected columns and constraints', () => {
   const now = Date.now()
 

--- a/server/db/sqlite.ts
+++ b/server/db/sqlite.ts
@@ -208,6 +208,13 @@ type StmtCache = {
   listDags?: ReturnType<Database['prepare']>
   deleteDag?: ReturnType<Database['prepare']>
   upsertDagNode?: ReturnType<Database['prepare']>
+  getDagNodeBySessionId?: ReturnType<Database['prepare']>
+}
+
+export interface DagNodeSessionLookup {
+  dag_id: string
+  node_id: string
+  status: DagNodeStatus
 }
 
 const dbCaches = new WeakMap<Database, StmtCache>()
@@ -711,5 +718,17 @@ export const prepared = {
       .query<DagNodeDbRow, [string]>('SELECT * FROM dag_nodes WHERE dag_id = ?')
       .all(dagId)
     return rows.map(mapDagNodeRow)
+  },
+
+  getDagNodeBySessionId(db: Database, sessionId: string): DagNodeSessionLookup | null {
+    const c = stmts(db)
+    if (!c.getDagNodeBySessionId) {
+      c.getDagNodeBySessionId = db.prepare<{ dag_id: string; id: string; status: DagNodeStatus }, [string]>(
+        'SELECT dag_id, id, status FROM dag_nodes WHERE session_id = ? LIMIT 1',
+      )
+    }
+    const row = c.getDagNodeBySessionId.get(sessionId) as { dag_id: string; id: string; status: DagNodeStatus } | null
+    if (!row) return null
+    return { dag_id: row.dag_id, node_id: row.id, status: row.status }
   },
 }


### PR DESCRIPTION
## Summary

Adds `prepared.getDagNodeBySessionId(db, sessionId)` — an indexed reverse
lookup `(session_id) → (dag_id, node_id, status)` backed by the existing
`idx_dag_nodes_session` index. The scheduler can now resolve a session's
DAG node without scanning all DAGs or relying on its in-memory
`nodeToSession` / `nodeToGraph` maps.

Concrete uses:

- `scheduler.onSessionCompleted` falls back to the DB lookup when the
  in-memory cache is empty (e.g. session-completion events that arrive
  before `reconcileOnBoot`, or for code paths that bypass the live
  scheduler instance) instead of silently dropping them.
- `scheduler.onSessionResumed` now reads from the indexed `dag_nodes.session_id`
  column instead of parsing unindexed `sessions.metadata` JSON.

This is the smallest persistent-state primitive needed to unwind the
in-memory map without changing boot reconciliation or other scheduler
contracts.

## Test plan

- [x] `bun test server/db/sqlite.test.ts` — 3 new tests for
  `getDagNodeBySessionId` (linked node, unlinked session, session_id replacement on retry)
- [x] `bun test server/dag/scheduler.test.ts` — 3 new tests covering the
  DB-fallback path in `onSessionCompleted`, the running-only guard, and
  the indexed `onSessionResumed` lookup
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (vitest unit + component) — 1083 passing
- [x] `bun test server/ shared/` — same 14 pre-existing failures as baseline,
  no new regressions
