### PR TITLE
fix(mcp): forward MINION_API_TOKEN to memory MCP server

### DIFF
--- a/server/mcp/config.test.ts
+++ b/server/mcp/config.test.ts
@@ -12,6 +12,7 @@ const MCP_ENV_KEYS = [
   'GITHUB_TOKEN',
   'GITHUB_PERSONAL_ACCESS_TOKEN',
   'SUPABASE_ACCESS_TOKEN',
+  'MINION_API_TOKEN',
   'PORT',
 ]
 
@@ -135,6 +136,19 @@ describe('buildMcpConfig', () => {
     const cfg = buildMcpConfig({ apiPort: '7777' })
     const memory = cfg.mcpServers['memory']
     expect(memory!.env?.['API_PORT']).toBe('7777')
+  })
+
+  test('memory server forwards MINION_API_TOKEN when set', () => {
+    process.env['MINION_API_TOKEN'] = 'secret-token-123'
+    const cfg = buildMcpConfig()
+    const memory = cfg.mcpServers['memory']
+    expect(memory!.env?.['MINION_API_TOKEN']).toBe('secret-token-123')
+  })
+
+  test('memory server omits MINION_API_TOKEN when unset', () => {
+    const cfg = buildMcpConfig()
+    const memory = cfg.mcpServers['memory']
+    expect(memory!.env?.['MINION_API_TOKEN']).toBeUndefined()
   })
 })
 

--- a/server/mcp/config.ts
+++ b/server/mcp/config.ts
@@ -72,6 +72,8 @@ export function buildMcpConfig(toggles: McpToggles = {}): McpConfigJson {
       MEMORY_SESSION_ID: toggles.memorySessionId ?? '',
       API_PORT: toggles.apiPort ?? process.env.PORT ?? '8080',
     }
+    const token = process.env.MINION_API_TOKEN
+    if (token) env['MINION_API_TOKEN'] = token
     mcpServers['memory'] = {
       command: 'bun',
       args: ['run', 'server/mcp/memory-server.ts'],

--- a/server/mcp/memory-server.test.ts
+++ b/server/mcp/memory-server.test.ts
@@ -23,6 +23,13 @@ describe('memory-server tool definitions', () => {
     expect(content).toContain('forget')
     expect(content).toContain('@modelcontextprotocol/sdk')
   })
+
+  test('memory-server.ts forwards MINION_API_TOKEN as Bearer Authorization header', () => {
+    const serverPath = resolve(__dirname, 'memory-server.ts')
+    const content = readFileSync(serverPath, 'utf-8')
+    expect(content).toContain('MINION_API_TOKEN')
+    expect(content).toMatch(/Bearer \$\{API_TOKEN\}/)
+  })
 })
 
 describe('memory-server HTTP integration', () => {

--- a/server/mcp/memory-server.ts
+++ b/server/mcp/memory-server.ts
@@ -12,6 +12,7 @@ import {
 const MEMORY_REPO = process.env.MEMORY_REPO ?? ''
 const MEMORY_SESSION_ID = process.env.MEMORY_SESSION_ID ?? ''
 const API_PORT = process.env.API_PORT ?? '8080'
+const API_TOKEN = process.env.MINION_API_TOKEN ?? ''
 const API_BASE = `http://127.0.0.1:${API_PORT}`
 
 interface RememberInput {
@@ -44,6 +45,7 @@ async function apiRequest(method: string, path: string, body?: unknown): Promise
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   }
+  if (API_TOKEN) headers['Authorization'] = `Bearer ${API_TOKEN}`
 
   const res = await fetch(url, {
     method,


### PR DESCRIPTION
## Summary

Feedback minions calling `mcp__memory__remember` (and friends) were getting `401 unauthorized` from the engine, silently breaking the memories-tab pipeline whenever `MINION_API_TOKEN` is set — i.e. the documented production setup (`CLAUDE.md` "Required env vars").

Two-file gap in the wiring:

- `server/mcp/config.ts` registered the memory MCP server with `MEMORY_REPO`, `MEMORY_SESSION_ID`, `API_PORT` — but no token. This mirrors how `github-mcp-server` already gets `GITHUB_PERSONAL_ACCESS_TOKEN`.
- `server/mcp/memory-server.ts` built loopback `fetch` calls to `/api/memories` with only `Content-Type` — no `Authorization` header.

Now `MINION_API_TOKEN` is forwarded into the spawned MCP server's env (when set on the engine) and attached as `Authorization: Bearer <token>` on outbound requests. The MCP server still talks only to `127.0.0.1:${API_PORT}`, so giving it the engine token is the same trust scope it already operated within.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `bun test server/mcp/` — 20 pass (added 2 config tests for set/unset token, 1 memory-server content assertion for the Bearer header)
- [x] `npm run test` — 1085 pass
- [ ] Manual: with `MINION_API_TOKEN` set in `docker/.env`, spawn a feedback minion and call `remember` from inside it — entry should appear in the memories Inbox tab instead of returning 401
