### PR TITLE
feat(palette): Cmd-K command palette + ? shortcut cheatsheet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { signal } from '@preact/signals'
 import { useState, useEffect, useMemo, useRef, useCallback } from 'preact/hooks'
 import { useRegisterSW } from 'virtual:pwa-register/preact'
-import { connections, activeId, getActiveStore } from './connections/store'
+import { connections, activeId, getActiveStore, setActive } from './connections/store'
 import { ConnectionSettings } from './connections/ConnectionSettings'
 import { ConnectionPicker } from './connections/ConnectionPicker'
 import { ConnectionsDrawer } from './connections/ConnectionsDrawer'
@@ -9,7 +9,10 @@ import { ResourceChip } from './components/ResourceChip'
 import { RunningBadge } from './components/RunningBadge'
 import { countRunning } from './state/running'
 import { RuntimeConfigDrawer, type RuntimeTab } from './settings/RuntimeConfigDrawer'
-import { NewTaskBar } from './chat/NewTaskBar'
+import { NewTaskBar, requestNewTaskFocus } from './chat/NewTaskBar'
+import { CommandPalette } from './components/CommandPalette'
+import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp'
+import { useGlobalShortcuts } from './hooks/useGlobalShortcuts'
 import { AttentionBar, filterSessionsByReason } from './components/AttentionBar'
 import { UniverseCanvas } from './components/UniverseCanvas'
 import { SessionLogsPopup } from './components/SessionLogsPopup'
@@ -42,6 +45,8 @@ const showSettings = signal(false)
 const showDrawer = signal(false)
 const showRuntime = signal<RuntimeTab | null>(null)
 const showMemory = signal(false)
+const showPalette = signal(false)
+const showShortcutsHelp = signal(false)
 export const viewMode = signal<ViewMode>('list')
 
 function ViewToggle({ mode, onChange, showKanban }: { mode: ViewMode; onChange: (m: ViewMode) => void; showKanban?: boolean }) {
@@ -514,6 +519,22 @@ function ActiveView() {
     }
   }, [store])
 
+  useGlobalShortcuts({
+    onOpenPalette: () => { showPalette.value = true },
+    onOpenHelp: () => { showShortcutsHelp.value = true },
+    onNewTask: () => { requestNewTaskFocus() },
+    onSwitchView: (v) => { viewMode.value = v },
+    onRefresh: () => { void store?.refresh() },
+  })
+
+  const handleJumpSession = useCallback((slug: string) => {
+    const match = sessions.find((s) => s.slug === slug)
+    if (match) {
+      selectSession(match.id)
+      viewMode.value = 'list'
+    }
+  }, [sessions, selectSession])
+
   if (!store || !conn) return null
 
   const selected = sessionId ? sessions.find((s) => s.id === sessionId) ?? null : null
@@ -822,6 +843,24 @@ function ActiveView() {
           onClose={() => { showMemory.value = false }}
         />
       )}
+      <CommandPalette
+        open={showPalette.value}
+        store={store}
+        sessions={sessions}
+        connections={connections.value}
+        activeConnectionId={activeId.value}
+        onClose={() => { showPalette.value = false }}
+        onShowHelp={() => { showShortcutsHelp.value = true }}
+        onSwitchView={(v) => { viewMode.value = v }}
+        onSwitchConnection={(cid) => { setActive(cid) }}
+        onNewTask={() => { requestNewTaskFocus() }}
+        onRefresh={() => { void store.refresh() }}
+        onJumpSession={handleJumpSession}
+      />
+      <KeyboardShortcutsHelp
+        open={showShortcutsHelp.value}
+        onClose={() => { showShortcutsHelp.value = false }}
+      />
       {logsSessionId !== null && (() => {
         const logsSession = sessions.find((s) => s.id === logsSessionId)
         const transcript = logsSession ? store.getTranscript(logsSession.id) : null

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -32,6 +32,13 @@ function readFileAsBase64(file: File): Promise<{ mediaType: string; dataBase64: 
 
 const COLLAPSE_KEY = 'minions-ui:newtaskbar-collapsed'
 
+export const NEW_TASK_FOCUS_EVENT = 'minions-ui:focus-new-task'
+
+export function requestNewTaskFocus(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent(NEW_TASK_FOCUS_EVENT))
+}
+
 function readCollapsed(): boolean {
   if (typeof localStorage === 'undefined') return false
   return localStorage.getItem(COLLAPSE_KEY) === 'true'
@@ -169,12 +176,27 @@ export function NewTaskBar({
   // Collapsed state is user-controlled via the − button, persisted in
   // localStorage. Defaults to expanded; tests rely on the expanded render.
   const collapsed = useSignal(readCollapsed())
+  const promptRef = useRef<HTMLTextAreaElement>(null)
 
   function toggleCollapsed() {
     const next = !collapsed.value
     collapsed.value = next
     writeCollapsed(next)
   }
+
+  useEffect(() => {
+    const handler = () => {
+      if (collapsed.value) {
+        collapsed.value = false
+        writeCollapsed(false)
+      }
+      setTimeout(() => promptRef.current?.focus(), 0)
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener(NEW_TASK_FOCUS_EVENT, handler)
+      return () => window.removeEventListener(NEW_TASK_FOCUS_EVENT, handler)
+    }
+  }, [collapsed])
 
   if (!canCreate) {
     return (
@@ -401,6 +423,7 @@ export function NewTaskBar({
           <PaperclipIcon />
         </button>
         <textarea
+          ref={promptRef}
           value={prompt.value}
           onInput={(e) => { prompt.value = (e.currentTarget as HTMLTextAreaElement).value }}
           onPaste={handlePaste}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,457 @@
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import type { ApiSession } from '../api/types'
+import type { Connection } from '../connections/types'
+import type { ConnectionStore } from '../state/types'
+import type { ViewMode } from '../App'
+import { formatRoute } from '../routing/route'
+
+export type CommandKind =
+  | 'help'
+  | 'view'
+  | 'new-task'
+  | 'switch-connection'
+  | 'jump-session'
+  | 'stop-session'
+  | 'open-pr'
+  | 'refresh'
+
+export interface PaletteCommand {
+  id: string
+  kind: CommandKind
+  title: string
+  subtitle?: string
+  hint?: string
+  keywords: string
+  run: () => void | Promise<void>
+}
+
+export interface CommandPaletteProps {
+  open: boolean
+  store: ConnectionStore | null
+  sessions: ApiSession[]
+  connections: Connection[]
+  activeConnectionId: string | null
+  onClose: () => void
+  onShowHelp: () => void
+  onSwitchView: (view: ViewMode) => void
+  onSwitchConnection: (id: string) => void
+  onNewTask: () => void
+  onRefresh: () => void
+  onJumpSession?: (slug: string) => void
+}
+
+interface CommandSourceContext {
+  store: ConnectionStore | null
+  sessions: ApiSession[]
+  connections: Connection[]
+  activeConnectionId: string | null
+  onClose: () => void
+  onShowHelp: () => void
+  onSwitchView: (view: ViewMode) => void
+  onSwitchConnection: (id: string) => void
+  onNewTask: () => void
+  onRefresh: () => void
+  onJumpSession?: (slug: string) => void
+}
+
+export function buildCommands(ctx: CommandSourceContext): PaletteCommand[] {
+  const commands: PaletteCommand[] = []
+  const close = ctx.onClose
+
+  commands.push({
+    id: 'new-task',
+    kind: 'new-task',
+    title: 'New task',
+    subtitle: 'Open the task bar and start drafting',
+    hint: 'n',
+    keywords: 'new task create start prompt',
+    run: () => {
+      close()
+      ctx.onNewTask()
+    },
+  })
+
+  commands.push({
+    id: 'view-list',
+    kind: 'view',
+    title: 'View: Sessions list',
+    hint: 'g l',
+    keywords: 'view list sessions sidebar',
+    run: () => {
+      close()
+      ctx.onSwitchView('list')
+    },
+  })
+  commands.push({
+    id: 'view-canvas',
+    kind: 'view',
+    title: 'View: Canvas',
+    hint: 'g c',
+    keywords: 'view canvas dag graph universe',
+    run: () => {
+      close()
+      ctx.onSwitchView('canvas')
+    },
+  })
+  commands.push({
+    id: 'view-ship',
+    kind: 'view',
+    title: 'View: Ship pipeline',
+    hint: 'g s',
+    keywords: 'view ship pipeline pr',
+    run: () => {
+      close()
+      ctx.onSwitchView('ship')
+    },
+  })
+  commands.push({
+    id: 'view-kanban',
+    kind: 'view',
+    title: 'View: Kanban',
+    hint: 'g k',
+    keywords: 'view kanban board',
+    run: () => {
+      close()
+      ctx.onSwitchView('kanban')
+    },
+  })
+
+  commands.push({
+    id: 'refresh',
+    kind: 'refresh',
+    title: 'Refresh sessions and DAGs',
+    hint: 'r',
+    keywords: 'refresh refetch reload sync',
+    run: () => {
+      close()
+      ctx.onRefresh()
+    },
+  })
+
+  commands.push({
+    id: 'help',
+    kind: 'help',
+    title: 'Show keyboard shortcuts',
+    hint: '?',
+    keywords: 'help keyboard shortcuts cheatsheet ?',
+    run: () => {
+      close()
+      ctx.onShowHelp()
+    },
+  })
+
+  for (const conn of ctx.connections) {
+    if (conn.id === ctx.activeConnectionId) continue
+    commands.push({
+      id: `switch-${conn.id}`,
+      kind: 'switch-connection',
+      title: `Switch to ${conn.label}`,
+      subtitle: conn.baseUrl,
+      keywords: `switch connection ${conn.label} ${conn.baseUrl}`,
+      run: () => {
+        close()
+        ctx.onSwitchConnection(conn.id)
+      },
+    })
+  }
+
+  for (const session of ctx.sessions) {
+    commands.push({
+      id: `jump-${session.id}`,
+      kind: 'jump-session',
+      title: `Jump to ${session.slug}`,
+      subtitle: sessionSubtitle(session),
+      keywords: `jump session ${session.slug} ${session.command} ${session.mode} ${session.status}`,
+      run: () => {
+        close()
+        if (ctx.onJumpSession) {
+          ctx.onJumpSession(session.slug)
+        } else if (typeof window !== 'undefined') {
+          window.location.hash = formatRoute({ name: 'session', sessionSlug: session.slug })
+        }
+      },
+    })
+  }
+
+  if (ctx.store) {
+    const store = ctx.store
+    for (const session of ctx.sessions) {
+      if (session.status !== 'running' && session.status !== 'pending') continue
+      commands.push({
+        id: `stop-${session.id}`,
+        kind: 'stop-session',
+        title: `Stop ${session.slug}`,
+        subtitle: 'Send /stop to this session',
+        keywords: `stop kill cancel session ${session.slug}`,
+        run: () => {
+          close()
+          void store.sendCommand({ action: 'stop', sessionId: session.id })
+        },
+      })
+    }
+  }
+
+  for (const session of ctx.sessions) {
+    if (!session.prUrl) continue
+    commands.push({
+      id: `pr-${session.id}`,
+      kind: 'open-pr',
+      title: `Open PR for ${session.slug}`,
+      subtitle: session.prUrl,
+      keywords: `pr pull request open ${session.slug} ${session.prUrl}`,
+      run: () => {
+        close()
+        if (typeof window !== 'undefined') {
+          window.open(session.prUrl, '_blank', 'noopener,noreferrer')
+        }
+      },
+    })
+  }
+
+  return commands
+}
+
+function sessionSubtitle(session: ApiSession): string {
+  const parts: string[] = [session.status]
+  if (session.mode) parts.push(session.mode)
+  if (session.repo) parts.push(session.repo)
+  return parts.join(' · ')
+}
+
+export function fuzzyMatch(query: string, text: string): boolean {
+  if (!query) return true
+  const q = query.toLowerCase()
+  const t = text.toLowerCase()
+  let i = 0
+  for (let j = 0; j < t.length && i < q.length; j++) {
+    if (t[j] === q[i]) i++
+  }
+  return i === q.length
+}
+
+export function rankCommand(query: string, command: PaletteCommand): number {
+  if (!query) return 0
+  const q = query.toLowerCase()
+  const title = command.title.toLowerCase()
+  if (title === q) return 1000
+  if (title.startsWith(q)) return 800
+  const titleIdx = title.indexOf(q)
+  if (titleIdx !== -1) return 500 - titleIdx
+  if (command.keywords.toLowerCase().includes(q)) return 200
+  if (fuzzyMatch(q, title)) return 100
+  if (fuzzyMatch(q, command.keywords)) return 50
+  return -1
+}
+
+export function filterCommands(commands: PaletteCommand[], query: string): PaletteCommand[] {
+  if (!query.trim()) return commands
+  const ranked = commands
+    .map((c) => ({ c, score: rankCommand(query.trim(), c) }))
+    .filter((x) => x.score >= 0)
+  ranked.sort((a, b) => b.score - a.score)
+  return ranked.map((x) => x.c)
+}
+
+const KIND_LABEL: Record<CommandKind, string> = {
+  'help': 'Help',
+  'view': 'View',
+  'new-task': 'Action',
+  'switch-connection': 'Connection',
+  'jump-session': 'Navigate',
+  'stop-session': 'Session',
+  'open-pr': 'Session',
+  'refresh': 'Action',
+}
+
+export function CommandPalette({
+  open,
+  store,
+  sessions,
+  connections,
+  activeConnectionId,
+  onClose,
+  onShowHelp,
+  onSwitchView,
+  onSwitchConnection,
+  onNewTask,
+  onRefresh,
+  onJumpSession,
+}: CommandPaletteProps) {
+  const [query, setQuery] = useState('')
+  const [activeIdx, setActiveIdx] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLUListElement>(null)
+
+  const commands = useMemo(
+    () => buildCommands({
+      store,
+      sessions,
+      connections,
+      activeConnectionId,
+      onClose,
+      onShowHelp,
+      onSwitchView,
+      onSwitchConnection,
+      onNewTask,
+      onRefresh,
+      onJumpSession,
+    }),
+    [store, sessions, connections, activeConnectionId, onClose, onShowHelp, onSwitchView, onSwitchConnection, onNewTask, onRefresh, onJumpSession],
+  )
+
+  const filtered = useMemo(() => filterCommands(commands, query), [commands, query])
+
+  useEffect(() => {
+    if (!open) return
+    setQuery('')
+    setActiveIdx(0)
+    const t = setTimeout(() => inputRef.current?.focus(), 0)
+    return () => clearTimeout(t)
+  }, [open])
+
+  useEffect(() => {
+    setActiveIdx(0)
+  }, [query])
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+        return
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setActiveIdx((i) => Math.min(filtered.length - 1, i + 1))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setActiveIdx((i) => Math.max(0, i - 1))
+      } else if (e.key === 'Enter') {
+        const cmd = filtered[activeIdx]
+        if (cmd) {
+          e.preventDefault()
+          void cmd.run()
+        }
+      } else if (e.key === 'Home') {
+        e.preventDefault()
+        setActiveIdx(0)
+      } else if (e.key === 'End') {
+        e.preventDefault()
+        setActiveIdx(Math.max(0, filtered.length - 1))
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, filtered, activeIdx, onClose])
+
+  useEffect(() => {
+    if (!open) return
+    const list = listRef.current
+    if (!list) return
+    const item = list.querySelector<HTMLElement>(`[data-idx="${activeIdx}"]`)
+    if (item && typeof item.scrollIntoView === 'function') {
+      item.scrollIntoView({ block: 'nearest' })
+    }
+  }, [activeIdx, open])
+
+  if (!open) return null
+
+  return (
+    <div
+      class="fixed inset-0 z-[60] flex items-start justify-center pt-[10vh] px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+      data-testid="command-palette"
+    >
+      <div
+        class="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        data-testid="command-palette-backdrop"
+      />
+      <div class="relative z-10 w-full max-w-xl rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-2xl flex flex-col overflow-hidden max-h-[70vh]">
+        <div class="flex items-center gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700">
+          <span class="text-slate-400 dark:text-slate-500 text-sm" aria-hidden="true">⌘</span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onInput={(e) => setQuery((e.currentTarget as HTMLInputElement).value)}
+            placeholder="Type a command or search…"
+            class="flex-1 bg-transparent border-0 outline-none text-sm text-slate-900 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500 py-1.5"
+            aria-label="Command palette search"
+            data-testid="command-palette-input"
+            autoComplete="off"
+            spellcheck={false}
+          />
+          <kbd class="hidden sm:inline-block text-[10px] font-mono text-slate-400 dark:text-slate-500 border border-slate-200 dark:border-slate-700 rounded px-1.5 py-0.5">esc</kbd>
+        </div>
+        {filtered.length === 0 ? (
+          <div
+            class="px-4 py-8 text-center text-sm text-slate-500 dark:text-slate-400"
+            data-testid="command-palette-empty"
+          >
+            No commands match "{query}"
+          </div>
+        ) : (
+          <ul
+            ref={listRef}
+            role="listbox"
+            aria-label="Available commands"
+            class="overflow-y-auto py-1"
+            data-testid="command-palette-list"
+          >
+            {filtered.map((cmd, idx) => {
+              const active = idx === activeIdx
+              return (
+                <li key={cmd.id}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={active}
+                    data-idx={idx}
+                    data-testid={`command-palette-item-${cmd.id}`}
+                    onMouseEnter={() => setActiveIdx(idx)}
+                    onClick={() => void cmd.run()}
+                    class={`w-full flex items-center gap-3 px-3 py-2 text-left text-sm transition-colors ${
+                      active
+                        ? 'bg-indigo-50 dark:bg-indigo-900/40 text-slate-900 dark:text-slate-100'
+                        : 'text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700'
+                    }`}
+                  >
+                    <span
+                      class={`shrink-0 inline-flex items-center justify-center text-[10px] font-medium uppercase tracking-wide rounded px-1.5 py-0.5 ${
+                        active
+                          ? 'bg-indigo-100 dark:bg-indigo-800 text-indigo-700 dark:text-indigo-200'
+                          : 'bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300'
+                      }`}
+                    >
+                      {KIND_LABEL[cmd.kind]}
+                    </span>
+                    <span class="flex-1 min-w-0">
+                      <span class="block truncate font-medium">{cmd.title}</span>
+                      {cmd.subtitle && (
+                        <span class="block truncate text-xs text-slate-500 dark:text-slate-400">{cmd.subtitle}</span>
+                      )}
+                    </span>
+                    {cmd.hint && (
+                      <kbd class="shrink-0 text-[10px] font-mono text-slate-500 dark:text-slate-400 border border-slate-200 dark:border-slate-600 rounded px-1.5 py-0.5">
+                        {cmd.hint}
+                      </kbd>
+                    )}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+        <div class="flex items-center gap-3 px-3 py-1.5 border-t border-slate-200 dark:border-slate-700 text-[10px] text-slate-500 dark:text-slate-400 font-mono">
+          <span><kbd class="border border-slate-200 dark:border-slate-700 rounded px-1">↑↓</kbd> navigate</span>
+          <span><kbd class="border border-slate-200 dark:border-slate-700 rounded px-1">↵</kbd> run</span>
+          <span class="ml-auto">{filtered.length} of {commands.length}</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,138 @@
+import { useEffect } from 'preact/hooks'
+
+export interface ShortcutEntry {
+  keys: string[]
+  description: string
+}
+
+export interface ShortcutSection {
+  title: string
+  entries: ShortcutEntry[]
+}
+
+export const SHORTCUT_SECTIONS: ShortcutSection[] = [
+  {
+    title: 'Global',
+    entries: [
+      { keys: ['⌘', 'K'], description: 'Open command palette' },
+      { keys: ['Ctrl', 'K'], description: 'Open command palette (Linux/Windows)' },
+      { keys: ['?'], description: 'Show this shortcuts help' },
+      { keys: ['n'], description: 'New task — focus the task bar' },
+      { keys: ['r'], description: 'Refresh sessions and DAGs' },
+      { keys: ['Esc'], description: 'Close any open overlay' },
+    ],
+  },
+  {
+    title: 'Navigation',
+    entries: [
+      { keys: ['g', 'l'], description: 'Go to sessions list' },
+      { keys: ['g', 'c'], description: 'Go to canvas' },
+      { keys: ['g', 's'], description: 'Go to ship pipeline' },
+      { keys: ['g', 'k'], description: 'Go to kanban' },
+    ],
+  },
+  {
+    title: 'Command palette',
+    entries: [
+      { keys: ['↑', '↓'], description: 'Move selection' },
+      { keys: ['↵'], description: 'Run selected command' },
+      { keys: ['Esc'], description: 'Close palette' },
+    ],
+  },
+  {
+    title: 'Task bar',
+    entries: [
+      { keys: ['⌘', '↵'], description: 'Submit task (when prompt focused)' },
+      { keys: ['Ctrl', '↵'], description: 'Submit task (Linux/Windows)' },
+    ],
+  },
+]
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export function KeyboardShortcutsHelp({ open, onClose }: Props) {
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' || e.key === '?') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      class="fixed inset-0 z-[60] flex items-center justify-center px-4 py-8"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="kbd-help-title"
+      data-testid="keyboard-shortcuts-help"
+    >
+      <div
+        class="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        data-testid="keyboard-shortcuts-backdrop"
+      />
+      <div class="relative z-10 w-full max-w-lg rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-2xl flex flex-col overflow-hidden max-h-[80vh]">
+        <div class="flex items-center justify-between px-4 py-3 border-b border-slate-200 dark:border-slate-700">
+          <h2 id="kbd-help-title" class="text-sm font-semibold text-slate-900 dark:text-slate-100">
+            Keyboard shortcuts
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            class="rounded-md text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 px-2 py-1 text-xs"
+            aria-label="Close keyboard shortcuts help"
+            data-testid="keyboard-shortcuts-close"
+          >
+            ✕
+          </button>
+        </div>
+        <div class="overflow-y-auto px-4 py-3 flex flex-col gap-4">
+          {SHORTCUT_SECTIONS.map((section) => (
+            <section key={section.title} aria-labelledby={`kbd-section-${section.title}`}>
+              <h3
+                id={`kbd-section-${section.title}`}
+                class="text-[10px] font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-1.5"
+              >
+                {section.title}
+              </h3>
+              <ul class="flex flex-col gap-1.5">
+                {section.entries.map((entry, idx) => (
+                  <li
+                    key={`${section.title}-${idx}`}
+                    class="flex items-center gap-3 text-sm text-slate-700 dark:text-slate-200"
+                    data-testid={`shortcut-entry-${section.title}-${idx}`}
+                  >
+                    <span class="flex-1 min-w-0">{entry.description}</span>
+                    <span class="shrink-0 flex items-center gap-1">
+                      {entry.keys.map((k, kidx) => (
+                        <kbd
+                          key={kidx}
+                          class="text-[11px] font-mono text-slate-700 dark:text-slate-200 border border-slate-300 dark:border-slate-600 rounded px-1.5 py-0.5 bg-slate-50 dark:bg-slate-900"
+                        >
+                          {k}
+                        </kbd>
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+        <div class="px-4 py-2 border-t border-slate-200 dark:border-slate-700 text-[10px] text-slate-500 dark:text-slate-400">
+          Press <kbd class="border border-slate-200 dark:border-slate-700 rounded px-1 font-mono">?</kbd> to toggle, <kbd class="border border-slate-200 dark:border-slate-700 rounded px-1 font-mono">Esc</kbd> to close.
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from 'preact/hooks'
+
+export interface GlobalShortcutHandlers {
+  onOpenPalette: () => void
+  onOpenHelp: () => void
+  onNewTask?: () => void
+  onSwitchView?: (view: 'list' | 'canvas' | 'ship' | 'kanban') => void
+  onRefresh?: () => void
+}
+
+export function isTextInputTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.isContentEditable) return true
+  const tag = target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  return false
+}
+
+export function useGlobalShortcuts(handlers: GlobalShortcutHandlers): void {
+  const ref = useRef(handlers)
+  ref.current = handlers
+
+  useEffect(() => {
+    let pendingChord: 'g' | null = null
+    let chordTimer: ReturnType<typeof setTimeout> | null = null
+
+    const clearChord = () => {
+      pendingChord = null
+      if (chordTimer) {
+        clearTimeout(chordTimer)
+        chordTimer = null
+      }
+    }
+
+    const handler = (e: KeyboardEvent) => {
+      const h = ref.current
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault()
+        clearChord()
+        h.onOpenPalette()
+        return
+      }
+
+      if (isTextInputTarget(e.target)) return
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+
+      if (pendingChord === 'g') {
+        const next = e.key.toLowerCase()
+        if (next === 'l' && h.onSwitchView) {
+          e.preventDefault()
+          h.onSwitchView('list')
+        } else if (next === 'c' && h.onSwitchView) {
+          e.preventDefault()
+          h.onSwitchView('canvas')
+        } else if (next === 's' && h.onSwitchView) {
+          e.preventDefault()
+          h.onSwitchView('ship')
+        } else if (next === 'k' && h.onSwitchView) {
+          e.preventDefault()
+          h.onSwitchView('kanban')
+        }
+        clearChord()
+        return
+      }
+
+      if (e.key === '?') {
+        e.preventDefault()
+        h.onOpenHelp()
+        return
+      }
+      if (e.key === 'n' && h.onNewTask) {
+        e.preventDefault()
+        h.onNewTask()
+        return
+      }
+      if (e.key === 'r' && h.onRefresh) {
+        e.preventDefault()
+        h.onRefresh()
+        return
+      }
+      if (e.key === 'g') {
+        e.preventDefault()
+        pendingChord = 'g'
+        chordTimer = setTimeout(clearChord, 1500)
+        return
+      }
+    }
+
+    document.addEventListener('keydown', handler)
+    return () => {
+      document.removeEventListener('keydown', handler)
+      clearChord()
+    }
+  }, [])
+}

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -290,6 +290,44 @@ describe('App', () => {
     await screen.findByTestId('transcript-upgrade-notice')
   })
 
+  it('opens the command palette on Cmd+K and closes it on Escape', { timeout: 15000 }, async () => {
+    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
+      version: 1,
+      connections: [
+        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+      ],
+      activeId: 'c1',
+    }))
+    stubFetch([session()])
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    await screen.findByText('My Minion')
+    expect(screen.queryByTestId('command-palette')).toBeNull()
+    fireEvent.keyDown(document, { key: 'k', metaKey: true })
+    expect(screen.getByTestId('command-palette')).toBeTruthy()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('command-palette')).toBeNull()
+  })
+
+  it('opens the keyboard shortcuts help on ?', { timeout: 15000 }, async () => {
+    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
+      version: 1,
+      connections: [
+        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+      ],
+      activeId: 'c1',
+    }))
+    stubFetch([session()])
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    await screen.findByText('My Minion')
+    expect(screen.queryByTestId('keyboard-shortcuts-help')).toBeNull()
+    fireEvent.keyDown(document, { key: '?' })
+    expect(screen.getByTestId('keyboard-shortcuts-help')).toBeTruthy()
+  })
+
   it('updates the route hash when switching sessions from a routed session page', { timeout: 15000 }, async () => {
     localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
       version: 1,

--- a/test/components/CommandPalette.test.tsx
+++ b/test/components/CommandPalette.test.tsx
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, screen, cleanup } from '@testing-library/preact'
+import {
+  CommandPalette,
+  buildCommands,
+  filterCommands,
+  rankCommand,
+  fuzzyMatch,
+} from '../../src/components/CommandPalette'
+import type { ApiSession } from '../../src/api/types'
+import type { Connection } from '../../src/connections/types'
+import type { ConnectionStore } from '../../src/state/types'
+
+function session(over: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 's1',
+    slug: 'brave-fox',
+    status: 'running',
+    command: '/task foo',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...over,
+  }
+}
+
+function connection(over: Partial<Connection> = {}): Connection {
+  return {
+    id: 'c1',
+    label: 'Primary',
+    baseUrl: 'https://example.com',
+    token: 'tok',
+    color: '#3b82f6',
+    ...over,
+  }
+}
+
+function makeStore(): ConnectionStore {
+  return {
+    sendCommand: vi.fn().mockResolvedValue({ success: true }),
+    refresh: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ConnectionStore
+}
+
+const noop = () => {}
+
+function defaultProps(over: Partial<Parameters<typeof CommandPalette>[0]> = {}) {
+  return {
+    open: true,
+    store: null,
+    sessions: [] as ApiSession[],
+    connections: [] as Connection[],
+    activeConnectionId: null,
+    onClose: noop,
+    onShowHelp: noop,
+    onSwitchView: noop,
+    onSwitchConnection: noop,
+    onNewTask: noop,
+    onRefresh: noop,
+    ...over,
+  }
+}
+
+describe('fuzzyMatch', () => {
+  it('returns true for empty query', () => {
+    expect(fuzzyMatch('', 'anything')).toBe(true)
+  })
+  it('matches sequential characters', () => {
+    expect(fuzzyMatch('nt', 'new task')).toBe(true)
+    expect(fuzzyMatch('ntsk', 'new task')).toBe(true)
+  })
+  it('rejects non-matching characters', () => {
+    expect(fuzzyMatch('xyz', 'new task')).toBe(false)
+  })
+  it('is case insensitive', () => {
+    expect(fuzzyMatch('NEW', 'new task')).toBe(true)
+  })
+})
+
+describe('rankCommand', () => {
+  const cmd = {
+    id: 'x',
+    kind: 'view' as const,
+    title: 'View: Canvas',
+    keywords: 'view canvas dag',
+    run: () => {},
+  }
+
+  it('returns 0 for empty query', () => {
+    expect(rankCommand('', cmd)).toBe(0)
+  })
+  it('scores exact title higher than prefix', () => {
+    const exact = rankCommand('view: canvas', cmd)
+    const prefix = rankCommand('view', cmd)
+    expect(exact).toBeGreaterThan(prefix)
+  })
+  it('scores keyword match below title match', () => {
+    const titlePrefix = rankCommand('view', cmd)
+    const keyword = rankCommand('dag', cmd)
+    expect(titlePrefix).toBeGreaterThan(keyword)
+  })
+  it('returns -1 when nothing matches', () => {
+    expect(rankCommand('zzz', cmd)).toBe(-1)
+  })
+})
+
+describe('buildCommands', () => {
+  const ctx = {
+    store: null,
+    sessions: [
+      session({ id: 's1', slug: 'brave-fox', status: 'running', prUrl: 'https://gh.example/pr/1' }),
+      session({ id: 's2', slug: 'wise-owl', status: 'completed' }),
+    ],
+    connections: [
+      connection({ id: 'c1', label: 'Primary' }),
+      connection({ id: 'c2', label: 'Secondary' }),
+    ],
+    activeConnectionId: 'c1',
+    onClose: noop,
+    onShowHelp: noop,
+    onSwitchView: noop,
+    onSwitchConnection: noop,
+    onNewTask: noop,
+    onRefresh: noop,
+  }
+
+  it('includes baseline commands (new-task, views, refresh, help)', () => {
+    const cmds = buildCommands(ctx)
+    const ids = cmds.map((c) => c.id)
+    expect(ids).toContain('new-task')
+    expect(ids).toContain('view-list')
+    expect(ids).toContain('view-canvas')
+    expect(ids).toContain('view-ship')
+    expect(ids).toContain('view-kanban')
+    expect(ids).toContain('refresh')
+    expect(ids).toContain('help')
+  })
+
+  it('excludes the active connection from switch commands', () => {
+    const cmds = buildCommands(ctx)
+    expect(cmds.find((c) => c.id === 'switch-c1')).toBeUndefined()
+    expect(cmds.find((c) => c.id === 'switch-c2')).toBeDefined()
+  })
+
+  it('emits a jump command for every session', () => {
+    const cmds = buildCommands(ctx)
+    expect(cmds.find((c) => c.id === 'jump-s1')).toBeDefined()
+    expect(cmds.find((c) => c.id === 'jump-s2')).toBeDefined()
+  })
+
+  it('emits a stop command only for running/pending sessions when a store is provided', () => {
+    const store = makeStore()
+    const cmds = buildCommands({ ...ctx, store })
+    expect(cmds.find((c) => c.id === 'stop-s1')).toBeDefined()
+    expect(cmds.find((c) => c.id === 'stop-s2')).toBeUndefined()
+  })
+
+  it('omits stop commands when no store is provided', () => {
+    const cmds = buildCommands(ctx)
+    expect(cmds.find((c) => c.kind === 'stop-session')).toBeUndefined()
+  })
+
+  it('emits an open-pr command only for sessions with a prUrl', () => {
+    const cmds = buildCommands(ctx)
+    expect(cmds.find((c) => c.id === 'pr-s1')).toBeDefined()
+    expect(cmds.find((c) => c.id === 'pr-s2')).toBeUndefined()
+  })
+})
+
+describe('filterCommands', () => {
+  const cmds = buildCommands({
+    store: null,
+    sessions: [session({ id: 's1', slug: 'brave-fox' })],
+    connections: [connection({ id: 'c1' }), connection({ id: 'c2', label: 'Beta' })],
+    activeConnectionId: 'c1',
+    onClose: noop,
+    onShowHelp: noop,
+    onSwitchView: noop,
+    onSwitchConnection: noop,
+    onNewTask: noop,
+    onRefresh: noop,
+  })
+
+  it('returns all commands for empty query', () => {
+    expect(filterCommands(cmds, '').length).toBe(cmds.length)
+  })
+
+  it('narrows results by query', () => {
+    const out = filterCommands(cmds, 'canvas')
+    expect(out.find((c) => c.id === 'view-canvas')).toBeDefined()
+    expect(out.find((c) => c.id === 'view-list')).toBeUndefined()
+  })
+
+  it('orders title-prefix matches before keyword-only matches', () => {
+    const out = filterCommands(cmds, 'view')
+    expect(out[0].id.startsWith('view-')).toBe(true)
+  })
+})
+
+describe('CommandPalette', () => {
+  beforeEach(() => {
+    if (!window.matchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn(() => ({
+          matches: false,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        })),
+      })
+    }
+  })
+  afterEach(() => cleanup())
+
+  it('returns nothing when closed', () => {
+    const { container } = render(<CommandPalette {...defaultProps({ open: false })} />)
+    expect(container.querySelector('[data-testid="command-palette"]')).toBeNull()
+  })
+
+  it('renders the input and command list when open', () => {
+    render(<CommandPalette {...defaultProps()} />)
+    expect(screen.getByTestId('command-palette-input')).toBeTruthy()
+    expect(screen.getByTestId('command-palette-list')).toBeTruthy()
+  })
+
+  it('filters list as the user types', () => {
+    render(<CommandPalette {...defaultProps()} />)
+    const input = screen.getByTestId('command-palette-input') as HTMLInputElement
+    fireEvent.input(input, { target: { value: 'canvas' } })
+    expect(screen.getByTestId('command-palette-item-view-canvas')).toBeTruthy()
+    expect(screen.queryByTestId('command-palette-item-view-list')).toBeNull()
+  })
+
+  it('renders empty state when no commands match', () => {
+    render(<CommandPalette {...defaultProps()} />)
+    const input = screen.getByTestId('command-palette-input') as HTMLInputElement
+    fireEvent.input(input, { target: { value: 'definitely-no-such-command-zzqq' } })
+    expect(screen.getByTestId('command-palette-empty')).toBeTruthy()
+  })
+
+  it('runs the first command on Enter and calls onClose', () => {
+    const onSwitchView = vi.fn()
+    const onClose = vi.fn()
+    render(<CommandPalette {...defaultProps({ onSwitchView, onClose })} />)
+    const input = screen.getByTestId('command-palette-input') as HTMLInputElement
+    fireEvent.input(input, { target: { value: 'view: canvas' } })
+    fireEvent.keyDown(document, { key: 'Enter' })
+    expect(onSwitchView).toHaveBeenCalledWith('canvas')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<CommandPalette {...defaultProps({ onClose })} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('moves selection with arrow keys', () => {
+    render(<CommandPalette {...defaultProps()} />)
+    const list = screen.getByTestId('command-palette-list')
+    const firstSelected = list.querySelector('[aria-selected="true"]')
+    expect(firstSelected?.getAttribute('data-idx')).toBe('0')
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    const next = list.querySelector('[aria-selected="true"]')
+    expect(next?.getAttribute('data-idx')).toBe('1')
+    fireEvent.keyDown(document, { key: 'ArrowUp' })
+    const back = list.querySelector('[aria-selected="true"]')
+    expect(back?.getAttribute('data-idx')).toBe('0')
+  })
+
+  it('switches connection when the corresponding command is clicked', () => {
+    const onSwitchConnection = vi.fn()
+    render(
+      <CommandPalette
+        {...defaultProps({
+          connections: [
+            connection({ id: 'c1', label: 'Primary' }),
+            connection({ id: 'c2', label: 'Secondary' }),
+          ],
+          activeConnectionId: 'c1',
+          onSwitchConnection,
+        })}
+      />
+    )
+    fireEvent.click(screen.getByTestId('command-palette-item-switch-c2'))
+    expect(onSwitchConnection).toHaveBeenCalledWith('c2')
+  })
+
+  it('jumps to a session via custom handler when provided', () => {
+    const onJumpSession = vi.fn()
+    render(
+      <CommandPalette
+        {...defaultProps({
+          sessions: [session({ id: 's1', slug: 'brave-fox' })],
+          onJumpSession,
+        })}
+      />
+    )
+    fireEvent.click(screen.getByTestId('command-palette-item-jump-s1'))
+    expect(onJumpSession).toHaveBeenCalledWith('brave-fox')
+  })
+
+  it('stops a running session via store.sendCommand', () => {
+    const sendCommand = vi.fn().mockResolvedValue({ success: true })
+    const store = { sendCommand } as unknown as ConnectionStore
+    render(
+      <CommandPalette
+        {...defaultProps({
+          sessions: [session({ id: 's1', slug: 'brave-fox', status: 'running' })],
+          store,
+        })}
+      />
+    )
+    fireEvent.click(screen.getByTestId('command-palette-item-stop-s1'))
+    expect(sendCommand).toHaveBeenCalledWith({ action: 'stop', sessionId: 's1' })
+  })
+
+  it('opens a PR in a new window when the PR command runs', () => {
+    const open = vi.fn()
+    const originalOpen = window.open
+    window.open = open as unknown as typeof window.open
+    try {
+      render(
+        <CommandPalette
+          {...defaultProps({
+            sessions: [
+              session({ id: 's1', slug: 'brave-fox', prUrl: 'https://gh.example/pr/1' }),
+            ],
+          })}
+        />
+      )
+      fireEvent.click(screen.getByTestId('command-palette-item-pr-s1'))
+      expect(open).toHaveBeenCalled()
+      const args = open.mock.calls[0]
+      expect(args[0]).toBe('https://gh.example/pr/1')
+      expect(args[1]).toBe('_blank')
+    } finally {
+      window.open = originalOpen
+    }
+  })
+
+  it('clicks the backdrop to close', () => {
+    const onClose = vi.fn()
+    render(<CommandPalette {...defaultProps({ onClose })} />)
+    fireEvent.click(screen.getByTestId('command-palette-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows N of M counter in footer', () => {
+    render(<CommandPalette {...defaultProps()} />)
+    const input = screen.getByTestId('command-palette-input') as HTMLInputElement
+    fireEvent.input(input, { target: { value: 'canvas' } })
+    const palette = screen.getByTestId('command-palette')
+    expect(palette.textContent).toMatch(/1 of \d+/)
+  })
+})

--- a/test/components/KeyboardShortcutsHelp.test.tsx
+++ b/test/components/KeyboardShortcutsHelp.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, screen, cleanup } from '@testing-library/preact'
+import {
+  KeyboardShortcutsHelp,
+  SHORTCUT_SECTIONS,
+} from '../../src/components/KeyboardShortcutsHelp'
+
+describe('KeyboardShortcutsHelp', () => {
+  afterEach(() => cleanup())
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <KeyboardShortcutsHelp open={false} onClose={() => {}} />,
+    )
+    expect(container.querySelector('[data-testid="keyboard-shortcuts-help"]')).toBeNull()
+  })
+
+  it('renders all sections and entries when open', () => {
+    render(<KeyboardShortcutsHelp open={true} onClose={() => {}} />)
+    for (const section of SHORTCUT_SECTIONS) {
+      expect(screen.getByText(section.title)).toBeTruthy()
+      for (let i = 0; i < section.entries.length; i++) {
+        expect(
+          screen.getByTestId(`shortcut-entry-${section.title}-${i}`),
+        ).toBeTruthy()
+      }
+    }
+  })
+
+  it('closes when the close button is clicked', () => {
+    const onClose = vi.fn()
+    render(<KeyboardShortcutsHelp open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('keyboard-shortcuts-close'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes when the backdrop is clicked', () => {
+    const onClose = vi.fn()
+    render(<KeyboardShortcutsHelp open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('keyboard-shortcuts-backdrop'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<KeyboardShortcutsHelp open={true} onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('closes on ? toggle', () => {
+    const onClose = vi.fn()
+    render(<KeyboardShortcutsHelp open={true} onClose={onClose} />)
+    fireEvent.keyDown(document, { key: '?' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('does not register listeners when closed', () => {
+    const onClose = vi.fn()
+    render(<KeyboardShortcutsHelp open={false} onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/test/hooks/useGlobalShortcuts.test.tsx
+++ b/test/hooks/useGlobalShortcuts.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/preact'
+import {
+  useGlobalShortcuts,
+  isTextInputTarget,
+  type GlobalShortcutHandlers,
+} from '../../src/hooks/useGlobalShortcuts'
+
+function Harness(props: GlobalShortcutHandlers) {
+  useGlobalShortcuts(props)
+  return (
+    <div>
+      <input data-testid="text-input" />
+      <textarea data-testid="textarea" />
+    </div>
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('isTextInputTarget', () => {
+  it('returns true for INPUT, TEXTAREA, SELECT', () => {
+    const input = document.createElement('input')
+    const textarea = document.createElement('textarea')
+    const select = document.createElement('select')
+    expect(isTextInputTarget(input)).toBe(true)
+    expect(isTextInputTarget(textarea)).toBe(true)
+    expect(isTextInputTarget(select)).toBe(true)
+  })
+  it('returns false for other elements', () => {
+    const div = document.createElement('div')
+    expect(isTextInputTarget(div)).toBe(false)
+    expect(isTextInputTarget(null)).toBe(false)
+  })
+})
+
+describe('useGlobalShortcuts', () => {
+  it('opens palette on Cmd+K', () => {
+    const onOpenPalette = vi.fn()
+    render(<Harness onOpenPalette={onOpenPalette} onOpenHelp={() => {}} />)
+    fireEvent.keyDown(document, { key: 'k', metaKey: true })
+    expect(onOpenPalette).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens palette on Ctrl+K', () => {
+    const onOpenPalette = vi.fn()
+    render(<Harness onOpenPalette={onOpenPalette} onOpenHelp={() => {}} />)
+    fireEvent.keyDown(document, { key: 'K', ctrlKey: true })
+    expect(onOpenPalette).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens palette even when focus is in a text input (Cmd+K is global)', () => {
+    const onOpenPalette = vi.fn()
+    const { getByTestId } = render(
+      <Harness onOpenPalette={onOpenPalette} onOpenHelp={() => {}} />,
+    )
+    const input = getByTestId('text-input') as HTMLInputElement
+    input.focus()
+    fireEvent.keyDown(input, { key: 'k', metaKey: true })
+    expect(onOpenPalette).toHaveBeenCalled()
+  })
+
+  it('opens help on ?', () => {
+    const onOpenHelp = vi.fn()
+    render(<Harness onOpenPalette={() => {}} onOpenHelp={onOpenHelp} />)
+    fireEvent.keyDown(document, { key: '?' })
+    expect(onOpenHelp).toHaveBeenCalledTimes(1)
+  })
+
+  it('triggers onNewTask on n', () => {
+    const onNewTask = vi.fn()
+    render(
+      <Harness
+        onOpenPalette={() => {}}
+        onOpenHelp={() => {}}
+        onNewTask={onNewTask}
+      />,
+    )
+    fireEvent.keyDown(document, { key: 'n' })
+    expect(onNewTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('triggers onRefresh on r', () => {
+    const onRefresh = vi.fn()
+    render(
+      <Harness
+        onOpenPalette={() => {}}
+        onOpenHelp={() => {}}
+        onRefresh={onRefresh}
+      />,
+    )
+    fireEvent.keyDown(document, { key: 'r' })
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles g-then-c chord for canvas view', () => {
+    const onSwitchView = vi.fn()
+    render(
+      <Harness
+        onOpenPalette={() => {}}
+        onOpenHelp={() => {}}
+        onSwitchView={onSwitchView}
+      />,
+    )
+    fireEvent.keyDown(document, { key: 'g' })
+    fireEvent.keyDown(document, { key: 'c' })
+    expect(onSwitchView).toHaveBeenCalledWith('canvas')
+  })
+
+  it('handles g-then-l chord for list view', () => {
+    const onSwitchView = vi.fn()
+    render(
+      <Harness
+        onOpenPalette={() => {}}
+        onOpenHelp={() => {}}
+        onSwitchView={onSwitchView}
+      />,
+    )
+    fireEvent.keyDown(document, { key: 'g' })
+    fireEvent.keyDown(document, { key: 'l' })
+    expect(onSwitchView).toHaveBeenCalledWith('list')
+  })
+
+  it('handles g-then-s chord for ship view', () => {
+    const onSwitchView = vi.fn()
+    render(
+      <Harness
+        onOpenPalette={() => {}}
+        onOpenHelp={() => {}}
+        onSwitchView={onSwitchView}
+      />,
+    )
+    fireEvent.keyDown(document, { key: 'g' })
+    fireEvent.keyDown(document, { key: 's' })
+    expect(onSwitchView).toHaveBeenCalledWith('ship')
+  })
+
+  it('does not fire single-key shortcuts when focus is in an input', () => {
+    const onNewTask = vi.fn()
+    const onOpenHelp = vi.fn()
+    const { getByTestId } = render(
+      <Harness
+        onOpenPalette={() => {}}
+        onOpenHelp={onOpenHelp}
+        onNewTask={onNewTask}
+      />,
+    )
+    const input = getByTestId('text-input') as HTMLInputElement
+    input.focus()
+    fireEvent.keyDown(input, { key: 'n' })
+    fireEvent.keyDown(input, { key: '?' })
+    expect(onNewTask).not.toHaveBeenCalled()
+    expect(onOpenHelp).not.toHaveBeenCalled()
+  })
+
+  it('does not fire single-key shortcuts when modifier keys are held', () => {
+    const onNewTask = vi.fn()
+    render(
+      <Harness
+        onOpenPalette={() => {}}
+        onOpenHelp={() => {}}
+        onNewTask={onNewTask}
+      />,
+    )
+    fireEvent.keyDown(document, { key: 'n', ctrlKey: true })
+    expect(onNewTask).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Adds a Cmd/Ctrl-K **command palette** and a `?` **keyboard shortcuts cheatsheet** to the UI. Surfaces high-leverage actions that previously required clicking through the header or sidebar:

- **Switch connection** — one entry per non-active connection
- **New task** — opens & focuses the task bar (via a `minions-ui:focus-new-task` event so other minions' rail/empty-state work isn't touched)
- **Stop session** — running/pending sessions only
- **Open PR** — sessions with a `prUrl`
- **Jump to session** — fuzzy-search by slug, mode, repo, or status
- **View switching** — list / canvas / ship / kanban
- **Refresh** + **Show shortcuts**

Fuzzy ranking: exact title > prefix > substring > keyword > sequential characters.

### Global keyboard shortcuts
- `Cmd/Ctrl+K` — open palette (works even when typing)
- `?` — toggle the shortcut cheatsheet
- `n` — new task
- `r` — refresh
- `g` then `l` / `c` / `s` / `k` — jump to list / canvas / ship / kanban
- `Esc` — close any open overlay

Single-key bindings are suppressed inside `<input>`, `<textarea>`, `<select>`, and contenteditable targets, and when modifiers are held — so they don't fight the task-bar prompt or other text inputs.

### Files
- `src/components/CommandPalette.tsx` — palette UI + pure `buildCommands` / `filterCommands` / `rankCommand` / `fuzzyMatch` helpers (separately testable)
- `src/components/KeyboardShortcutsHelp.tsx` — cheatsheet overlay with sectioned bindings
- `src/hooks/useGlobalShortcuts.ts` — single global keydown listener with chord support and a stale-callback-safe ref pattern
- `src/chat/NewTaskBar.tsx` — listens for `minions-ui:focus-new-task` to expand & focus the prompt
- `src/App.tsx` — wires the palette/help signals + `useGlobalShortcuts` into `ActiveView`

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 1137 passing (51 new)
- [x] `test/components/CommandPalette.test.tsx` — pure logic + UI behaviors (filter, arrows/Enter, click, switch-connection, jump, stop, open-PR, backdrop, counter)
- [x] `test/components/KeyboardShortcutsHelp.test.tsx` — open/close, all sections render, Esc + `?` toggle
- [x] `test/hooks/useGlobalShortcuts.test.tsx` — Cmd+K, Ctrl+K, `?`, `n`, `r`, `g`-chords, input suppression, modifier suppression
- [x] `test/App.test.tsx` — Cmd+K opens the palette and Escape closes it; `?` opens the cheatsheet
