### PR TITLE
feat(scheduler): persist DAG state to DB and serialize per-DAG mutations

### DIFF
--- a/server/dag/scheduler.test.ts
+++ b/server/dag/scheduler.test.ts
@@ -541,6 +541,268 @@ describe("DagScheduler", () => {
   })
 })
 
+describe("DagScheduler durable state", () => {
+  let db: Database
+  let bus: EngineEventBus
+
+  beforeEach(() => {
+    db = makeTestDb()
+    bus = new EngineEventBus()
+  })
+
+  function makeScheduler(registry: SessionRegistry) {
+    return createDagScheduler({
+      registry,
+      db,
+      bus,
+      workspace: "/tmp",
+      ciBabysitter: {
+        babysitPR: async () => {},
+        queueDeferredBabysit: async () => {},
+        babysitDagChildCI: async () => {},
+      },
+      updateStackComment: async () => {},
+    })
+  }
+
+  it("persists cancellation so a fresh scheduler instance honors it", async () => {
+    const graph = buildDag("dag-cancel-persist", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessionsA: string[] = []
+    const registryA = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessionsA.length}`, db)
+      sessionsA.push(session.id)
+      return { session, runtime: {} as never }
+    })
+    const stoppedA: string[] = []
+    registryA.stop = async (id) => { stoppedA.push(id) }
+
+    const schedulerA = makeScheduler(registryA)
+    await schedulerA.start("dag-cancel-persist")
+    expect(sessionsA).toHaveLength(1)
+
+    await schedulerA.cancel("dag-cancel-persist")
+    expect(stoppedA).toEqual([sessionsA[0]!])
+
+    const dagRow = prepared.getDag(db, "dag-cancel-persist")
+    expect(dagRow?.cancelled_at).not.toBeNull()
+    expect(dagRow?.cancelled_at).toBeTypeOf("number")
+
+    const sessionsB: string[] = []
+    const registryB = makeRegistry(db, async () => {
+      const session = makeSession(`s-b-${sessionsB.length}`, db)
+      sessionsB.push(session.id)
+      return { session, runtime: {} as never }
+    })
+    const schedulerB = makeScheduler(registryB)
+    await schedulerB.reconcileOnBoot()
+
+    expect(sessionsB).toHaveLength(0)
+
+    const after = schedulerB.status("dag-cancel-persist")
+    expect(after.nodes.find((n) => n.id === "a")?.status).toBe("failed")
+    expect(after.nodes.find((n) => n.id === "b")?.status).toBe("pending")
+  })
+
+  it("findOwnerBySession lets a fresh scheduler resolve completion without in-memory map", async () => {
+    const graph = buildDag("dag-no-cache", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessionsA: string[] = []
+    const registryA = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessionsA.length}`, db)
+      sessionsA.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const schedulerA = makeScheduler(registryA)
+    await schedulerA.start("dag-no-cache")
+    const childSessionId = sessionsA[0]!
+
+    const sessionsB: string[] = []
+    const registryB = makeRegistry(db, async () => {
+      const session = makeSession(`s-b-${sessionsB.length}`, db)
+      sessionsB.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const schedulerB = makeScheduler(registryB)
+    await schedulerB.onSessionCompleted(childSessionId, "completed")
+
+    const after = schedulerB.status("dag-no-cache")
+    expect(after.nodes.find((n) => n.id === "a")?.status).toBe("done")
+    expect(after.nodes.find((n) => n.id === "b")?.status).toBe("running")
+    expect(sessionsB).toHaveLength(1)
+  })
+
+  it("ignores onSessionCompleted for an already-completed node (idempotent)", async () => {
+    const graph = buildDag("dag-idempotent", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-idempotent")
+    await scheduler.onSessionCompleted(sessions[0]!, "completed")
+
+    const completedEvents: unknown[] = []
+    bus.onKind("dag.node.completed", (e) => completedEvents.push(e))
+
+    await scheduler.onSessionCompleted(sessions[0]!, "completed")
+
+    expect(completedEvents).toHaveLength(0)
+  })
+
+  it("status() reads from DB without in-memory cache", async () => {
+    const graph = buildDag("dag-status-from-db", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const registry = makeRegistry(db, async () => ({ session: makeSession("s-0", db), runtime: {} as never }))
+    const schedulerA = makeScheduler(registry)
+    await schedulerA.start("dag-status-from-db")
+
+    const schedulerB = makeScheduler(registry)
+    const status = schedulerB.status("dag-status-from-db")
+    expect(status.nodes).toHaveLength(1)
+    expect(status.nodes[0]?.status).toBe("running")
+    expect(status.nodes[0]?.sessionId).toBe("s-0")
+  })
+
+  it("reconcileOnBoot does NOT spawn new nodes for cancelled DAGs", async () => {
+    const graph = buildDag("dag-cancel-reconcile", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    prepared.cancelDag(db, "dag-cancel-reconcile", Date.now())
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.reconcileOnBoot()
+
+    expect(sessions).toHaveLength(0)
+  })
+
+  it("retryNode clears cancellation so the DAG is restartable", async () => {
+    const graph = buildDag("dag-retry-uncancel", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+    registry.stop = async () => {}
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-retry-uncancel")
+    await scheduler.onSessionCompleted(sessions[0]!, "errored")
+    await scheduler.cancel("dag-retry-uncancel")
+
+    expect(prepared.getDag(db, "dag-retry-uncancel")?.cancelled_at).not.toBeNull()
+
+    await scheduler.retryNode("a", "dag-retry-uncancel")
+
+    expect(prepared.getDag(db, "dag-retry-uncancel")?.cancelled_at).toBeNull()
+    expect(sessions).toHaveLength(2)
+  })
+
+  it("serializes concurrent onSessionCompleted calls for the same DAG", async () => {
+    const graph = buildDag("dag-mutex", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: [] },
+      { id: "c", title: "Task C", description: "C", dependsOn: ["a", "b"] },
+    ], "root-session", "https://github.com/org/repo")
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      await new Promise<void>((r) => setTimeout(r, 0))
+      return { session, runtime: {} as never }
+    })
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-mutex")
+
+    expect(sessions).toHaveLength(2)
+    const sessionA = sessions[0]!
+    const sessionB = sessions[1]!
+
+    await Promise.all([
+      scheduler.onSessionCompleted(sessionA, "completed"),
+      scheduler.onSessionCompleted(sessionB, "completed"),
+    ])
+
+    const after = scheduler.status("dag-mutex")
+    expect(after.nodes.find((n) => n.id === "a")?.status).toBe("done")
+    expect(after.nodes.find((n) => n.id === "b")?.status).toBe("done")
+    expect(after.nodes.find((n) => n.id === "c")?.status).toBe("running")
+  })
+
+  it("ignores dag.node.pushed events for cancelled DAGs", async () => {
+    const graph = buildDag("dag-cancel-push", [
+      { id: "a", title: "Task A", description: "A", dependsOn: [] },
+      { id: "b", title: "Task B", description: "B", dependsOn: ["a"] },
+    ], "root-session", "https://github.com/org/repo")
+    graph.nodes[0]!.branch = "minion/test-a"
+    graph.nodes[1]!.branch = "minion/test-b"
+    saveDag(graph, db)
+
+    const sessions: string[] = []
+    const registry = makeRegistry(db, async () => {
+      const session = makeSession(`s${sessions.length}`, db)
+      sessions.push(session.id)
+      return { session, runtime: {} as never }
+    })
+    registry.stop = async () => {}
+
+    const scheduler = makeScheduler(registry)
+    await scheduler.start("dag-cancel-push")
+    await scheduler.cancel("dag-cancel-push")
+
+    bus.emit({
+      kind: "dag.node.pushed",
+      dagId: "dag-cancel-push",
+      nodeId: "a",
+      parentSha: "old-sha",
+      newSha: "new-sha",
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const after = scheduler.status("dag-cancel-push")
+    expect(after.nodes.find((n) => n.id === "a")?.status).toBe("failed")
+  })
+})
+
 describe("DagScheduler restack integration", () => {
   it("defers restack when node is running", async () => {
     const db = makeTestDb()

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -1,7 +1,7 @@
 import type { Database } from "bun:sqlite"
 import { readyNodes, advanceDag, failNode, resetFailedNode, nodeIndex, getUpstreamBranches, isDagComplete, dagGraphStatus } from "./dag"
 import type { DagGraph, DagNode, DagInput } from "./dag"
-import { saveDag, loadDag, listDags } from "./store"
+import { saveDag, loadDag, listDags, isDagCancelled, markDagCancelled, clearDagCancelled, findDagOwnerBySession } from "./store"
 import { prepared } from "../db/sqlite"
 import { updateStackComment } from "./stack-comment"
 import { buildDagChildPrompt } from "./dag-extract"
@@ -124,11 +124,6 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
   const { registry, db, bus, ciBabysitter } = opts
   const commentUpdater = opts.updateStackComment ?? updateStackComment
 
-  const activeGraphs = new Map<string, DagGraph>()
-  const nodeToSession = new Map<string, string>()
-  const nodeToGraph = new Map<string, string>()
-  const cancelledDags = new Set<string>()
-
   const restackManager: RestackManager = createRestackManager({
     bus,
     workspaceRoot: opts.workspace,
@@ -136,6 +131,20 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
   })
 
   const deferredRestacks = new Map<string, Array<{ dagId: string; nodeId: string; parentSha: string; newSha: string; cascadeDepth: number }>>()
+
+  const dagLocks = new Map<string, Promise<unknown>>()
+
+  function withDagLock<T>(dagId: string, fn: () => Promise<T>): Promise<T> {
+    const prev = dagLocks.get(dagId) ?? Promise.resolve()
+    const next = prev.then(fn, fn)
+    dagLocks.set(
+      dagId,
+      next.catch(() => undefined).then(() => {
+        if (dagLocks.get(dagId) === next) dagLocks.delete(dagId)
+      }),
+    )
+    return next
+  }
 
   function runningCount(graph: DagGraph): number {
     return graph.nodes.filter((n) => n.status === "running").length
@@ -179,7 +188,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
   }
 
   async function spawnNode(node: DagNode, graph: DagGraph): Promise<void> {
-    if (cancelledDags.has(graph.id)) return
+    if (isDagCancelled(graph.id, db)) return
     if (runningCount(graph) >= MAX_DAG_CONCURRENCY) return
 
     node.status = "running"
@@ -205,8 +214,6 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
 
       node.status = "running"
       node.sessionId = session.id
-      nodeToSession.set(node.id, session.id)
-      nodeToGraph.set(session.id, graph.id)
 
       bus.emit({
         kind: "dag.node.started",
@@ -228,7 +235,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
   }
 
   async function tickGraph(graph: DagGraph): Promise<void> {
-    if (cancelledDags.has(graph.id)) return
+    if (isDagCancelled(graph.id, db)) return
 
     const ready = readyNodes(graph)
     const available = MAX_DAG_CONCURRENCY - runningCount(graph)
@@ -239,135 +246,130 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     }
 
     if (isDagComplete(graph)) {
-      activeGraphs.delete(graph.id)
       persist(graph)
       await advanceShip(graph.rootSessionId, "verify", { db, registry, scheduler: { start } })
     }
   }
 
   async function start(dagId: string): Promise<void> {
-    const existing = loadDag(dagId, db)
-    if (!existing) throw new Error(`DAG ${dagId} not found in store`)
+    return withDagLock(dagId, async () => {
+      const existing = loadDag(dagId, db)
+      if (!existing) throw new Error(`DAG ${dagId} not found in store`)
 
-    activeGraphs.set(dagId, existing)
-    cancelledDags.delete(dagId)
-
-    await tickGraph(existing)
+      clearDagCancelled(dagId, db)
+      await tickGraph(existing)
+    })
   }
 
   async function onSessionCompleted(sessionId: string, state: SessionRunState): Promise<void> {
-    const dagId = nodeToGraph.get(sessionId)
-    if (!dagId) return
+    const owner = findDagOwnerBySession(sessionId, db)
+    if (!owner) return
 
-    const graph = activeGraphs.get(dagId)
-    if (!graph) return
+    await withDagLock(owner.dagId, async () => {
+      const graph = loadDag(owner.dagId, db)
+      if (!graph) return
 
-    const nodeEntry = Array.from(nodeToSession.entries()).find(([, sid]) => sid === sessionId)
-    if (!nodeEntry) return
-    const [nodeId] = nodeEntry
+      const idx = nodeIndex(graph)
+      const node = idx.get(owner.nodeId)
+      if (!node) return
+      if (node.status !== "running") return
 
-    const idx = nodeIndex(graph)
-    const node = idx.get(nodeId)
-    if (!node) return
+      if (state === "completed") {
+        const { prUrl, branch } = readNodePrInfo(db, sessionId)
+        if (branch) node.branch = branch
+        if (prUrl) node.prUrl = prUrl
 
-    nodeToSession.delete(nodeId)
-    nodeToGraph.delete(sessionId)
+        if (prUrl) {
+          const metaRow = db
+            .query<{ metadata: string }, [string]>("SELECT metadata FROM sessions WHERE id = ?")
+            .get(sessionId)
 
-    if (state === "completed") {
-      const { prUrl, branch } = readNodePrInfo(db, sessionId)
-      if (branch) node.branch = branch
-      if (prUrl) node.prUrl = prUrl
+          let metadata: Record<string, unknown>
+          try {
+            const parsed = metaRow?.metadata ? JSON.parse(metaRow.metadata) : {}
+            metadata = (parsed && typeof parsed === "object") ? parsed as Record<string, unknown> : {}
+          } catch {
+            metadata = {}
+          }
 
-      if (prUrl) {
-        const metaRow = db
-          .query<{ metadata: string }, [string]>("SELECT metadata FROM sessions WHERE id = ?")
-          .get(sessionId)
-
-        let metadata: Record<string, unknown>
-        try {
-          const parsed = metaRow?.metadata ? JSON.parse(metaRow.metadata) : {}
-          metadata = (parsed && typeof parsed === "object") ? parsed as Record<string, unknown> : {}
-        } catch {
-          metadata = {}
+          if (!metadata.ciBabysitStartedAt) {
+            metadata.ciBabysitStartedAt = Date.now()
+            metadata.ciBabysitTrigger = "completion"
+            prepared.updateSession(db, {
+              id: sessionId,
+              metadata,
+              updated_at: Date.now(),
+            })
+            void ciBabysitter.babysitDagChildCI(sessionId, prUrl)
+          }
         }
 
-        if (!metadata.ciBabysitStartedAt) {
-          metadata.ciBabysitStartedAt = Date.now()
-          metadata.ciBabysitTrigger = "completion"
-          prepared.updateSession(db, {
-            id: sessionId,
-            metadata,
-            updated_at: Date.now(),
-          })
-          void ciBabysitter.babysitDagChildCI(sessionId, prUrl)
-        }
+        node.status = "done"
+        advanceDag(graph)
+
+        bus.emit({
+          kind: "dag.node.completed",
+          dagId: owner.dagId,
+          nodeId: owner.nodeId,
+          sessionId,
+          state: "completed",
+        })
+      } else {
+        node.status = "failed"
+        node.error = `session ended with state: ${state}`
+        failNode(graph, owner.nodeId)
+
+        bus.emit({
+          kind: "dag.node.completed",
+          dagId: owner.dagId,
+          nodeId: owner.nodeId,
+          sessionId,
+          state: state === "quota_exhausted" ? "quota_exhausted" : "errored",
+        })
       }
 
-      node.status = "done"
-      advanceDag(graph)
+      persist(graph)
+      await commentUpdater(graph)
+      await tickGraph(graph)
 
-      bus.emit({
-        kind: "dag.node.completed",
-        dagId,
-        nodeId,
-        sessionId,
-        state: "completed",
-      })
-    } else {
-      node.status = "failed"
-      node.error = `session ended with state: ${state}`
-      failNode(graph, nodeId)
-
-      bus.emit({
-        kind: "dag.node.completed",
-        dagId,
-        nodeId,
-        sessionId,
-        state: state === "quota_exhausted" ? "quota_exhausted" : "errored",
-      })
-    }
-
-    persist(graph)
-    await commentUpdater(graph)
-    await tickGraph(graph)
-
-    const deferred = deferredRestacks.get(sessionId)
-    if (deferred) {
-      deferredRestacks.delete(sessionId)
-      for (const event of deferred) {
-        const dagGraph = activeGraphs.get(event.dagId)
-        if (dagGraph) {
-          await restackManager.onParentPushed(event, dagGraph).catch((err) => {
-            console.error(`[scheduler] deferred restack failed for node ${event.nodeId}:`, err)
-          })
+      const deferred = deferredRestacks.get(sessionId)
+      if (deferred) {
+        deferredRestacks.delete(sessionId)
+        const refreshed = loadDag(owner.dagId, db)
+        if (refreshed) {
+          for (const event of deferred) {
+            await restackManager.onParentPushed(event, refreshed).catch((err) => {
+              console.error(`[scheduler] deferred restack failed for node ${event.nodeId}:`, err)
+            })
+          }
         }
       }
-    }
+    })
   }
 
   async function cancel(dagId: string): Promise<void> {
-    cancelledDags.add(dagId)
-    const graph = activeGraphs.get(dagId)
-    if (!graph) return
+    return withDagLock(dagId, async () => {
+      markDagCancelled(dagId, db)
 
-    const runningNodes = graph.nodes.filter((n) => n.status === "running")
-    for (const node of runningNodes) {
-      const sessionId = nodeToSession.get(node.id)
-      if (sessionId) {
-        await registry.stop(sessionId, "dag cancelled")
-        nodeToSession.delete(node.id)
-        nodeToGraph.delete(sessionId)
+      const graph = loadDag(dagId, db)
+      if (!graph) return
+
+      const runningNodes = graph.nodes.filter((n) => n.status === "running")
+      for (const node of runningNodes) {
+        const sessionId = node.sessionId
+        if (sessionId) {
+          await registry.stop(sessionId, "dag cancelled")
+        }
+        node.status = "failed"
+        node.error = "dag cancelled"
       }
-      node.status = "failed"
-      node.error = "dag cancelled"
-    }
 
-    persist(graph)
-    activeGraphs.delete(dagId)
+      persist(graph)
+    })
   }
 
   function status(dagId: string): DagStatusSnapshot {
-    const graph = activeGraphs.get(dagId) ?? loadDag(dagId, db)
+    const graph = loadDag(dagId, db)
     if (!graph) {
       return { dagId, nodes: [] }
     }
@@ -377,26 +379,23 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
       nodes: graph.nodes.map((n) => ({
         id: n.id,
         status: n.status,
-        sessionId: nodeToSession.get(n.id),
+        sessionId: n.status === "running" ? n.sessionId : undefined,
         error: n.error,
       })),
     }
   }
 
   async function retryNode(nodeId: string, dagId: string): Promise<void> {
-    let graph = activeGraphs.get(dagId)
-    if (!graph) {
-      const stored = loadDag(dagId, db)
-      if (!stored) throw new Error(`DAG ${dagId} not found`)
-      graph = stored
-      activeGraphs.set(dagId, graph)
-      cancelledDags.delete(dagId)
-    }
+    return withDagLock(dagId, async () => {
+      const graph = loadDag(dagId, db)
+      if (!graph) throw new Error(`DAG ${dagId} not found`)
 
-    resetFailedNode(graph, nodeId)
-    persist(graph)
-    await commentUpdater(graph)
-    await tickGraph(graph)
+      clearDagCancelled(dagId, db)
+      resetFailedNode(graph, nodeId)
+      persist(graph)
+      await commentUpdater(graph)
+      await tickGraph(graph)
+    })
   }
 
   async function onSessionResumed(sessionId: string): Promise<void> {
@@ -405,113 +404,110 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
     const meta = row.metadata as { dagId?: string; dagNodeId?: string }
     if (!meta.dagId || !meta.dagNodeId) return
 
-    let graph = activeGraphs.get(meta.dagId)
-    if (!graph) {
-      const stored = loadDag(meta.dagId, db)
-      if (!stored) return
-      graph = stored
-      activeGraphs.set(meta.dagId, graph)
-      cancelledDags.delete(meta.dagId)
-    }
+    const dagId = meta.dagId
+    const nodeId = meta.dagNodeId
 
-    const idx = nodeIndex(graph)
-    const node = idx.get(meta.dagNodeId)
-    if (!node) return
-    if (node.status !== "failed" && node.status !== "ci-failed") return
+    await withDagLock(dagId, async () => {
+      const graph = loadDag(dagId, db)
+      if (!graph) return
 
-    node.status = "running"
-    node.error = undefined
-    node.sessionId = sessionId
-    nodeToSession.set(node.id, sessionId)
-    nodeToGraph.set(sessionId, graph.id)
+      clearDagCancelled(dagId, db)
 
-    persist(graph)
-    await commentUpdater(graph).catch(() => {})
+      const idx = nodeIndex(graph)
+      const node = idx.get(nodeId)
+      if (!node) return
+      if (node.status !== "failed" && node.status !== "ci-failed") return
+
+      node.status = "running"
+      node.error = undefined
+      node.sessionId = sessionId
+
+      persist(graph)
+      await commentUpdater(graph).catch(() => {})
+    })
   }
 
   async function reconcileOnBoot(): Promise<void> {
     const graphs = listDags(db)
     for (const graph of graphs) {
+      if (isDagCancelled(graph.id, db)) continue
+
       const nonTerminal = graph.nodes.some((n) =>
         n.status === "pending" || n.status === "ready" || n.status === "running"
       )
       if (!nonTerminal) continue
 
-      activeGraphs.set(graph.id, graph)
+      await withDagLock(graph.id, async () => {
+        for (const node of graph.nodes) {
+          if (node.status !== "running") continue
+          if (!node.sessionId) {
+            node.status = "failed"
+            node.error = "session id missing after engine restart"
+            failNode(graph, node.id)
+            continue
+          }
 
-      for (const node of graph.nodes) {
-        if (node.status !== "running") continue
-        if (!node.sessionId) {
-          node.status = "failed"
-          node.error = "session id missing after engine restart"
-          failNode(graph, node.id)
-          continue
+          const row = db
+            .query<{ status: string }, [string]>("SELECT status FROM sessions WHERE id = ?")
+            .get(node.sessionId)
+
+          if (!row) {
+            node.status = "failed"
+            node.error = "session row missing after engine restart"
+            failNode(graph, node.id)
+            continue
+          }
+
+          if (row.status === "completed") {
+            const { prUrl, branch } = readNodePrInfo(db, node.sessionId)
+            if (branch) node.branch = branch
+            if (prUrl) node.prUrl = prUrl
+            node.status = "done"
+            advanceDag(graph)
+          } else if (row.status === "failed") {
+            node.status = "failed"
+            node.error = "session ended (failed) while engine was down"
+            failNode(graph, node.id)
+          }
         }
 
-        const row = db
-          .query<{ status: string }, [string]>("SELECT status FROM sessions WHERE id = ?")
-          .get(node.sessionId)
-
-        if (!row) {
-          node.status = "failed"
-          node.error = "session row missing after engine restart"
-          failNode(graph, node.id)
-          continue
-        }
-
-        if (row.status === "completed") {
-          const { prUrl, branch } = readNodePrInfo(db, node.sessionId)
-          if (branch) node.branch = branch
-          if (prUrl) node.prUrl = prUrl
-          node.status = "done"
-          advanceDag(graph)
-        } else if (row.status === "failed") {
-          node.status = "failed"
-          node.error = "session ended (failed) while engine was down"
-          failNode(graph, node.id)
-        } else {
-          nodeToSession.set(node.id, node.sessionId)
-          nodeToGraph.set(node.sessionId, graph.id)
-        }
-      }
-
-      persist(graph)
-      await commentUpdater(graph).catch(() => {})
-      await tickGraph(graph)
+        persist(graph)
+        await commentUpdater(graph).catch(() => {})
+        await tickGraph(graph)
+      })
     }
   }
 
   async function forceNodeLanded(nodeId: string, dagId: string): Promise<void> {
-    let graph = activeGraphs.get(dagId)
-    if (!graph) {
-      const stored = loadDag(dagId, db)
-      if (!stored) throw new Error(`DAG ${dagId} not found`)
-      graph = stored
-      activeGraphs.set(dagId, graph)
-      cancelledDags.delete(dagId)
-    }
+    return withDagLock(dagId, async () => {
+      const graph = loadDag(dagId, db)
+      if (!graph) throw new Error(`DAG ${dagId} not found`)
 
-    const idx = nodeIndex(graph)
-    const node = idx.get(nodeId)
-    if (!node) throw new Error(`node ${nodeId} not found in DAG ${dagId}`)
+      clearDagCancelled(dagId, db)
 
-    node.status = "landed"
-    advanceDag(graph)
+      const idx = nodeIndex(graph)
+      const node = idx.get(nodeId)
+      if (!node) throw new Error(`node ${nodeId} not found in DAG ${dagId}`)
 
-    bus.emit({
-      kind: "dag.node.landed",
-      dagId,
-      nodeId,
+      node.status = "landed"
+      advanceDag(graph)
+
+      bus.emit({
+        kind: "dag.node.landed",
+        dagId,
+        nodeId,
+      })
+
+      persist(graph)
+      await commentUpdater(graph)
+      await tickGraph(graph)
     })
-
-    persist(graph)
-    await commentUpdater(graph)
-    await tickGraph(graph)
   }
 
   bus.onKind("dag.node.pushed", async (event) => {
-    const graph = activeGraphs.get(event.dagId)
+    const graph = loadDag(event.dagId, db)
     if (!graph) return
+    if (isDagCancelled(event.dagId, db)) return
 
     const idx = nodeIndex(graph)
     const node = idx.get(event.nodeId)

--- a/server/dag/store.ts
+++ b/server/dag/store.ts
@@ -12,6 +12,7 @@ function graphToRows(graph: DagGraph): { dagRow: Parameters<typeof prepared.inse
     repo: repo && repo.length > 0 ? repo : null,
     created_at: graph.createdAt,
     updated_at: Date.now(),
+    cancelled_at: null,
   }
 
   const idx = nodeIndex(graph)
@@ -160,4 +161,26 @@ export function listDags(db?: Database): DagGraph[] {
 export function deleteDag(id: string, db?: Database): void {
   const database = db ?? getDb()
   prepared.deleteDag(database, id)
+}
+
+export function isDagCancelled(id: string, db?: Database): boolean {
+  const database = db ?? getDb()
+  const row = prepared.getDag(database, id)
+  return row?.cancelled_at != null
+}
+
+export function markDagCancelled(id: string, db?: Database): void {
+  const database = db ?? getDb()
+  prepared.cancelDag(database, id, Date.now())
+}
+
+export function clearDagCancelled(id: string, db?: Database): void {
+  const database = db ?? getDb()
+  prepared.uncancelDag(database, id, Date.now())
+}
+
+export function findDagOwnerBySession(sessionId: string, db?: Database): { dagId: string; nodeId: string } | null {
+  const database = db ?? getDb()
+  const row = prepared.findDagNodeBySession(database, sessionId)
+  return row ? { dagId: row.dag_id, nodeId: row.id } : null
 }

--- a/server/db/migrations/0012_dag_cancelled.sql
+++ b/server/db/migrations/0012_dag_cancelled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dags ADD COLUMN cancelled_at INTEGER;

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -103,7 +103,8 @@ CREATE TABLE IF NOT EXISTS dags (
   status TEXT NOT NULL CHECK (status IN ('pending','running','completed','failed')),
   repo TEXT,
   created_at INTEGER NOT NULL,
-  updated_at INTEGER NOT NULL
+  updated_at INTEGER NOT NULL,
+  cancelled_at INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS dag_nodes (

--- a/server/db/sqlite.test.ts
+++ b/server/db/sqlite.test.ts
@@ -406,6 +406,7 @@ test('memories table has all expected columns and constraints', () => {
     repo: 'test/repo',
     created_at: now,
     updated_at: now,
+    cancelled_at: null,
   })
 
   db.run(

--- a/server/db/sqlite.ts
+++ b/server/db/sqlite.ts
@@ -157,6 +157,7 @@ interface DagRow {
   repo: string | null
   created_at: number
   updated_at: number
+  cancelled_at: number | null
 }
 
 interface DagNodeRow {
@@ -204,10 +205,12 @@ type StmtCache = {
   getSessionCheckpoint?: ReturnType<Database['prepare']>
   insertDag?: ReturnType<Database['prepare']>
   updateDag?: ReturnType<Database['prepare']>
+  cancelDag?: ReturnType<Database['prepare']>
   getDag?: ReturnType<Database['prepare']>
   listDags?: ReturnType<Database['prepare']>
   deleteDag?: ReturnType<Database['prepare']>
   upsertDagNode?: ReturnType<Database['prepare']>
+  findDagNodeBySession?: ReturnType<Database['prepare']>
 }
 
 const dbCaches = new WeakMap<Database, StmtCache>()
@@ -620,8 +623,8 @@ export const prepared = {
     const c = stmts(db)
     if (!c.insertDag) {
       c.insertDag = db.prepare(
-        `INSERT INTO dags (id, root_task_id, status, repo, created_at, updated_at)
-         VALUES ($id, $root_task_id, $status, $repo, $created_at, $updated_at)`,
+        `INSERT INTO dags (id, root_task_id, status, repo, created_at, updated_at, cancelled_at)
+         VALUES ($id, $root_task_id, $status, $repo, $created_at, $updated_at, $cancelled_at)`,
       )
     }
     c.insertDag.run({
@@ -631,6 +634,7 @@ export const prepared = {
       $repo: row.repo,
       $created_at: row.created_at,
       $updated_at: row.updated_at,
+      $cancelled_at: row.cancelled_at,
     })
   },
 
@@ -655,6 +659,20 @@ export const prepared = {
     })
   },
 
+  cancelDag(db: Database, id: string, cancelledAt: number): void {
+    const c = stmts(db)
+    if (!c.cancelDag) {
+      c.cancelDag = db.prepare(
+        `UPDATE dags SET cancelled_at = $cancelled_at, updated_at = $updated_at WHERE id = $id`,
+      )
+    }
+    c.cancelDag.run({ $id: id, $cancelled_at: cancelledAt, $updated_at: cancelledAt })
+  },
+
+  uncancelDag(db: Database, id: string, updatedAt: number): void {
+    db.run('UPDATE dags SET cancelled_at = NULL, updated_at = ? WHERE id = ?', [updatedAt, id])
+  },
+
   getDag(db: Database, id: string): DagRow | null {
     const c = stmts(db)
     if (!c.getDag) {
@@ -677,6 +695,17 @@ export const prepared = {
       c.deleteDag = db.prepare('DELETE FROM dags WHERE id = ?')
     }
     c.deleteDag.run(id)
+  },
+
+  findDagNodeBySession(db: Database, sessionId: string): { dag_id: string; id: string } | null {
+    const c = stmts(db)
+    if (!c.findDagNodeBySession) {
+      c.findDagNodeBySession = db.prepare<{ dag_id: string; id: string }, [string]>(
+        'SELECT dag_id, id FROM dag_nodes WHERE session_id = ? LIMIT 1',
+      )
+    }
+    const row = c.findDagNodeBySession.get(sessionId) as { dag_id: string; id: string } | null
+    return row ?? null
   },
 
   upsertDagNode(db: Database, row: DagNodeRow): void {


### PR DESCRIPTION
## Summary

Engine crashes used to lose scheduler state held only in closure maps (`activeGraphs`, `nodeToSession`, `nodeToGraph`, `cancelledDags`), and several recent bug fixes traced back to "memory and DB drifted." This PR makes the database authoritative for scheduler state and adds a per-DAG mutex so the new load → mutate → save pattern stays correct under concurrent session completions.

- Adds `cancelled_at` column to `dags` (migration `0012_dag_cancelled.sql`) so cancellation survives restart.
- Replaces in-memory maps with `loadDag` + new `dag/store` helpers (`isDagCancelled`, `markDagCancelled`, `clearDagCancelled`, `findDagOwnerBySession`).
- Adds `prepared.cancelDag` / `uncancelDag` / `findDagNodeBySession` to `db/sqlite.ts`.
- Adds a small promise-chained mutex (`withDagLock`) so concurrent `onSessionCompleted` calls can't lose each other's mutations across the load/save round-trip.
- `reconcileOnBoot` now skips cancelled DAGs; `start` / `retryNode` / `forceNodeLanded` clear cancellation as part of the user-initiated action.
- The deferred-restack queue is left in memory — persistence for that is owned by another minion.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (vitest, 1083 tests)
- [x] `bun test server/dag/scheduler.test.ts server/db/sqlite.test.ts` — 39 pass, 2 pre-existing FTS5 fails unrelated to this change
- [x] New tests cover: cancellation persists across a fresh scheduler instance, completion lookup works without an in-memory map, repeated completion is idempotent, `status()` reads from DB, `reconcileOnBoot` ignores cancelled DAGs, `retryNode` un-cancels, concurrent completions on the same DAG are serialized, and `dag.node.pushed` is dropped on cancelled DAGs.
- [ ] Did not run Playwright locally (per CLAUDE.md guidance — covered by CI).
