### PR TITLE
fix(ship): rebuild coordinator stage from DAG completeness on boot

### DIFF
--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -1221,6 +1221,126 @@ describe("DagScheduler", () => {
   })
 })
 
+describe("DagScheduler boot reconcile + ship coordinator", () => {
+  it("ship reconcile recovers stuck ship when DAG was already terminal pre-restart", async () => {
+    const db = makeTestDb()
+    const bus = new EngineEventBus()
+
+    const rootId = "ship-root-stuck"
+    insertShipRoot(db, rootId, "dag")
+
+    const childId = "child-already-done"
+    const session = makeSession(childId, db)
+    void session
+
+    const graph = buildDag(
+      "dag-pre-terminated",
+      [{ id: "a", title: "Task A", description: "A", dependsOn: [] }],
+      rootId,
+      "https://github.com/org/repo",
+    )
+    graph.nodes[0]!.status = "done"
+    graph.nodes[0]!.sessionId = childId
+    graph.nodes[0]!.branch = "minion/test-child-already-done"
+    saveDag(graph, db)
+
+    const replies: Array<{ sessionId: string; text: string }> = []
+    const registry = makeRegistry(db)
+    registry.reply = async (sid, text) => {
+      replies.push({ sessionId: sid, text })
+      return true
+    }
+
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp/workspace",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+      updateStackComment: async () => {},
+    })
+
+    await scheduler.reconcileOnBoot()
+
+    let row = prepared.getSession(db, rootId)
+    expect(row?.stage).toBe("dag")
+    expect(replies).toHaveLength(0)
+
+    const { reconcileShipsOnBoot } = await import("../ship/coordinator")
+    const result = await reconcileShipsOnBoot({ db, registry, scheduler })
+
+    expect(result.advanced).toEqual([{ sessionId: rootId, from: "dag", to: "verify" }])
+
+    row = prepared.getSession(db, rootId)
+    expect(row?.stage).toBe("verify")
+    expect(replies).toHaveLength(1)
+    expect(replies[0]?.sessionId).toBe(rootId)
+    expect(replies[0]?.text).toContain(buildVerifyDirective([
+      { title: "Task A", description: "A", branch: "minion/test-child-already-done", prUrl: null },
+    ]))
+  })
+
+  it("ship reconcile is a no-op when scheduler reconcile already advanced the ship", async () => {
+    const db = makeTestDb()
+    const bus = new EngineEventBus()
+
+    const rootId = "ship-root-mid-flight"
+    insertShipRoot(db, rootId, "dag")
+
+    const childId = "child-running-at-crash"
+    const childSession = makeSession(childId, db)
+    void childSession
+
+    const graph = buildDag(
+      "dag-mid-flight",
+      [{ id: "a", title: "Task A", description: "A", dependsOn: [] }],
+      rootId,
+      "https://github.com/org/repo",
+    )
+    graph.nodes[0]!.status = "running"
+    graph.nodes[0]!.sessionId = childId
+    saveDag(graph, db)
+
+    prepared.updateSession(db, { id: childId, status: "completed", updated_at: Date.now() })
+
+    const replies: Array<{ sessionId: string; text: string }> = []
+    const registry = makeRegistry(db)
+    registry.reply = async (sid, text) => {
+      replies.push({ sessionId: sid, text })
+      return true
+    }
+
+    const scheduler = createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp/workspace",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+      updateStackComment: async () => {},
+    })
+
+    await scheduler.reconcileOnBoot()
+
+    const rowAfterScheduler = prepared.getSession(db, rootId)
+    expect(rowAfterScheduler?.stage).toBe("verify")
+    expect(replies).toHaveLength(1)
+
+    const { reconcileShipsOnBoot } = await import("../ship/coordinator")
+    const result = await reconcileShipsOnBoot({ db, registry, scheduler })
+
+    expect(result.advanced).toEqual([])
+    expect(replies).toHaveLength(1)
+  })
+})
+
 describe("DagScheduler restack integration", () => {
   function countDeferredRestacks(db: Database): number {
     const row = db

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,7 @@ import {
 } from './handlers/stubs'
 import { createDagScheduler } from './dag/scheduler'
 import { createLandingManager } from './dag/landing'
+import { reconcileShipsOnBoot } from './ship/coordinator'
 import { LoopScheduler } from './loops/scheduler'
 import { createAdmissionController } from './orchestration/admission'
 import { DEFAULT_LOOPS } from './loops/definitions'
@@ -94,6 +95,13 @@ console.log(`[minion] engine on :${PORT}, ${reconciled} sessions resumed`)
 const ciBabysitter = createRealCIBabysitter(registry, db)
 const scheduler = createDagScheduler({ registry, db, bus, workspace: WORKSPACE_ROOT, ciBabysitter })
 await scheduler.reconcileOnBoot()
+
+const shipReconcile = await reconcileShipsOnBoot({ db, registry, scheduler })
+if (shipReconcile.advanced.length > 0 || shipReconcile.failures.length > 0) {
+  console.log(
+    `[minion] ship reconcile: ${shipReconcile.advanced.length} advanced, ${shipReconcile.failures.length} failed (scanned ${shipReconcile.scanned})`,
+  )
+}
 
 bus.onKind('session.resumed', (ev) => { void scheduler.onSessionResumed(ev.sessionId) })
 bus.onKind('session.reply_injected', (ev) => { void scheduler.onSessionResumed(ev.sessionId) })

--- a/server/ship/coordinator.test.ts
+++ b/server/ship/coordinator.test.ts
@@ -1,13 +1,13 @@
 import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test'
 import type { Database } from 'bun:sqlite'
 import { openDatabase, prepared, runMigrations } from '../db/sqlite'
-import { advanceShip, cancelShip, DIRECTIVE_PLAN, DIRECTIVE_VERIFY } from './coordinator'
-import { buildDag } from '../dag/dag'
-import { saveDag, loadDag } from '../dag/store'
+import { advanceShip, cancelShip, DIRECTIVE_PLAN, DIRECTIVE_VERIFY, reconcileShipsOnBoot } from './coordinator'
 import type { PlanActionCtx } from '../commands/plan-actions'
 import type { SessionRegistry } from '../session/registry'
 import { getEventBus, resetEventBus } from '../events/bus'
 import type { ShipStage } from '../../shared/api-types'
+import { buildDag } from '../dag/dag'
+import { saveDag, loadDag } from '../dag/store'
 
 function createTestDb(): Database {
   const db = openDatabase(':memory:')
@@ -684,5 +684,298 @@ describe('cancelShip', () => {
     const reloaded = loadDag(dagId, db)
     expect(reloaded!.nodes.find((n) => n.id === 'a')?.status).toBe('cancelled')
     expect(reloaded!.nodes.find((n) => n.id === 'b')?.status).toBe('cancelled')
+  })
+})
+
+describe('reconcileShipsOnBoot', () => {
+  let db: Database
+  let registry: SessionRegistry
+  let scheduler: ReturnType<typeof createMockScheduler>
+  let ctx: PlanActionCtx
+
+  beforeEach(() => {
+    resetEventBus()
+    db = createTestDb()
+    registry = createMockRegistry()
+    scheduler = createMockScheduler()
+    ctx = { db, registry, scheduler }
+  })
+
+  function makeCompleteDag(dagId: string, rootSessionId: string, opts?: { allDone?: boolean; failed?: boolean }): void {
+    const allDone = opts?.allDone ?? true
+    const failed = opts?.failed ?? false
+    const graph = buildDag(
+      dagId,
+      [
+        { id: 'a', title: 'Task A', description: 'A', dependsOn: [] },
+        { id: 'b', title: 'Task B', description: 'B', dependsOn: ['a'] },
+      ],
+      rootSessionId,
+      'https://github.com/test/repo',
+    )
+    if (allDone) {
+      graph.nodes[0]!.status = 'done'
+      graph.nodes[0]!.branch = 'minion/task-a'
+      graph.nodes[1]!.status = failed ? 'failed' : 'done'
+      if (!failed) graph.nodes[1]!.branch = 'minion/task-b'
+    }
+    saveDag(graph, db)
+  }
+
+  function makeRunningDag(dagId: string, rootSessionId: string): void {
+    const graph = buildDag(
+      dagId,
+      [
+        { id: 'a', title: 'Task A', description: 'A', dependsOn: [] },
+        { id: 'b', title: 'Task B', description: 'B', dependsOn: ['a'] },
+      ],
+      rootSessionId,
+      'https://github.com/test/repo',
+    )
+    graph.nodes[0]!.status = 'done'
+    graph.nodes[1]!.status = 'running'
+    saveDag(graph, db)
+  }
+
+  test('advances stuck ship from dag to verify when DAG is fully complete', async () => {
+    const sessionId = 'session-stuck-1'
+    createSession(db, sessionId, 'ship', 'dag')
+    makeCompleteDag('dag-recover-1', sessionId)
+
+    const result = await reconcileShipsOnBoot(ctx)
+
+    expect(result.scanned).toBe(1)
+    expect(result.advanced).toEqual([
+      { sessionId, from: 'dag', to: 'verify' },
+    ])
+    expect(result.failures).toEqual([])
+
+    const row = prepared.getSession(db, sessionId)
+    expect(row?.stage).toBe('verify')
+
+    expect(registry.reply).toHaveBeenCalledTimes(1)
+    const replyMock = registry.reply as unknown as ReturnType<typeof mock>
+    const [calledSessionId, directive] = replyMock.mock.calls[0] as [string, string]
+    expect(calledSessionId).toBe(sessionId)
+    expect(directive).toContain('Task A')
+    expect(directive).toContain('Task B')
+    expect(directive).toContain('minion/task-a')
+    expect(directive).toContain('minion/task-b')
+  })
+
+  test('advances stuck ship even when DAG ended in failure (all nodes terminal)', async () => {
+    const sessionId = 'session-stuck-fail'
+    createSession(db, sessionId, 'ship', 'dag')
+    makeCompleteDag('dag-recover-fail', sessionId, { allDone: true, failed: true })
+
+    const result = await reconcileShipsOnBoot(ctx)
+
+    expect(result.advanced).toHaveLength(1)
+    expect(result.advanced[0]).toEqual({ sessionId, from: 'dag', to: 'verify' })
+
+    const row = prepared.getSession(db, sessionId)
+    expect(row?.stage).toBe('verify')
+  })
+
+  test('leaves ship at dag stage when DAG still has running nodes', async () => {
+    const sessionId = 'session-running-dag'
+    createSession(db, sessionId, 'ship', 'dag')
+    makeRunningDag('dag-still-running', sessionId)
+
+    const result = await reconcileShipsOnBoot(ctx)
+
+    expect(result.scanned).toBe(1)
+    expect(result.advanced).toEqual([])
+    expect(result.failures).toEqual([])
+
+    const row = prepared.getSession(db, sessionId)
+    expect(row?.stage).toBe('dag')
+    expect(registry.reply).not.toHaveBeenCalled()
+  })
+
+  test('skips ships not in dag stage', async () => {
+    const thinkSession = 'ship-think'
+    const planSession = 'ship-plan'
+    const verifySession = 'ship-verify'
+    createSession(db, thinkSession, 'ship', 'think')
+    createSession(db, planSession, 'ship', 'plan')
+    createSession(db, verifySession, 'ship', 'verify')
+    makeCompleteDag('dag-think', thinkSession)
+    makeCompleteDag('dag-plan', planSession)
+    makeCompleteDag('dag-verify', verifySession)
+
+    const result = await reconcileShipsOnBoot(ctx)
+
+    expect(result.scanned).toBe(3)
+    expect(result.advanced).toEqual([])
+    expect(registry.reply).not.toHaveBeenCalled()
+    expect(prepared.getSession(db, thinkSession)?.stage).toBe('think')
+    expect(prepared.getSession(db, planSession)?.stage).toBe('plan')
+    expect(prepared.getSession(db, verifySession)?.stage).toBe('verify')
+  })
+
+  test('skips ships with stage=dag but no associated DAG row', async () => {
+    const sessionId = 'session-no-dag'
+    createSession(db, sessionId, 'ship', 'dag')
+
+    const result = await reconcileShipsOnBoot(ctx)
+
+    expect(result.scanned).toBe(1)
+    expect(result.advanced).toEqual([])
+    expect(result.failures).toEqual([])
+
+    const row = prepared.getSession(db, sessionId)
+    expect(row?.stage).toBe('dag')
+  })
+
+  test('ignores non-ship sessions', async () => {
+    const taskSession = 'task-1'
+    createSession(db, taskSession, 'task', null)
+
+    const result = await reconcileShipsOnBoot(ctx)
+
+    expect(result.scanned).toBe(0)
+    expect(result.advanced).toEqual([])
+  })
+
+  test('skips ships already marked completed', async () => {
+    const sessionId = 'session-already-completed'
+    createSession(db, sessionId, 'ship', 'dag')
+    makeCompleteDag('dag-already-done', sessionId)
+    db.run("UPDATE sessions SET status = 'completed' WHERE id = ?", [sessionId])
+
+    const result = await reconcileShipsOnBoot(ctx)
+
+    expect(result.scanned).toBe(0)
+    expect(result.advanced).toEqual([])
+    expect(registry.reply).not.toHaveBeenCalled()
+  })
+
+  test('skips ships already marked failed', async () => {
+    const sessionId = 'session-already-failed'
+    createSession(db, sessionId, 'ship', 'dag')
+    makeCompleteDag('dag-already-failed', sessionId)
+    db.run("UPDATE sessions SET status = 'failed' WHERE id = ?", [sessionId])
+
+    const result = await reconcileShipsOnBoot(ctx)
+
+    expect(result.scanned).toBe(0)
+    expect(result.advanced).toEqual([])
+  })
+
+  test('handles multiple stuck ships in one pass', async () => {
+    const sessionA = 'multi-aaa'
+    const sessionB = 'multi-bbb'
+    const sessionC = 'multi-ccc'
+    createSession(db, sessionA, 'ship', 'dag')
+    createSession(db, sessionB, 'ship', 'dag')
+    createSession(db, sessionC, 'ship', 'dag')
+    makeCompleteDag('dag-multi-a', sessionA)
+    makeRunningDag('dag-multi-b', sessionB)
+    makeCompleteDag('dag-multi-c', sessionC)
+
+    const result = await reconcileShipsOnBoot(ctx)
+
+    expect(result.scanned).toBe(3)
+    expect(result.advanced).toHaveLength(2)
+    const advancedIds = result.advanced.map((a) => a.sessionId).sort()
+    expect(advancedIds).toEqual([sessionA, sessionC].sort())
+
+    expect(prepared.getSession(db, sessionA)?.stage).toBe('verify')
+    expect(prepared.getSession(db, sessionB)?.stage).toBe('dag')
+    expect(prepared.getSession(db, sessionC)?.stage).toBe('verify')
+  })
+
+  test('emits session.snapshot event for each advanced ship', async () => {
+    const sessionId = 'session-snapshot-emit'
+    createSession(db, sessionId, 'ship', 'dag')
+    makeCompleteDag('dag-snapshot', sessionId)
+
+    const events: Array<{ id: string; stage?: string }> = []
+    getEventBus().onKind('session.snapshot', (e) => {
+      events.push({ id: e.session.id, stage: e.session.stage })
+    })
+
+    await reconcileShipsOnBoot(ctx)
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({ id: sessionId, stage: 'verify' })
+  })
+
+  test('reports failures when advance throws and continues with other ships', async () => {
+    const sessionGood = 'ship-good'
+    const sessionBad = 'ship-bad'
+    createSession(db, sessionGood, 'ship', 'dag')
+    createSession(db, sessionBad, 'ship', 'dag')
+    makeCompleteDag('dag-good', sessionGood)
+    makeCompleteDag('dag-bad', sessionBad)
+
+    const realReply = registry.reply
+    let callCount = 0
+    registry.reply = mock(async (id: string, text: string) => {
+      callCount++
+      if (id === sessionBad) throw new Error('injection failed')
+      return (realReply as unknown as (sid: string, t: string) => Promise<boolean>)(id, text)
+    }) as typeof registry.reply
+
+    const consoleErrorSpy = spyOn(console, 'error')
+
+    const result = await reconcileShipsOnBoot(ctx)
+
+    expect(result.scanned).toBe(2)
+    expect(result.advanced).toHaveLength(1)
+    expect(result.advanced[0]?.sessionId).toBe(sessionGood)
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.sessionId).toBe(sessionBad)
+    expect(result.failures[0]?.reason).toContain('injection failed')
+
+    expect(callCount).toBe(2)
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('returns empty result when no ship sessions exist', async () => {
+    const result = await reconcileShipsOnBoot(ctx)
+    expect(result).toEqual({ scanned: 0, advanced: [], failures: [] })
+  })
+
+  test('uses child branch info from DAG when building verify directive', async () => {
+    const sessionId = 'session-with-children'
+    createSession(db, sessionId, 'ship', 'dag')
+
+    const dagId = 'dag-with-prs'
+    const graph = buildDag(
+      dagId,
+      [{ id: 'task-1', title: 'Implement feature', description: 'Do the thing.', dependsOn: [] }],
+      sessionId,
+      'https://github.com/test/repo',
+    )
+    graph.nodes[0]!.status = 'done'
+    graph.nodes[0]!.branch = 'minion/feature-branch'
+    graph.nodes[0]!.prUrl = 'https://github.com/test/repo/pull/42'
+    saveDag(graph, db)
+
+    await reconcileShipsOnBoot(ctx)
+
+    const row = prepared.getSession(db, sessionId)
+    expect(row?.stage).toBe('verify')
+
+    expect(registry.reply).toHaveBeenCalledTimes(1)
+    const replyMock = registry.reply as unknown as ReturnType<typeof mock>
+    const [, directive] = replyMock.mock.calls[0] as [string, string]
+    expect(directive).toContain('minion/feature-branch')
+    expect(directive).toContain('https://github.com/test/repo/pull/42')
+  })
+
+  test('is idempotent: running twice does not double-advance', async () => {
+    const sessionId = 'session-idempotent'
+    createSession(db, sessionId, 'ship', 'dag')
+    makeCompleteDag('dag-idempotent', sessionId)
+
+    const first = await reconcileShipsOnBoot(ctx)
+    expect(first.advanced).toHaveLength(1)
+
+    const second = await reconcileShipsOnBoot(ctx)
+    expect(second.advanced).toEqual([])
+    expect(second.scanned).toBe(1)
   })
 })

--- a/server/ship/coordinator.ts
+++ b/server/ship/coordinator.ts
@@ -3,6 +3,7 @@ import { prepared } from '../db/sqlite'
 import { getEventBus } from '../events/bus'
 import { handleDag, type PlanActionCtx } from '../commands/plan-actions'
 import { listDags } from '../dag/store'
+import { isDagComplete, dagGraphStatus } from '../dag/dag'
 import { buildVerifyDirective, type VerifyTask } from './verification'
 
 // Stage directive constants
@@ -326,4 +327,73 @@ export async function cancelShip(
 
     return { ok: true, dagId: dag?.id, cancelledChildren }
   })
+}
+
+export interface ReconcileShipsResult {
+  scanned: number
+  advanced: Array<{ sessionId: string; from: ShipStage; to: ShipStage }>
+  failures: Array<{ sessionId: string; reason: string }>
+}
+
+/**
+ * Re-derive ship coordinator stages from DAG state at engine boot.
+ *
+ * If the engine crashes between DAG completion and the dag→verify transition,
+ * the persisted ship row is left at stage='dag' even though every DAG node has
+ * reached a terminal state. The DAG scheduler's reconcileOnBoot skips fully
+ * terminal DAGs, so the stuck ship is never recovered through the normal path.
+ *
+ * This pass walks every active ship row, looks up its DAG, and forces a
+ * dag→verify transition whenever the DAG is complete. The transition reuses
+ * advanceShip so directive injection, status emission, and the stage update
+ * stay consistent with the live path.
+ */
+export async function reconcileShipsOnBoot(ctx: PlanActionCtx): Promise<ReconcileShipsResult> {
+  const result: ReconcileShipsResult = { scanned: 0, advanced: [], failures: [] }
+
+  const rows = ctx.db
+    .query<{ id: string; stage: string | null }, []>(
+      "SELECT id, stage FROM sessions WHERE mode = 'ship' AND status NOT IN ('completed','failed')",
+    )
+    .all()
+
+  if (rows.length === 0) return result
+
+  const dags = listDags(ctx.db)
+  const dagsByRoot = new Map(dags.map((g) => [g.rootSessionId, g] as const))
+
+  for (const row of rows) {
+    result.scanned++
+    const stage = (row.stage as ShipStage | null) ?? 'think'
+    if (stage !== 'dag') continue
+
+    const dag = dagsByRoot.get(row.id)
+    if (!dag) continue
+    if (!isDagComplete(dag)) continue
+
+    console.log(
+      '[ship] reconcileShipsOnBoot: dag',
+      dag.id,
+      'is',
+      dagGraphStatus(dag),
+      '— advancing ship',
+      row.id,
+      'from dag to verify',
+    )
+
+    try {
+      const advanceResult = await advanceShip(row.id, 'verify', ctx)
+      if (advanceResult.ok && advanceResult.from && advanceResult.to) {
+        result.advanced.push({ sessionId: row.id, from: advanceResult.from, to: advanceResult.to })
+      } else {
+        result.failures.push({ sessionId: row.id, reason: advanceResult.reason ?? 'advanceShip returned ok=false' })
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err)
+      console.error('[ship] reconcileShipsOnBoot: advanceShip threw for', row.id, reason)
+      result.failures.push({ sessionId: row.id, reason })
+    }
+  }
+
+  return result
 }


### PR DESCRIPTION
## Summary

If the engine crashes between DAG completion and the `dag→verify` transition, the persisted ship row is left at `stage='dag'` even though every DAG node has reached a terminal state. The DAG scheduler's `reconcileOnBoot` early-returns on fully terminal DAGs (skips when no node is `pending|ready|running`), so the stuck ship is never recovered through the normal `tickGraph → advanceShip` path.

This adds `reconcileShipsOnBoot` (in `server/ship/coordinator.ts`) which walks every active ship row, looks up its DAG, and forces a `dag→verify` transition whenever the DAG is complete. It reuses `advanceShip(sessionId, 'verify', ctx)` so directive injection, SSE emission, and the persisted stage update stay consistent with the live path.

Wired into `server/index.ts` to run after `scheduler.reconcileOnBoot()` (so the live path gets first crack — the ship reconcile is a fallback for the DAGs that the scheduler skipped).

### What it does NOT do

- Does not advance from `plan` (DAG creation has side effects we don't want to redo).
- Does not touch ships at `think`, `verify`, or `done`.
- Does not auto-recover ships whose DAG row is missing entirely.

## Test plan

- [x] `bun test server/ship/coordinator.test.ts` — 38 pass (12 new tests)
- [x] `bun test server/dag/scheduler.test.ts` — 21 pass (2 new integration tests covering the boot-path interplay between scheduler reconcile and ship reconcile)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run test` (vitest) — 1083 pass

New test coverage:
- Ship at `dag` stage with fully terminal DAG → advances to `verify` and injects verify directive
- Failed-DAG case (terminal but with failures) → still advances to `verify`
- Ship at `dag` with running nodes → leaves stage unchanged
- Ships at `think|plan|verify` → ignored
- Ship at `dag` with no DAG row → ignored
- Non-ship sessions → ignored
- `completed` / `failed` ship status → ignored
- Multiple stuck ships processed in one pass
- Per-advanced-ship `session.snapshot` SSE emission
- Failure isolation: one ship's `advanceShip` throwing doesn't block others
- Idempotency: running twice does not double-advance
- Verify directive includes per-child `branch` and `prUrl` from DAG nodes
- Integration: pre-terminated DAG (scheduler skips it) → ship reconcile catches and advances
- Integration: scheduler already advanced ship via tickGraph → reconcile is a no-op
