### PR TITLE
ui: detail panel as right-side slide-over on desktop

### DIFF
--- a/src/components/NodeDetailPopup.tsx
+++ b/src/components/NodeDetailPopup.tsx
@@ -421,13 +421,13 @@ export function NodeDetailPopup({
   }
 
   return (
-    <div class="fixed inset-0 z-50 flex items-center justify-center">
-      <div class={`absolute inset-0 ${overlayBg}`} onClick={onClose} />
+    <div class="fixed inset-y-0 right-0 z-50 flex pointer-events-none">
       <div
         ref={popupRef}
-        class={`relative ${dialogBg} rounded-xl max-w-sm w-full mx-4 shadow-xl overflow-hidden`}
+        data-anim="slide-in-right"
+        data-testid="node-detail-slideover"
+        class={`relative ${dialogBg} w-full sm:w-[24rem] md:w-[26rem] h-full shadow-2xl border-l ${borderColor} pointer-events-auto overflow-y-auto`}
         role="dialog"
-        aria-modal="true"
         aria-labelledby="node-detail-title"
       >
         <div class={`px-4 pt-4 pb-3 border-b ${borderColor}`}>

--- a/src/index.css
+++ b/src/index.css
@@ -124,3 +124,11 @@ body {
   animation: minions-focus-pulse 650ms ease-out;
   border-radius: 0.375rem;
 }
+
+@keyframes minions-slide-in-right {
+  0% { transform: translateX(100%); }
+  100% { transform: translateX(0); }
+}
+[data-anim="slide-in-right"] {
+  animation: minions-slide-in-right 180ms ease-out;
+}

--- a/test/components/NodeDetailPopup.test.tsx
+++ b/test/components/NodeDetailPopup.test.tsx
@@ -612,7 +612,7 @@ describe('NodeDetailPopup mobile bottom sheet', () => {
     expect(handle).toBeTruthy()
   })
 
-  it('renders as centered modal on desktop', () => {
+  it('renders as right-side slide-over on desktop', () => {
     window.matchMedia = vi.fn().mockImplementation((query: string) => ({
       matches: query !== '(max-width: 767px)',
       media: query,
@@ -622,10 +622,59 @@ describe('NodeDetailPopup mobile bottom sheet', () => {
 
     const session = makeSession()
     const { container } = render(<NodeDetailPopup session={session} onClose={vi.fn()} />)
-    const modal = container.querySelector('.flex.items-center.justify-center')
-    expect(modal).toBeTruthy()
+    const slideover = container.querySelector('[data-testid="node-detail-slideover"]')
+    expect(slideover).toBeTruthy()
+    expect(slideover!.className).toContain('h-full')
+    expect(slideover!.className).toContain('border-l')
     const handle = container.querySelector('.w-10.h-1.rounded-full')
     expect(handle).toBeFalsy()
+  })
+
+  it('does not render a backdrop overlay on desktop (canvas stays interactive)', () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query !== '(max-width: 767px)',
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+
+    const session = makeSession()
+    const { container } = render(<NodeDetailPopup session={session} onClose={vi.fn()} />)
+    const overlays = container.querySelectorAll('[class*="bg-black/"]')
+    expect(overlays.length).toBe(0)
+
+    const wrapper = container.querySelector('[role="dialog"]')!.parentElement!
+    expect(wrapper.className).toContain('pointer-events-none')
+    expect(wrapper.className).toContain('right-0')
+  })
+
+  it('desktop slide-over panel itself remains clickable while wrapper passes events through', () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query !== '(max-width: 767px)',
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+
+    const session = makeSession()
+    const { container } = render(<NodeDetailPopup session={session} onClose={vi.fn()} />)
+    const slideover = container.querySelector('[data-testid="node-detail-slideover"]') as HTMLElement
+    expect(slideover.className).toContain('pointer-events-auto')
+  })
+
+  it('desktop slide-over closes on Escape key', () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query !== '(max-width: 767px)',
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+
+    const session = makeSession()
+    const onClose = vi.fn()
+    render(<NodeDetailPopup session={session} onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
## Summary

The desktop "node detail" popup was a centered modal with a black backdrop, which obscured the DAG canvas every time you clicked a node. This swaps the desktop variant for a non-modal right-side slide-over — the canvas stays visible and pannable while you read or act on a node.

- Desktop: fixed `inset-y-0 right-0` panel, no overlay, `pointer-events-none` wrapper so the canvas behind remains interactive; close via `×` button or `Escape`.
- Subtle `slide-in-right` keyframe (180ms) added to `index.css` for the enter animation.
- Mobile bottom sheet behavior is unchanged (the change is gated on the existing `useMediaQuery('(max-width: 767px)')`).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 1088 pass, including new cases for slide-over markup, no-backdrop guarantee, pointer-event semantics, and Escape-to-close.
- [ ] Manual: open a session on desktop and confirm the canvas remains pannable behind the panel.
