### PR TITLE
feat(ui): Slack-style vertical connection rail on desktop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { useRegisterSW } from 'virtual:pwa-register/preact'
 import { connections, activeId, getActiveStore, setActive } from './connections/store'
 import { ConnectionSettings } from './connections/ConnectionSettings'
 import { ConnectionPicker } from './connections/ConnectionPicker'
+import { ConnectionRail } from './connections/ConnectionRail'
 import { ConnectionsDrawer } from './connections/ConnectionsDrawer'
 import { ResourceChip } from './components/ResourceChip'
 import { RunningBadge } from './components/RunningBadge'
@@ -573,7 +574,11 @@ function ActiveView() {
   }
 
   return (
-    <div class="flex flex-col h-[100dvh] overflow-hidden bg-slate-50 dark:bg-slate-900">
+    <div class="flex h-[100dvh] overflow-hidden">
+      {isDesktop.value && (
+        <ConnectionRail onManage={() => { showDrawer.value = true }} />
+      )}
+      <div class="flex flex-col flex-1 min-w-0 overflow-hidden bg-slate-50 dark:bg-slate-900">
       {showOfflineBanner && (
         <div class="flex items-center justify-center px-4 py-1.5 bg-amber-500 text-amber-950 text-xs font-medium shrink-0" data-testid="offline-banner">
           Offline — showing last snapshot
@@ -873,6 +878,7 @@ function ActiveView() {
           />
         )
       })()}
+      </div>
     </div>
   )
 }

--- a/src/connections/ConnectionRail.tsx
+++ b/src/connections/ConnectionRail.tsx
@@ -1,0 +1,136 @@
+import { useComputed } from '@preact/signals'
+import { connections, activeId, setActive, getAllStores } from './store'
+import { useHaptics } from '../hooks/useHaptics'
+import { computeConnectionStats, type ConnectionStats } from './stats'
+import type { Connection } from './types'
+
+interface ConnectionRailProps {
+  onManage: () => void
+}
+
+function initials(label: string): string {
+  const trimmed = label.trim()
+  if (!trimmed) return '?'
+  const parts = trimmed.split(/\s+/).filter(Boolean)
+  if (parts.length === 1) {
+    return parts[0]!.slice(0, 2).toUpperCase()
+  }
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase()
+}
+
+export function ConnectionRail({ onManage }: ConnectionRailProps) {
+  const { vibrate } = useHaptics()
+  const conns = connections.value
+  const active = activeId.value
+
+  const statsMap = useComputed<Map<string, ConnectionStats>>(() => {
+    const stores = getAllStores()
+    const map = new Map<string, ConnectionStats>()
+    for (const c of connections.value) {
+      const s = stores.get(c.id)
+      if (s) map.set(c.id, computeConnectionStats(s.sessions.value, s.dags.value))
+    }
+    return map
+  })
+
+  if (conns.length === 0) return null
+
+  const handleSelect = (id: string) => {
+    if (id === activeId.value) return
+    vibrate('light')
+    setActive(id)
+  }
+
+  const handleManage = () => {
+    vibrate('light')
+    onManage()
+  }
+
+  return (
+    <nav
+      data-testid="connection-rail"
+      aria-label="Connections"
+      class="flex flex-col items-center gap-2 px-2 py-3 border-r border-slate-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-950 shrink-0 w-[68px] overflow-y-auto"
+    >
+      {conns.map((conn) => {
+        const stats = statsMap.value.get(conn.id)
+        return (
+          <ConnectionAvatar
+            key={conn.id}
+            conn={conn}
+            active={conn.id === active}
+            unread={stats?.unreadCount ?? 0}
+            failed={stats?.dagProgress?.failed ?? 0}
+            onClick={() => handleSelect(conn.id)}
+          />
+        )
+      })}
+      <div class="my-1 h-px w-8 bg-slate-300 dark:bg-slate-700" aria-hidden="true" />
+      <button
+        type="button"
+        onClick={handleManage}
+        data-testid="connection-rail-manage"
+        title="Manage connections"
+        aria-label="Manage connections"
+        class="w-12 h-12 rounded-2xl border border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 flex items-center justify-center hover:bg-white dark:hover:bg-slate-800 hover:border-slate-400 dark:hover:border-slate-500 hover:rounded-xl transition-all"
+      >
+        <span class="text-xl leading-none" aria-hidden="true">+</span>
+      </button>
+    </nav>
+  )
+}
+
+interface ConnectionAvatarProps {
+  conn: Connection
+  active: boolean
+  unread: number
+  failed: number
+  onClick: () => void
+}
+
+function ConnectionAvatar({ conn, active, unread, failed, onClick }: ConnectionAvatarProps) {
+  const labelParts = [conn.label]
+  if (unread > 0) labelParts.push(`${unread} unread`)
+  if (failed > 0) labelParts.push(`${failed} failed`)
+  const ariaLabel = labelParts.join(', ')
+
+  return (
+    <div class="relative">
+      {active && (
+        <span
+          aria-hidden="true"
+          data-testid={`rail-active-indicator-${conn.id}`}
+          class="absolute -left-2 top-1/2 -translate-y-1/2 h-7 w-1 rounded-r-full bg-slate-900 dark:bg-white"
+        />
+      )}
+      <button
+        type="button"
+        onClick={onClick}
+        aria-current={active ? 'true' : undefined}
+        aria-label={ariaLabel}
+        title={conn.label}
+        data-testid={`rail-conn-${conn.id}`}
+        class={`relative w-12 h-12 flex items-center justify-center text-white text-sm font-semibold transition-all duration-150 ${active ? 'rounded-xl' : 'rounded-2xl hover:rounded-xl'}`}
+        style={{ backgroundColor: conn.color }}
+      >
+        <span aria-hidden="true">{initials(conn.label)}</span>
+        {unread > 0 && (
+          <span
+            data-testid={`rail-unread-${conn.id}`}
+            class="absolute -top-1 -right-1 min-w-[18px] h-[18px] rounded-full bg-red-500 text-white text-[10px] font-medium px-1 flex items-center justify-center ring-2 ring-slate-100 dark:ring-slate-950"
+            aria-hidden="true"
+          >
+            {unread > 9 ? '9+' : unread}
+          </span>
+        )}
+        {unread === 0 && failed > 0 && (
+          <span
+            data-testid={`rail-failed-${conn.id}`}
+            class="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-red-500 ring-2 ring-slate-100 dark:ring-slate-950"
+            aria-hidden="true"
+          />
+        )}
+      </button>
+    </div>
+  )
+}

--- a/test/connections/ConnectionRail.test.tsx
+++ b/test/connections/ConnectionRail.test.tsx
@@ -1,0 +1,334 @@
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { signal } from '@preact/signals'
+import { ConnectionRail } from '../../src/connections/ConnectionRail'
+import * as store from '../../src/connections/store'
+import type { Connection } from '../../src/connections/types'
+import type { ConnectionStore } from '../../src/state/types'
+import type { ApiSession, ApiDagGraph, ApiDagNode } from '../../src/api/types'
+
+vi.mock('../../src/connections/store', () => ({
+  connections: signal<Connection[]>([]),
+  activeId: signal<string | null>(null),
+  setActive: vi.fn(),
+  getAllStores: vi.fn(() => new Map()),
+}))
+
+vi.mock('../../src/hooks/useHaptics', () => ({
+  useHaptics: () => ({ vibrate: vi.fn(), supported: true }),
+}))
+
+function mockConn(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'c1',
+    label: 'Alpha',
+    baseUrl: 'https://a.example.com',
+    token: 'tok',
+    color: '#3b82f6',
+    ...overrides,
+  }
+}
+
+function mockSession(overrides: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 's1',
+    slug: 'session',
+    status: 'running',
+    command: '/task',
+    mode: 'task',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    conversation: [],
+    ...overrides,
+  }
+}
+
+function mockDagNode(overrides: Partial<ApiDagNode> = {}): ApiDagNode {
+  return {
+    id: 'node-1',
+    slug: 'node-1',
+    status: 'pending',
+    dependencies: [],
+    dependents: [],
+    ...overrides,
+  }
+}
+
+function mockDag(overrides: Partial<ApiDagGraph> = {}): ApiDagGraph {
+  return {
+    id: 'd1',
+    rootTaskId: 'root',
+    nodes: {},
+    status: 'pending',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function mockStore(
+  sessions: ApiSession[],
+  dags: ApiDagGraph[],
+): Partial<ConnectionStore> {
+  return {
+    sessions: signal(sessions) as ConnectionStore['sessions'],
+    dags: signal(dags) as ConnectionStore['dags'],
+  }
+}
+
+describe('ConnectionRail', () => {
+  let connectionsSignal: ReturnType<typeof signal<Connection[]>>
+  let activeIdSignal: ReturnType<typeof signal<string | null>>
+
+  beforeEach(() => {
+    connectionsSignal = signal<Connection[]>([])
+    activeIdSignal = signal<string | null>(null)
+    ;(vi.mocked(store).connections as typeof connectionsSignal) = connectionsSignal
+    ;(vi.mocked(store).activeId as typeof activeIdSignal) = activeIdSignal
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when there are no connections', () => {
+    const { container } = render(<ConnectionRail onManage={vi.fn()} />)
+    expect(container.querySelector('[data-testid="connection-rail"]')).toBeNull()
+  })
+
+  it('renders an avatar for each connection', () => {
+    connectionsSignal.value = [
+      mockConn({ id: 'c1', label: 'Alpha' }),
+      mockConn({ id: 'c2', label: 'Beta', color: '#10b981' }),
+    ]
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+
+    expect(screen.getByTestId('connection-rail')).toBeTruthy()
+    expect(screen.getByTestId('rail-conn-c1')).toBeTruthy()
+    expect(screen.getByTestId('rail-conn-c2')).toBeTruthy()
+  })
+
+  it('renders the manage button', () => {
+    connectionsSignal.value = [mockConn()]
+    render(<ConnectionRail onManage={vi.fn()} />)
+    expect(screen.getByTestId('connection-rail-manage')).toBeTruthy()
+  })
+
+  it('shows the active indicator on the active connection only', () => {
+    connectionsSignal.value = [
+      mockConn({ id: 'c1', label: 'Alpha' }),
+      mockConn({ id: 'c2', label: 'Beta' }),
+    ]
+    activeIdSignal.value = 'c2'
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+
+    expect(screen.queryByTestId('rail-active-indicator-c1')).toBeNull()
+    expect(screen.getByTestId('rail-active-indicator-c2')).toBeTruthy()
+  })
+
+  it('exposes aria-current on the active button', () => {
+    connectionsSignal.value = [mockConn({ id: 'c1' }), mockConn({ id: 'c2', label: 'Beta' })]
+    activeIdSignal.value = 'c1'
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+
+    expect(screen.getByTestId('rail-conn-c1').getAttribute('aria-current')).toBe('true')
+    expect(screen.getByTestId('rail-conn-c2').getAttribute('aria-current')).toBeNull()
+  })
+
+  it('uses the connection color as the avatar background', () => {
+    connectionsSignal.value = [mockConn({ id: 'c1', color: '#ec4899' })]
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+
+    const btn = screen.getByTestId('rail-conn-c1') as HTMLElement
+    expect(btn.style.backgroundColor).toMatch(/rgb\(236,\s*72,\s*153\)|#ec4899/i)
+  })
+
+  it('renders initials from a single-word label', () => {
+    connectionsSignal.value = [mockConn({ id: 'c1', label: 'Alpha' })]
+    render(<ConnectionRail onManage={vi.fn()} />)
+    expect(screen.getByTestId('rail-conn-c1').textContent).toContain('AL')
+  })
+
+  it('renders initials from a multi-word label using first + last', () => {
+    connectionsSignal.value = [mockConn({ id: 'c1', label: 'My Cool Minion' })]
+    render(<ConnectionRail onManage={vi.fn()} />)
+    expect(screen.getByTestId('rail-conn-c1').textContent).toContain('MM')
+  })
+
+  it('clicking an inactive avatar calls setActive', () => {
+    connectionsSignal.value = [mockConn({ id: 'c1' }), mockConn({ id: 'c2', label: 'Beta' })]
+    activeIdSignal.value = 'c1'
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('rail-conn-c2'))
+    expect(store.setActive).toHaveBeenCalledWith('c2')
+  })
+
+  it('clicking the already-active avatar does not call setActive', () => {
+    connectionsSignal.value = [mockConn({ id: 'c1' })]
+    activeIdSignal.value = 'c1'
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('rail-conn-c1'))
+    expect(store.setActive).not.toHaveBeenCalled()
+  })
+
+  it('clicking manage button calls onManage', () => {
+    connectionsSignal.value = [mockConn()]
+    const onManage = vi.fn()
+
+    render(<ConnectionRail onManage={onManage} />)
+
+    fireEvent.click(screen.getByTestId('connection-rail-manage'))
+    expect(onManage).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows unread badge when sessions need attention', () => {
+    const conn = mockConn({ id: 'c1' })
+    connectionsSignal.value = [conn]
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([
+        [
+          conn.id,
+          mockStore(
+            [mockSession({ needsAttention: true, attentionReasons: ['failed'] })],
+            [],
+          ) as ConnectionStore,
+        ],
+      ]),
+    )
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+
+    const badge = screen.getByTestId('rail-unread-c1')
+    expect(badge).toBeTruthy()
+    expect(badge.textContent).toBe('1')
+  })
+
+  it('caps unread count display at 9+', () => {
+    const conn = mockConn({ id: 'c1' })
+    connectionsSignal.value = [conn]
+
+    const sessions = Array.from({ length: 12 }, (_, i) =>
+      mockSession({ id: `s${i}`, needsAttention: true, attentionReasons: ['failed'] }),
+    )
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([[conn.id, mockStore(sessions, []) as ConnectionStore]]),
+    )
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+    expect(screen.getByTestId('rail-unread-c1').textContent).toBe('9+')
+  })
+
+  it('shows failed dot when a DAG node has failed and there are no unreads', () => {
+    const conn = mockConn({ id: 'c1' })
+    connectionsSignal.value = [conn]
+
+    const dag = mockDag({
+      nodes: {
+        n1: mockDagNode({ status: 'completed' }),
+        n2: mockDagNode({ status: 'failed' }),
+      },
+    })
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([[conn.id, mockStore([], [dag]) as ConnectionStore]]),
+    )
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+    expect(screen.getByTestId('rail-failed-c1')).toBeTruthy()
+    expect(screen.queryByTestId('rail-unread-c1')).toBeNull()
+  })
+
+  it('prefers the unread badge over the failed dot when both apply', () => {
+    const conn = mockConn({ id: 'c1' })
+    connectionsSignal.value = [conn]
+
+    const dag = mockDag({
+      nodes: {
+        n1: mockDagNode({ status: 'failed' }),
+      },
+    })
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([
+        [
+          conn.id,
+          mockStore(
+            [mockSession({ needsAttention: true, attentionReasons: ['failed'] })],
+            [dag],
+          ) as ConnectionStore,
+        ],
+      ]),
+    )
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+    expect(screen.getByTestId('rail-unread-c1')).toBeTruthy()
+    expect(screen.queryByTestId('rail-failed-c1')).toBeNull()
+  })
+
+  it('aria-label includes counts when there are unread or failures', () => {
+    const conn = mockConn({ id: 'c1', label: 'Alpha' })
+    connectionsSignal.value = [conn]
+
+    const dag = mockDag({
+      nodes: { n1: mockDagNode({ status: 'failed' }) },
+    })
+
+    vi.mocked(store.getAllStores).mockReturnValue(
+      new Map([
+        [
+          conn.id,
+          mockStore(
+            [mockSession({ needsAttention: true, attentionReasons: ['failed'] })],
+            [dag],
+          ) as ConnectionStore,
+        ],
+      ]),
+    )
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+    const aria = screen.getByTestId('rail-conn-c1').getAttribute('aria-label')
+    expect(aria).toContain('Alpha')
+    expect(aria).toContain('1 unread')
+    expect(aria).toContain('1 failed')
+  })
+
+  it('reactively updates when active connection changes', () => {
+    connectionsSignal.value = [mockConn({ id: 'c1' }), mockConn({ id: 'c2', label: 'Beta' })]
+    activeIdSignal.value = 'c1'
+
+    const { rerender } = render(<ConnectionRail onManage={vi.fn()} />)
+    expect(screen.getByTestId('rail-active-indicator-c1')).toBeTruthy()
+
+    activeIdSignal.value = 'c2'
+    rerender(<ConnectionRail onManage={vi.fn()} />)
+    expect(screen.queryByTestId('rail-active-indicator-c1')).toBeNull()
+    expect(screen.getByTestId('rail-active-indicator-c2')).toBeTruthy()
+  })
+
+  it('keyboard accessible via Enter on a button', () => {
+    connectionsSignal.value = [mockConn({ id: 'c1' }), mockConn({ id: 'c2', label: 'Beta' })]
+    activeIdSignal.value = 'c1'
+
+    render(<ConnectionRail onManage={vi.fn()} />)
+
+    const btn = screen.getByTestId('rail-conn-c2')
+    btn.focus()
+    fireEvent.click(btn)
+
+    expect(store.setActive).toHaveBeenCalledWith('c2')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a Slack-style vertical avatar rail on the left side (desktop only) for switching between minion deployments at a glance, using the existing accent palette in \`src/theme/colors.ts\`.
- Each connection renders as a colored rounded square with the connection's initials, an active-bar indicator, and badges for unread sessions / failed DAG nodes.
- Mobile keeps the existing \`ConnectionPicker\` bottom-sheet — a rail is impractical on small screens.

The rail makes multi-deployment usable: previously the dropdown picker was the only switcher, hidden behind a click. Now switching is one click on a persistent vertical stack of avatars, with notification dots so you can see which deployment needs attention without opening anything.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test\` — 1103 tests pass, including 18 new \`ConnectionRail\` tests covering avatars, active state, color/initials rendering, click handling, manage button, unread/failed badges, aria-label content, and reactive updates.
- [ ] Visual: open with multiple connections on desktop ≥768px → see vertical rail; click an avatar to switch; bottom \`+\` button opens the connections drawer.
- [ ] Visual: open on mobile <768px → rail is hidden, \`ConnectionPicker\` continues to work.