### PR TITLE
feat(land): add landingMode flag with all-or-nothing rollback

### DIFF
--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -118,6 +118,15 @@ const ImageSchema = z.object({
   dataBase64: z.string().min(1),
 })
 
+function parseLandMode(rest: string): 'best-effort' | 'all-or-nothing' | 'invalid' | undefined {
+  const arg = rest.trim()
+  if (!arg) return undefined
+  const normalized = arg.toLowerCase()
+  if (normalized === 'all-or-nothing' || normalized === 'atomic') return 'all-or-nothing'
+  if (normalized === 'best-effort' || normalized === 'partial') return 'best-effort'
+  return 'invalid'
+}
+
 function validateImagePayloads(
   images: Array<{ dataBase64: string }> | undefined,
 ): string | null {
@@ -149,7 +158,7 @@ const CommandSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('stop'), sessionId: z.string() }),
   z.object({ action: z.literal('close'), sessionId: z.string() }),
   z.object({ action: z.literal('plan_action'), sessionId: z.string(), planAction: z.enum(['execute', 'split', 'stack', 'dag']), markdown: z.string().optional(), message: z.string().optional() }),
-  z.object({ action: z.literal('land'), dagId: z.string(), nodeId: z.string() }),
+  z.object({ action: z.literal('land'), dagId: z.string(), nodeId: z.string(), mode: z.enum(['best-effort', 'all-or-nothing']).optional() }),
   z.object({ action: z.literal('retry_rebase'), dagId: z.string(), nodeId: z.string() }),
   z.object({ action: z.literal('ship_advance'), sessionId: z.string(), to: z.enum(['think', 'plan', 'dag', 'verify', 'done']).optional() }),
   z.object({
@@ -498,6 +507,7 @@ export function registerApiRoutes(
         const result = await handleLandCommand(command.nodeId, command.dagId, {
           landingManager,
           db: resolveDb(),
+          mode: command.mode,
         })
         const body: ApiResponse<CommandResult> = {
           data: result.ok ? { success: true } : { success: false, error: result.error ?? 'land failed' },
@@ -723,6 +733,11 @@ export function registerApiRoutes(
         const graph = findDagForSession(db, sessionId)
         if (!graph) return c.json({ error: 'no DAG associated with this session' }, 422)
 
+        const mode = parseLandMode(rest)
+        if (mode === 'invalid') {
+          return c.json({ error: `unknown /land argument "${rest}"; expected "all-or-nothing" or "best-effort"` }, 400)
+        }
+
         const idx = nodeIndex(graph)
         const order = topologicalSort(graph)
         const landable = order
@@ -733,44 +748,71 @@ export function registerApiRoutes(
           return c.json({ error: 'no nodes with a PR URL are ready to land' }, 422)
         }
 
+        const effectiveMode = mode ?? 'best-effort'
         console.log(
-          `[land] dag=${graph.id} attempting ${landable.length} node(s):`,
+          `[land] dag=${graph.id} mode=${effectiveMode} attempting ${landable.length} node(s):`,
           landable.map((n) => `${n.id}@${n.prUrl}`).join(', '),
         )
-        const landed: Array<{ nodeId: string; prUrl?: string; closedSessionId?: string }> = []
-        const failed: Array<{ nodeId: string; error: string }> = []
-        for (const node of landable) {
-          console.log(`[land] dag=${graph.id} node=${node.id} pr=${node.prUrl} -> attempting merge`)
-          const result = await landingManager.landNode(node.id, graph)
-          if (result.ok) {
-            console.log(
-              `[land] dag=${graph.id} node=${node.id} merged${
-                result.closedSessionId ? ` (closed session ${result.closedSessionId})` : ''
-              }`,
-            )
-            landed.push({
-              nodeId: node.id,
-              prUrl: result.prUrl,
-              closedSessionId: result.closedSessionId,
-            })
-          } else {
-            console.error(`[land] dag=${graph.id} node=${node.id} failed: ${result.error}`)
-            failed.push({ nodeId: node.id, error: result.error ?? 'unknown error' })
+
+        const sequence = await landingManager.landSequence(
+          landable.map((n) => n.id),
+          graph,
+          { mode: effectiveMode },
+        )
+
+        const landed = sequence.landed.map((r) => {
+          const node = landable.find((n) => n.prUrl === r.prUrl)
+          return {
+            nodeId: node?.id ?? '',
+            prUrl: r.prUrl,
+            closedSessionId: r.closedSessionId,
           }
+        })
+        const failed = sequence.failed.map((r) => {
+          const node = landable.find((n) => n.prUrl === r.prUrl)
+          return { nodeId: node?.id ?? '', error: r.error ?? 'unknown error' }
+        })
+
+        for (const l of landed) {
+          console.log(
+            `[land] dag=${graph.id} node=${l.nodeId} merged${
+              l.closedSessionId ? ` (closed session ${l.closedSessionId})` : ''
+            }`,
+          )
         }
+        for (const f of failed) {
+          console.error(`[land] dag=${graph.id} node=${f.nodeId} failed: ${f.error}`)
+        }
+
+        if (sequence.rollback) {
+          console.warn(
+            `[land] dag=${graph.id} rollback ${sequence.rollback.fullySuccessful ? 'completed' : 'partial'}: ${sequence.rollback.entries
+              .map((e) => `${e.nodeId}=${e.reverted ? 'reverted' : 'failed'}`)
+              .join(', ')}`,
+          )
+        }
+
         console.log(
-          `[land] dag=${graph.id} done: landed=${landed.length} failed=${failed.length}`,
+          `[land] dag=${graph.id} done: landed=${landed.length} failed=${failed.length}${
+            sequence.rollback ? ` rolledBack=${sequence.rollback.entries.filter((e) => e.reverted).length}` : ''
+          }`,
         )
 
         return c.json({
           data: {
-            ok: failed.length === 0,
+            ok: sequence.ok,
             sessionId,
             dagId: graph.id,
-            attempted: landable.length,
+            mode: effectiveMode,
+            attempted: sequence.attempted,
             landed: landed.length,
             failed: failed.length,
-            details: { landed, failed },
+            aborted: sequence.aborted,
+            details: {
+              landed,
+              failed,
+              ...(sequence.rollback ? { rollback: sequence.rollback } : {}),
+            },
           },
         })
       }

--- a/server/commands/help.ts
+++ b/server/commands/help.ts
@@ -22,6 +22,7 @@ const HELP_TEXT = `**Task / Plan / Think / Review**
   /retry <nodeId> <dagId>       Retry a failed DAG node
   /force <nodeId> <dagId>       Force a DAG node to landed state
   /land <nodeId> <dagId>        Land a DAG node (merge PR)
+  /land [all-or-nothing|best-effort]  Land all ready PRs in a session's DAG; default best-effort
 
 **Status**
   /status [sessionId]  Summary of sessions

--- a/server/commands/land.test.ts
+++ b/server/commands/land.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "bun:test"
+import { Database } from "bun:sqlite"
+import { handleLandCommand } from "./land"
+import { buildDag } from "../dag/dag"
+import { saveDag } from "../dag/store"
+import { openDatabase, runMigrations } from "../db/sqlite"
+import type { LandingManager, LandSequenceResult, LandSequenceOpts, LandNodeResult } from "../dag/landing"
+import type { DagGraph } from "../dag/dag"
+
+function makeDb(): Database {
+  const db = openDatabase(":memory:")
+  runMigrations(db)
+  return db
+}
+
+function makeStubManager(impl: Partial<LandingManager>): LandingManager {
+  return {
+    landNode: async () => ({ ok: false, error: "not implemented" }),
+    landSequence: async () => ({
+      ok: false,
+      mode: "best-effort",
+      attempted: 0,
+      landed: [],
+      failed: [],
+      aborted: false,
+    }),
+    ...impl,
+  }
+}
+
+describe("handleLandCommand", () => {
+  it("forwards mode to landSequence", async () => {
+    const db = makeDb()
+    const graph = buildDag(
+      "dag-1",
+      [{ id: "a", title: "A", description: "", dependsOn: [] }],
+      "root-session",
+      "https://github.com/org/repo",
+    )
+    graph.nodes[0]!.prUrl = "https://github.com/org/repo/pull/1"
+    graph.nodes[0]!.status = "done"
+    saveDag(graph, db)
+
+    const seenOpts: LandSequenceOpts[] = []
+    const manager = makeStubManager({
+      landSequence: async (_ids: string[], _g: DagGraph, opts?: LandSequenceOpts) => {
+        seenOpts.push(opts ?? {})
+        const landed: LandNodeResult = { ok: true, prUrl: "https://github.com/org/repo/pull/1" }
+        const result: LandSequenceResult = {
+          ok: true,
+          mode: opts?.mode ?? "best-effort",
+          attempted: 1,
+          landed: [landed],
+          failed: [],
+          aborted: false,
+        }
+        return result
+      },
+    })
+
+    const r = await handleLandCommand("a", "dag-1", { landingManager: manager, db, mode: "all-or-nothing" })
+    expect(r.ok).toBe(true)
+    expect(r.prUrl).toBe("https://github.com/org/repo/pull/1")
+    expect(r.mode).toBe("all-or-nothing")
+    expect(seenOpts).toEqual([{ mode: "all-or-nothing" }])
+  })
+
+  it("defaults mode to best-effort when not given", async () => {
+    const db = makeDb()
+    const graph = buildDag(
+      "dag-2",
+      [{ id: "a", title: "A", description: "", dependsOn: [] }],
+      "root-session",
+      "https://github.com/org/repo",
+    )
+    saveDag(graph, db)
+
+    const seen: LandSequenceOpts[] = []
+    const manager = makeStubManager({
+      landSequence: async (_ids: string[], _g: DagGraph, opts?: LandSequenceOpts) => {
+        seen.push(opts ?? {})
+        return { ok: true, mode: "best-effort", attempted: 0, landed: [], failed: [], aborted: false }
+      },
+    })
+
+    await handleLandCommand("a", "dag-2", { landingManager: manager, db })
+    expect(seen[0]?.mode).toBe("best-effort")
+  })
+
+  it("surfaces rollback summary when present", async () => {
+    const db = makeDb()
+    const graph = buildDag(
+      "dag-3",
+      [{ id: "a", title: "A", description: "", dependsOn: [] }],
+      "root",
+      "https://github.com/org/repo",
+    )
+    saveDag(graph, db)
+
+    const manager = makeStubManager({
+      landSequence: async () => ({
+        ok: false,
+        mode: "all-or-nothing",
+        attempted: 1,
+        landed: [],
+        failed: [{ ok: false, error: "boom", prUrl: "https://github.com/org/repo/pull/1" }],
+        aborted: true,
+        rollback: {
+          attempted: true,
+          fullySuccessful: true,
+          entries: [
+            { nodeId: "x", reverted: true, prUrl: "https://github.com/org/repo/pull/9" },
+          ],
+        },
+      }),
+    })
+
+    const r = await handleLandCommand("a", "dag-3", { landingManager: manager, db, mode: "all-or-nothing" })
+    expect(r.ok).toBe(false)
+    expect(r.error).toBe("boom")
+    expect(r.rolledBack).toBe(1)
+    expect(r.rollbackFullySuccessful).toBe(true)
+  })
+
+  it("returns error when DAG not found", async () => {
+    const db = makeDb()
+    const manager = makeStubManager({})
+    const r = await handleLandCommand("a", "missing", { landingManager: manager, db })
+    expect(r.ok).toBe(false)
+    expect(r.error).toContain("not found")
+  })
+})

--- a/server/commands/land.ts
+++ b/server/commands/land.ts
@@ -1,16 +1,20 @@
-import type { LandingManager } from '../dag/landing'
+import type { LandingManager, LandingMode } from '../dag/landing'
 import type { Database } from 'bun:sqlite'
 import { loadDag } from '../dag/store'
 
 export interface LandCommandCtx {
   landingManager: LandingManager
   db: Database
+  mode?: LandingMode
 }
 
 export interface LandCommandResult {
   ok: boolean
   prUrl?: string
   error?: string
+  mode?: LandingMode
+  rolledBack?: number
+  rollbackFullySuccessful?: boolean
 }
 
 export async function handleLandCommand(
@@ -24,6 +28,17 @@ export async function handleLandCommand(
   const graph = loadDag(dagId, ctx.db)
   if (!graph) return { ok: false, error: `DAG ${dagId} not found` }
 
-  const result = await ctx.landingManager.landNode(nodeId, graph)
-  return { ok: result.ok, prUrl: result.prUrl, error: result.error }
+  const mode = ctx.mode ?? 'best-effort'
+  const sequence = await ctx.landingManager.landSequence([nodeId], graph, { mode })
+  const landed = sequence.landed[0]
+  const failed = sequence.failed[0]
+  const rolledBack = sequence.rollback?.entries.filter((e) => e.reverted).length ?? 0
+
+  return {
+    ok: sequence.ok,
+    prUrl: landed?.prUrl ?? failed?.prUrl,
+    error: failed?.error,
+    mode,
+    ...(sequence.rollback ? { rolledBack, rollbackFullySuccessful: sequence.rollback.fullySuccessful } : {}),
+  }
 }

--- a/server/dag/landing.test.ts
+++ b/server/dag/landing.test.ts
@@ -185,4 +185,229 @@ describe("LandingManager.landNode", () => {
     const fetchCalls = calls.filter((c) => c.args[0] === "fetch")
     expect(fetchCalls.length).toBe(0)
   })
+
+  it("captures mergeCommitSha when gh pr view returns one", async () => {
+    const exec: ExecFn = async ({ args }) => {
+      if (args[0] === "pr" && args[1] === "view" && args.includes("mergeCommit")) {
+        return { stdout: "deadbeef0000\n", stderr: "" }
+      }
+      return { stdout: "", stderr: "" }
+    }
+    const bus = makeBus()
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
+    const graph = makeGraph()
+
+    const result = await manager.landNode("a", graph)
+    expect(result.ok).toBe(true)
+    expect(result.mergeCommitSha).toBe("deadbeef0000")
+  })
+})
+
+describe("LandingManager.landSequence", () => {
+  it("best-effort: continues past failures and returns aggregated result", async () => {
+    const calls: string[][] = []
+    const exec: ExecFn = async ({ args }) => {
+      calls.push([...args])
+      if (args[0] === "pr" && args[1] === "merge" && args[2]?.includes("/pull/2")) {
+        throw new Error("PR is not mergeable")
+      }
+      return { stdout: "", stderr: "" }
+    }
+    const bus = makeBus()
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
+    const graph = makeGraph()
+
+    const result = await manager.landSequence(["a", "b"], graph, { mode: "best-effort" })
+    expect(result.mode).toBe("best-effort")
+    expect(result.ok).toBe(false)
+    expect(result.aborted).toBe(false)
+    expect(result.attempted).toBe(2)
+    expect(result.landed).toHaveLength(1)
+    expect(result.failed).toHaveLength(1)
+    expect(result.failed[0]!.error).toContain("merge failed")
+    expect(result.rollback).toBeUndefined()
+  })
+
+  it("all-or-nothing: aborts at first failure without attempting subsequent merges", async () => {
+    const mergeCalls: string[] = []
+    const exec: ExecFn = async ({ args }) => {
+      if (args[0] === "pr" && args[1] === "merge") {
+        mergeCalls.push(args[2] ?? "")
+        throw new Error("PR is not mergeable")
+      }
+      return { stdout: "", stderr: "" }
+    }
+    const bus = makeBus()
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
+    const graph = makeGraph()
+
+    const result = await manager.landSequence(["a", "b"], graph, { mode: "all-or-nothing" })
+    expect(result.aborted).toBe(true)
+    expect(result.attempted).toBe(1)
+    expect(mergeCalls).toHaveLength(1)
+    expect(result.failed).toHaveLength(1)
+    expect(result.landed).toHaveLength(0)
+    expect(result.rollback).toBeUndefined()
+  })
+
+  it("all-or-nothing: rolls back previously merged commits via revert and resets node statuses", async () => {
+    const calls: string[][] = []
+    let prViewCount = 0
+    const exec: ExecFn = async ({ args }) => {
+      calls.push([...args])
+      if (args[0] === "pr" && args[1] === "view" && args.includes("mergeCommit")) {
+        prViewCount++
+        return { stdout: prViewCount === 1 ? "sha-A\n" : "sha-B\n", stderr: "" }
+      }
+      if (args[0] === "pr" && args[1] === "merge" && args[2]?.includes("/pull/3")) {
+        throw new Error("merge conflict")
+      }
+      if (args[0] === "rev-parse" && args[1] === "HEAD") {
+        return { stdout: "revert-sha\n", stderr: "" }
+      }
+      return { stdout: "", stderr: "" }
+    }
+    const bareDir = path.join(workspaceRoot, ".repos", "repo.git")
+    fs.mkdirSync(bareDir, { recursive: true })
+
+    const graph = buildDag("dag-rb", [
+      { id: "a", title: "A", description: "", dependsOn: [] },
+      { id: "b", title: "B", description: "", dependsOn: ["a"] },
+      { id: "c", title: "C", description: "", dependsOn: ["b"] },
+    ], "root", "https://github.com/org/repo")
+    graph.nodes[0]!.prUrl = "https://github.com/org/repo/pull/1"
+    graph.nodes[0]!.branch = "minion/slug-a"
+    graph.nodes[0]!.status = "done"
+    graph.nodes[1]!.prUrl = "https://github.com/org/repo/pull/2"
+    graph.nodes[1]!.branch = "minion/slug-b"
+    graph.nodes[1]!.status = "done"
+    graph.nodes[2]!.prUrl = "https://github.com/org/repo/pull/3"
+    graph.nodes[2]!.branch = "minion/slug-c"
+    graph.nodes[2]!.status = "done"
+    fs.mkdirSync(path.join(workspaceRoot, "slug-c"), { recursive: true })
+
+    const bus = makeBus()
+    const persisted: number[] = []
+    const manager = createLandingManager({
+      bus,
+      workspaceRoot,
+      execFile: exec,
+      persistDag: () => { persisted.push(Date.now()) },
+    })
+
+    const revertedNodes: string[] = []
+    bus.onKind("dag.node.land_reverted", (e) => { revertedNodes.push(e.nodeId) })
+
+    const result = await manager.landSequence(["a", "b", "c"], graph, { mode: "all-or-nothing" })
+
+    expect(result.aborted).toBe(true)
+    expect(result.landed).toHaveLength(2)
+    expect(result.failed).toHaveLength(1)
+    expect(result.rollback).toBeDefined()
+    expect(result.rollback!.attempted).toBe(true)
+    expect(result.rollback!.fullySuccessful).toBe(true)
+    expect(result.rollback!.entries).toHaveLength(2)
+
+    const revertCalls = calls.filter((c) => c[0] === "revert")
+    expect(revertCalls).toHaveLength(2)
+    expect(revertCalls[0]![2]).toBe("sha-B")
+    expect(revertCalls[1]![2]).toBe("sha-A")
+
+    const pushMainCalls = calls.filter((c) => c[0] === "push" && c.includes("HEAD:main"))
+    expect(pushMainCalls).toHaveLength(2)
+
+    expect(graph.nodes[0]!.status).toBe("done")
+    expect(graph.nodes[1]!.status).toBe("done")
+
+    expect(revertedNodes.sort()).toEqual(["a", "b"])
+
+    expect(persisted.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it("all-or-nothing: marks rollback as not fully successful when revert push fails", async () => {
+    const exec: ExecFn = async ({ args }) => {
+      if (args[0] === "pr" && args[1] === "view" && args.includes("mergeCommit")) {
+        return { stdout: "sha-X\n", stderr: "" }
+      }
+      if (args[0] === "pr" && args[1] === "merge" && args[2]?.includes("/pull/2")) {
+        throw new Error("conflict")
+      }
+      if (args[0] === "rev-parse" && args[1] === "HEAD") {
+        return { stdout: "revert-x\n", stderr: "" }
+      }
+      if (args[0] === "push" && args.includes("HEAD:main")) {
+        throw new Error("protected branch — push rejected")
+      }
+      return { stdout: "", stderr: "" }
+    }
+    const bareDir = path.join(workspaceRoot, ".repos", "repo.git")
+    fs.mkdirSync(bareDir, { recursive: true })
+
+    const bus = makeBus()
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
+    const graph = makeGraph()
+
+    const result = await manager.landSequence(["a", "b"], graph, { mode: "all-or-nothing" })
+
+    expect(result.rollback).toBeDefined()
+    expect(result.rollback!.fullySuccessful).toBe(false)
+    expect(result.rollback!.entries[0]!.reverted).toBe(false)
+    expect(result.rollback!.entries[0]!.error).toContain("revert failed")
+  })
+
+  it("rolls back nothing when no nodes had been landed before failure", async () => {
+    const exec: ExecFn = async ({ args }) => {
+      if (args[0] === "pr" && args[1] === "merge") throw new Error("first merge fails")
+      return { stdout: "", stderr: "" }
+    }
+    const bus = makeBus()
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
+    const graph = makeGraph()
+
+    const result = await manager.landSequence(["a", "b"], graph, { mode: "all-or-nothing" })
+    expect(result.aborted).toBe(true)
+    expect(result.landed).toHaveLength(0)
+    expect(result.rollback).toBeUndefined()
+  })
+
+  it("rollback skipped when graph has no resolvable bare repo", async () => {
+    const exec: ExecFn = async ({ args }) => {
+      if (args[0] === "pr" && args[1] === "view" && args.includes("mergeCommit")) {
+        return { stdout: "sha-X\n", stderr: "" }
+      }
+      if (args[0] === "pr" && args[1] === "merge" && args[2]?.includes("/pull/2")) {
+        throw new Error("conflict")
+      }
+      return { stdout: "", stderr: "" }
+    }
+    const bus = makeBus()
+    const manager = createLandingManager({
+      bus,
+      workspaceRoot,
+      execFile: exec,
+      resolveBareDir: () => null,
+    })
+    const graph = makeGraph()
+
+    const result = await manager.landSequence(["a", "b"], graph, { mode: "all-or-nothing" })
+    expect(result.rollback).toBeDefined()
+    expect(result.rollback!.error).toContain("bare repo path could not be resolved")
+    expect(result.rollback!.entries.every((e) => !e.reverted)).toBe(true)
+  })
+
+  it("default mode is best-effort when none supplied", async () => {
+    const exec: ExecFn = async ({ args }) => {
+      if (args[0] === "pr" && args[1] === "merge" && args[2]?.includes("/pull/1")) {
+        throw new Error("first fails")
+      }
+      return { stdout: "", stderr: "" }
+    }
+    const bus = makeBus()
+    const manager = createLandingManager({ bus, workspaceRoot, execFile: exec })
+    const graph = makeGraph()
+
+    const result = await manager.landSequence(["a", "b"], graph)
+    expect(result.mode).toBe("best-effort")
+    expect(result.attempted).toBe(2)
+  })
 })

--- a/server/dag/landing.ts
+++ b/server/dag/landing.ts
@@ -2,8 +2,10 @@ import { execFile as execFileCb } from "node:child_process"
 import { promisify } from "node:util"
 import path from "node:path"
 import fs from "node:fs"
+import os from "node:os"
+import crypto from "node:crypto"
 import { nodeIndex, getDownstreamNodes } from "./dag"
-import type { DagGraph } from "./dag"
+import type { DagGraph, DagNode } from "./dag"
 import type { EngineEventBus } from "../events/bus"
 import type { ExecCall, ExecFn } from "./preflight"
 import type { SessionRegistry } from "../session/registry"
@@ -14,11 +16,38 @@ function defaultExec({ cmd, args, opts }: ExecCall): Promise<{ stdout: string; s
   return execFileP(cmd, args, opts ?? {}) as Promise<{ stdout: string; stderr: string }>
 }
 
+export type LandingMode = "best-effort" | "all-or-nothing"
+
 export interface LandNodeResult {
   ok: boolean
   prUrl?: string
   error?: string
   closedSessionId?: string
+  mergeCommitSha?: string
+}
+
+export interface LandRollbackEntry {
+  nodeId: string
+  prUrl?: string
+  mergeCommitSha?: string
+  reverted: boolean
+  revertCommitSha?: string
+  error?: string
+}
+
+export interface LandSequenceResult {
+  ok: boolean
+  mode: LandingMode
+  attempted: number
+  landed: LandNodeResult[]
+  failed: LandNodeResult[]
+  aborted: boolean
+  rollback?: {
+    attempted: boolean
+    fullySuccessful: boolean
+    entries: LandRollbackEntry[]
+    error?: string
+  }
 }
 
 export interface LandingManagerOpts {
@@ -27,10 +56,16 @@ export interface LandingManagerOpts {
   execFile?: ExecFn
   registry?: SessionRegistry
   persistDag?: (graph: DagGraph) => void
+  resolveBareDir?: (graph: DagGraph) => string | null
+}
+
+export interface LandSequenceOpts {
+  mode?: LandingMode
 }
 
 export interface LandingManager {
   landNode(nodeId: string, graph: DagGraph): Promise<LandNodeResult>
+  landSequence(nodeIds: string[], graph: DagGraph, opts?: LandSequenceOpts): Promise<LandSequenceResult>
 }
 
 interface ParsedPrUrl {
@@ -50,9 +85,19 @@ function worktreeDir(workspaceRoot: string, branch: string): string {
   return path.join(workspaceRoot, slug)
 }
 
+function defaultResolveBareDir(workspaceRoot: string, graph: DagGraph): string | null {
+  const repoUrl = graph.repoUrl ?? graph.repo
+  if (!repoUrl) return null
+  const segment = repoUrl.split("/").pop() ?? repoUrl
+  const repoName = segment.replace(/\.git$/, "")
+  if (!repoName) return null
+  return path.join(workspaceRoot, ".repos", `${repoName}.git`)
+}
+
 export function createLandingManager(opts: LandingManagerOpts): LandingManager {
   const { bus, workspaceRoot, registry, persistDag } = opts
   const run = opts.execFile ?? defaultExec
+  const resolveBareDir = opts.resolveBareDir ?? ((graph: DagGraph) => defaultResolveBareDir(workspaceRoot, graph))
 
   async function retargetAllStackedPRs(graph: DagGraph): Promise<void> {
     const prNodes = graph.nodes.filter((n) => n.prUrl && n.status !== "landed")
@@ -112,6 +157,21 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
     }
   }
 
+  async function fetchMergeCommitSha(prUrl: string): Promise<string | undefined> {
+    try {
+      const { stdout } = await run({
+        cmd: "gh",
+        args: ["pr", "view", prUrl, "--json", "mergeCommit", "-q", ".mergeCommit.oid"],
+        opts: { timeout: 30_000, encoding: "utf-8" },
+      })
+      const sha = stdout.trim()
+      return sha.length > 0 ? sha : undefined
+    } catch (err) {
+      console.error(`[landing] failed to fetch merge commit SHA for ${prUrl}:`, err)
+      return undefined
+    }
+  }
+
   async function landNode(nodeId: string, graph: DagGraph): Promise<LandNodeResult> {
     const idx = nodeIndex(graph)
     const node = idx.get(nodeId)
@@ -137,6 +197,8 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
     }
 
     node.status = "landed"
+
+    const mergeCommitSha = await fetchMergeCommitSha(node.prUrl)
 
     if (persistDag) {
       try {
@@ -164,8 +226,180 @@ export function createLandingManager(opts: LandingManagerOpts): LandingManager {
 
     await rebaseDownstream(nodeId, graph)
 
-    return { ok: true, prUrl: node.prUrl, closedSessionId }
+    return { ok: true, prUrl: node.prUrl, closedSessionId, mergeCommitSha }
   }
 
-  return { landNode }
+  async function revertMergedCommits(
+    landed: LandNodeResult[],
+    graph: DagGraph,
+  ): Promise<{ entries: LandRollbackEntry[]; error?: string }> {
+    const idx = nodeIndex(graph)
+    const entries: LandRollbackEntry[] = landed.map((r) => ({
+      nodeId: nodeIdForResult(r, graph) ?? "",
+      prUrl: r.prUrl,
+      mergeCommitSha: r.mergeCommitSha,
+      reverted: false,
+    }))
+
+    const bareDir = resolveBareDir(graph)
+    if (!bareDir) {
+      const error = "rollback skipped: bare repo path could not be resolved"
+      for (const entry of entries) entry.error = error
+      return { entries, error }
+    }
+
+    let scratch: string
+    try {
+      scratch = await createScratchWorktree(bareDir)
+    } catch (err) {
+      const error = `rollback skipped: failed to create scratch worktree: ${errMessage(err)}`
+      for (const entry of entries) entry.error = error
+      return { entries, error }
+    }
+
+    try {
+      for (let i = entries.length - 1; i >= 0; i--) {
+        const entry = entries[i]!
+        if (!entry.mergeCommitSha) {
+          entry.error = "no merge commit SHA captured; cannot revert"
+          continue
+        }
+        try {
+          await run({
+            cmd: "git",
+            args: ["revert", "--no-edit", entry.mergeCommitSha],
+            opts: { cwd: scratch, timeout: 60_000, encoding: "utf-8" },
+          })
+          const headOut = await run({
+            cmd: "git",
+            args: ["rev-parse", "HEAD"],
+            opts: { cwd: scratch, timeout: 30_000, encoding: "utf-8" },
+          })
+          entry.revertCommitSha = headOut.stdout.trim() || undefined
+          await run({
+            cmd: "git",
+            args: ["push", "origin", "HEAD:main"],
+            opts: { cwd: scratch, timeout: 60_000, encoding: "utf-8" },
+          })
+          entry.reverted = true
+
+          const node = idx.get(entry.nodeId)
+          if (node && node.status === "landed") {
+            node.status = "done"
+          }
+
+          bus.emit({
+            kind: "dag.node.land_reverted",
+            dagId: graph.id,
+            nodeId: entry.nodeId,
+          })
+        } catch (err) {
+          entry.error = `revert failed: ${errMessage(err)}`
+          break
+        }
+      }
+    } finally {
+      if (persistDag) {
+        try {
+          persistDag(graph)
+        } catch (err) {
+          console.error(`[landing] persistDag failed during rollback:`, err)
+        }
+      }
+      try {
+        await run({
+          cmd: "git",
+          args: ["worktree", "remove", "--force", scratch],
+          opts: { cwd: bareDir, timeout: 30_000, encoding: "utf-8" },
+        })
+      } catch {
+        // best-effort cleanup
+      }
+      try {
+        if (fs.existsSync(scratch)) fs.rmSync(scratch, { recursive: true, force: true })
+      } catch {
+        // best-effort cleanup
+      }
+    }
+
+    return { entries }
+  }
+
+  async function createScratchWorktree(bareDir: string): Promise<string> {
+    const scratch = path.join(os.tmpdir(), `minion-landing-rollback-${crypto.randomBytes(6).toString("hex")}`)
+    await run({
+      cmd: "git",
+      args: ["fetch", "origin", "main"],
+      opts: { cwd: bareDir, timeout: 60_000, encoding: "utf-8" },
+    })
+    await run({
+      cmd: "git",
+      args: ["worktree", "add", "--detach", scratch, "origin/main"],
+      opts: { cwd: bareDir, timeout: 60_000, encoding: "utf-8" },
+    })
+    return scratch
+  }
+
+  async function landSequence(
+    nodeIds: string[],
+    graph: DagGraph,
+    sequenceOpts?: LandSequenceOpts,
+  ): Promise<LandSequenceResult> {
+    const mode: LandingMode = sequenceOpts?.mode ?? "best-effort"
+    const landed: LandNodeResult[] = []
+    const failed: LandNodeResult[] = []
+    let aborted = false
+
+    for (const nodeId of nodeIds) {
+      const result = await landNode(nodeId, graph)
+      if (result.ok) {
+        landed.push({ ...result })
+      } else {
+        failed.push({ ...result, error: result.error, prUrl: result.prUrl })
+        if (mode === "all-or-nothing") {
+          aborted = true
+          break
+        }
+      }
+    }
+
+    let rollback: LandSequenceResult["rollback"]
+    if (mode === "all-or-nothing" && failed.length > 0 && landed.length > 0) {
+      const { entries, error } = await revertMergedCommits(landed, graph)
+      const fullySuccessful = entries.every((e) => e.reverted)
+      rollback = {
+        attempted: true,
+        fullySuccessful,
+        entries,
+        ...(error ? { error } : {}),
+      }
+    }
+
+    return {
+      ok: failed.length === 0,
+      mode,
+      attempted: landed.length + failed.length,
+      landed,
+      failed,
+      aborted,
+      ...(rollback ? { rollback } : {}),
+    }
+  }
+
+  return { landNode, landSequence }
+}
+
+function nodeIdForResult(result: LandNodeResult, graph: DagGraph): string | null {
+  if (!result.prUrl) return null
+  const match = graph.nodes.find((n) => n.prUrl === result.prUrl)
+  return match?.id ?? null
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+export function nodeForLandResult(result: LandNodeResult, graph: DagGraph): DagNode | undefined {
+  if (!result.prUrl) return undefined
+  return graph.nodes.find((n) => n.prUrl === result.prUrl)
 }

--- a/server/events/types.ts
+++ b/server/events/types.ts
@@ -33,6 +33,7 @@ export type EngineEvent =
   | { kind: 'dag.snapshot'; dag: ApiDagGraph }
   | { kind: 'dag.deleted'; dagId: string }
   | { kind: 'dag.node.landed'; dagId: string; nodeId: string }
+  | { kind: 'dag.node.land_reverted'; dagId: string; nodeId: string }
   | { kind: 'dag.node.pushed'; dagId: string; nodeId: string; parentSha: string; newSha: string }
   | { kind: 'dag.node.restack.started'; dagId: string; nodeId: string; parentNodeId: string }
   | {

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -349,7 +349,7 @@ export type MinionCommand =
   | { action: 'close'; sessionId: string }
   | { action: 'plan_action'; sessionId: string; planAction: PlanActionType; markdown?: string; message?: string }
   | { action: 'ship_advance'; sessionId: string; to?: ShipStage }
-  | { action: 'land'; dagId: string; nodeId: string }
+  | { action: 'land'; dagId: string; nodeId: string; mode?: 'best-effort' | 'all-or-nothing' }
   | { action: 'retry_rebase'; dagId: string; nodeId: string }
   | {
       action: 'submit_feedback'


### PR DESCRIPTION
## Summary
- Adds `landingMode: 'best-effort' | 'all-or-nothing'` to `/land` and the structured `action: 'land'` API.
- `best-effort` (default) preserves current behavior — try every landable node in topological order, log and continue past failures.
- `all-or-nothing` stops at the first failure and rolls back previously-merged commits on `main` by creating revert commits in a scratch worktree, then resets affected node statuses from `landed` back to `done`.
- Pushes orchestration into `LandingManager.landSequence(nodeIds, graph, { mode })` so the loop lives in one place rather than duplicated in `routes.ts`.
- Captures squash-merge SHAs via `gh pr view` so they're available for revert.
- Emits a new `dag.node.land_reverted` engine event for observability.

## Why
With multi-node landings (Stack/DAG), a partial failure can leave `main` in a state where the first N PRs of the stack are merged but a downstream merge conflicts or fails CI. Atomic mode lets a caller request "land everything or nothing" semantics, automatically reverting the partial progress instead of leaving the stack in a half-merged state.

## Test plan
- [x] `bun test server/dag/landing.test.ts server/commands/land.test.ts` — 24 pass / 0 fail
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (vitest, 1083 pass)
- [x] New unit tests cover: best-effort continues, all-or-nothing aborts, rollback reverts in reverse order with pushes to `HEAD:main`, partial-rollback failure path, missing bare repo path, mode forwarding through `handleLandCommand`.