### PR TITLE
feat(ui): status glyphs, button spinners, persisted canvas viewport

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -548,6 +548,7 @@ function ActiveView() {
     onRetryRebase: handleRetryRebase,
     isActionLoading,
     accentColor: conn.color,
+    viewportStorageKey: `minions-ui:viewport:${conn.id}`,
   }
 
   return (

--- a/src/chat/ChatPane.tsx
+++ b/src/chat/ChatPane.tsx
@@ -13,7 +13,7 @@ import { DagStatusPanel } from './DagStatusPanel'
 import { Transcript, TranscriptUpgradeNotice } from './transcript'
 import { PrPreviewCard } from '../components/PrPreviewCard'
 import { WorktreeHeader, truncateCwd } from '../components/WorktreeHeader'
-import { statusDot } from '../components/SessionList'
+import { StatusIndicator } from '../components/SessionList'
 import { hasFeature } from '../api/features'
 import type { ApiSession, MinionCommand, QuickAction } from '../api/types'
 import type { ConnectionStore } from '../state/types'
@@ -163,7 +163,7 @@ export function ChatPane({
             ↑ {parentSession.slug}
           </button>
         )}
-        <span class={`inline-block h-2 w-2 rounded-full ${statusDot(session.status)}`} />
+        <StatusIndicator status={session.status} label={`${session.slug}: ${session.status}`} />
         <span class="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">{session.slug}</span>
         {isDesktopPane.value ? (
           <>

--- a/src/chat/MessageInput.tsx
+++ b/src/chat/MessageInput.tsx
@@ -214,11 +214,19 @@ export function MessageInput({ store, value, onValueChange, onSend }: MessageInp
           type="button"
           onClick={() => void submit(value, attachments)}
           disabled={sending || (!trimmed && attachments.length === 0)}
-          class="shrink-0 rounded-lg px-4 py-3 text-sm font-medium transition-colors text-white shadow-sm bg-indigo-600 hover:bg-indigo-700 active:bg-indigo-800 disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]"
+          class="shrink-0 inline-flex items-center justify-center gap-2 rounded-lg px-4 py-3 text-sm font-medium transition-colors text-white shadow-sm bg-indigo-600 hover:bg-indigo-700 active:bg-indigo-800 disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]"
           data-testid="send-btn"
           aria-label={sending ? 'Sending' : 'Send'}
+          aria-busy={sending}
         >
-          {sending ? 'Sending…' : 'Send'}
+          {sending && (
+            <span
+              class="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin"
+              aria-hidden="true"
+              data-testid="send-btn-spinner"
+            />
+          )}
+          <span>{sending ? 'Sending…' : 'Send'}</span>
         </button>
       </div>
     </div>

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -86,9 +86,18 @@ export function ConfirmDialog({
           <button
             onClick={onConfirm}
             disabled={isLoading}
-            class={`px-4 py-2 text-sm font-medium rounded transition-colors disabled:opacity-50 ${confirmButtonClass}`}
+            class={`inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded transition-colors disabled:opacity-50 ${confirmButtonClass}`}
+            data-testid="confirm-dialog-confirm-btn"
+            aria-busy={isLoading}
           >
-            {isLoading ? 'Processing...' : confirmLabel}
+            {isLoading && (
+              <span
+                class="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin"
+                aria-hidden="true"
+                data-testid="confirm-dialog-spinner"
+              />
+            )}
+            <span>{isLoading ? 'Processing...' : confirmLabel}</span>
           </button>
         </div>
       </div>
@@ -168,9 +177,18 @@ export function ReplyDialog({ isOpen, sessionId, isLoading, onSend, onCancel }: 
           <button
             type="submit"
             disabled={isLoading}
-            class={`px-4 py-2 text-sm font-medium rounded transition-colors disabled:opacity-50 ${submitBg}`}
+            class={`inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded transition-colors disabled:opacity-50 ${submitBg}`}
+            data-testid="reply-dialog-send-btn"
+            aria-busy={isLoading}
           >
-            {isLoading ? 'Sending...' : 'Send'}
+            {isLoading && (
+              <span
+                class="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin"
+                aria-hidden="true"
+                data-testid="reply-dialog-spinner"
+              />
+            )}
+            <span>{isLoading ? 'Sending...' : 'Send'}</span>
           </button>
         </div>
       </form>

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -11,6 +11,40 @@ export function statusDot(status: ApiSession['status']): string {
   return 'bg-slate-400'
 }
 
+export function statusGlyph(status: ApiSession['status']): string {
+  if (status === 'running') return '⟳'
+  if (status === 'completed') return '✓'
+  if (status === 'failed') return '!'
+  return '·'
+}
+
+interface StatusIndicatorProps {
+  status: ApiSession['status']
+  label?: string
+}
+
+export function StatusIndicator({ status, label }: StatusIndicatorProps) {
+  const glyph = statusGlyph(status)
+  const accessibleLabel = label ?? `Status: ${status}`
+  return (
+    <span
+      class="inline-flex items-center gap-1 shrink-0"
+      role="img"
+      aria-label={accessibleLabel}
+      data-testid={`status-indicator-${status}`}
+    >
+      <span class={`inline-block h-2 w-2 rounded-full ${statusDot(status)}`} aria-hidden="true" />
+      <span
+        class="inline-block text-[10px] leading-none font-mono text-slate-500 dark:text-slate-400"
+        aria-hidden="true"
+        data-testid={`status-glyph-${status}`}
+      >
+        {glyph}
+      </span>
+    </span>
+  )
+}
+
 function useFlashOnChange(session: ApiSession): 'success' | 'fail' | 'update' | null {
   const [flash, setFlash] = useState<'success' | 'fail' | 'update' | null>(null)
   const prev = useRef({ status: session.status, updatedAt: session.updatedAt, mounted: false })
@@ -94,7 +128,7 @@ function SessionItem({ session, active, onSelect, indent = 0, kind }: SessionIte
         data-testid={`session-item-${session.id}`}
       >
         <div class="flex items-center gap-2">
-          <span class={`inline-block h-2 w-2 rounded-full shrink-0 ${statusDot(session.status)}`} />
+          <StatusIndicator status={session.status} label={`${session.slug}: ${session.status}`} />
           {kind && <KindBadge kind={kind} />}
           <span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">{session.slug}</span>
           {session.repo && (

--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -303,6 +303,46 @@ export interface UniverseCanvasProps {
   onViewLogs?: (sessionId: string) => void
   onRetryRebase?: (dagId: string, nodeId: string) => Promise<void>
   accentColor?: string
+  viewportStorageKey?: string
+}
+
+interface PersistedViewport {
+  x: number
+  y: number
+  zoom: number
+}
+
+export function loadPersistedViewport(storageKey: string): PersistedViewport | null {
+  if (typeof window === 'undefined' || !window.localStorage) return null
+  try {
+    const raw = window.localStorage.getItem(storageKey)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (
+      parsed &&
+      typeof parsed.x === 'number' &&
+      typeof parsed.y === 'number' &&
+      typeof parsed.zoom === 'number' &&
+      Number.isFinite(parsed.x) &&
+      Number.isFinite(parsed.y) &&
+      Number.isFinite(parsed.zoom) &&
+      parsed.zoom > 0
+    ) {
+      return { x: parsed.x, y: parsed.y, zoom: parsed.zoom }
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+export function savePersistedViewport(storageKey: string, viewport: PersistedViewport): void {
+  if (typeof window === 'undefined' || !window.localStorage) return
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(viewport))
+  } catch {
+    return
+  }
 }
 
 export function UniverseCanvas(props: UniverseCanvasProps) {
@@ -326,6 +366,7 @@ function UniverseCanvasInner({
   onOpenChat,
   onViewLogs,
   onRetryRebase,
+  viewportStorageKey,
 }: UniverseCanvasProps) {
   const theme = useTheme()
   const isDark = theme.value === 'dark'
@@ -504,6 +545,18 @@ function UniverseCanvasInner({
     reactFlow.fitView({ padding: 0.2, duration: 400 })
   }, [reactFlow])
 
+  const persistedViewport = useMemo(
+    () => (viewportStorageKey ? loadPersistedViewport(viewportStorageKey) : null),
+    [viewportStorageKey]
+  )
+  const handleMoveEnd = useCallback(
+    (_event: MouseEvent | TouchEvent | null, viewport: PersistedViewport) => {
+      if (!viewportStorageKey || !viewport) return
+      savePersistedViewport(viewportStorageKey, viewport)
+    },
+    [viewportStorageKey]
+  )
+
   const minZoom = isMobile.value ? 0.15 : 0.1
   const maxZoom = isMobile.value ? 1.5 : 2
 
@@ -514,8 +567,10 @@ function UniverseCanvasInner({
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
+        onMoveEnd={handleMoveEnd}
         nodeTypes={nodeTypes}
-        fitView
+        defaultViewport={persistedViewport ?? undefined}
+        fitView={!persistedViewport}
         fitViewOptions={{ padding: 0.3 }}
         minZoom={minZoom}
         maxZoom={maxZoom}

--- a/src/groups/VariantGroupView.tsx
+++ b/src/groups/VariantGroupView.tsx
@@ -7,6 +7,7 @@ import { confirm } from '../hooks/useConfirm'
 import { hasFeature } from '../api/features'
 import { formatRoute } from '../routing/route'
 import { variantGroupsSignal, setVariantWinner } from './store'
+import { StatusIndicator } from '../components/SessionList'
 import type { VariantGroup } from './types'
 
 interface VariantGroupViewProps {
@@ -19,13 +20,6 @@ function defaultNavigate(hash: string): void {
   if (typeof window !== 'undefined') {
     window.location.hash = hash
   }
-}
-
-function statusDot(status: ApiSession['status']): string {
-  if (status === 'running') return 'bg-blue-500 animate-pulse'
-  if (status === 'completed') return 'bg-green-500'
-  if (status === 'failed') return 'bg-red-500'
-  return 'bg-slate-400'
 }
 
 export function VariantGroupView({ store, groupId, navigate = defaultNavigate }: VariantGroupViewProps) {
@@ -226,7 +220,7 @@ function VariantColumn({ id, session, group, store, onPickWinner, onOpen }: Vari
       <div class="flex items-center gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700 shrink-0">
         {session ? (
           <>
-            <span class={`inline-block h-2 w-2 rounded-full ${statusDot(session.status)}`} />
+            <StatusIndicator status={session.status} label={`${session.slug}: ${session.status}`} />
             <button
               type="button"
               onClick={onOpen}
@@ -241,7 +235,7 @@ function VariantColumn({ id, session, group, store, onPickWinner, onOpen }: Vari
           </>
         ) : (
           <>
-            <span class="inline-block h-2 w-2 rounded-full bg-slate-400" />
+            <span class="inline-block h-2 w-2 rounded-full bg-slate-400" aria-hidden="true" />
             <span class="font-mono text-xs text-slate-500 dark:text-slate-400 truncate">waiting…</span>
           </>
         )}

--- a/test/chat/MessageInput.test.tsx
+++ b/test/chat/MessageInput.test.tsx
@@ -91,6 +91,27 @@ describe('MessageInput', () => {
     act(() => { resolve!() })
   })
 
+  it('shows a spinner and aria-busy=true while onSend is pending', async () => {
+    let resolve: () => void
+    const onSend = vi.fn().mockReturnValue(new Promise<void>((r) => { resolve = r }))
+    render(<Controlled onSend={onSend} />)
+    fireEvent.input(getTextarea(), { target: { value: 'spinner test' } })
+    act(() => {
+      fireEvent.click(getSendBtn())
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('send-btn-spinner')).toBeTruthy()
+      expect(getSendBtn().getAttribute('aria-busy')).toBe('true')
+      expect(getSendBtn().textContent).toContain('Sending')
+    })
+    act(() => { resolve!() })
+    await waitFor(() => {
+      expect(screen.queryByTestId('send-btn-spinner')).toBeNull()
+      expect(getSendBtn().getAttribute('aria-busy')).toBe('false')
+      expect(getSendBtn().textContent).toContain('Send')
+    })
+  })
+
   it('shows retry banner when onSend rejects', async () => {
     const onSend = vi.fn().mockRejectedValue(new Error('network error'))
     render(<Controlled onSend={onSend} />)

--- a/test/components/ConfirmDialog.test.tsx
+++ b/test/components/ConfirmDialog.test.tsx
@@ -89,6 +89,40 @@ describe('ConfirmDialog', () => {
     expect(screen.getByText('Processing...')).toBeTruthy()
   })
 
+  it('should render a spinner and aria-busy when loading', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test message"
+        isLoading={true}
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    expect(screen.getByTestId('confirm-dialog-spinner')).toBeTruthy()
+    const button = screen.getByTestId('confirm-dialog-confirm-btn')
+    expect(button.getAttribute('aria-busy')).toBe('true')
+  })
+
+  it('should not render a spinner when not loading', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test message"
+        isLoading={false}
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    expect(screen.queryByTestId('confirm-dialog-spinner')).toBe(null)
+    const button = screen.getByTestId('confirm-dialog-confirm-btn')
+    expect(button.getAttribute('aria-busy')).toBe('false')
+  })
+
   it('should disable buttons when loading', () => {
     render(
       <ConfirmDialog
@@ -101,7 +135,7 @@ describe('ConfirmDialog', () => {
       />
     )
 
-    const confirmButton = screen.getByText('Processing...')
+    const confirmButton = screen.getByTestId('confirm-dialog-confirm-btn')
     expect(confirmButton.hasAttribute('disabled')).toBe(true)
   })
 
@@ -241,5 +275,37 @@ describe('ReplyDialog', () => {
     )
 
     expect(screen.getByText('Sending...')).toBeTruthy()
+  })
+
+  it('should render a spinner and aria-busy when loading', () => {
+    render(
+      <ReplyDialog
+        isOpen={true}
+        sessionId="session-1"
+        isLoading={true}
+        onSend={mockOnSend}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    expect(screen.getByTestId('reply-dialog-spinner')).toBeTruthy()
+    const button = screen.getByTestId('reply-dialog-send-btn')
+    expect(button.getAttribute('aria-busy')).toBe('true')
+  })
+
+  it('should not render a spinner when not loading', () => {
+    render(
+      <ReplyDialog
+        isOpen={true}
+        sessionId="session-1"
+        isLoading={false}
+        onSend={mockOnSend}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    expect(screen.queryByTestId('reply-dialog-spinner')).toBe(null)
+    const button = screen.getByTestId('reply-dialog-send-btn')
+    expect(button.getAttribute('aria-busy')).toBe('false')
   })
 })

--- a/test/components/SessionList.test.tsx
+++ b/test/components/SessionList.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/preact'
+import { StatusIndicator, statusDot, statusGlyph } from '../../src/components/SessionList'
+import type { ApiSession } from '../../src/api/types'
+
+describe('statusDot', () => {
+  it('returns a pulsing blue class for running', () => {
+    expect(statusDot('running')).toContain('bg-blue-500')
+    expect(statusDot('running')).toContain('animate-pulse')
+  })
+
+  it('returns green for completed and red for failed', () => {
+    expect(statusDot('completed')).toContain('bg-green-500')
+    expect(statusDot('failed')).toContain('bg-red-500')
+  })
+
+  it('returns slate for any other status', () => {
+    expect(statusDot('pending')).toContain('bg-slate-400')
+    expect(statusDot('skipped' as ApiSession['status'])).toContain('bg-slate-400')
+  })
+})
+
+describe('statusGlyph', () => {
+  it('returns ⟳ for running', () => {
+    expect(statusGlyph('running')).toBe('⟳')
+  })
+
+  it('returns ✓ for completed', () => {
+    expect(statusGlyph('completed')).toBe('✓')
+  })
+
+  it('returns ! for failed', () => {
+    expect(statusGlyph('failed')).toBe('!')
+  })
+
+  it('returns · for any other status', () => {
+    expect(statusGlyph('pending')).toBe('·')
+    expect(statusGlyph('skipped' as ApiSession['status'])).toBe('·')
+  })
+})
+
+describe('StatusIndicator', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders both a dot and a glyph for the given status', () => {
+    render(<StatusIndicator status="running" />)
+    const wrapper = screen.getByTestId('status-indicator-running')
+    expect(wrapper).toBeTruthy()
+    const dot = wrapper.querySelector('span.bg-blue-500')
+    expect(dot).toBeTruthy()
+    expect(screen.getByTestId('status-glyph-running').textContent).toBe('⟳')
+  })
+
+  it('renders the completed glyph and dot together', () => {
+    render(<StatusIndicator status="completed" />)
+    expect(screen.getByTestId('status-glyph-completed').textContent).toBe('✓')
+    expect(screen.getByTestId('status-indicator-completed').querySelector('span.bg-green-500')).toBeTruthy()
+  })
+
+  it('renders the failed glyph and dot together', () => {
+    render(<StatusIndicator status="failed" />)
+    expect(screen.getByTestId('status-glyph-failed').textContent).toBe('!')
+    expect(screen.getByTestId('status-indicator-failed').querySelector('span.bg-red-500')).toBeTruthy()
+  })
+
+  it('uses the provided label as accessible name', () => {
+    render(<StatusIndicator status="running" label="bold-meadow: running" />)
+    const wrapper = screen.getByTestId('status-indicator-running')
+    expect(wrapper.getAttribute('aria-label')).toBe('bold-meadow: running')
+    expect(wrapper.getAttribute('role')).toBe('img')
+  })
+
+  it('falls back to a generic accessible label when not provided', () => {
+    render(<StatusIndicator status="completed" />)
+    const wrapper = screen.getByTestId('status-indicator-completed')
+    expect(wrapper.getAttribute('aria-label')).toBe('Status: completed')
+  })
+
+  it('marks the dot and glyph as aria-hidden so screen readers only see the wrapper', () => {
+    render(<StatusIndicator status="running" />)
+    const wrapper = screen.getByTestId('status-indicator-running')
+    const children = wrapper.querySelectorAll('span[aria-hidden="true"]')
+    expect(children.length).toBe(2)
+  })
+})

--- a/test/components/UniverseCanvas.test.tsx
+++ b/test/components/UniverseCanvas.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, fireEvent, cleanup } from '@testing-library/preact'
-import { UniverseCanvas } from '../../src/components/UniverseCanvas'
+import {
+  UniverseCanvas,
+  loadPersistedViewport,
+  savePersistedViewport,
+} from '../../src/components/UniverseCanvas'
 import type { ApiSession, ApiDagGraph, FeedbackMetadata } from '../../src/api/types'
 
 vi.mock('@reactflow/core', async () => {
@@ -525,6 +529,112 @@ describe('UniverseCanvas', () => {
       expect(nodes[0].data.scale).toBeGreaterThan(0)
       expect(nodes[0].data.scale).toBeLessThanOrEqual(1)
     }
+  })
+
+  it('uses fitView and no defaultViewport when no viewportStorageKey is provided', async () => {
+    const mockModule = await import('@reactflow/core')
+    const sessions = [createSession()]
+    render(<UniverseCanvas {...defaultProps} sessions={sessions} />)
+    const calls = vi.mocked(mockModule.ReactFlow).mock.calls
+    const props = calls[calls.length - 1][0]
+    expect(props.fitView).toBe(true)
+    expect(props.defaultViewport).toBeUndefined()
+  })
+
+  it('passes defaultViewport from localStorage and disables fitView when persisted viewport is present', async () => {
+    const storageKey = 'minions-ui:viewport:test-conn'
+    window.localStorage.setItem(storageKey, JSON.stringify({ x: 42, y: -17, zoom: 0.75 }))
+    const mockModule = await import('@reactflow/core')
+    const sessions = [createSession()]
+    render(
+      <UniverseCanvas
+        {...defaultProps}
+        sessions={sessions}
+        viewportStorageKey={storageKey}
+      />
+    )
+    const calls = vi.mocked(mockModule.ReactFlow).mock.calls
+    const props = calls[calls.length - 1][0]
+    expect(props.defaultViewport).toEqual({ x: 42, y: -17, zoom: 0.75 })
+    expect(props.fitView).toBe(false)
+    window.localStorage.removeItem(storageKey)
+  })
+
+  it('persists viewport to localStorage when ReactFlow emits onMoveEnd', async () => {
+    const storageKey = 'minions-ui:viewport:onmove-test'
+    window.localStorage.removeItem(storageKey)
+    const mockModule = await import('@reactflow/core')
+    const sessions = [createSession()]
+    render(
+      <UniverseCanvas
+        {...defaultProps}
+        sessions={sessions}
+        viewportStorageKey={storageKey}
+      />
+    )
+    const calls = vi.mocked(mockModule.ReactFlow).mock.calls
+    const props = calls[calls.length - 1][0]
+    expect(typeof props.onMoveEnd).toBe('function')
+    props.onMoveEnd?.(null as unknown as MouseEvent, { x: 100, y: 200, zoom: 1.25 })
+    expect(JSON.parse(window.localStorage.getItem(storageKey)!)).toEqual({
+      x: 100,
+      y: 200,
+      zoom: 1.25,
+    })
+    window.localStorage.removeItem(storageKey)
+  })
+
+  it('ignores invalid viewport stored in localStorage', async () => {
+    const storageKey = 'minions-ui:viewport:bad'
+    window.localStorage.setItem(storageKey, 'not-json')
+    const mockModule = await import('@reactflow/core')
+    const sessions = [createSession()]
+    render(
+      <UniverseCanvas
+        {...defaultProps}
+        sessions={sessions}
+        viewportStorageKey={storageKey}
+      />
+    )
+    const calls = vi.mocked(mockModule.ReactFlow).mock.calls
+    const props = calls[calls.length - 1][0]
+    expect(props.defaultViewport).toBeUndefined()
+    expect(props.fitView).toBe(true)
+    window.localStorage.removeItem(storageKey)
+  })
+})
+
+describe('loadPersistedViewport / savePersistedViewport', () => {
+  const key = 'minions-ui:viewport:unit'
+
+  afterEach(() => {
+    window.localStorage.removeItem(key)
+  })
+
+  it('returns null when no value is stored', () => {
+    expect(loadPersistedViewport(key)).toBeNull()
+  })
+
+  it('round-trips a viewport through localStorage', () => {
+    savePersistedViewport(key, { x: 11, y: 22, zoom: 1.5 })
+    expect(loadPersistedViewport(key)).toEqual({ x: 11, y: 22, zoom: 1.5 })
+  })
+
+  it('returns null for malformed JSON', () => {
+    window.localStorage.setItem(key, '{{')
+    expect(loadPersistedViewport(key)).toBeNull()
+  })
+
+  it('returns null when zoom is not positive', () => {
+    window.localStorage.setItem(key, JSON.stringify({ x: 0, y: 0, zoom: 0 }))
+    expect(loadPersistedViewport(key)).toBeNull()
+  })
+
+  it('returns null when fields are missing or non-finite', () => {
+    window.localStorage.setItem(key, JSON.stringify({ x: 1, y: 2 }))
+    expect(loadPersistedViewport(key)).toBeNull()
+    window.localStorage.setItem(key, JSON.stringify({ x: Infinity, y: 0, zoom: 1 }))
+    expect(loadPersistedViewport(key)).toBeNull()
   })
 
   it('renders feedback badge on canvas node when session has feedback metadata', () => {


### PR DESCRIPTION
## Summary

Three small accessibility / visual-polish wins suggested by the planning agent:

1. **Status glyphs alongside colors.** `StatusIndicator` now renders a tiny `⟳ / ✓ / ! / ·` glyph next to the colored dot, so session status is decodable in monochrome / high-contrast / color-blind contexts. Replaces the bare `statusDot` span in `SessionList`, `ChatPane`, and `VariantGroupView`.
2. **Spinners on Stop / Close / Send.** `ConfirmDialog`, `ReplyDialog`, and the `MessageInput` Send button now show an inline animated spinner and `aria-busy="true"` while a request is in flight (in addition to the existing label change and disabled state).
3. **Persisted canvas viewport.** `UniverseCanvas` persists the ReactFlow viewport per connection (`localStorage["minions-ui:viewport:<connId>"]`). Restored via `defaultViewport` on mount, saved on `onMoveEnd`, so pan/zoom survives snapshot updates, view-mode toggles, and page reloads. When no persisted viewport exists, the original `fitView` behavior still runs.

No engine / API changes. Pure UI.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 1112/1112 passing (added unit tests for `StatusIndicator`, `statusGlyph`, `loadPersistedViewport` / `savePersistedViewport`, viewport plumbing through `<UniverseCanvas/>`, and spinner / aria-busy on the three buttons)
- [ ] (CI) Playwright e2e suite
