### PR TITLE
feat(orchestration): priority-ordered admission control

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,7 @@ import {
 import { createDagScheduler } from './dag/scheduler'
 import { createLandingManager } from './dag/landing'
 import { LoopScheduler } from './loops/scheduler'
+import { createAdmissionController } from './orchestration/admission'
 import { DEFAULT_LOOPS } from './loops/definitions'
 import { listLoops } from './loops/store'
 import { ResourceMonitor } from './metrics/resource'
@@ -46,6 +47,9 @@ const DEFAULT_REPO = process.env['DEFAULT_REPO'] ?? ''
 const MAX_CONCURRENT_SESSIONS = Number(process.env['MAX_CONCURRENT_SESSIONS'] ?? 10)
 const MAX_CONCURRENT_LOOPS = Number(process.env['MAX_CONCURRENT_LOOPS'] ?? 3)
 const RESERVED_INTERACTIVE_SLOTS = Number(process.env['RESERVED_INTERACTIVE_SLOTS'] ?? 2)
+const RESERVED_SHIP_ROOT_SLOTS = Number(process.env['RESERVED_SHIP_ROOT_SLOTS'] ?? 1)
+const RESERVED_SHIP_VERIFY_SLOTS = Number(process.env['RESERVED_SHIP_VERIFY_SLOTS'] ?? 0)
+const RESERVED_DAG_TASK_SLOTS = Number(process.env['RESERVED_DAG_TASK_SLOTS'] ?? 0)
 const QUOTA_RETRY_MAX = Number(process.env['QUOTA_RETRY_MAX'] ?? 3)
 const QUOTA_DEFAULT_SLEEP_MS = Number(process.env['QUOTA_DEFAULT_SLEEP_MS'] ?? 5 * 60 * 1000)
 const DISK_PATH = process.env['METRICS_DISK_PATH'] ?? WORKSPACE_ROOT
@@ -61,7 +65,18 @@ const askpass = installAskpass()
 process.env['GIT_ASKPASS'] = askpass.envOverrides['GIT_ASKPASS']
 process.env['SSH_ASKPASS'] = askpass.envOverrides['SSH_ASKPASS']
 
-const registry = createSessionRegistry({ getDb: () => db })
+const admission = createAdmissionController({
+  totalCap: MAX_CONCURRENT_SESSIONS,
+  reservedSlots: {
+    interactive: RESERVED_INTERACTIVE_SLOTS,
+    'ship-root': RESERVED_SHIP_ROOT_SLOTS,
+    'ship-verify': RESERVED_SHIP_VERIFY_SLOTS,
+    'dag-task': RESERVED_DAG_TASK_SLOTS,
+    loop: 0,
+  },
+})
+
+const registry = createSessionRegistry({ getDb: () => db, admission })
 const bus = getEventBus()
 
 await registry.reconcileOnBoot()
@@ -90,6 +105,7 @@ const loopScheduler = new LoopScheduler({
   maxConcurrentSessions: MAX_CONCURRENT_SESSIONS,
   getInteractiveSessionCount: () =>
     registry.list().filter((s) => s.mode !== 'loop').length,
+  admission,
 })
 
 const replyQueueFactory: ReplyQueueFactory = {

--- a/server/loops/scheduler.test.ts
+++ b/server/loops/scheduler.test.ts
@@ -7,6 +7,7 @@ import { getLoop, listLoops } from './store'
 import type { SessionRegistry, CreateSessionOpts } from '../session/registry'
 import type { ApiSession } from '../../shared/api-types'
 import type { SessionRuntime } from '../session/runtime'
+import { AdmissionDeniedError, createAdmissionController } from '../orchestration/admission'
 
 function makeTestDb(): Database {
   const db = openDatabase(':memory:')
@@ -200,5 +201,127 @@ describe('LoopScheduler', () => {
 
     await sched.tick(Date.now())
     expect(created).toHaveLength(0)
+  })
+
+  describe('admission integration', () => {
+    test('tick skips when admission peek denies loop priority', async () => {
+      const created: string[] = []
+      const admission = createAdmissionController({
+        totalCap: 2,
+        reservedSlots: { interactive: 2, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+      })
+
+      const sched = new LoopScheduler({
+        db,
+        registry: makeRegistry(async (opts) => {
+          created.push(opts.prompt)
+          return { session: makeSession('s'), runtime: {} as SessionRuntime }
+        }),
+        workspaceRoot: '/tmp/test-ws',
+        repo: 'https://github.com/org/repo',
+        maxConcurrentSessions: 10,
+        getInteractiveSessionCount: () => 0,
+        admission,
+      })
+
+      await sched.tick(Date.now())
+      expect(created).toHaveLength(0)
+    })
+
+    test('AdmissionDeniedError from registry.create does not increment failure counter', async () => {
+      const admission = createAdmissionController({
+        totalCap: 1,
+        reservedSlots: { interactive: 0, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+      })
+
+      let createCalls = 0
+      const sched = new LoopScheduler({
+        db,
+        registry: makeRegistry(async () => {
+          createCalls++
+          throw new AdmissionDeniedError({
+            admitted: false,
+            priority: 'loop',
+            capForPriority: 1,
+            active: 1,
+            activeAtOrBelow: 1,
+            reason: 'denied for test',
+          })
+        }),
+        workspaceRoot: '/tmp/test-ws',
+        repo: 'https://github.com/org/repo',
+        maxConcurrentSessions: 10,
+        getInteractiveSessionCount: () => 0,
+        admission,
+      })
+
+      await sched.kickLoop('test-coverage')
+
+      expect(createCalls).toBe(1)
+      const row = getLoop(db, 'test-coverage')
+      expect(row!.consecutive_failures).toBe(0)
+    })
+
+    test('non-admission errors still increment failure counter', async () => {
+      const sched = new LoopScheduler({
+        db,
+        registry: makeRegistry(async () => {
+          throw new Error('something else broke')
+        }),
+        workspaceRoot: '/tmp/test-ws',
+        repo: 'https://github.com/org/repo',
+        maxConcurrentSessions: 10,
+        getInteractiveSessionCount: () => 0,
+      })
+
+      await sched.kickLoop('test-coverage')
+
+      const row = getLoop(db, 'test-coverage')
+      expect(row!.consecutive_failures).toBe(1)
+    })
+
+    test('tick fires loops when admission peek for loop priority is admitted', async () => {
+      const admission = createAdmissionController({
+        totalCap: 5,
+        reservedSlots: { interactive: 2, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+      })
+
+      const created: string[] = []
+      const sched = new LoopScheduler({
+        db,
+        registry: makeRegistry(async () => {
+          created.push('called')
+          return { session: makeSession('s-' + created.length), runtime: {} as SessionRuntime }
+        }),
+        workspaceRoot: '/tmp/test-ws',
+        repo: 'https://github.com/org/repo',
+        maxConcurrentSessions: 10,
+        getInteractiveSessionCount: () => 0,
+        admission,
+      })
+
+      await sched.tick(Date.now())
+      expect(created.length).toBeGreaterThan(0)
+    })
+
+    test('kickLoop passes loopId in metadata so admission classifies as loop priority', async () => {
+      const seenMetadata: Array<Record<string, unknown> | undefined> = []
+      const sched = new LoopScheduler({
+        db,
+        registry: makeRegistry(async (opts) => {
+          seenMetadata.push(opts.metadata)
+          return { session: makeSession('s'), runtime: {} as SessionRuntime }
+        }),
+        workspaceRoot: '/tmp/test-ws',
+        repo: 'https://github.com/org/repo',
+        maxConcurrentSessions: 10,
+        getInteractiveSessionCount: () => 0,
+      })
+
+      await sched.kickLoop('test-coverage')
+
+      expect(seenMetadata).toHaveLength(1)
+      expect(seenMetadata[0]).toMatchObject({ loopId: 'test-coverage' })
+    })
   })
 })

--- a/server/loops/scheduler.ts
+++ b/server/loops/scheduler.ts
@@ -4,6 +4,7 @@ import type { LoopScheduler as LoopSchedulerInterface } from '../handlers/types'
 import { DEFAULT_LOOPS, type LoopDefinition } from './definitions'
 import { upsertLoop, getLoop, listLoops, setLoopEnabled, setLoopInterval, recordLoopRun, dumpLoopsJson } from './store'
 import { buildLoopPrompt } from './prompt-builder'
+import { AdmissionDeniedError, type AdmissionController } from '../orchestration/admission'
 
 const MAX_CONSECUTIVE_FAILURES = 5
 const BACKOFF_BASE_MS = 10 * 60 * 1000
@@ -17,6 +18,7 @@ export interface LoopSchedulerOpts {
   repo: string
   maxConcurrentSessions: number
   getInteractiveSessionCount: () => number
+  admission?: AdmissionController
 }
 
 export class LoopScheduler implements LoopSchedulerInterface {
@@ -26,6 +28,7 @@ export class LoopScheduler implements LoopSchedulerInterface {
   private readonly repo: string
   private maxConcurrentSessions: number
   private readonly getInteractiveSessionCount: () => number
+  private readonly admission: AdmissionController | undefined
   private readonly definitions = new Map<string, LoopDefinition>()
   private timer: ReturnType<typeof setInterval> | null = null
   private lastKickAt = new Map<string, number>()
@@ -38,6 +41,7 @@ export class LoopScheduler implements LoopSchedulerInterface {
     this.repo = opts.repo
     this.maxConcurrentSessions = opts.maxConcurrentSessions
     this.getInteractiveSessionCount = opts.getInteractiveSessionCount
+    this.admission = opts.admission
 
     for (const def of DEFAULT_LOOPS) {
       this.definitions.set(def.id, def)
@@ -60,9 +64,13 @@ export class LoopScheduler implements LoopSchedulerInterface {
   }
 
   async tick(now: number): Promise<void> {
-    const interactiveCount = this.getInteractiveSessionCount()
-    const reserved = this.maxConcurrentSessions - interactiveCount
-    if (reserved < 2) return
+    if (this.admission) {
+      if (!this.admission.peek('loop').admitted) return
+    } else {
+      const interactiveCount = this.getInteractiveSessionCount()
+      const reserved = this.maxConcurrentSessions - interactiveCount
+      if (reserved < 2) return
+    }
 
     const rows = listLoops(this.db)
     let staggerOffset = 0
@@ -76,6 +84,8 @@ export class LoopScheduler implements LoopSchedulerInterface {
       const nextRunAt = (row.last_run_at ?? 0) + intervalMs
 
       if (now + staggerOffset < nextRunAt) continue
+
+      if (this.admission && !this.admission.peek('loop').admitted) break
 
       this.lastKickAt.set(row.id, now)
       staggerOffset += STAGGER_MS
@@ -104,16 +114,14 @@ export class LoopScheduler implements LoopSchedulerInterface {
         prompt,
         repo: this.repo,
         workspaceRoot: this.workspaceRoot,
+        metadata: { loopId },
       })
 
       this.activeLoopSessions.set(loopId, session.id)
-
-      const sessionDb = this.db
-      sessionDb.run(
-        `UPDATE sessions SET metadata = json_set(COALESCE(metadata, '{}'), '$.loopId', ?) WHERE id = ?`,
-        [loopId, session.id],
-      )
-    } catch {
+    } catch (err) {
+      if (err instanceof AdmissionDeniedError) {
+        return
+      }
       await this.recordOutcome(loopId, 'errored')
     }
   }

--- a/server/orchestration/admission.test.ts
+++ b/server/orchestration/admission.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'bun:test'
+import {
+  AdmissionDeniedError,
+  createAdmissionController,
+  priorityForMode,
+  PRIORITY_ORDER,
+} from './admission'
+
+describe('priorityForMode', () => {
+  it('classifies dag-task as dag-task', () => {
+    expect(priorityForMode({ mode: 'dag-task' })).toBe('dag-task')
+  })
+
+  it('classifies ship at verify stage as ship-verify', () => {
+    expect(priorityForMode({ mode: 'ship', stage: 'verify' })).toBe('ship-verify')
+  })
+
+  it('classifies ship without verify stage as ship-root', () => {
+    expect(priorityForMode({ mode: 'ship' })).toBe('ship-root')
+    expect(priorityForMode({ mode: 'ship', stage: 'plan' })).toBe('ship-root')
+    expect(priorityForMode({ mode: 'ship', stage: 'dag' })).toBe('ship-root')
+  })
+
+  it('classifies sessions with loopId metadata as loop', () => {
+    expect(priorityForMode({ mode: 'task', metadata: { loopId: 'test-coverage' } })).toBe('loop')
+  })
+
+  it('classifies task/plan/think/review/rebase-resolver as interactive', () => {
+    expect(priorityForMode({ mode: 'task' })).toBe('interactive')
+    expect(priorityForMode({ mode: 'plan' })).toBe('interactive')
+    expect(priorityForMode({ mode: 'think' })).toBe('interactive')
+    expect(priorityForMode({ mode: 'review' })).toBe('interactive')
+    expect(priorityForMode({ mode: 'rebase-resolver' })).toBe('interactive')
+  })
+
+  it('does not treat metadata without a loopId string as loop', () => {
+    expect(priorityForMode({ mode: 'task', metadata: {} })).toBe('interactive')
+    expect(priorityForMode({ mode: 'task', metadata: { loopId: 42 as unknown as string } })).toBe('interactive')
+  })
+})
+
+describe('AdmissionController', () => {
+  it('admits up to totalCap when all priorities equal', () => {
+    const ctrl = createAdmissionController({
+      totalCap: 3,
+      reservedSlots: { interactive: 0, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+    })
+    expect(ctrl.tryAdmit('s1', 'loop').admitted).toBe(true)
+    expect(ctrl.tryAdmit('s2', 'loop').admitted).toBe(true)
+    expect(ctrl.tryAdmit('s3', 'loop').admitted).toBe(true)
+    expect(ctrl.tryAdmit('s4', 'loop').admitted).toBe(false)
+  })
+
+  it('reserves slots for higher priorities to prevent starvation by lower priorities', () => {
+    const ctrl = createAdmissionController({
+      totalCap: 5,
+      reservedSlots: { interactive: 2, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+    })
+
+    expect(ctrl.tryAdmit('l1', 'loop').admitted).toBe(true)
+    expect(ctrl.tryAdmit('l2', 'loop').admitted).toBe(true)
+    expect(ctrl.tryAdmit('l3', 'loop').admitted).toBe(true)
+    const denied = ctrl.tryAdmit('l4', 'loop')
+    expect(denied.admitted).toBe(false)
+    expect(denied.reason).toContain('priority "loop"')
+    expect(denied.reason).toContain('cap is 3')
+
+    expect(ctrl.tryAdmit('i1', 'interactive').admitted).toBe(true)
+    expect(ctrl.tryAdmit('i2', 'interactive').admitted).toBe(true)
+    expect(ctrl.tryAdmit('i3', 'interactive').admitted).toBe(false)
+  })
+
+  it('releases slots so subsequent admissions succeed', () => {
+    const ctrl = createAdmissionController({
+      totalCap: 2,
+      reservedSlots: { interactive: 0, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+    })
+
+    expect(ctrl.tryAdmit('a', 'dag-task').admitted).toBe(true)
+    expect(ctrl.tryAdmit('b', 'dag-task').admitted).toBe(true)
+    expect(ctrl.tryAdmit('c', 'dag-task').admitted).toBe(false)
+
+    expect(ctrl.release('a')).toBe('dag-task')
+    expect(ctrl.tryAdmit('c', 'dag-task').admitted).toBe(true)
+  })
+
+  it('release() returns undefined for unknown session id', () => {
+    const ctrl = createAdmissionController({ totalCap: 4 })
+    expect(ctrl.release('missing')).toBeUndefined()
+  })
+
+  it('tryAdmit is idempotent for the same session id', () => {
+    const ctrl = createAdmissionController({ totalCap: 2 })
+    const first = ctrl.tryAdmit('s1', 'interactive')
+    expect(first.admitted).toBe(true)
+    const second = ctrl.tryAdmit('s1', 'interactive')
+    expect(second.admitted).toBe(true)
+    expect(ctrl.stats().total).toBe(1)
+  })
+
+  it('peek does not mutate state', () => {
+    const ctrl = createAdmissionController({
+      totalCap: 2,
+      reservedSlots: { interactive: 0, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+    })
+    expect(ctrl.peek('loop').admitted).toBe(true)
+    expect(ctrl.stats().total).toBe(0)
+  })
+
+  it('peek reflects reserved slots for higher priorities', () => {
+    const ctrl = createAdmissionController({
+      totalCap: 3,
+      reservedSlots: { interactive: 1, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+    })
+    ctrl.tryAdmit('l1', 'loop')
+    ctrl.tryAdmit('l2', 'loop')
+    const peek = ctrl.peek('loop')
+    expect(peek.admitted).toBe(false)
+    expect(peek.capForPriority).toBe(2)
+  })
+
+  it('blocks lower priorities while preserving reservation for higher', () => {
+    const ctrl = createAdmissionController({
+      totalCap: 4,
+      reservedSlots: { interactive: 2, 'ship-root': 1, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+    })
+
+    expect(ctrl.tryAdmit('d1', 'dag-task').admitted).toBe(true)
+    const denied = ctrl.tryAdmit('d2', 'dag-task')
+    expect(denied.admitted).toBe(false)
+    expect(denied.capForPriority).toBe(1)
+
+    expect(ctrl.tryAdmit('s1', 'ship-root').admitted).toBe(true)
+    expect(ctrl.tryAdmit('s2', 'ship-root').admitted).toBe(false)
+    expect(ctrl.tryAdmit('i1', 'interactive').admitted).toBe(true)
+    expect(ctrl.tryAdmit('i2', 'interactive').admitted).toBe(true)
+
+    expect(ctrl.tryAdmit('i3', 'interactive').admitted).toBe(false)
+  })
+
+  it('ship-verify ranks below ship-root but above dag-task and loop', () => {
+    const ctrl = createAdmissionController({
+      totalCap: 3,
+      reservedSlots: { interactive: 0, 'ship-root': 0, 'ship-verify': 1, 'dag-task': 0, loop: 0 },
+    })
+
+    expect(ctrl.tryAdmit('l1', 'loop').admitted).toBe(true)
+    expect(ctrl.tryAdmit('l2', 'loop').admitted).toBe(true)
+    const denied = ctrl.tryAdmit('l3', 'loop')
+    expect(denied.admitted).toBe(false)
+    expect(denied.capForPriority).toBe(2)
+
+    expect(ctrl.tryAdmit('v1', 'ship-verify').admitted).toBe(true)
+    expect(ctrl.tryAdmit('s1', 'ship-root').admitted).toBe(false)
+  })
+
+  it('stats reflect counts by priority', () => {
+    const ctrl = createAdmissionController({ totalCap: 10 })
+    ctrl.tryAdmit('a', 'interactive')
+    ctrl.tryAdmit('b', 'dag-task')
+    ctrl.tryAdmit('c', 'loop')
+    const s = ctrl.stats()
+    expect(s.total).toBe(3)
+    expect(s.byPriority.interactive).toBe(1)
+    expect(s.byPriority['dag-task']).toBe(1)
+    expect(s.byPriority.loop).toBe(1)
+  })
+
+  it('reserve() pre-counts a session without re-checking caps', () => {
+    const ctrl = createAdmissionController({
+      totalCap: 1,
+      reservedSlots: { interactive: 0, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+    })
+    ctrl.reserve('boot-1', 'interactive')
+    expect(ctrl.stats().total).toBe(1)
+    expect(ctrl.tryAdmit('next', 'interactive').admitted).toBe(false)
+  })
+
+  it('AdmissionDeniedError carries decision details', () => {
+    const ctrl = createAdmissionController({
+      totalCap: 1,
+      reservedSlots: { interactive: 0, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+    })
+    ctrl.tryAdmit('a', 'loop')
+    const decision = ctrl.tryAdmit('b', 'loop')
+    const err = new AdmissionDeniedError(decision)
+    expect(err.priority).toBe('loop')
+    expect(err.capForPriority).toBe(1)
+    expect(err.message).toContain('admission denied')
+    expect(err.name).toBe('AdmissionDeniedError')
+  })
+
+  it('rejects invalid totalCap construction', () => {
+    expect(() => createAdmissionController({ totalCap: 0 })).toThrow()
+    expect(() => createAdmissionController({ totalCap: -3 })).toThrow()
+  })
+
+  it('rejects negative reservedSlots', () => {
+    expect(() =>
+      createAdmissionController({
+        totalCap: 5,
+        reservedSlots: { interactive: -1 } as never,
+      }),
+    ).toThrow()
+  })
+
+  it('setTotalCap allows live resize', () => {
+    const ctrl = createAdmissionController({
+      totalCap: 1,
+      reservedSlots: { interactive: 0, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+    })
+    ctrl.tryAdmit('a', 'loop')
+    expect(ctrl.tryAdmit('b', 'loop').admitted).toBe(false)
+    ctrl.setTotalCap(3)
+    expect(ctrl.tryAdmit('b', 'loop').admitted).toBe(true)
+  })
+
+  it('PRIORITY_ORDER lists priorities high-to-low', () => {
+    expect(PRIORITY_ORDER).toEqual(['interactive', 'ship-root', 'ship-verify', 'dag-task', 'loop'])
+  })
+})

--- a/server/orchestration/admission.ts
+++ b/server/orchestration/admission.ts
@@ -1,0 +1,251 @@
+export type SessionPriority =
+  | 'interactive'
+  | 'ship-root'
+  | 'ship-verify'
+  | 'dag-task'
+  | 'loop'
+
+export const PRIORITY_ORDER: readonly SessionPriority[] = [
+  'interactive',
+  'ship-root',
+  'ship-verify',
+  'dag-task',
+  'loop',
+] as const
+
+const PRIORITY_RANK: Record<SessionPriority, number> = {
+  interactive: 0,
+  'ship-root': 1,
+  'ship-verify': 2,
+  'dag-task': 3,
+  loop: 4,
+}
+
+export interface AdmissionConfig {
+  totalCap: number
+  reservedSlots: Record<SessionPriority, number>
+}
+
+export interface AdmissionDecision {
+  admitted: boolean
+  reason?: string
+  priority: SessionPriority
+  capForPriority: number
+  active: number
+  activeAtOrBelow: number
+}
+
+export interface AdmissionStats {
+  total: number
+  byPriority: Record<SessionPriority, number>
+}
+
+export interface PriorityResolutionInput {
+  mode: string
+  metadata?: Record<string, unknown> | null
+  stage?: string | null
+}
+
+export class AdmissionDeniedError extends Error {
+  readonly priority: SessionPriority
+  readonly capForPriority: number
+  readonly active: number
+
+  constructor(decision: AdmissionDecision) {
+    super(decision.reason ?? `admission denied for priority ${decision.priority}`)
+    this.name = 'AdmissionDeniedError'
+    this.priority = decision.priority
+    this.capForPriority = decision.capForPriority
+    this.active = decision.active
+  }
+}
+
+export function priorityForMode(input: PriorityResolutionInput): SessionPriority {
+  const meta = input.metadata ?? undefined
+  if (meta && typeof meta === 'object' && 'loopId' in meta && typeof meta.loopId === 'string') {
+    return 'loop'
+  }
+  if (input.mode === 'dag-task') return 'dag-task'
+  if (input.mode === 'ship') {
+    if (input.stage === 'verify') return 'ship-verify'
+    return 'ship-root'
+  }
+  return 'interactive'
+}
+
+export interface AdmissionController {
+  tryAdmit(sessionId: string, priority: SessionPriority): AdmissionDecision
+  peek(priority: SessionPriority): AdmissionDecision
+  release(sessionId: string): SessionPriority | undefined
+  reserve(sessionId: string, priority: SessionPriority): void
+  active(): number
+  stats(): AdmissionStats
+  capForPriority(priority: SessionPriority): number
+  setTotalCap(n: number): void
+  setReservedSlots(reserved: Partial<Record<SessionPriority, number>>): void
+  config(): AdmissionConfig
+}
+
+export interface AdmissionControllerOpts {
+  totalCap: number
+  reservedSlots?: Partial<Record<SessionPriority, number>>
+}
+
+const DEFAULT_RESERVED: Record<SessionPriority, number> = {
+  interactive: 2,
+  'ship-root': 1,
+  'ship-verify': 0,
+  'dag-task': 0,
+  loop: 0,
+}
+
+function normalizeReserved(
+  partial: Partial<Record<SessionPriority, number>> | undefined,
+): Record<SessionPriority, number> {
+  const result = { ...DEFAULT_RESERVED }
+  if (!partial) return result
+  for (const key of PRIORITY_ORDER) {
+    const v = partial[key]
+    if (v !== undefined) {
+      if (!Number.isFinite(v) || v < 0) {
+        throw new Error(`reservedSlots[${key}] must be a non-negative number`)
+      }
+      result[key] = Math.floor(v)
+    }
+  }
+  return result
+}
+
+export function createAdmissionController(opts: AdmissionControllerOpts): AdmissionController {
+  if (!Number.isFinite(opts.totalCap) || opts.totalCap < 1) {
+    throw new Error('totalCap must be a positive number')
+  }
+
+  let totalCap = Math.floor(opts.totalCap)
+  let reservedSlots = normalizeReserved(opts.reservedSlots)
+  const sessions = new Map<string, SessionPriority>()
+  const counts: Record<SessionPriority, number> = {
+    interactive: 0,
+    'ship-root': 0,
+    'ship-verify': 0,
+    'dag-task': 0,
+    loop: 0,
+  }
+
+  function reservedForHigherThan(priority: SessionPriority): number {
+    const rank = PRIORITY_RANK[priority]
+    let total = 0
+    for (const p of PRIORITY_ORDER) {
+      if (PRIORITY_RANK[p] < rank) total += reservedSlots[p]
+    }
+    return total
+  }
+
+  function capForPriority(priority: SessionPriority): number {
+    const cap = totalCap - reservedForHigherThan(priority)
+    return Math.max(0, cap)
+  }
+
+  function totalActive(): number {
+    let s = 0
+    for (const p of PRIORITY_ORDER) s += counts[p]
+    return s
+  }
+
+  function activeAtOrBelow(priority: SessionPriority): number {
+    const rank = PRIORITY_RANK[priority]
+    let s = 0
+    for (const p of PRIORITY_ORDER) {
+      if (PRIORITY_RANK[p] >= rank) s += counts[p]
+    }
+    return s
+  }
+
+  function evaluate(priority: SessionPriority): AdmissionDecision {
+    const cap = capForPriority(priority)
+    const atOrBelow = activeAtOrBelow(priority)
+    const active = totalActive()
+    if (atOrBelow + 1 > cap) {
+      const reason =
+        `admission denied: priority "${priority}" cap is ${cap} ` +
+        `(total ${totalCap}, reserved-above ${reservedForHigherThan(priority)}); ` +
+        `${atOrBelow} session(s) at or below this priority already running`
+      return { admitted: false, reason, priority, capForPriority: cap, active, activeAtOrBelow: atOrBelow }
+    }
+    return { admitted: true, priority, capForPriority: cap, active, activeAtOrBelow: atOrBelow }
+  }
+
+  function tryAdmit(sessionId: string, priority: SessionPriority): AdmissionDecision {
+    if (sessions.has(sessionId)) {
+      const existing = sessions.get(sessionId)!
+      return {
+        admitted: true,
+        priority: existing,
+        capForPriority: capForPriority(existing),
+        active: totalActive(),
+        activeAtOrBelow: activeAtOrBelow(existing),
+      }
+    }
+    const decision = evaluate(priority)
+    if (decision.admitted) {
+      sessions.set(sessionId, priority)
+      counts[priority] += 1
+    }
+    return decision
+  }
+
+  function reserve(sessionId: string, priority: SessionPriority): void {
+    if (sessions.has(sessionId)) return
+    sessions.set(sessionId, priority)
+    counts[priority] += 1
+  }
+
+  function release(sessionId: string): SessionPriority | undefined {
+    const priority = sessions.get(sessionId)
+    if (!priority) return undefined
+    sessions.delete(sessionId)
+    counts[priority] = Math.max(0, counts[priority] - 1)
+    return priority
+  }
+
+  function active(): number {
+    return totalActive()
+  }
+
+  function stats(): AdmissionStats {
+    return {
+      total: totalActive(),
+      byPriority: { ...counts },
+    }
+  }
+
+  function setTotalCap(n: number): void {
+    if (!Number.isFinite(n) || n < 1) throw new Error('totalCap must be a positive number')
+    totalCap = Math.floor(n)
+  }
+
+  function setReservedSlots(reserved: Partial<Record<SessionPriority, number>>): void {
+    reservedSlots = normalizeReserved({ ...reservedSlots, ...reserved })
+  }
+
+  function config(): AdmissionConfig {
+    return { totalCap, reservedSlots: { ...reservedSlots } }
+  }
+
+  function peek(priority: SessionPriority): AdmissionDecision {
+    return evaluate(priority)
+  }
+
+  return {
+    tryAdmit,
+    peek,
+    release,
+    reserve,
+    active,
+    stats,
+    capForPriority,
+    setTotalCap,
+    setReservedSlots,
+    config,
+  }
+}

--- a/server/session/registry.test.ts
+++ b/server/session/registry.test.ts
@@ -9,6 +9,7 @@ import { resetEventBus, getEventBus } from '../events/bus'
 import { runMigrations } from '../db/sqlite'
 import { spawnWithTimeout } from '../workspace/git'
 import type { SpawnFn, SubprocessHandle } from './runtime'
+import { AdmissionDeniedError, createAdmissionController } from '../orchestration/admission'
 
 // ---------------------------------------------------------------------------
 // Infrastructure helpers
@@ -772,5 +773,100 @@ describe('SessionRegistry', () => {
       expect(snap!.mode).toBe('ship')
       expect(snap!.stage).toBeUndefined()
     }, 30_000)
+  })
+
+  describe('priority-ordered admission control', () => {
+    test('throws AdmissionDeniedError when total cap is reached for the requested priority', async () => {
+      const admission = createAdmissionController({
+        totalCap: 2,
+        reservedSlots: { interactive: 0, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+      })
+      admission.reserve('existing-1', 'loop')
+      admission.reserve('existing-2', 'loop')
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn(), admission })
+
+      let caught: unknown
+      try {
+        await registry.create({
+          mode: 'task',
+          prompt: 'should be denied',
+          repo: '/nonexistent-this-call-must-not-reach-prepareWorkspace',
+          metadata: { loopId: 'overflow' },
+        })
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught).toBeInstanceOf(AdmissionDeniedError)
+      expect((caught as AdmissionDeniedError).priority).toBe('loop')
+    })
+
+    test('reserved interactive slots prevent loops from filling the engine', async () => {
+      const admission = createAdmissionController({
+        totalCap: 3,
+        reservedSlots: { interactive: 2, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+      })
+
+      admission.reserve('a', 'loop')
+      const denied = admission.tryAdmit('b', 'loop')
+      expect(denied.admitted).toBe(false)
+
+      const registry = createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn(), admission })
+
+      let caught: unknown
+      try {
+        await registry.create({
+          mode: 'task',
+          prompt: 'overflow loop',
+          repo: '/x',
+          metadata: { loopId: 'lp' },
+        })
+      } catch (err) {
+        caught = err
+      }
+      expect(caught).toBeInstanceOf(AdmissionDeniedError)
+      expect((caught as AdmissionDeniedError).priority).toBe('loop')
+
+      const interactivePeek = admission.peek('interactive')
+      expect(interactivePeek.admitted).toBe(true)
+    })
+
+    test('admission slot is released when session.completed is emitted', async () => {
+      const admission = createAdmissionController({
+        totalCap: 1,
+        reservedSlots: { interactive: 0, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+      })
+
+      createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn(), admission })
+
+      admission.reserve('s1', 'interactive')
+      expect(admission.stats().total).toBe(1)
+      expect(admission.peek('interactive').admitted).toBe(false)
+
+      getEventBus().emit({
+        kind: 'session.completed',
+        sessionId: 's1',
+        state: 'completed',
+        durationMs: 0,
+      })
+
+      expect(admission.stats().total).toBe(0)
+      expect(admission.peek('interactive').admitted).toBe(true)
+    })
+
+    test('admission slot is released when session.deleted is emitted', async () => {
+      const admission = createAdmissionController({
+        totalCap: 1,
+        reservedSlots: { interactive: 0, 'ship-root': 0, 'ship-verify': 0, 'dag-task': 0, loop: 0 },
+      })
+
+      createSessionRegistry({ getDb: () => db, spawnFn: makeNoopSpawnFn(), admission })
+
+      admission.reserve('s1', 'interactive')
+      getEventBus().emit({ kind: 'session.deleted', sessionId: 's1' })
+
+      expect(admission.stats().total).toBe(0)
+    })
   })
 })

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -9,6 +9,12 @@ import { getDb, prepared, type SessionRow } from '../db/sqlite'
 import { getEventBus } from '../events/bus'
 import type { Database } from 'bun:sqlite'
 import { injectAgentFiles } from './inject-assets'
+import {
+  AdmissionDeniedError,
+  priorityForMode,
+  type AdmissionController,
+  type SessionPriority,
+} from '../orchestration/admission'
 
 const ADJECTIVES = ['brisk','wide','quiet','loud','smart','bright','dim','warm','cool','fast','slow','neat','crisp','rough','sharp','soft']
 const NOUNS = ['ivy','oak','fern','river','meadow','peak','bay','cliff','dune','grove','lake','mesa','pond','reef','stream','wood']
@@ -94,13 +100,24 @@ export interface SessionRegistry {
 export interface RegistryOpts {
   getDb?: () => Database
   spawnFn?: SpawnFn
+  admission?: AdmissionController
 }
 
 export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry {
   const db = opts.getDb ?? getDb
   const bus = getEventBus()
+  const admission = opts.admission
   const runtimes = new Map<string, SessionRuntime>()
   const handles = new Map<string, WorkspaceHandle>()
+
+  function resolvePriority(mode: string, metadata?: Record<string, unknown>): SessionPriority {
+    return priorityForMode({ mode, metadata })
+  }
+
+  if (admission) {
+    bus.onKind('session.completed', (e) => { admission.release(e.sessionId) })
+    bus.onKind('session.deleted', (e) => { admission.release(e.sessionId) })
+  }
 
   function makeRuntime(startOpts: RuntimeStartOpts): SessionRuntime {
     return new SessionRuntime({
@@ -129,12 +146,26 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
     const slug = createOpts.slug ?? generateSlug()
     const workspaceRoot = createOpts.workspaceRoot ?? process.env['WORKSPACE_ROOT'] ?? './.minion-data'
 
-    const handle = await prepareWorkspace({
-      slug,
-      repoUrl: createOpts.repo,
-      workspaceRoot,
-      startRef: createOpts.startRef,
-    })
+    if (admission) {
+      const priority = resolvePriority(createOpts.mode, createOpts.metadata)
+      const decision = admission.tryAdmit(sessionId, priority)
+      if (!decision.admitted) {
+        throw new AdmissionDeniedError(decision)
+      }
+    }
+
+    let handle: WorkspaceHandle
+    try {
+      handle = await prepareWorkspace({
+        slug,
+        repoUrl: createOpts.repo,
+        workspaceRoot,
+        startRef: createOpts.startRef,
+      })
+    } catch (err) {
+      admission?.release(sessionId)
+      throw err
+    }
     injectAgentFiles(handle.cwd, undefined, workspaceRoot)
 
     const now = Date.now()
@@ -323,6 +354,9 @@ export function createSessionRegistry(opts: RegistryOpts = {}): SessionRegistry 
       if (row.claude_session_id) {
         try {
           const runtime = await resumeRuntime(row, row.command)
+          if (admission) {
+            admission.reserve(id, resolvePriority(row.mode, row.metadata))
+          }
           prepared.updateSession(db(), { id, status: 'running', updated_at: Date.now() })
           emitSnapshot(id)
           void runtime.start()


### PR DESCRIPTION
## Summary

- Replace the flat `MAX_CONCURRENT_SESSIONS=10` global cap with a priority-aware admission controller (`interactive > ship-root > ship-verify > dag-task > loop`).
- Reserved slots per priority guarantee that low-priority work (loops, DAG tasks) cannot starve interactive sessions or ship-coordinator roots.
- Wire the controller into `SessionRegistry.create` (rejects with `AdmissionDeniedError` before workspace prep), `reconcileOnBoot` (resumed sessions re-occupy their slot), and `LoopScheduler` (peeks each tick; admission denials don't trip the loop's failure counter).

## Design

`server/orchestration/admission.ts` exposes:

- `priorityForMode({ mode, metadata, stage })` — maps a `CreateSessionMode` (plus stage / `metadata.loopId`) to one of five priorities.
- `createAdmissionController({ totalCap, reservedSlots })` — `tryAdmit(sessionId, priority)`, `peek(priority)`, `release(sessionId)`, `reserve(sessionId, priority)`, `setTotalCap(n)`, and `stats()`. The cap visible to priority `P` is `totalCap - sum(reservedSlots[Q] for Q higher than P)`, and a request is admitted iff `(active sessions at-or-below P) + 1 ≤ capForP`.

Default reservations: `interactive=2`, `ship-root=1`, `ship-verify=0`, `dag-task=0`, `loop=0` — overridable via `RESERVED_INTERACTIVE_SLOTS`, `RESERVED_SHIP_ROOT_SLOTS`, `RESERVED_SHIP_VERIFY_SLOTS`, `RESERVED_DAG_TASK_SLOTS` env vars in `server/index.ts`.

The registry releases slots automatically by subscribing to `session.completed` and `session.deleted`. `LoopScheduler.kickLoop` now sets `metadata.loopId` at create time (instead of post-insert), so admission classifies loop sessions correctly on the first call.

## Test plan

- [x] `bun test server/orchestration/` — 22 unit tests for admission semantics (priority mapping, cap math, idempotent admit, reservations, error type).
- [x] `bun test server/session/registry.test.ts -t \"priority-ordered admission control\"` — 4 integration tests: denial throws `AdmissionDeniedError` before `prepareWorkspace`, reservations protect interactive priority, slot is released on `session.completed` / `session.deleted`.
- [x] `bun test server/loops/scheduler.test.ts` — 5 new tests for admission integration: tick skips when peek denies, `AdmissionDeniedError` does NOT bump `consecutive_failures`, generic errors still do, loopId is passed via metadata.
- [x] `npm run typecheck && npm run lint && npm run test` — clean (1083 vitest passing).
- [x] Server-side `bun test server/ shared/` shows the same 14 failures as `main` (pre-existing flakes around git workspace setup, FTS triggers, and feedback API tests in this sandbox); no new failures introduced.