### PR TITLE
feat(diff): file tree, sticky headers, viewed checkboxes, line comments

### DIFF
--- a/src/chat/DiffTab.tsx
+++ b/src/chat/DiffTab.tsx
@@ -4,6 +4,13 @@ import type { WorkspaceDiff } from '../api/types'
 import { parseUnifiedDiff, type DiffFile, countChanges, fileDisplayPath } from './diff-parse'
 import { detectLanguage, highlightLine, tokenClass } from './syntax-highlight'
 import { Skeleton, SkeletonLines } from '../components/Skeleton'
+import {
+  buildFileTree,
+  type FileTreeNode,
+  type FileTreeDirNode,
+  type FileTreeFileNode,
+} from './diff-tree'
+import { useMediaQuery } from '../hooks/useMediaQuery'
 
 interface DiffTabProps {
   sessionId: string
@@ -11,12 +18,102 @@ interface DiffTabProps {
   client: ApiClient
 }
 
-export function DiffTab({ sessionId, sessionUpdatedAt, client }: DiffTabProps) {
+type CommentMap = Record<string, string[]>
+
+function viewedStorageKey(sessionId: string): string {
+  return `minions-ui:diff-viewed:${sessionId}`
+}
+
+function commentsStorageKey(sessionId: string): string {
+  return `minions-ui:diff-comments:${sessionId}`
+}
+
+function loadViewed(sessionId: string): Set<string> {
+  if (typeof window === 'undefined') return new Set()
+  try {
+    const raw = window.localStorage.getItem(viewedStorageKey(sessionId))
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return new Set()
+    return new Set(parsed.filter((x): x is string => typeof x === 'string'))
+  } catch {
+    return new Set()
+  }
+}
+
+function saveViewed(sessionId: string, set: Set<string>): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(viewedStorageKey(sessionId), JSON.stringify(Array.from(set)))
+  } catch {
+    // best-effort persistence
+  }
+}
+
+function loadComments(sessionId: string): CommentMap {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = window.localStorage.getItem(commentsStorageKey(sessionId))
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') return {}
+    const out: CommentMap = {}
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (Array.isArray(v) && v.every((x) => typeof x === 'string')) {
+        out[k] = v as string[]
+      }
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+function saveComments(sessionId: string, comments: CommentMap): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(commentsStorageKey(sessionId), JSON.stringify(comments))
+  } catch {
+    // best-effort persistence
+  }
+}
+
+function lineCommentKey(filePath: string, hunkIdx: number, lineIdx: number): string {
+  return `${filePath}#${hunkIdx}:${lineIdx}`
+}
+
+function countCommentsForFile(comments: CommentMap, filePath: string): number {
+  const prefix = `${filePath}#`
+  let total = 0
+  for (const [k, v] of Object.entries(comments)) {
+    if (k.startsWith(prefix)) total += v.length
+  }
+  return total
+}
+
+export function DiffTab(props: DiffTabProps) {
+  return <DiffTabInner key={props.sessionId} {...props} />
+}
+
+function DiffTabInner({ sessionId, sessionUpdatedAt, client }: DiffTabProps) {
   const [diff, setDiff] = useState<WorkspaceDiff | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [copied, setCopied] = useState(false)
+  const [commentsCopied, setCommentsCopied] = useState(false)
+  const [viewed, setViewed] = useState<Set<string>>(() => loadViewed(sessionId))
+  const [comments, setComments] = useState<CommentMap>(() => loadComments(sessionId))
+  const [collapsedManually, setCollapsedManually] = useState<Set<string>>(new Set())
+
+  const isDesktop = useMediaQuery('(min-width: 1024px)')
+  const [treeOpen, setTreeOpen] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true
+    return window.matchMedia('(min-width: 1024px)').matches
+  })
+
   const abortRef = useRef<AbortController | null>(null)
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const fileRefs = useRef<Map<string, HTMLDivElement>>(new Map())
 
   useEffect(() => {
     abortRef.current?.abort()
@@ -45,10 +142,20 @@ export function DiffTab({ sessionId, sessionUpdatedAt, client }: DiffTabProps) {
     }
   }, [sessionId, sessionUpdatedAt, client])
 
+  useEffect(() => {
+    saveViewed(sessionId, viewed)
+  }, [sessionId, viewed])
+
+  useEffect(() => {
+    saveComments(sessionId, comments)
+  }, [sessionId, comments])
+
   const files = useMemo<DiffFile[]>(() => {
     if (!diff) return []
     return parseUnifiedDiff(diff.patch)
   }, [diff])
+
+  const tree = useMemo<FileTreeNode[]>(() => buildFileTree(files), [files])
 
   const handleCopy = async () => {
     if (!diff) return
@@ -59,6 +166,73 @@ export function DiffTab({ sessionId, sessionUpdatedAt, client }: DiffTabProps) {
     } catch {
       setError('Failed to copy patch')
     }
+  }
+
+  const handleCopyComments = async () => {
+    const md = renderCommentsMarkdown(files, comments)
+    if (!md) return
+    try {
+      await navigator.clipboard.writeText(md)
+      setCommentsCopied(true)
+      setTimeout(() => setCommentsCopied(false), 1500)
+    } catch {
+      setError('Failed to copy comments')
+    }
+  }
+
+  const toggleViewed = (filePath: string) => {
+    setViewed((prev) => {
+      const next = new Set(prev)
+      if (next.has(filePath)) next.delete(filePath)
+      else next.add(filePath)
+      return next
+    })
+  }
+
+  const toggleCollapsed = (filePath: string) => {
+    setCollapsedManually((prev) => {
+      const next = new Set(prev)
+      if (next.has(filePath)) next.delete(filePath)
+      else next.add(filePath)
+      return next
+    })
+  }
+
+  const addComment = (filePath: string, hunkIdx: number, lineIdx: number, text: string) => {
+    const trimmed = text.trim()
+    if (!trimmed) return
+    const key = lineCommentKey(filePath, hunkIdx, lineIdx)
+    setComments((prev) => {
+      const next = { ...prev }
+      next[key] = [...(next[key] ?? []), trimmed]
+      return next
+    })
+  }
+
+  const removeComment = (filePath: string, hunkIdx: number, lineIdx: number, commentIdx: number) => {
+    const key = lineCommentKey(filePath, hunkIdx, lineIdx)
+    setComments((prev) => {
+      const existing = prev[key]
+      if (!existing) return prev
+      const next = { ...prev }
+      const filtered = existing.filter((_, i) => i !== commentIdx)
+      if (filtered.length === 0) delete next[key]
+      else next[key] = filtered
+      return next
+    })
+  }
+
+  const scrollToFile = (filePath: string) => {
+    const el = fileRefs.current.get(filePath)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+    if (!isDesktop.value) setTreeOpen(false)
+  }
+
+  const registerFileRef = (filePath: string, el: HTMLDivElement | null) => {
+    if (el) fileRefs.current.set(filePath, el)
+    else fileRefs.current.delete(filePath)
   }
 
   if (loading && !diff) {
@@ -77,7 +251,10 @@ export function DiffTab({ sessionId, sessionUpdatedAt, client }: DiffTabProps) {
 
   if (error && !diff) {
     return (
-      <div class="flex-1 flex items-center justify-center text-xs text-red-600 dark:text-red-400" data-testid="diff-error">
+      <div
+        class="flex-1 flex items-center justify-center text-xs text-red-600 dark:text-red-400"
+        data-testid="diff-error"
+      >
         {error}
       </div>
     )
@@ -86,53 +263,294 @@ export function DiffTab({ sessionId, sessionUpdatedAt, client }: DiffTabProps) {
   if (!diff) return null
 
   const empty = files.length === 0 && diff.stats.filesChanged === 0
+  const totalFiles = files.length
+  const viewedCount = files.reduce((acc, f) => (viewed.has(fileDisplayPath(f)) ? acc + 1 : acc), 0)
+  const totalCommentCount = Object.values(comments).reduce((acc, v) => acc + v.length, 0)
 
   return (
     <div class="flex flex-col flex-1 min-h-0 bg-slate-50 dark:bg-slate-900" data-testid="diff-tab">
       <div class="flex items-center gap-3 px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0">
+        {!empty && (
+          <button
+            type="button"
+            onClick={() => setTreeOpen((v) => !v)}
+            aria-pressed={treeOpen}
+            aria-label={treeOpen ? 'Hide file tree' : 'Show file tree'}
+            class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+            data-testid="diff-tree-toggle"
+          >
+            Files
+          </button>
+        )}
         <span class="text-xs text-slate-500 dark:text-slate-400">
           <span class="font-mono text-slate-900 dark:text-slate-100">{diff.branch}</span>
           <span class="text-slate-400 dark:text-slate-500"> vs </span>
           <span class="font-mono text-slate-900 dark:text-slate-100">{diff.baseBranch}</span>
         </span>
-        <span class="text-xs text-slate-500 dark:text-slate-400">
-          <span class="font-semibold text-slate-700 dark:text-slate-200">{diff.stats.filesChanged}</span> files{' '}
+        <span class="text-xs text-slate-500 dark:text-slate-400" data-testid="diff-stats-summary">
           <span class="text-green-600 dark:text-green-400">+{diff.stats.insertions}</span>{' '}
-          <span class="text-red-600 dark:text-red-400">-{diff.stats.deletions}</span>
+          <span class="text-red-600 dark:text-red-400">-{diff.stats.deletions}</span>{' '}
+          <span class="text-slate-400 dark:text-slate-500">across</span>{' '}
+          <span class="font-semibold text-slate-700 dark:text-slate-200">
+            {diff.stats.filesChanged}
+          </span>{' '}
+          files
         </span>
-        <button
-          type="button"
-          onClick={() => void handleCopy()}
-          class="ml-auto rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
-          data-testid="diff-copy-btn"
-        >
-          {copied ? 'Copied' : 'Copy patch'}
-        </button>
+        {totalFiles > 0 && (
+          <span
+            class="text-xs text-slate-500 dark:text-slate-400 hidden sm:inline"
+            data-testid="diff-stats-viewed"
+          >
+            <span
+              class={
+                viewedCount === totalFiles
+                  ? 'font-semibold text-emerald-600 dark:text-emerald-400'
+                  : 'font-semibold text-slate-700 dark:text-slate-200'
+              }
+            >
+              {viewedCount}
+            </span>
+            {' / '}
+            {totalFiles} viewed
+          </span>
+        )}
+        <div class="ml-auto flex items-center gap-2">
+          {totalCommentCount > 0 && (
+            <button
+              type="button"
+              onClick={() => void handleCopyComments()}
+              class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+              data-testid="diff-copy-comments-btn"
+            >
+              {commentsCopied ? 'Copied' : `Copy ${totalCommentCount} comment${totalCommentCount === 1 ? '' : 's'}`}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => void handleCopy()}
+            class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-2 py-1 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700"
+            data-testid="diff-copy-btn"
+          >
+            {copied ? 'Copied' : 'Copy patch'}
+          </button>
+        </div>
       </div>
       {diff.truncated && (
-        <div class="px-4 py-1.5 bg-amber-50 dark:bg-amber-950/40 border-b border-amber-200 dark:border-amber-800 text-xs text-amber-800 dark:text-amber-300 shrink-0" data-testid="diff-truncated-banner">
+        <div
+          class="px-4 py-1.5 bg-amber-50 dark:bg-amber-950/40 border-b border-amber-200 dark:border-amber-800 text-xs text-amber-800 dark:text-amber-300 shrink-0"
+          data-testid="diff-truncated-banner"
+        >
           Diff truncated by server — view full patch on the minion or git log.
         </div>
       )}
       {empty ? (
-        <div class="flex-1 flex items-center justify-center text-xs text-slate-500 dark:text-slate-400 italic" data-testid="diff-empty">
+        <div
+          class="flex-1 flex items-center justify-center text-xs text-slate-500 dark:text-slate-400 italic"
+          data-testid="diff-empty"
+        >
           No workspace changes.
         </div>
       ) : (
-        <div class="flex-1 overflow-auto">
-          {files.map((file, idx) => (
-            <DiffFileView key={`${fileDisplayPath(file)}-${idx}`} file={file} />
-          ))}
+        <div class="flex flex-1 min-h-0 overflow-hidden">
+          {treeOpen && (
+            <DiffFileTree
+              tree={tree}
+              viewed={viewed}
+              comments={comments}
+              onSelect={scrollToFile}
+            />
+          )}
+          <div ref={scrollRef} class="flex-1 overflow-auto" data-testid="diff-scroll">
+            {files.map((file, idx) => {
+              const path = fileDisplayPath(file)
+              const isViewed = viewed.has(path)
+              const isManuallyCollapsed = collapsedManually.has(path)
+              const collapsed = isManuallyCollapsed || isViewed
+              return (
+                <DiffFileView
+                  key={`${path}-${idx}`}
+                  file={file}
+                  filePath={path}
+                  collapsed={collapsed}
+                  viewed={isViewed}
+                  comments={comments}
+                  onToggleCollapsed={() => toggleCollapsed(path)}
+                  onToggleViewed={() => toggleViewed(path)}
+                  onAddComment={addComment}
+                  onRemoveComment={removeComment}
+                  registerRef={registerFileRef}
+                />
+              )
+            })}
+          </div>
         </div>
       )}
     </div>
   )
 }
 
-function DiffFileView({ file }: { file: DiffFile }) {
-  const [collapsed, setCollapsed] = useState(false)
-  const path = fileDisplayPath(file)
-  const lang = detectLanguage(path)
+interface DiffFileTreeProps {
+  tree: FileTreeNode[]
+  viewed: Set<string>
+  comments: CommentMap
+  onSelect: (filePath: string) => void
+}
+
+function DiffFileTree({ tree, viewed, comments, onSelect }: DiffFileTreeProps) {
+  const [collapsedDirs, setCollapsedDirs] = useState<Set<string>>(new Set())
+  const toggleDir = (path: string) => {
+    setCollapsedDirs((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }
+  return (
+    <aside
+      class="w-56 sm:w-64 shrink-0 border-r border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-auto py-2"
+      data-testid="diff-tree"
+      aria-label="Files changed"
+    >
+      <ul class="text-xs">
+        {tree.map((node) => (
+          <TreeNodeRow
+            key={node.path}
+            node={node}
+            depth={0}
+            viewed={viewed}
+            comments={comments}
+            collapsedDirs={collapsedDirs}
+            onSelect={onSelect}
+            onToggleDir={toggleDir}
+          />
+        ))}
+      </ul>
+    </aside>
+  )
+}
+
+interface TreeNodeRowProps {
+  node: FileTreeNode
+  depth: number
+  viewed: Set<string>
+  comments: CommentMap
+  collapsedDirs: Set<string>
+  onSelect: (filePath: string) => void
+  onToggleDir: (path: string) => void
+}
+
+function TreeNodeRow({
+  node,
+  depth,
+  viewed,
+  comments,
+  collapsedDirs,
+  onSelect,
+  onToggleDir,
+}: TreeNodeRowProps) {
+  const indentStyle = { paddingLeft: `${depth * 12 + 8}px` }
+  if (node.kind === 'dir') {
+    const dir = node as FileTreeDirNode
+    const collapsed = collapsedDirs.has(dir.path)
+    return (
+      <li>
+        <button
+          type="button"
+          onClick={() => onToggleDir(dir.path)}
+          style={indentStyle}
+          class="w-full flex items-center gap-1 py-0.5 text-left hover:bg-slate-100 dark:hover:bg-slate-700/60 text-slate-700 dark:text-slate-200"
+          data-testid="diff-tree-dir"
+        >
+          <span class="text-[10px] text-slate-400 dark:text-slate-500 w-3 inline-block">
+            {collapsed ? '▸' : '▾'}
+          </span>
+          <span class="truncate font-medium">{dir.name}/</span>
+        </button>
+        {!collapsed && (
+          <ul>
+            {dir.children.map((child) => (
+              <TreeNodeRow
+                key={child.path}
+                node={child}
+                depth={depth + 1}
+                viewed={viewed}
+                comments={comments}
+                collapsedDirs={collapsedDirs}
+                onSelect={onSelect}
+                onToggleDir={onToggleDir}
+              />
+            ))}
+          </ul>
+        )}
+      </li>
+    )
+  }
+  const file = node as FileTreeFileNode
+  const isViewed = viewed.has(file.path)
+  const { insertions, deletions } = countChanges(file.file)
+  const commentCount = countCommentsForFile(comments, file.path)
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(file.path)}
+        style={indentStyle}
+        class={
+          'w-full flex items-center gap-1 py-0.5 text-left hover:bg-slate-100 dark:hover:bg-slate-700/60 ' +
+          (isViewed
+            ? 'text-slate-400 dark:text-slate-500 line-through'
+            : 'text-slate-800 dark:text-slate-100')
+        }
+        data-testid="diff-tree-file"
+        data-file-path={file.path}
+      >
+        <span class="text-[10px] text-slate-400 dark:text-slate-500 w-3 inline-block" aria-hidden="true" />
+        <span class="truncate flex-1">{file.name}</span>
+        {commentCount > 0 && (
+          <span
+            class="text-[10px] rounded bg-indigo-100 dark:bg-indigo-900/60 text-indigo-700 dark:text-indigo-300 px-1"
+            data-testid="diff-tree-file-comments"
+            aria-label={`${commentCount} comment${commentCount === 1 ? '' : 's'}`}
+          >
+            {commentCount}
+          </span>
+        )}
+        <span class="text-[10px] whitespace-nowrap">
+          <span class="text-green-600 dark:text-green-400">+{insertions}</span>{' '}
+          <span class="text-red-600 dark:text-red-400">-{deletions}</span>
+        </span>
+      </button>
+    </li>
+  )
+}
+
+interface DiffFileViewProps {
+  file: DiffFile
+  filePath: string
+  collapsed: boolean
+  viewed: boolean
+  comments: CommentMap
+  onToggleCollapsed: () => void
+  onToggleViewed: () => void
+  onAddComment: (filePath: string, hunkIdx: number, lineIdx: number, text: string) => void
+  onRemoveComment: (filePath: string, hunkIdx: number, lineIdx: number, commentIdx: number) => void
+  registerRef: (filePath: string, el: HTMLDivElement | null) => void
+}
+
+function DiffFileView({
+  file,
+  filePath,
+  collapsed,
+  viewed,
+  comments,
+  onToggleCollapsed,
+  onToggleViewed,
+  onAddComment,
+  onRemoveComment,
+  registerRef,
+}: DiffFileViewProps) {
+  const lang = detectLanguage(filePath)
   const { insertions, deletions } = countChanges(file)
   const tag = file.isNew
     ? 'NEW'
@@ -145,27 +563,64 @@ function DiffFileView({ file }: { file: DiffFile }) {
           : null
 
   return (
-    <div class="border-b border-slate-200 dark:border-slate-700" data-testid="diff-file">
-      <button
-        type="button"
-        onClick={() => setCollapsed((v) => !v)}
-        class="w-full flex items-center gap-2 px-4 py-2 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-left"
-        data-testid="diff-file-toggle"
+    <div
+      ref={(el) => registerRef(filePath, el)}
+      class="border-b border-slate-200 dark:border-slate-700"
+      data-testid="diff-file"
+      data-file-path={filePath}
+    >
+      <div
+        class={
+          'sticky top-0 z-10 flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-700 ' +
+          (viewed
+            ? 'bg-emerald-50 dark:bg-emerald-950/40'
+            : 'bg-slate-100 dark:bg-slate-800')
+        }
       >
-        <span class="text-[10px] text-slate-500 dark:text-slate-400 w-4 inline-block">
-          {collapsed ? '▸' : '▾'}
-        </span>
-        {tag && (
-          <span class="text-[10px] uppercase tracking-wide font-semibold rounded bg-slate-200 dark:bg-slate-700 px-1.5 py-0.5 text-slate-700 dark:text-slate-200">
-            {tag}
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          class="flex items-center gap-2 flex-1 min-w-0 text-left hover:opacity-80"
+          data-testid="diff-file-toggle"
+        >
+          <span class="text-[10px] text-slate-500 dark:text-slate-400 w-4 inline-block">
+            {collapsed ? '▸' : '▾'}
           </span>
-        )}
-        <span class="font-mono text-xs text-slate-900 dark:text-slate-100 truncate">{path}</span>
-        <span class="ml-auto text-[10px] text-slate-500 dark:text-slate-400 whitespace-nowrap">
-          <span class="text-green-600 dark:text-green-400">+{insertions}</span>{' '}
-          <span class="text-red-600 dark:text-red-400">-{deletions}</span>
-        </span>
-      </button>
+          {tag && (
+            <span class="text-[10px] uppercase tracking-wide font-semibold rounded bg-slate-200 dark:bg-slate-700 px-1.5 py-0.5 text-slate-700 dark:text-slate-200">
+              {tag}
+            </span>
+          )}
+          <span
+            class={
+              'font-mono text-xs truncate ' +
+              (viewed
+                ? 'text-slate-500 dark:text-slate-400 line-through'
+                : 'text-slate-900 dark:text-slate-100')
+            }
+          >
+            {filePath}
+          </span>
+          <span class="text-[10px] text-slate-500 dark:text-slate-400 whitespace-nowrap">
+            <span class="text-green-600 dark:text-green-400">+{insertions}</span>{' '}
+            <span class="text-red-600 dark:text-red-400">-{deletions}</span>
+          </span>
+        </button>
+        <label
+          class="flex items-center gap-1.5 text-[11px] text-slate-600 dark:text-slate-300 cursor-pointer select-none whitespace-nowrap"
+          data-testid="diff-file-viewed-label"
+        >
+          <input
+            type="checkbox"
+            checked={viewed}
+            onChange={onToggleViewed}
+            class="h-3.5 w-3.5 rounded border-slate-300 dark:border-slate-600"
+            data-testid="diff-file-viewed"
+            aria-label={`Mark ${filePath} as viewed`}
+          />
+          Viewed
+        </label>
+      </div>
       {!collapsed && (
         <div class="font-mono text-xs bg-white dark:bg-slate-900">
           {file.isBinary && (
@@ -177,40 +632,153 @@ function DiffFileView({ file }: { file: DiffFile }) {
                 {hunk.header}
               </div>
               {hunk.lines.map((line, li) => {
-                const bg =
-                  line.type === 'add'
-                    ? 'bg-green-50 dark:bg-green-950/30'
-                    : line.type === 'del'
-                      ? 'bg-red-50 dark:bg-red-950/30'
-                      : 'bg-transparent'
-                const sign = line.type === 'add' ? '+' : line.type === 'del' ? '-' : ' '
-                const signColor =
-                  line.type === 'add'
-                    ? 'text-green-700 dark:text-green-400'
-                    : line.type === 'del'
-                      ? 'text-red-700 dark:text-red-400'
-                      : 'text-slate-400 dark:text-slate-500'
+                const key = lineCommentKey(filePath, hi, li)
+                const lineComments = comments[key] ?? []
                 return (
-                  <div
+                  <LineRow
                     key={li}
-                    class={`flex gap-2 px-2 sm:px-4 py-0.5 ${bg}`}
-                    data-testid={`diff-line-${line.type}`}
-                  >
-                    <span class="text-[10px] text-slate-400 dark:text-slate-500 w-6 sm:w-8 text-right shrink-0 select-none">
-                      {line.oldLineNo ?? ''}
-                    </span>
-                    <span class="hidden sm:inline text-[10px] text-slate-400 dark:text-slate-500 w-8 text-right shrink-0 select-none">
-                      {line.newLineNo ?? ''}
-                    </span>
-                    <span class={`${signColor} w-3 shrink-0 select-none`}>{sign}</span>
-                    <span class="flex-1 min-w-0 whitespace-pre-wrap break-all text-slate-800 dark:text-slate-200">
-                      <HighlightedCode text={line.text} lang={lang} />
-                    </span>
-                  </div>
+                    line={line}
+                    lang={lang}
+                    comments={lineComments}
+                    onAddComment={(text) => onAddComment(filePath, hi, li, text)}
+                    onRemoveComment={(idx) => onRemoveComment(filePath, hi, li, idx)}
+                  />
                 )
               })}
             </div>
           ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface LineRowProps {
+  line: { type: 'add' | 'del' | 'context'; text: string; oldLineNo?: number; newLineNo?: number }
+  lang: string | null
+  comments: string[]
+  onAddComment: (text: string) => void
+  onRemoveComment: (commentIdx: number) => void
+}
+
+function LineRow({ line, lang, comments, onAddComment, onRemoveComment }: LineRowProps) {
+  const [composing, setComposing] = useState(false)
+  const [draft, setDraft] = useState('')
+
+  const bg =
+    line.type === 'add'
+      ? 'bg-green-50 dark:bg-green-950/30'
+      : line.type === 'del'
+        ? 'bg-red-50 dark:bg-red-950/30'
+        : 'bg-transparent'
+  const sign = line.type === 'add' ? '+' : line.type === 'del' ? '-' : ' '
+  const signColor =
+    line.type === 'add'
+      ? 'text-green-700 dark:text-green-400'
+      : line.type === 'del'
+        ? 'text-red-700 dark:text-red-400'
+        : 'text-slate-400 dark:text-slate-500'
+
+  const submit = () => {
+    const text = draft.trim()
+    if (!text) {
+      setComposing(false)
+      return
+    }
+    onAddComment(text)
+    setDraft('')
+    setComposing(false)
+  }
+
+  const cancel = () => {
+    setDraft('')
+    setComposing(false)
+  }
+
+  return (
+    <div class="group/line">
+      <div class={`flex gap-2 px-2 sm:px-4 py-0.5 ${bg}`} data-testid={`diff-line-${line.type}`}>
+        <span class="text-[10px] text-slate-400 dark:text-slate-500 w-6 sm:w-8 text-right shrink-0 select-none">
+          {line.oldLineNo ?? ''}
+        </span>
+        <span class="hidden sm:inline text-[10px] text-slate-400 dark:text-slate-500 w-8 text-right shrink-0 select-none">
+          {line.newLineNo ?? ''}
+        </span>
+        <button
+          type="button"
+          onClick={() => setComposing(true)}
+          aria-label="Add comment"
+          class="hidden group-hover/line:inline-flex items-center justify-center w-4 h-4 -my-0.5 rounded bg-indigo-600 hover:bg-indigo-700 text-white text-[10px] font-bold shrink-0"
+          data-testid="diff-comment-add-btn"
+        >
+          +
+        </button>
+        <span class={`${signColor} w-3 shrink-0 select-none`}>{sign}</span>
+        <span class="flex-1 min-w-0 whitespace-pre-wrap break-all text-slate-800 dark:text-slate-200">
+          <HighlightedCode text={line.text} lang={lang} />
+        </span>
+      </div>
+      {(comments.length > 0 || composing) && (
+        <div class="border-l-2 border-indigo-300 dark:border-indigo-700 bg-indigo-50/40 dark:bg-indigo-950/20 ml-12 sm:ml-20 px-3 py-2 my-1 rounded-r">
+          {comments.map((c, idx) => (
+            <div
+              key={idx}
+              class="flex items-start gap-2 text-xs text-slate-700 dark:text-slate-200 mb-1 last:mb-0"
+              data-testid="diff-comment"
+            >
+              <span class="flex-1 whitespace-pre-wrap break-words font-sans">{c}</span>
+              <button
+                type="button"
+                onClick={() => onRemoveComment(idx)}
+                aria-label="Delete comment"
+                class="text-[10px] text-slate-400 hover:text-red-600 dark:hover:text-red-400"
+                data-testid="diff-comment-delete"
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+          {composing && (
+            <div class="flex flex-col gap-1.5 mt-1">
+              <textarea
+                value={draft}
+                onInput={(e) => setDraft((e.target as HTMLTextAreaElement).value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                    e.preventDefault()
+                    submit()
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault()
+                    cancel()
+                  }
+                }}
+                placeholder="Leave a comment…"
+                rows={2}
+                class="w-full text-xs p-1.5 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 font-sans"
+                data-testid="diff-comment-input"
+                autofocus
+              />
+              <div class="flex items-center gap-2 justify-end">
+                <button
+                  type="button"
+                  onClick={cancel}
+                  class="text-[11px] px-2 py-0.5 rounded text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700"
+                  data-testid="diff-comment-cancel"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={submit}
+                  disabled={draft.trim().length === 0}
+                  class="text-[11px] px-2 py-0.5 rounded bg-indigo-600 text-white font-medium disabled:opacity-50 hover:bg-indigo-700"
+                  data-testid="diff-comment-submit"
+                >
+                  Comment
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -234,4 +802,23 @@ function HighlightedCode({ text, lang }: { text: string; lang: string | null }) 
       })}
     </>
   )
+}
+
+function renderCommentsMarkdown(files: DiffFile[], comments: CommentMap): string {
+  const blocks: string[] = []
+  for (const file of files) {
+    const path = fileDisplayPath(file)
+    const prefix = `${path}#`
+    file.hunks.forEach((hunk, hi) => {
+      hunk.lines.forEach((line, li) => {
+        const key = `${prefix}${hi}:${li}`
+        const list = comments[key]
+        if (!list || list.length === 0) return
+        const lineNo = line.newLineNo ?? line.oldLineNo ?? '?'
+        const sign = line.type === 'add' ? '+' : line.type === 'del' ? '-' : ' '
+        blocks.push(`**${path}:${lineNo}**\n\`\`\`\n${sign}${line.text}\n\`\`\`\n${list.join('\n\n')}`)
+      })
+    })
+  }
+  return blocks.join('\n\n---\n\n')
 }

--- a/src/chat/diff-tree.ts
+++ b/src/chat/diff-tree.ts
@@ -1,0 +1,104 @@
+import type { DiffFile } from './diff-parse'
+import { fileDisplayPath } from './diff-parse'
+
+export interface FileTreeFileNode {
+  kind: 'file'
+  name: string
+  path: string
+  file: DiffFile
+  index: number
+}
+
+export interface FileTreeDirNode {
+  kind: 'dir'
+  name: string
+  path: string
+  children: FileTreeNode[]
+}
+
+export type FileTreeNode = FileTreeDirNode | FileTreeFileNode
+
+export function buildFileTree(files: DiffFile[]): FileTreeNode[] {
+  const root: FileTreeDirNode = { kind: 'dir', name: '', path: '', children: [] }
+
+  files.forEach((file, index) => {
+    const path = fileDisplayPath(file)
+    if (!path) return
+    const segments = path.split('/').filter((s) => s.length > 0)
+    if (segments.length === 0) return
+    insertFile(root, segments, '', file, index)
+  })
+
+  collapseSingleChildDirs(root)
+  sortNodes(root)
+  return root.children
+}
+
+function insertFile(
+  parent: FileTreeDirNode,
+  segments: string[],
+  parentPath: string,
+  file: DiffFile,
+  index: number,
+): void {
+  const [head, ...rest] = segments
+  const segPath = parentPath ? `${parentPath}/${head}` : head
+  if (rest.length === 0) {
+    parent.children.push({ kind: 'file', name: head, path: segPath, file, index })
+    return
+  }
+  let dir = parent.children.find(
+    (c): c is FileTreeDirNode => c.kind === 'dir' && c.name === head,
+  )
+  if (!dir) {
+    dir = { kind: 'dir', name: head, path: segPath, children: [] }
+    parent.children.push(dir)
+  }
+  insertFile(dir, rest, segPath, file, index)
+}
+
+function collapseSingleChildDirs(node: FileTreeDirNode): void {
+  for (const child of node.children) {
+    if (child.kind === 'dir') collapseSingleChildDirs(child)
+  }
+  for (let i = 0; i < node.children.length; i++) {
+    const child = node.children[i]
+    if (
+      child.kind === 'dir' &&
+      child.children.length === 1 &&
+      child.children[0].kind === 'dir'
+    ) {
+      const inner = child.children[0]
+      const merged: FileTreeDirNode = {
+        kind: 'dir',
+        name: `${child.name}/${inner.name}`,
+        path: inner.path,
+        children: inner.children,
+      }
+      node.children[i] = merged
+      i--
+    }
+  }
+}
+
+function sortNodes(node: FileTreeDirNode): void {
+  node.children.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === 'dir' ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+  for (const child of node.children) {
+    if (child.kind === 'dir') sortNodes(child)
+  }
+}
+
+export function collectFileIndexes(nodes: FileTreeNode[]): number[] {
+  const out: number[] = []
+  const walk = (list: FileTreeNode[]) => {
+    for (const n of list) {
+      if (n.kind === 'file') out.push(n.index)
+      else walk(n.children)
+    }
+  }
+  walk(nodes)
+  return out
+}

--- a/test/chat/DiffTab.test.tsx
+++ b/test/chat/DiffTab.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/preact'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { DiffTab } from '../../src/chat/DiffTab'
 import type { ApiClient } from '../../src/api/client'
 import type { WorkspaceDiff } from '../../src/api/types'
@@ -51,6 +51,15 @@ beforeEach(() => {
       value: vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
     })
   }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn()
+  }
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.clear()
 })
 
 describe('DiffTab', () => {
@@ -162,5 +171,265 @@ describe('DiffTab', () => {
     const client = makeClient({ getDiff })
     render(<DiffTab sessionId="s-1" sessionUpdatedAt="t1" client={client} />)
     await waitFor(() => expect(screen.getByTestId('diff-empty')).toBeTruthy())
+  })
+})
+
+const MULTI_FILE_DIFF: WorkspaceDiff = {
+  branch: 'feature',
+  baseBranch: 'main',
+  patch: [
+    'diff --git a/src/foo.ts b/src/foo.ts',
+    '--- a/src/foo.ts',
+    '+++ b/src/foo.ts',
+    '@@ -1,2 +1,3 @@',
+    ' keep',
+    '-old',
+    '+new',
+    '+extra',
+    'diff --git a/src/bar.ts b/src/bar.ts',
+    '--- a/src/bar.ts',
+    '+++ b/src/bar.ts',
+    '@@ -1,1 +1,1 @@',
+    '-removed',
+    '+added',
+    'diff --git a/README.md b/README.md',
+    '--- a/README.md',
+    '+++ b/README.md',
+    '@@ -1,1 +1,2 @@',
+    ' line',
+    '+more',
+  ].join('\n'),
+  truncated: false,
+  stats: { filesChanged: 3, insertions: 4, deletions: 2 },
+}
+
+describe('DiffTab — file tree', () => {
+  it('renders the file tree with directory and file rows', async () => {
+    const getDiff = vi.fn().mockResolvedValue(MULTI_FILE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-tree" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('diff-tree-toggle'))
+    expect(screen.getByTestId('diff-tree')).toBeTruthy()
+    const fileRows = screen.getAllByTestId('diff-tree-file')
+    expect(fileRows.map((r) => r.getAttribute('data-file-path'))).toEqual(
+      expect.arrayContaining(['src/foo.ts', 'src/bar.ts', 'README.md']),
+    )
+    expect(screen.getAllByTestId('diff-tree-dir').length).toBeGreaterThan(0)
+  })
+
+  it('toggles tree visibility via the Files button', async () => {
+    const getDiff = vi.fn().mockResolvedValue(MULTI_FILE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-tree" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    expect(screen.queryByTestId('diff-tree')).toBeNull()
+    fireEvent.click(screen.getByTestId('diff-tree-toggle'))
+    expect(screen.getByTestId('diff-tree')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('diff-tree-toggle'))
+    expect(screen.queryByTestId('diff-tree')).toBeNull()
+  })
+
+  it('clicking a file in the tree scrolls its file section into view', async () => {
+    const scrollSpy = vi.fn()
+    Element.prototype.scrollIntoView = scrollSpy
+    const getDiff = vi.fn().mockResolvedValue(MULTI_FILE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-tree" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('diff-tree-toggle'))
+    const target = screen
+      .getAllByTestId('diff-tree-file')
+      .find((r) => r.getAttribute('data-file-path') === 'src/bar.ts')
+    expect(target).toBeTruthy()
+    fireEvent.click(target!)
+    expect(scrollSpy).toHaveBeenCalled()
+  })
+
+  it('hides the file tree when no files are changed', async () => {
+    const getDiff = vi.fn().mockResolvedValue({
+      ...SAMPLE_DIFF,
+      patch: '',
+      stats: { filesChanged: 0, insertions: 0, deletions: 0 },
+    })
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-tree-empty" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-empty')).toBeTruthy())
+    expect(screen.queryByTestId('diff-tree-toggle')).toBeNull()
+  })
+
+  it('summary shows the standard "+X -Y across N files" format', async () => {
+    const getDiff = vi.fn().mockResolvedValue(MULTI_FILE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-summary" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    const summary = screen.getByTestId('diff-stats-summary')
+    expect(summary.textContent).toMatch(/\+4/)
+    expect(summary.textContent).toMatch(/-2/)
+    expect(summary.textContent).toMatch(/across/)
+    expect(summary.textContent).toMatch(/3 files/)
+  })
+})
+
+describe('DiffTab — viewed checkbox', () => {
+  it('marks a file viewed and collapses its hunks', async () => {
+    const getDiff = vi.fn().mockResolvedValue(MULTI_FILE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-viewed" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    const checkboxes = screen.getAllByTestId('diff-file-viewed') as HTMLInputElement[]
+    expect(checkboxes).toHaveLength(3)
+    expect(screen.getAllByTestId('diff-line-add').length).toBeGreaterThan(0)
+    fireEvent.click(checkboxes[0])
+    fireEvent.click(checkboxes[1])
+    fireEvent.click(checkboxes[2])
+    await waitFor(() => expect(screen.queryByTestId('diff-line-add')).toBeNull())
+  })
+
+  it('reflects viewed count in the toolbar (X / Y viewed)', async () => {
+    const getDiff = vi.fn().mockResolvedValue(MULTI_FILE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-count" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    expect(screen.getByTestId('diff-stats-viewed').textContent).toMatch(/0\s*\/\s*3/)
+    const checkboxes = screen.getAllByTestId('diff-file-viewed') as HTMLInputElement[]
+    fireEvent.click(checkboxes[0])
+    await waitFor(() =>
+      expect(screen.getByTestId('diff-stats-viewed').textContent).toMatch(/1\s*\/\s*3/),
+    )
+  })
+
+  it('persists viewed state per session in localStorage and restores on remount', async () => {
+    const getDiff = vi.fn().mockResolvedValue(MULTI_FILE_DIFF)
+    const client = makeClient({ getDiff })
+    const first = render(<DiffTab sessionId="persist-A" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    fireEvent.click(screen.getAllByTestId('diff-file-viewed')[0])
+    await waitFor(() => {
+      expect(window.localStorage.getItem('minions-ui:diff-viewed:persist-A')).toBeTruthy()
+    })
+    first.unmount()
+    cleanup()
+    render(<DiffTab sessionId="persist-A" sessionUpdatedAt="t2" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    const remounted = screen.getAllByTestId('diff-file-viewed') as HTMLInputElement[]
+    expect(remounted.filter((c) => c.checked)).toHaveLength(1)
+  })
+
+  it('does not leak viewed state across different sessionIds', async () => {
+    const getDiff = vi.fn().mockResolvedValue(MULTI_FILE_DIFF)
+    const client = makeClient({ getDiff })
+    const a = render(<DiffTab sessionId="iso-A" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    fireEvent.click(screen.getAllByTestId('diff-file-viewed')[0])
+    await waitFor(() => {
+      expect(window.localStorage.getItem('minions-ui:diff-viewed:iso-A')).toBeTruthy()
+    })
+    a.unmount()
+    cleanup()
+    render(<DiffTab sessionId="iso-B" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    const checkboxes = screen.getAllByTestId('diff-file-viewed') as HTMLInputElement[]
+    expect(checkboxes.every((c) => !c.checked)).toBe(true)
+  })
+})
+
+describe('DiffTab — line comments', () => {
+  it('adds a comment via the inline composer and renders it under the line', async () => {
+    const getDiff = vi.fn().mockResolvedValue(SAMPLE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-comm" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    const addBtns = screen.getAllByTestId('diff-comment-add-btn')
+    expect(addBtns.length).toBeGreaterThan(0)
+    fireEvent.click(addBtns[0])
+    const input = screen.getByTestId('diff-comment-input') as HTMLTextAreaElement
+    fireEvent.input(input, { target: { value: 'this looks wrong' } })
+    fireEvent.click(screen.getByTestId('diff-comment-submit'))
+    await waitFor(() => expect(screen.getByTestId('diff-comment')).toBeTruthy())
+    expect(screen.getByTestId('diff-comment').textContent).toContain('this looks wrong')
+  })
+
+  it('cancels the composer without adding a comment', async () => {
+    const getDiff = vi.fn().mockResolvedValue(SAMPLE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-cancel" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    fireEvent.click(screen.getAllByTestId('diff-comment-add-btn')[0])
+    fireEvent.click(screen.getByTestId('diff-comment-cancel'))
+    expect(screen.queryByTestId('diff-comment-input')).toBeNull()
+    expect(screen.queryByTestId('diff-comment')).toBeNull()
+  })
+
+  it('removes a comment when the delete button is clicked', async () => {
+    const getDiff = vi.fn().mockResolvedValue(SAMPLE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-del" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    fireEvent.click(screen.getAllByTestId('diff-comment-add-btn')[0])
+    fireEvent.input(screen.getByTestId('diff-comment-input'), {
+      target: { value: 'temporary' },
+    })
+    fireEvent.click(screen.getByTestId('diff-comment-submit'))
+    await waitFor(() => expect(screen.getByTestId('diff-comment')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('diff-comment-delete'))
+    await waitFor(() => expect(screen.queryByTestId('diff-comment')).toBeNull())
+  })
+
+  it('renders comment count badge on the file tree row', async () => {
+    const getDiff = vi.fn().mockResolvedValue(SAMPLE_DIFF)
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-tree-count" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('diff-tree-toggle'))
+    expect(screen.queryByTestId('diff-tree-file-comments')).toBeNull()
+    fireEvent.click(screen.getAllByTestId('diff-comment-add-btn')[0])
+    fireEvent.input(screen.getByTestId('diff-comment-input'), {
+      target: { value: 'note' },
+    })
+    fireEvent.click(screen.getByTestId('diff-comment-submit'))
+    await waitFor(() => expect(screen.getByTestId('diff-tree-file-comments')).toBeTruthy())
+    expect(screen.getByTestId('diff-tree-file-comments').textContent).toBe('1')
+  })
+
+  it('shows the Copy comments button only when comments exist and copies markdown', async () => {
+    const getDiff = vi.fn().mockResolvedValue(SAMPLE_DIFF)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    const client = makeClient({ getDiff })
+    render(<DiffTab sessionId="s-cpy-comm" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    expect(screen.queryByTestId('diff-copy-comments-btn')).toBeNull()
+    fireEvent.click(screen.getAllByTestId('diff-comment-add-btn')[0])
+    fireEvent.input(screen.getByTestId('diff-comment-input'), {
+      target: { value: 'review note' },
+    })
+    fireEvent.click(screen.getByTestId('diff-comment-submit'))
+    await waitFor(() => expect(screen.getByTestId('diff-copy-comments-btn')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('diff-copy-comments-btn'))
+    await waitFor(() => expect(writeText).toHaveBeenCalled())
+    const md = writeText.mock.calls[0][0] as string
+    expect(md).toContain('foo.ts')
+    expect(md).toContain('review note')
+  })
+
+  it('persists comments per session in localStorage', async () => {
+    const getDiff = vi.fn().mockResolvedValue(SAMPLE_DIFF)
+    const client = makeClient({ getDiff })
+    const first = render(<DiffTab sessionId="persist-comm" sessionUpdatedAt="t1" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    fireEvent.click(screen.getAllByTestId('diff-comment-add-btn')[0])
+    fireEvent.input(screen.getByTestId('diff-comment-input'), {
+      target: { value: 'persisted note' },
+    })
+    fireEvent.click(screen.getByTestId('diff-comment-submit'))
+    await waitFor(() =>
+      expect(window.localStorage.getItem('minions-ui:diff-comments:persist-comm')).toBeTruthy(),
+    )
+    first.unmount()
+    cleanup()
+    render(<DiffTab sessionId="persist-comm" sessionUpdatedAt="t2" client={client} />)
+    await waitFor(() => expect(screen.getByTestId('diff-tab')).toBeTruthy())
+    expect(screen.getByTestId('diff-comment').textContent).toContain('persisted note')
   })
 })

--- a/test/chat/diff-tree.test.ts
+++ b/test/chat/diff-tree.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { buildFileTree, collectFileIndexes, type FileTreeDirNode, type FileTreeFileNode } from '../../src/chat/diff-tree'
+import type { DiffFile } from '../../src/chat/diff-parse'
+
+function makeFile(path: string, opts: Partial<DiffFile> = {}): DiffFile {
+  return {
+    oldPath: path,
+    newPath: path,
+    isNew: false,
+    isDeleted: false,
+    isRename: false,
+    isBinary: false,
+    hunks: [],
+    ...opts,
+  }
+}
+
+describe('buildFileTree', () => {
+  it('returns empty tree for no files', () => {
+    expect(buildFileTree([])).toEqual([])
+  })
+
+  it('places a single root-level file under no directory', () => {
+    const tree = buildFileTree([makeFile('README.md')])
+    expect(tree).toHaveLength(1)
+    expect(tree[0].kind).toBe('file')
+    expect(tree[0].name).toBe('README.md')
+    expect(tree[0].path).toBe('README.md')
+  })
+
+  it('groups files into nested directories', () => {
+    const files = [
+      makeFile('src/chat/foo.ts'),
+      makeFile('src/chat/bar.ts'),
+      makeFile('src/api/client.ts'),
+    ]
+    const tree = buildFileTree(files)
+    expect(tree).toHaveLength(1)
+    const src = tree[0] as FileTreeDirNode
+    expect(src.kind).toBe('dir')
+    expect(src.name).toBe('src')
+    expect(src.children.map((c) => c.name).sort()).toEqual(['api', 'chat'])
+    const chat = src.children.find((c) => c.name === 'chat') as FileTreeDirNode
+    expect(chat.children.map((c) => c.name)).toEqual(['bar.ts', 'foo.ts'])
+  })
+
+  it('collapses chains of single-child directories into one node', () => {
+    const tree = buildFileTree([makeFile('a/b/c/file.ts')])
+    expect(tree).toHaveLength(1)
+    const dir = tree[0] as FileTreeDirNode
+    expect(dir.kind).toBe('dir')
+    expect(dir.name).toBe('a/b/c')
+    expect(dir.children).toHaveLength(1)
+    expect(dir.children[0].kind).toBe('file')
+  })
+
+  it('does not collapse a directory that has multiple children', () => {
+    const files = [
+      makeFile('a/b/x.ts'),
+      makeFile('a/c/y.ts'),
+    ]
+    const tree = buildFileTree(files)
+    expect(tree).toHaveLength(1)
+    const a = tree[0] as FileTreeDirNode
+    expect(a.name).toBe('a')
+    expect(a.children).toHaveLength(2)
+  })
+
+  it('orders directories before files at each level', () => {
+    const files = [
+      makeFile('zzz.ts'),
+      makeFile('aaa/inner.ts'),
+    ]
+    const tree = buildFileTree(files)
+    expect(tree.map((n) => n.kind)).toEqual(['dir', 'file'])
+  })
+
+  it('preserves file index for tree-to-list mapping', () => {
+    const files = [
+      makeFile('src/a.ts'),
+      makeFile('src/b.ts'),
+      makeFile('top.md'),
+    ]
+    const tree = buildFileTree(files)
+    const indexes = collectFileIndexes(tree).sort()
+    expect(indexes).toEqual([0, 1, 2])
+  })
+
+  it('uses oldPath as the display name for deleted files', () => {
+    const tree = buildFileTree([
+      makeFile('removed/old.ts', { isDeleted: true, newPath: '' }),
+    ])
+    const dir = tree[0] as FileTreeDirNode
+    expect(dir.name).toBe('removed')
+    expect((dir.children[0] as FileTreeFileNode).name).toBe('old.ts')
+  })
+})
+
+describe('collectFileIndexes', () => {
+  it('walks tree depth-first and returns file indexes in tree order', () => {
+    const files = [
+      makeFile('src/a.ts'),
+      makeFile('src/b.ts'),
+      makeFile('lib/c.ts'),
+    ]
+    const tree = buildFileTree(files)
+    const indexes = collectFileIndexes(tree)
+    expect(indexes).toHaveLength(3)
+    expect(indexes.sort()).toEqual([0, 1, 2])
+  })
+})


### PR DESCRIPTION
## Summary

Brings `DiffTab` closer to GitHub/Cursor PR review surfaces.

- **File tree sidebar** (`src/chat/diff-tree.ts`) — pure tree builder with single-child directory collapsing (VS Code Explorer style); rendered as a collapsible left panel with per-file +/− counts and a comment-count badge.
- **Sticky file headers** — each file's header sticks to the top of the scroll container as you read through its hunks.
- **Viewed checkboxes** — per-file checkbox; checking it collapses + dims the file, persists to `localStorage` keyed per session, and updates a new `X / Y viewed` counter in the toolbar.
- **Comment-on-line UI** — hover a line, click `+`, write a comment (Cmd+Enter to submit, Esc to cancel). Comments persist per session, show inline below the line, surface a count badge in the tree, and a `Copy N comments` toolbar button exports them as markdown.
- **Top-bar summary** updated to the standard `+X -Y across N files` format.

State is keyed on `sessionId` so switching sessions presents a clean slate. All existing `data-testid`s are preserved so unrelated tests are unaffected.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 1109 / 1109 passing
- [x] New unit tests cover: tree building, single-child dir collapsing, depth-first index walk, file-tree render, tree toggle, scroll-to-file, viewed-collapses-hunks, viewed counter, viewed persistence + cross-session isolation, comment add / cancel / delete, tree comment badge, copy-as-markdown, comment persistence.
- [ ] Manual smoke in dev mode (E2E left to CI per `CLAUDE.md`).
