### PR TITLE
feat(logger): structured logger with correlation IDs for DAG orchestration

### DIFF
--- a/server/dag/landing.ts
+++ b/server/dag/landing.ts
@@ -9,8 +9,10 @@ import type { DagGraph, DagNode } from "./dag"
 import type { EngineEventBus } from "../events/bus"
 import type { ExecCall, ExecFn } from "./preflight"
 import type { SessionRegistry } from "../session/registry"
+import { createLogger } from "./logger"
 
 const execFileP = promisify(execFileCb)
+const log = createLogger("landing")
 
 function defaultExec({ cmd, args, opts }: ExecCall): Promise<{ stdout: string; stderr: string }> {
   return execFileP(cmd, args, opts ?? {}) as Promise<{ stdout: string; stderr: string }>
@@ -104,7 +106,7 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
     for (const node of prNodes) {
       const parsed = parsePrUrl(node.prUrl!)
       if (!parsed) {
-        console.error(`[landing] cannot parse PR URL ${node.prUrl}`)
+        log.error({ dagId: graph.id, nodeId: node.id, prUrl: node.prUrl }, "cannot parse PR URL")
         continue
       }
       try {
@@ -121,7 +123,7 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
           opts: { timeout: 30_000, encoding: "utf-8" },
         })
       } catch (err) {
-        console.error(`[landing] failed to retarget PR ${node.prUrl} to main:`, err)
+        log.error({ dagId: graph.id, nodeId: node.id, prUrl: node.prUrl, err }, "failed to retarget PR to main")
       }
     }
   }
@@ -134,7 +136,7 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
 
       const cwd = worktreeDir(workspaceRoot, node.branch)
       if (!fs.existsSync(cwd)) {
-        console.error(`[landing] skip rebase for ${node.id}: worktree ${cwd} missing`)
+        log.error({ dagId: graph.id, nodeId: node.id, cwd }, "skip rebase: worktree missing")
         continue
       }
 
@@ -152,7 +154,7 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
         })
         await run({ cmd: "git", args: ["push", "--force-with-lease"], opts: { cwd, timeout: 60_000, encoding: "utf-8" } })
       } catch (err) {
-        console.error(`[landing] rebase failed for node ${node.id} branch ${node.branch}:`, err)
+        log.error({ dagId: graph.id, nodeId: node.id, branch: node.branch, err }, "rebase failed")
       }
     }
   }
@@ -204,7 +206,7 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
       try {
         persistDag(graph)
       } catch (err) {
-        console.error(`[landing] persistDag failed for ${nodeId}:`, err)
+        log.error({ dagId: graph.id, nodeId, err }, "persistDag failed")
       }
     }
 
@@ -214,7 +216,7 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
         await registry.close(node.sessionId)
         closedSessionId = node.sessionId
       } catch (err) {
-        console.error(`[landing] failed to close session ${node.sessionId} for node ${nodeId}:`, err)
+        log.error({ dagId: graph.id, nodeId, sessionId: node.sessionId, err }, "failed to close session")
       }
     }
 

--- a/server/dag/logger.test.ts
+++ b/server/dag/logger.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import {
+  createLogger,
+  setLogLevel,
+  getLogLevel,
+  setLogSink,
+  resetLogSink,
+  type LogEntry,
+  type Logger,
+} from "./logger"
+
+describe("logger", () => {
+  let entries: LogEntry[]
+  let originalLevel: ReturnType<typeof getLogLevel>
+
+  beforeEach(() => {
+    entries = []
+    originalLevel = getLogLevel()
+    setLogLevel("debug")
+    setLogSink((entry) => entries.push(entry))
+  })
+
+  afterEach(() => {
+    resetLogSink()
+    setLogLevel(originalLevel)
+  })
+
+  it("emits entries with the component, level, and message", () => {
+    const log = createLogger("scheduler")
+    log.info("ticked")
+    expect(entries).toHaveLength(1)
+    expect(entries[0]!.component).toBe("scheduler")
+    expect(entries[0]!.level).toBe("info")
+    expect(entries[0]!.msg).toBe("ticked")
+  })
+
+  it("merges fields from the call site into the entry", () => {
+    const log = createLogger("scheduler")
+    log.info({ dagId: "dag-1", nodeId: "n1" }, "spawned")
+    expect(entries[0]!.fields).toEqual({ dagId: "dag-1", nodeId: "n1" })
+    expect(entries[0]!.msg).toBe("spawned")
+  })
+
+  it("threads bound context via child()", () => {
+    const log = createLogger("restack").child({ dagId: "dag-1", nodeId: "n1" })
+    log.error({ err: "boom" }, "rebase failed")
+    expect(entries).toHaveLength(1)
+    expect(entries[0]!.fields).toEqual({ dagId: "dag-1", nodeId: "n1", err: "boom" })
+  })
+
+  it("nested child() merges bindings rather than replacing them", () => {
+    const log = createLogger("restack")
+      .child({ dagId: "dag-1" })
+      .child({ nodeId: "n1" })
+      .child({ sessionId: "s1" })
+
+    log.warn("debounced")
+    expect(entries[0]!.fields).toEqual({ dagId: "dag-1", nodeId: "n1", sessionId: "s1" })
+  })
+
+  it("call-site fields override bindings on collision", () => {
+    const log = createLogger("c").child({ dagId: "old" })
+    log.info({ dagId: "new" }, "x")
+    expect(entries[0]!.fields).toEqual({ dagId: "new" })
+  })
+
+  it("respects log levels", () => {
+    setLogLevel("warn")
+    const log = createLogger("c")
+    log.debug("d")
+    log.info("i")
+    log.warn("w")
+    log.error("e")
+    expect(entries.map((e) => e.level)).toEqual(["warn", "error"])
+  })
+
+  it("silent level suppresses everything", () => {
+    setLogLevel("silent")
+    const log = createLogger("c")
+    log.error({ dagId: "x" }, "e")
+    expect(entries).toHaveLength(0)
+  })
+
+  it("supports message-only signature", () => {
+    const log = createLogger("c").child({ dagId: "d" })
+    log.info("plain")
+    expect(entries[0]!.msg).toBe("plain")
+    expect(entries[0]!.fields).toEqual({ dagId: "d" })
+  })
+
+  it("attaches a timestamp", () => {
+    const before = Date.now()
+    createLogger("c").info("x")
+    const after = Date.now()
+    expect(entries[0]!.timestamp).toBeGreaterThanOrEqual(before)
+    expect(entries[0]!.timestamp).toBeLessThanOrEqual(after)
+  })
+
+  it("child loggers do not mutate parent bindings", () => {
+    const parent = createLogger("c").child({ dagId: "dag-1" })
+    const child = parent.child({ nodeId: "n1" })
+
+    parent.info("parent-msg")
+    child.info("child-msg")
+
+    const parentEntry = entries.find((e) => e.msg === "parent-msg")!
+    const childEntry = entries.find((e) => e.msg === "child-msg")!
+
+    expect(parentEntry.fields).toEqual({ dagId: "dag-1" })
+    expect(childEntry.fields).toEqual({ dagId: "dag-1", nodeId: "n1" })
+  })
+
+  it("logger interface satisfies the Logger type at compile time", () => {
+    const log: Logger = createLogger("compile-time-check")
+    log.info("ok")
+    expect(entries).toHaveLength(1)
+  })
+})

--- a/server/dag/logger.ts
+++ b/server/dag/logger.ts
@@ -1,19 +1,143 @@
-export interface Logger {
-  debug(obj: unknown, msg?: string): void
-  debug(msg: string): void
-  info(obj: unknown, msg?: string): void
-  info(msg: string): void
-  warn(obj: unknown, msg?: string): void
-  warn(msg: string): void
-  error(obj: unknown, msg?: string): void
-  error(msg: string): void
+export type LogLevel = "debug" | "info" | "warn" | "error" | "silent"
+
+export type LogFields = Record<string, unknown>
+
+export interface LogEntry {
+  level: Exclude<LogLevel, "silent">
+  component: string
+  msg: string
+  fields: LogFields
+  timestamp: number
 }
 
-function makeLogger(): Logger {
+export type LogSink = (entry: LogEntry) => void
+
+export interface Logger {
+  debug(obj: LogFields, msg?: string): void
+  debug(msg: string): void
+  info(obj: LogFields, msg?: string): void
+  info(msg: string): void
+  warn(obj: LogFields, msg?: string): void
+  warn(msg: string): void
+  error(obj: LogFields, msg?: string): void
+  error(msg: string): void
+  child(fields: LogFields): Logger
+}
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  silent: 100,
+}
+
+function envLevel(): LogLevel {
+  const env = typeof process !== "undefined" ? process.env : undefined
+  const raw = env?.["LOG_LEVEL"]?.toLowerCase()
+  if (raw === "debug" || raw === "info" || raw === "warn" || raw === "error" || raw === "silent") {
+    return raw
+  }
+  if (env?.["NODE_ENV"] === "test") return "silent"
+  return "info"
+}
+
+let activeLevel: LogLevel = envLevel()
+let activeSink: LogSink = defaultSink
+
+export function setLogLevel(level: LogLevel): void {
+  activeLevel = level
+}
+
+export function getLogLevel(): LogLevel {
+  return activeLevel
+}
+
+export function setLogSink(sink: LogSink): void {
+  activeSink = sink
+}
+
+export function resetLogSink(): void {
+  activeSink = defaultSink
+}
+
+function defaultSink(entry: LogEntry): void {
+  const payload: Record<string, unknown> = {
+    t: new Date(entry.timestamp).toISOString(),
+    level: entry.level,
+    component: entry.component,
+    msg: entry.msg,
+    ...entry.fields,
+  }
+  const line = JSON.stringify(payload, replaceErrors)
+  if (entry.level === "error" || entry.level === "warn") {
+    process.stderr.write(line + "\n")
+  } else {
+    process.stdout.write(line + "\n")
+  }
+}
+
+function replaceErrors(_key: string, value: unknown): unknown {
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message, stack: value.stack }
+  }
+  return value
+}
+
+function shouldLog(level: Exclude<LogLevel, "silent">): boolean {
+  return LEVEL_RANK[level] >= LEVEL_RANK[activeLevel]
+}
+
+function emit(level: Exclude<LogLevel, "silent">, component: string, bindings: LogFields, a: LogFields | string, b?: string): void {
+  if (!shouldLog(level)) return
+  let msg: string
+  let fields: LogFields
+  if (typeof a === "string") {
+    msg = a
+    fields = bindings
+  } else {
+    msg = b ?? ""
+    fields = { ...bindings, ...a }
+  }
+  activeSink({ level, component, msg, fields, timestamp: Date.now() })
+}
+
+function makeLogger(component: string, bindings: LogFields): Logger {
+  return {
+    debug(a: LogFields | string, b?: string) {
+      emit("debug", component, bindings, a as LogFields | string, b)
+    },
+    info(a: LogFields | string, b?: string) {
+      emit("info", component, bindings, a as LogFields | string, b)
+    },
+    warn(a: LogFields | string, b?: string) {
+      emit("warn", component, bindings, a as LogFields | string, b)
+    },
+    error(a: LogFields | string, b?: string) {
+      emit("error", component, bindings, a as LogFields | string, b)
+    },
+    child(fields: LogFields): Logger {
+      return makeLogger(component, { ...bindings, ...fields })
+    },
+  }
+}
+
+export function createLogger(component: string, bindings: LogFields = {}): Logger {
+  return makeLogger(component, bindings)
+}
+
+function makeNoopLogger(): Logger {
   const noop = () => {}
-  return { debug: noop, info: noop, warn: noop, error: noop }
+  const logger: Logger = {
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    child: () => logger,
+  }
+  return logger
 }
 
 export const loggers = {
-  dagExtract: makeLogger(),
+  dagExtract: makeNoopLogger(),
 } as const

--- a/server/dag/restack.test.ts
+++ b/server/dag/restack.test.ts
@@ -8,6 +8,7 @@ import { createRestackManager } from "./restack"
 import type { ExecFn } from "./preflight"
 import type { EngineEvent } from "../events/types"
 import type { SessionRegistry } from "../session/registry"
+import { setLogLevel, getLogLevel, setLogSink, resetLogSink, type LogEntry } from "./logger"
 
 function makeExecWithSha(headSha: string): { exec: ExecFn; calls: string[][]; setHeadSha: (sha: string) => void } {
   const calls: string[][] = []
@@ -368,5 +369,88 @@ describe("RestackManager.onParentPushed", () => {
     }, graph)
 
     expect(graph.nodes[1]!.headSha).toBe("new-sha-b-updated")
+  })
+})
+
+describe("RestackManager logging", () => {
+  let logEntries: LogEntry[]
+  let priorLevel: ReturnType<typeof getLogLevel>
+
+  beforeEach(() => {
+    logEntries = []
+    priorLevel = getLogLevel()
+    setLogLevel("debug")
+    setLogSink((entry) => logEntries.push(entry))
+  })
+
+  afterEach(() => {
+    resetLogSink()
+    setLogLevel(priorLevel)
+  })
+
+  it("threads dagId and nodeId into rebase failure logs", async () => {
+    const { exec } = makeFailingExec("rebase")
+    const { bus } = makeBus()
+    const manager = createRestackManager({ bus, workspaceRoot, registry: makeMockRegistry(), execFile: exec })
+    const graph = makeGraph()
+
+    await manager.onParentPushed({
+      dagId: "dag-1",
+      nodeId: "a",
+      parentSha: "old-sha-a",
+      newSha: "new-sha-a",
+      cascadeDepth: 0,
+    }, graph)
+
+    const rebaseFailEntry = logEntries.find((e) => e.msg === "rebase failed")
+    expect(rebaseFailEntry).toBeDefined()
+    expect(rebaseFailEntry!.component).toBe("restack")
+    expect(rebaseFailEntry!.level).toBe("error")
+    expect(rebaseFailEntry!.fields.dagId).toBe("dag-1")
+    expect(rebaseFailEntry!.fields.nodeId).toBe("b")
+  })
+
+  it("threads dagId and nodeId into max-depth logs", async () => {
+    const { exec } = makeExecWithSha("new-sha-b")
+    const { bus } = makeBus()
+    const manager = createRestackManager({ bus, workspaceRoot, registry: makeMockRegistry(), execFile: exec })
+    const graph = makeGraph()
+
+    await manager.onParentPushed({
+      dagId: "dag-1",
+      nodeId: "a",
+      parentSha: "old-sha-a",
+      newSha: "new-sha-a",
+      cascadeDepth: 5,
+    }, graph)
+
+    const depthEntry = logEntries.find((e) => e.msg === "max restack depth reached")
+    expect(depthEntry).toBeDefined()
+    expect(depthEntry!.fields.dagId).toBe("dag-1")
+    expect(depthEntry!.fields.nodeId).toBe("b")
+    expect(depthEntry!.fields.maxDepth).toBeDefined()
+  })
+
+  it("threads dagId and nodeId into worktree-missing logs", async () => {
+    const { exec } = makeExecWithSha("new-sha-b")
+    const { bus } = makeBus()
+    const graph = makeGraph()
+
+    fs.rmSync(path.join(workspaceRoot, "slug-b"), { recursive: true, force: true })
+
+    const manager = createRestackManager({ bus, workspaceRoot, registry: makeMockRegistry(), execFile: exec })
+    await manager.onParentPushed({
+      dagId: "dag-1",
+      nodeId: "a",
+      parentSha: "old-sha-a",
+      newSha: "new-sha-a",
+      cascadeDepth: 0,
+    }, graph)
+
+    const missingEntry = logEntries.find((e) => e.msg === "skip node: worktree missing")
+    expect(missingEntry).toBeDefined()
+    expect(missingEntry!.fields.dagId).toBe("dag-1")
+    expect(missingEntry!.fields.nodeId).toBe("b")
+    expect(missingEntry!.fields.cwd).toBeDefined()
   })
 })

--- a/server/dag/restack.ts
+++ b/server/dag/restack.ts
@@ -7,8 +7,10 @@ import type { DagGraph, DagNode } from "./dag"
 import type { EngineEventBus } from "../events/bus"
 import type { ExecCall, ExecFn } from "./preflight"
 import type { SessionRegistry } from "../session/registry"
+import { createLogger } from "./logger"
 
 const execFileP = promisify(execFileCb)
+const log = createLogger("restack")
 
 const MAX_RESTACK_DEPTH = Number(process.env["MAX_RESTACK_DEPTH"] ?? 5)
 const RESTACK_DEBOUNCE_MS = Number(process.env["RESTACK_DEBOUNCE_MS"] ?? 10_000)
@@ -86,7 +88,7 @@ export function createRestackManager(opts: RestackManagerOpts): RestackManager {
     const attempts = resolverAttempts.get(attemptKey) ?? 0
 
     if (attempts >= 1) {
-      console.error(`[restack] max resolver attempts (1) reached for node ${node.id}`)
+      log.error({ dagId: graph.id, nodeId: node.id, attempts }, "max resolver attempts reached")
       node.status = "rebase-conflict"
       node.error = "Automatic conflict resolution failed"
       bus.emit({
@@ -139,9 +141,9 @@ If the conflict cannot be resolved automatically or requires human judgment, run
           resolverAttemptKey: attemptKey,
         },
       })
-      console.log(`[restack] spawned resolver session for node ${node.id}`)
+      log.info({ dagId: graph.id, nodeId: node.id, parentBranch: ctx.parentBranch, parentSha: ctx.parentSha }, "spawned resolver session")
     } catch (err) {
-      console.error(`[restack] failed to spawn resolver for node ${node.id}:`, err)
+      log.error({ dagId: graph.id, nodeId: node.id, err }, "failed to spawn resolver")
       node.status = "rebase-conflict"
       node.error = `Failed to spawn resolver: ${err instanceof Error ? err.message : String(err)}`
       bus.emit({
@@ -191,25 +193,25 @@ If the conflict cannot be resolved automatically or requires human judgment, run
     ctx: RestackContext,
   ): Promise<void> {
     if (!node.branch) {
-      console.error(`[restack] skip node ${node.id}: no branch`)
+      log.error({ dagId: graph.id, nodeId: node.id }, "skip node: no branch")
       return
     }
 
     const cwd = worktreeDir(workspaceRoot, node.branch)
     if (!fs.existsSync(cwd)) {
-      console.error(`[restack] skip node ${node.id}: worktree ${cwd} missing`)
+      log.error({ dagId: graph.id, nodeId: node.id, cwd }, "skip node: worktree missing")
       return
     }
 
     const now = Date.now()
     const lastTime = lastRestackTime.get(node.id) ?? 0
     if (now - lastTime < RESTACK_DEBOUNCE_MS) {
-      console.log(`[restack] debounce node ${node.id}: ${now - lastTime}ms since last restack`)
+      log.info({ dagId: graph.id, nodeId: node.id, sinceMs: now - lastTime }, "debounce node restack")
       return
     }
 
     if (ctx.cascadeDepth >= MAX_RESTACK_DEPTH) {
-      console.error(`[restack] max depth ${MAX_RESTACK_DEPTH} reached for node ${node.id}`)
+      log.error({ dagId: graph.id, nodeId: node.id, maxDepth: MAX_RESTACK_DEPTH }, "max restack depth reached")
       node.status = "rebase-conflict"
       node.error = `Max restack depth (${MAX_RESTACK_DEPTH}) exceeded`
       bus.emit({
@@ -236,7 +238,7 @@ If the conflict cannot be resolved automatically or requires human judgment, run
     const rebaseResult = await rebaseOntoParent(node, ctx.parentBranch, cwd)
 
     if (!rebaseResult.success) {
-      console.error(`[restack] rebase failed for node ${node.id}:`, rebaseResult.error)
+      log.error({ dagId: graph.id, nodeId: node.id, error: rebaseResult.error }, "rebase failed")
       node.status = "rebasing"
       node.error = rebaseResult.error
       await spawnResolver(node, graph, ctx, cwd)
@@ -250,7 +252,7 @@ If the conflict cannot be resolved automatically or requires human judgment, run
         opts: { cwd, timeout: 60_000, encoding: "utf-8" },
       })
     } catch (err) {
-      console.error(`[restack] force-push failed for node ${node.id}:`, err)
+      log.error({ dagId: graph.id, nodeId: node.id, err }, "force-push failed")
       node.status = priorStatus
       node.error = err instanceof Error ? err.message : String(err)
       bus.emit({
@@ -297,7 +299,7 @@ If the conflict cannot be resolved automatically or requires human judgment, run
     const idx = nodeIndex(graph)
     const parent = idx.get(event.nodeId)
     if (!parent || !parent.branch) {
-      console.error(`[restack] parent node ${event.nodeId} has no branch`)
+      log.error({ dagId: event.dagId, nodeId: event.nodeId }, "parent node has no branch")
       return
     }
 
@@ -322,13 +324,13 @@ If the conflict cannot be resolved automatically or requires human judgment, run
 
     for (const child of directChildren) {
       if (child.status === "running") {
-        console.log(`[restack] defer restack for running node ${child.id}`)
+        log.info({ dagId: graph.id, nodeId: child.id, parentNodeId: event.nodeId }, "defer restack for running node")
         continue
       }
 
       const existingRestack = inflightRestacks.get(child.id)
       if (existingRestack) {
-        console.log(`[restack] restack already in flight for node ${child.id}`)
+        log.info({ dagId: graph.id, nodeId: child.id }, "restack already in flight")
         await existingRestack
         continue
       }

--- a/server/dag/scheduler.ts
+++ b/server/dag/scheduler.ts
@@ -17,6 +17,9 @@ import { createRestackManager } from "./restack"
 import type { RestackManager } from "./restack"
 import { createDagWatchdog } from "./watchdog"
 import type { DagWatchdog, DagWatchdogOpts, StallEvent, StallAction } from "./watchdog"
+import { createLogger } from "./logger"
+
+const log = createLogger("scheduler")
 
 function fetchRootConversation(db: Database, rootSessionId: string): TopicMessage[] {
   const rows = db
@@ -693,7 +696,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
           cascade_depth: 0,
           created_at: Date.now(),
         })
-        console.log(`[scheduler] defer restack for running node ${event.nodeId}`)
+        log.info({ dagId: event.dagId, nodeId: event.nodeId, sessionId }, "defer restack for running node")
         return
       }
     }
@@ -708,7 +711,7 @@ export function createDagScheduler(opts: DagSchedulerOpts): DagScheduler {
       },
       graph,
     ).catch((err) => {
-      console.error(`[scheduler] restack failed for node ${event.nodeId}:`, err)
+      log.error({ dagId: event.dagId, nodeId: event.nodeId, err }, "restack failed")
     })
   })
 

--- a/server/dag/stack-comment.ts
+++ b/server/dag/stack-comment.ts
@@ -3,8 +3,10 @@ import { promisify } from "node:util"
 import { renderDagForGitHub, upsertDagSection } from "./dag"
 import type { DagGraph } from "./dag"
 import type { ExecCall, ExecFn } from "./preflight"
+import { createLogger } from "./logger"
 
 const execFileP = promisify(execFileCb)
+const log = createLogger("stack-comment")
 
 function defaultExec({ cmd, args, opts }: ExecCall): Promise<{ stdout: string; stderr: string }> {
   return execFileP(cmd, args, opts ?? {}) as Promise<{ stdout: string; stderr: string }>
@@ -41,9 +43,10 @@ export async function updateStackComment(graph: DagGraph, execFn: ExecFn = defau
     }),
   )
 
-  for (const result of results) {
+  results.forEach((result, i) => {
     if (result.status === "rejected") {
-      console.error("[stack-comment] failed to update PR:", result.reason)
+      const node = openPrNodes[i]!
+      log.error({ dagId: graph.id, nodeId: node.id, prUrl: node.prUrl, err: result.reason }, "failed to update PR body")
     }
-  }
+  })
 }

--- a/server/handlers/ci-babysit-handler.ts
+++ b/server/handlers/ci-babysit-handler.ts
@@ -5,8 +5,10 @@ import { promisify } from 'node:util'
 import path from 'node:path'
 import { loadDag } from '../dag/store'
 import { HANDLER_PRIORITIES } from './priorities'
+import { createLogger } from '../dag/logger'
 
 const execFileP = promisify(execFileCb)
+const log = createLogger('ci-babysit-handler')
 
 export const ciBabysitHandler: CompletionHandler = {
   name: 'ci-babysit',
@@ -34,7 +36,7 @@ export const ciBabysitHandler: CompletionHandler = {
 
     if (meta.dagNodeId && row.workspace_root) {
       await detectAndEmitPush(ev.sessionId, row.workspace_root, meta, ctx).catch((err) => {
-        console.error(`[ci-babysit-handler] push detection failed for ${ev.sessionId}:`, err)
+        log.error({ sessionId: ev.sessionId, dagId: meta.dagId, nodeId: meta.dagNodeId, err }, "push detection failed")
       })
     }
 
@@ -84,7 +86,7 @@ async function detectAndEmitPush(
     }) as { stdout: string; stderr: string }
     currentSha = result.stdout.trim()
   } catch (err) {
-    console.error(`[ci-babysit-handler] failed to get HEAD SHA for ${node.id}:`, err)
+    log.error({ sessionId, dagId: meta.dagId, nodeId: node.id, err }, "failed to get HEAD SHA")
     return
   }
 

--- a/server/handlers/restack-resolver-handler.ts
+++ b/server/handlers/restack-resolver-handler.ts
@@ -4,8 +4,10 @@ import { promisify } from 'node:util'
 import path from 'node:path'
 import { loadDag } from '../dag/store'
 import { HANDLER_PRIORITIES } from './priorities'
+import { createLogger, type Logger } from '../dag/logger'
 
 const execFileP = promisify(execFileCb)
+const log = createLogger('restack-resolver-handler')
 
 export const restackResolverHandler: CompletionHandler = {
   name: 'restack-resolver',
@@ -35,28 +37,30 @@ export const restackResolverHandler: CompletionHandler = {
 
     const { dagId, dagNodeId, parentBranch, parentSha } = meta
     if (!dagId || !dagNodeId || !parentBranch || !parentSha) {
-      console.error(`[restack-resolver-handler] missing metadata for session ${ev.sessionId}`)
+      log.error({ sessionId: ev.sessionId }, "missing metadata for session")
       return { handled: false, reason: 'missing_metadata' }
     }
 
+    const childLog = log.child({ dagId, nodeId: dagNodeId, sessionId: ev.sessionId })
+
     const graph = loadDag(dagId, ctx.db)
     if (!graph) {
-      console.error(`[restack-resolver-handler] DAG ${dagId} not found`)
+      childLog.error("DAG not found")
       return { handled: false, reason: 'dag_not_found' }
     }
 
     const node = graph.nodes.find((n) => n.id === dagNodeId)
     if (!node) {
-      console.error(`[restack-resolver-handler] node ${dagNodeId} not found in DAG ${dagId}`)
+      childLog.error("node not found in DAG")
       return { handled: false, reason: 'node_not_found' }
     }
 
     const cwd = path.join(row.workspace_root, row.slug)
 
-    const rebaseStatus = await checkRebaseStatus(cwd)
+    const rebaseStatus = await checkRebaseStatus(cwd, childLog)
 
     if (rebaseStatus === 'in-progress') {
-      console.log(`[restack-resolver-handler] rebase still in progress for node ${dagNodeId}`)
+      childLog.info("rebase still in progress")
       node.status = 'rebase-conflict'
       node.error = 'Resolver completed but rebase is still in progress'
       ctx.bus.emit({
@@ -70,7 +74,7 @@ export const restackResolverHandler: CompletionHandler = {
     }
 
     if (rebaseStatus === 'dirty') {
-      console.log(`[restack-resolver-handler] workspace is dirty for node ${dagNodeId}`)
+      childLog.info("workspace is dirty")
       node.status = 'rebase-conflict'
       node.error = 'Resolver completed but workspace has uncommitted changes'
       ctx.bus.emit({
@@ -92,7 +96,7 @@ export const restackResolverHandler: CompletionHandler = {
       }) as { stdout: string; stderr: string }
       currentSha = result.stdout.trim()
     } catch (err) {
-      console.error(`[restack-resolver-handler] failed to get HEAD SHA for ${dagNodeId}:`, err)
+      childLog.error({ err }, "failed to get HEAD SHA")
       node.status = 'rebase-conflict'
       node.error = `Failed to get HEAD SHA: ${err instanceof Error ? err.message : String(err)}`
       ctx.bus.emit({
@@ -112,7 +116,7 @@ export const restackResolverHandler: CompletionHandler = {
         encoding: 'utf-8',
       })
     } catch (err) {
-      console.error(`[restack-resolver-handler] push failed for node ${dagNodeId}:`, err)
+      childLog.error({ err }, "push failed")
       node.status = 'rebase-conflict'
       node.error = `Push failed: ${err instanceof Error ? err.message : String(err)}`
       ctx.bus.emit({
@@ -125,7 +129,7 @@ export const restackResolverHandler: CompletionHandler = {
       return { handled: true, reason: 'push_failed' }
     }
 
-    console.log(`[restack-resolver-handler] successfully resolved and pushed node ${dagNodeId}`)
+    childLog.info({ headSha: currentSha }, "successfully resolved and pushed")
     node.headSha = currentSha
     node.error = undefined
 
@@ -147,7 +151,7 @@ export const restackResolverHandler: CompletionHandler = {
   },
 }
 
-async function checkRebaseStatus(cwd: string): Promise<'clean' | 'dirty' | 'in-progress'> {
+async function checkRebaseStatus(cwd: string, logger: Logger): Promise<'clean' | 'dirty' | 'in-progress'> {
   try {
     const statusResult = await execFileP('git', ['status', '--porcelain'], {
       cwd,
@@ -173,7 +177,7 @@ async function checkRebaseStatus(cwd: string): Promise<'clean' | 'dirty' | 'in-p
 
     return 'clean'
   } catch (err) {
-    console.error(`[restack-resolver-handler] failed to check rebase status:`, err)
+    logger.error({ err }, "failed to check rebase status")
     return 'dirty'
   }
 }

--- a/server/handlers/ship-advance-handler.ts
+++ b/server/handlers/ship-advance-handler.ts
@@ -1,8 +1,10 @@
 import type { CompletionHandler, HandlerCtx, HandlerResult, SessionCompletedEvent } from './types'
 import { handleExecute } from '../commands/plan-actions'
 import { HANDLER_PRIORITIES } from './priorities'
+import { createLogger } from '../dag/logger'
 
 const SHIP_ADVANCE_MODES = new Set(['ship-think', 'ship-plan'])
+const log = createLogger('ship-advance-handler')
 
 export const shipAdvanceHandler: CompletionHandler = {
   name: 'ship-advance',
@@ -31,7 +33,7 @@ export const shipAdvanceHandler: CompletionHandler = {
         scheduler: ctx.scheduler,
       })
     } catch (err) {
-      console.error(`[ship-advance] failed to advance session ${ev.sessionId} (mode=${row.mode}):`, err)
+      log.error({ sessionId: ev.sessionId, mode: row.mode, err }, "failed to advance session")
       throw err
     }
     return { handled: true }


### PR DESCRIPTION
## Summary

- Adds a structured logger (`server/dag/logger.ts`) that emits JSON-line entries tagged with `component`, `level`, and bound correlation IDs (`dagId`, `nodeId`, `sessionId`).
- Supports `child(fields)` for context propagation, level filtering via `LOG_LEVEL`, and an injectable sink for tests. Defaults to `silent` when `NODE_ENV=test`.
- Replaces all ad-hoc `console.error/log/warn` calls in the DAG scheduler, restack manager, landing manager, stack-comment updater, and completion handlers (`scheduler.ts`, `restack.ts`, `landing.ts`, `stack-comment.ts`, `restack-resolver-handler.ts`, `ci-babysit-handler.ts`, `ship-advance-handler.ts`) with structured calls that thread `dagId` / `nodeId` / `sessionId` into every line.
- Adds unit tests for the logger (level filtering, `child()` merging, error serialization) and integration tests in `restack.test.ts` that assert correlation IDs flow through real call sites (rebase failure, max-depth, missing worktree).

This makes state-divergence bugs (the 7eafc7b / fecc8db family) observable in logs by giving every line the IDs needed to reconstruct what happened to a particular DAG node across handler boundaries.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (vitest UI suite — 1083 pass)
- [x] `bun test server/ shared/` — same 14 pre-existing failures as `main`; no new failures
- [x] New unit tests in `server/dag/logger.test.ts` (11 pass)
- [x] New integration tests in `server/dag/restack.test.ts` ("RestackManager logging" — 3 pass)
