### PR TITLE
feat(scheduler): persist deferred restack queue

### DIFF
--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -1222,6 +1222,21 @@ describe("DagScheduler", () => {
 })
 
 describe("DagScheduler restack integration", () => {
+  function countDeferredRestacks(db: Database): number {
+    const row = db
+      .query<{ c: number }, []>("SELECT COUNT(*) as c FROM dag_deferred_restacks")
+      .get()
+    return row?.c ?? 0
+  }
+
+  function listDeferredRestacks(db: Database): Array<{ dag_id: string; session_id: string; node_id: string }> {
+    return db
+      .query<{ dag_id: string; session_id: string; node_id: string }, []>(
+        "SELECT dag_id, session_id, node_id FROM dag_deferred_restacks ORDER BY created_at ASC",
+      )
+      .all()
+  }
+
   it("defers restack when node is running", async () => {
     const db = makeTestDb()
     const bus = new EngineEventBus()
@@ -1315,5 +1330,317 @@ describe("DagScheduler restack integration", () => {
     })
 
     await scheduler.onSessionCompleted(sessions[0]!.id, "completed")
+  })
+
+  it("persists deferred restack to dag_deferred_restacks when node is running", async () => {
+    const db = makeTestDb()
+    const bus = new EngineEventBus()
+    const sessions: ApiSession[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`sess-${sessions.length}`, db)
+      sessions.push(session)
+      return { session, runtime: {} as never }
+    })
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp/workspace",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+    })
+
+    const graph = buildDag("dag-persist-deferred", [
+      { id: "a", title: "Task A", description: "First", dependsOn: [] },
+      { id: "b", title: "Task B", description: "Second", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    await scheduler.start("dag-persist-deferred")
+
+    graph.nodes[0]!.status = "running"
+    graph.nodes[0]!.sessionId = sessions[0]!.id
+    saveDag(graph, db)
+
+    expect(countDeferredRestacks(db)).toBe(0)
+
+    bus.emit({
+      kind: "dag.node.pushed",
+      dagId: "dag-persist-deferred",
+      nodeId: "a",
+      parentSha: "old-sha",
+      newSha: "new-sha",
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const rows = listDeferredRestacks(db)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.dag_id).toBe("dag-persist-deferred")
+    expect(rows[0]!.session_id).toBe(sessions[0]!.id)
+    expect(rows[0]!.node_id).toBe("a")
+  })
+
+  it("does not persist deferred restack when node is not running", async () => {
+    const db = makeTestDb()
+    const bus = new EngineEventBus()
+    const registry = makeRegistry(db)
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp/workspace",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+    })
+
+    const graph = buildDag("dag-no-defer", [
+      { id: "a", title: "Task A", description: "First", dependsOn: [] },
+      { id: "b", title: "Task B", description: "Second", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    graph.nodes[0]!.status = "done"
+    graph.nodes[0]!.branch = "minion/test-a"
+    saveDag(graph, db)
+
+    await scheduler.start("dag-no-defer")
+
+    bus.emit({
+      kind: "dag.node.pushed",
+      dagId: "dag-no-defer",
+      nodeId: "a",
+      parentSha: "old-sha",
+      newSha: "new-sha",
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(countDeferredRestacks(db)).toBe(0)
+  })
+
+  it("removes deferred restack rows after onSessionCompleted drains the queue", async () => {
+    const db = makeTestDb()
+    const bus = new EngineEventBus()
+    const sessions: ApiSession[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`sess-${sessions.length}`, db)
+      sessions.push(session)
+      return { session, runtime: {} as never }
+    })
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp/workspace",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+    })
+
+    const graph = buildDag("dag-drain-on-complete", [
+      { id: "a", title: "Task A", description: "First", dependsOn: [] },
+      { id: "b", title: "Task B", description: "Second", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    graph.nodes[0]!.branch = "minion/test-a"
+    graph.nodes[1]!.branch = "minion/test-b"
+    saveDag(graph, db)
+
+    await scheduler.start("dag-drain-on-complete")
+
+    graph.nodes[0]!.status = "running"
+    graph.nodes[0]!.sessionId = sessions[0]!.id
+    saveDag(graph, db)
+
+    bus.emit({
+      kind: "dag.node.pushed",
+      dagId: "dag-drain-on-complete",
+      nodeId: "a",
+      parentSha: "old-sha",
+      newSha: "new-sha",
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(countDeferredRestacks(db)).toBe(1)
+
+    await scheduler.onSessionCompleted(sessions[0]!.id, "completed")
+
+    expect(countDeferredRestacks(db)).toBe(0)
+  })
+
+  it("cancel removes deferred restacks for cancelled DAG sessions", async () => {
+    const db = makeTestDb()
+    const bus = new EngineEventBus()
+    const sessions: ApiSession[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`sess-${sessions.length}`, db)
+      sessions.push(session)
+      return { session, runtime: {} as never }
+    })
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp/workspace",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+    })
+
+    const graph = buildDag("dag-cancel-deferred", [
+      { id: "a", title: "Task A", description: "First", dependsOn: [] },
+      { id: "b", title: "Task B", description: "Second", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    await scheduler.start("dag-cancel-deferred")
+
+    graph.nodes[0]!.status = "running"
+    graph.nodes[0]!.sessionId = sessions[0]!.id
+    saveDag(graph, db)
+
+    bus.emit({
+      kind: "dag.node.pushed",
+      dagId: "dag-cancel-deferred",
+      nodeId: "a",
+      parentSha: "old-sha",
+      newSha: "new-sha",
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(countDeferredRestacks(db)).toBe(1)
+
+    await scheduler.cancel("dag-cancel-deferred")
+    expect(countDeferredRestacks(db)).toBe(0)
+  })
+
+  it("reconcileOnBoot drains deferred restacks for sessions that completed while engine was down", async () => {
+    const db = makeTestDb()
+
+    const graph = buildDag("dag-boot-drain", [
+      { id: "a", title: "Task A", description: "First", dependsOn: [] },
+      { id: "b", title: "Task B", description: "Second", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    graph.nodes[0]!.branch = "minion/test-a"
+    graph.nodes[0]!.status = "done"
+    graph.nodes[1]!.branch = "minion/test-b"
+    graph.nodes[1]!.status = "ready"
+    saveDag(graph, db)
+
+    prepared.insertDeferredRestack(db, {
+      id: "dr-1",
+      dag_id: "dag-boot-drain",
+      session_id: "completed-session",
+      node_id: "a",
+      parent_sha: "old",
+      new_sha: "new",
+      cascade_depth: 0,
+      created_at: Date.now(),
+    })
+    expect(countDeferredRestacks(db)).toBe(1)
+
+    const bus = new EngineEventBus()
+    const registry = makeRegistry(db)
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp/workspace",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+    })
+
+    await scheduler.reconcileOnBoot()
+
+    expect(countDeferredRestacks(db)).toBe(0)
+  })
+
+  it("reconcileOnBoot keeps deferred restacks for sessions that are still running", async () => {
+    const db = makeTestDb()
+
+    const session = makeSession("running-after-boot", db)
+    prepared.updateSession(db, {
+      id: session.id,
+      updated_at: Date.now(),
+      metadata: { dagId: "dag-boot-keep", dagNodeId: "a" },
+    })
+
+    const graph = buildDag("dag-boot-keep", [
+      { id: "a", title: "Task A", description: "First", dependsOn: [] },
+      { id: "b", title: "Task B", description: "Second", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    graph.nodes[0]!.status = "running"
+    graph.nodes[0]!.sessionId = session.id
+    graph.nodes[0]!.branch = "minion/test-a"
+    graph.nodes[1]!.branch = "minion/test-b"
+    saveDag(graph, db)
+
+    prepared.insertDeferredRestack(db, {
+      id: "dr-keep",
+      dag_id: "dag-boot-keep",
+      session_id: session.id,
+      node_id: "a",
+      parent_sha: "old",
+      new_sha: "new",
+      cascade_depth: 0,
+      created_at: Date.now(),
+    })
+    expect(countDeferredRestacks(db)).toBe(1)
+
+    const bus = new EngineEventBus()
+    const registry = makeRegistry(db)
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp/workspace",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+    })
+
+    await scheduler.reconcileOnBoot()
+
+    expect(countDeferredRestacks(db)).toBe(1)
+    const rows = listDeferredRestacks(db)
+    expect(rows[0]!.session_id).toBe(session.id)
+  })
+
+  it("deleting a DAG cascades and removes its deferred restacks", () => {
+    const db = makeTestDb()
+
+    const graph = buildDag("dag-cascade", [
+      { id: "a", title: "Task A", description: "First", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    prepared.insertDeferredRestack(db, {
+      id: "dr-cascade",
+      dag_id: "dag-cascade",
+      session_id: "any-session",
+      node_id: "a",
+      parent_sha: "old",
+      new_sha: "new",
+      cascade_depth: 0,
+      created_at: Date.now(),
+    })
+    expect(countDeferredRestacks(db)).toBe(1)
+
+    db.run("DELETE FROM dags WHERE id = ?", ["dag-cascade"])
+
+    expect(countDeferredRestacks(db)).toBe(0)
   })
 })

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -1,8 +1,10 @@
+import crypto from "node:crypto"
 import type { Database } from "bun:sqlite"
 import { readyNodes, advanceDag, failNode, resetFailedNode, nodeIndex, getUpstreamBranches, isDagComplete, dagGraphStatus, isTerminalStatus } from "./dag"
 import type { DagGraph, DagNode, DagInput } from "./dag"
 import { saveDag, loadDag, listDags } from "./store"
 import { prepared } from "../db/sqlite"
+import type { DagDeferredRestackRow } from "../db/sqlite"
 import { updateStackComment } from "./stack-comment"
 import { buildDagChildPrompt } from "./dag-extract"
 import type { TopicMessage } from "./types"
@@ -140,7 +142,38 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     registry,
   })
 
-  const deferredRestacks = new Map<string, Array<{ dagId: string; nodeId: string; parentSha: string; newSha: string; cascadeDepth: number }>>()
+  function rowToDeferredEvent(row: DagDeferredRestackRow): {
+    dagId: string
+    nodeId: string
+    parentSha: string
+    newSha: string
+    cascadeDepth: number
+  } {
+    return {
+      dagId: row.dag_id,
+      nodeId: row.node_id,
+      parentSha: row.parent_sha,
+      newSha: row.new_sha,
+      cascadeDepth: row.cascade_depth,
+    }
+  }
+
+  async function drainDeferredRestacksForSession(sessionId: string): Promise<void> {
+    const rows = prepared.listDeferredRestacksBySession(db, sessionId)
+    for (const row of rows) {
+      const dagGraph = activeGraphs.get(row.dag_id) ?? loadDag(row.dag_id, db)
+      if (!dagGraph) {
+        prepared.deleteDeferredRestack(db, row.id)
+        continue
+      }
+      try {
+        await restackManager.onParentPushed(rowToDeferredEvent(row), dagGraph)
+      } catch (err) {
+        console.error(`[scheduler] deferred restack failed for node ${row.node_id}:`, err)
+      }
+      prepared.deleteDeferredRestack(db, row.id)
+    }
+  }
 
   const watchdog: DagWatchdog = createDagWatchdog({
     bus,
@@ -422,18 +455,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     await commentUpdater(graph)
     await tickGraph(graph)
 
-    const deferred = deferredRestacks.get(sessionId)
-    if (deferred) {
-      deferredRestacks.delete(sessionId)
-      for (const event of deferred) {
-        const dagGraph = activeGraphs.get(event.dagId)
-        if (dagGraph) {
-          await restackManager.onParentPushed(event, dagGraph).catch((err) => {
-            console.error(`[scheduler] deferred restack failed for node ${event.nodeId}:`, err)
-          })
-        }
-      }
-    }
+    await drainDeferredRestacksForSession(sessionId)
   }
 
   async function cancel(dagId: string): Promise<void> {
@@ -456,7 +478,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
         if (node.status === "running") sessionsToStop.push(sessionId)
         nodeToSession.delete(node.id)
         nodeToGraph.delete(sessionId)
-        deferredRestacks.delete(sessionId)
+        prepared.deleteDeferredRestacksBySession(db, sessionId)
       }
 
       node.status = "cancelled"
@@ -596,6 +618,29 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
       await commentUpdater(graph).catch(() => {})
       await tickGraph(graph)
     }
+
+    await reconcileDeferredRestacks()
+  }
+
+  async function reconcileDeferredRestacks(): Promise<void> {
+    const rows = prepared.listAllDeferredRestacks(db)
+    const sessionsStillRunning = new Set(nodeToSession.values())
+    for (const row of rows) {
+      if (sessionsStillRunning.has(row.session_id)) continue
+
+      const dagGraph = activeGraphs.get(row.dag_id) ?? loadDag(row.dag_id, db)
+      if (!dagGraph) {
+        prepared.deleteDeferredRestack(db, row.id)
+        continue
+      }
+
+      try {
+        await restackManager.onParentPushed(rowToDeferredEvent(row), dagGraph)
+      } catch (err) {
+        console.error(`[scheduler] boot deferred restack failed for node ${row.node_id}:`, err)
+      }
+      prepared.deleteDeferredRestack(db, row.id)
+    }
   }
 
   async function forceNodeLanded(nodeId: string, dagId: string): Promise<void> {
@@ -638,15 +683,15 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     if (node.status === "running") {
       const sessionId = node.sessionId
       if (sessionId) {
-        if (!deferredRestacks.has(sessionId)) {
-          deferredRestacks.set(sessionId, [])
-        }
-        deferredRestacks.get(sessionId)!.push({
-          dagId: event.dagId,
-          nodeId: event.nodeId,
-          parentSha: event.parentSha,
-          newSha: event.newSha,
-          cascadeDepth: 0,
+        prepared.insertDeferredRestack(db, {
+          id: crypto.randomUUID(),
+          dag_id: event.dagId,
+          session_id: sessionId,
+          node_id: event.nodeId,
+          parent_sha: event.parentSha,
+          new_sha: event.newSha,
+          cascade_depth: 0,
+          created_at: Date.now(),
         })
         console.log(`[scheduler] defer restack for running node ${event.nodeId}`)
         return

--- a/server/db/migrations/0014_dag_deferred_restacks.sql
+++ b/server/db/migrations/0014_dag_deferred_restacks.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS dag_deferred_restacks (
+  id TEXT PRIMARY KEY,
+  dag_id TEXT NOT NULL REFERENCES dags(id) ON DELETE CASCADE,
+  session_id TEXT NOT NULL,
+  node_id TEXT NOT NULL,
+  parent_sha TEXT NOT NULL,
+  new_sha TEXT NOT NULL,
+  cascade_depth INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_dag_deferred_restacks_session ON dag_deferred_restacks(session_id);
+CREATE INDEX IF NOT EXISTS idx_dag_deferred_restacks_dag ON dag_deferred_restacks(dag_id);

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -121,6 +121,20 @@ CREATE TABLE IF NOT EXISTS dag_nodes (
 
 CREATE INDEX IF NOT EXISTS idx_dag_nodes_session ON dag_nodes(session_id);
 
+CREATE TABLE IF NOT EXISTS dag_deferred_restacks (
+  id TEXT PRIMARY KEY,
+  dag_id TEXT NOT NULL REFERENCES dags(id) ON DELETE CASCADE,
+  session_id TEXT NOT NULL,
+  node_id TEXT NOT NULL,
+  parent_sha TEXT NOT NULL,
+  new_sha TEXT NOT NULL,
+  cascade_depth INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_dag_deferred_restacks_session ON dag_deferred_restacks(session_id);
+CREATE INDEX IF NOT EXISTS idx_dag_deferred_restacks_dag ON dag_deferred_restacks(dag_id);
+
 CREATE TABLE IF NOT EXISTS push_subscriptions (
   id TEXT PRIMARY KEY,
   endpoint TEXT NOT NULL UNIQUE,

--- a/server/db/sqlite.ts
+++ b/server/db/sqlite.ts
@@ -171,6 +171,17 @@ interface DagNodeRow {
   payload: Record<string, unknown>
 }
 
+export interface DagDeferredRestackRow {
+  id: string
+  dag_id: string
+  session_id: string
+  node_id: string
+  parent_sha: string
+  new_sha: string
+  cascade_depth: number
+  created_at: number
+}
+
 interface DagNodeDbRow {
   dag_id: string
   id: string
@@ -210,6 +221,11 @@ type StmtCache = {
   deleteDag?: ReturnType<Database['prepare']>
   upsertDagNode?: ReturnType<Database['prepare']>
   getDagNodeBySessionId?: ReturnType<Database['prepare']>
+  insertDeferredRestack?: ReturnType<Database['prepare']>
+  listDeferredRestacksBySession?: ReturnType<Database['prepare']>
+  listAllDeferredRestacks?: ReturnType<Database['prepare']>
+  deleteDeferredRestack?: ReturnType<Database['prepare']>
+  deleteDeferredRestacksBySession?: ReturnType<Database['prepare']>
 }
 
 export interface DagNodeSessionLookup {
@@ -734,5 +750,63 @@ export const prepared = {
     const row = c.getDagNodeBySessionId.get(sessionId) as { dag_id: string; id: string; status: DagNodeStatus } | null
     if (!row) return null
     return { dag_id: row.dag_id, node_id: row.id, status: row.status }
+  },
+
+  insertDeferredRestack(db: Database, row: DagDeferredRestackRow): void {
+    const c = stmts(db)
+    if (!c.insertDeferredRestack) {
+      c.insertDeferredRestack = db.prepare(
+        `INSERT INTO dag_deferred_restacks (id, dag_id, session_id, node_id, parent_sha, new_sha, cascade_depth, created_at)
+         VALUES ($id, $dag_id, $session_id, $node_id, $parent_sha, $new_sha, $cascade_depth, $created_at)`,
+      )
+    }
+    c.insertDeferredRestack.run({
+      $id: row.id,
+      $dag_id: row.dag_id,
+      $session_id: row.session_id,
+      $node_id: row.node_id,
+      $parent_sha: row.parent_sha,
+      $new_sha: row.new_sha,
+      $cascade_depth: row.cascade_depth,
+      $created_at: row.created_at,
+    })
+  },
+
+  listDeferredRestacksBySession(db: Database, sessionId: string): DagDeferredRestackRow[] {
+    const c = stmts(db)
+    if (!c.listDeferredRestacksBySession) {
+      c.listDeferredRestacksBySession = db.prepare<DagDeferredRestackRow, [string]>(
+        'SELECT * FROM dag_deferred_restacks WHERE session_id = ? ORDER BY created_at ASC',
+      )
+    }
+    return c.listDeferredRestacksBySession.all(sessionId) as DagDeferredRestackRow[]
+  },
+
+  listAllDeferredRestacks(db: Database): DagDeferredRestackRow[] {
+    const c = stmts(db)
+    if (!c.listAllDeferredRestacks) {
+      c.listAllDeferredRestacks = db.prepare<DagDeferredRestackRow, []>(
+        'SELECT * FROM dag_deferred_restacks ORDER BY created_at ASC',
+      )
+    }
+    return c.listAllDeferredRestacks.all() as DagDeferredRestackRow[]
+  },
+
+  deleteDeferredRestack(db: Database, id: string): void {
+    const c = stmts(db)
+    if (!c.deleteDeferredRestack) {
+      c.deleteDeferredRestack = db.prepare('DELETE FROM dag_deferred_restacks WHERE id = ?')
+    }
+    c.deleteDeferredRestack.run(id)
+  },
+
+  deleteDeferredRestacksBySession(db: Database, sessionId: string): void {
+    const c = stmts(db)
+    if (!c.deleteDeferredRestacksBySession) {
+      c.deleteDeferredRestacksBySession = db.prepare(
+        'DELETE FROM dag_deferred_restacks WHERE session_id = ?',
+      )
+    }
+    c.deleteDeferredRestacksBySession.run(sessionId)
   },
 }


### PR DESCRIPTION
## Summary

The DAG scheduler defers restacks of children when their parent node is still running so the running session's branch doesn't get yanked under it. Until this change, the deferred queue was an in-memory `Map`, so a crash between deferral and the running session's completion silently lost the restack — downstream branches were left pointing at the pre-rebase parent SHA forever.

This PR persists deferred restacks to a new `dag_deferred_restacks` table keyed by `session_id` (with `ON DELETE CASCADE` on `dags`). The behavior on the happy path is unchanged; what changes is durability:

- **Enqueue** (`dag.node.pushed` for a running parent): insert a row instead of pushing onto the in-memory `Map`.
- **Drain on completion** (`onSessionCompleted`): query rows for the session, replay each via `restackManager.onParentPushed`, then delete.
- **Boot reconcile** (`reconcileOnBoot`): after rebuilding `nodeToSession`, replay any persisted rows whose session is no longer running. Rows for sessions still running stay in DB and drain naturally on completion.
- **Cancel** (`cancel`): purge rows for the cancelled DAG's sessions so they don't leak after the DAG goes away.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `bun test server/dag/` — 176/176 pass (was 168/168 before, +8 new tests)
- [x] `npm run test` (vitest) — 1083/1083 pass
- [x] New tests cover: enqueue persists row; non-running parents don't enqueue; completion drains the row; cancel purges; boot reconcile drains completed-while-down sessions; boot reconcile keeps still-running rows; FK cascade removes rows when DAG is deleted.
