### PR TITLE
feat(empty-state): example task chips that prefill NewTaskBar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { ResourceChip } from './components/ResourceChip'
 import { RunningBadge } from './components/RunningBadge'
 import { countRunning } from './state/running'
 import { RuntimeConfigDrawer, type RuntimeTab } from './settings/RuntimeConfigDrawer'
-import { NewTaskBar, requestNewTaskFocus } from './chat/NewTaskBar'
+import { NewTaskBar, NEW_TASK_EXAMPLES, prefillNewTask, requestNewTaskFocus } from './chat/NewTaskBar'
 import { CommandPalette } from './components/CommandPalette'
 import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp'
 import { useGlobalShortcuts } from './hooks/useGlobalShortcuts'
@@ -199,16 +199,43 @@ function ConnectionStatusBadge({
 
 function EmptyPane() {
   return (
-    <div class="flex-1 flex items-center justify-center p-8 bg-slate-50 dark:bg-slate-900">
-      <div class="text-center flex flex-col items-center gap-3">
+    <div
+      class="flex-1 flex items-center justify-center p-6 sm:p-10 bg-slate-50 dark:bg-slate-900 overflow-y-auto"
+      data-testid="empty-pane"
+    >
+      <div class="flex flex-col items-center gap-5 text-center max-w-md w-full">
         <img
           src="/minion.svg"
           alt=""
           aria-hidden="true"
-          class="w-16 h-16 opacity-20 dark:opacity-30 dark:invert"
+          class="w-20 h-20 opacity-30 dark:opacity-40 dark:invert"
         />
-        <div class="text-sm text-slate-500 dark:text-slate-400">
-          Select a session on the left, or start a new one with the task bar above.
+        <div class="flex flex-col gap-1.5">
+          <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Start a task
+          </h2>
+          <p class="text-sm text-slate-500 dark:text-slate-400">
+            Type a prompt in the bar above, or pick an example to get started.
+          </p>
+        </div>
+        <div class="flex flex-col gap-2 w-full" data-testid="empty-pane-examples">
+          <div class="text-[10px] uppercase tracking-wider font-semibold text-slate-400 dark:text-slate-500">
+            Try one of these
+          </div>
+          <div class="flex flex-wrap gap-2 justify-center">
+            {NEW_TASK_EXAMPLES.map((ex, idx) => (
+              <button
+                key={ex.label}
+                type="button"
+                onClick={() => prefillNewTask({ prompt: ex.prompt, mode: ex.mode })}
+                class="rounded-full border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3.5 py-2 text-xs font-medium text-slate-700 dark:text-slate-200 hover:bg-indigo-50 dark:hover:bg-indigo-950/40 hover:border-indigo-400 dark:hover:border-indigo-600 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors min-h-[44px]"
+                data-testid={`empty-pane-example-${idx}`}
+                title={ex.prompt}
+              >
+                {ex.label}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/chat/NewTaskBar.tsx
+++ b/src/chat/NewTaskBar.tsx
@@ -1,4 +1,4 @@
-import { useSignal, useComputed } from '@preact/signals'
+import { signal, useSignal, useComputed } from '@preact/signals'
 import { useRef, useCallback, useEffect, useState } from 'preact/hooks'
 import type { ConnectionStore } from '../state/types'
 import type { CreateSessionMode } from '../api/types'
@@ -63,6 +63,25 @@ export const NEW_TASK_MODES: ModeOption[] = [
 ]
 
 export const VARIANT_COUNTS: ReadonlyArray<number> = [1, 2, 3, 4]
+
+export interface NewTaskExample {
+  label: string
+  prompt: string
+  mode: CreateSessionMode
+}
+
+export const NEW_TASK_EXAMPLES: ReadonlyArray<NewTaskExample> = [
+  { label: 'Fix flaky test', mode: 'task', prompt: 'Fix the flaky test in <path/to/file> — describe symptoms and any leads.' },
+  { label: 'Add /health endpoint', mode: 'task', prompt: 'Add a /health endpoint that returns 200 with build info (commit, version, uptime).' },
+  { label: 'Refactor X to Y', mode: 'plan', prompt: 'Plan a refactor: replace <X> with <Y>. Survey call sites first, then propose a migration order.' },
+  { label: 'Brainstorm an approach', mode: 'think', prompt: 'Investigate how we could <goal>. Compare 2–3 options with tradeoffs; do not change code yet.' },
+]
+
+export const newTaskPrefill = signal<{ prompt: string; mode: CreateSessionMode } | null>(null)
+
+export function prefillNewTask(payload: { prompt: string; mode: CreateSessionMode }): void {
+  newTaskPrefill.value = payload
+}
 
 export interface NewTaskBarProps {
   store: ConnectionStore
@@ -197,6 +216,24 @@ export function NewTaskBar({
       return () => window.removeEventListener(NEW_TASK_FOCUS_EVENT, handler)
     }
   }, [collapsed])
+
+  const pendingPrefill = newTaskPrefill.value
+  useEffect(() => {
+    if (!pendingPrefill) return
+    prompt.value = pendingPrefill.prompt
+    mode.value = pendingPrefill.mode
+    if (collapsed.value) {
+      collapsed.value = false
+      writeCollapsed(false)
+    }
+    newTaskPrefill.value = null
+    queueMicrotask(() => {
+      const ta = promptRef.current
+      if (!ta) return
+      ta.focus()
+      ta.setSelectionRange(ta.value.length, ta.value.length)
+    })
+  }, [pendingPrefill])
 
   if (!canCreate) {
     return (

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -269,6 +269,49 @@ describe('App', () => {
     expect(body.sessionId).toBeUndefined()
   })
 
+  it('renders example task chips in EmptyPane when no session is selected', { timeout: 15000 }, async () => {
+    localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
+      version: 1,
+      connections: [
+        { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+      ],
+      activeId: 'c1',
+    }))
+    const versionWithCreate: VersionInfo = {
+      apiVersion: '1',
+      libraryVersion: '1.111.0',
+      features: ['sessions-create'],
+    }
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/api/version')) {
+        return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: versionWithCreate }) })
+      }
+      if (url.includes('/api/sessions')) {
+        return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: [] }) })
+      }
+      if (url.includes('/api/dags')) {
+        return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: [] }) })
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'NF', json: () => Promise.resolve({ data: null }) })
+    }))
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    const empty = await screen.findByTestId('empty-pane')
+    expect(empty).toBeTruthy()
+    const examples = screen.getByTestId('empty-pane-examples')
+    const chips = Array.from(examples.querySelectorAll('button'))
+    expect(chips.length).toBeGreaterThanOrEqual(3)
+
+    fireEvent.click(screen.getByTestId('empty-pane-example-0'))
+
+    await vi.waitFor(() => {
+      const ta = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
+      expect(ta.value.length).toBeGreaterThan(0)
+    })
+    expect(screen.getByTestId('mode-task').getAttribute('aria-checked')).toBe('true')
+  })
+
   it('switching sessions keeps the chat pane mounted', { timeout: 15000 }, async () => {
     localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
       version: 1,

--- a/test/chat/NewTaskBar.test.tsx
+++ b/test/chat/NewTaskBar.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/preact'
 import { signal } from '@preact/signals'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { NewTaskBar } from '../../src/chat/NewTaskBar'
+import { NewTaskBar, newTaskPrefill, prefillNewTask } from '../../src/chat/NewTaskBar'
 import { getVariantGroup, resetVariantGroupsForTests } from '../../src/groups/store'
 import type { ConnectionStore } from '../../src/state/types'
 import type {
@@ -101,6 +101,7 @@ describe('NewTaskBar', () => {
   beforeEach(() => {
     localStorage.clear()
     resetVariantGroupsForTests()
+    newTaskPrefill.value = null
     if (!window.matchMedia) {
       Object.defineProperty(window, 'matchMedia', {
         writable: true,
@@ -345,5 +346,37 @@ describe('NewTaskBar', () => {
     expect(screen.getByTestId('new-task-send').textContent).toBe('Launch')
     fireEvent.change(screen.getByTestId('variant-count'), { target: { value: '4' } })
     expect(screen.getByTestId('new-task-send').textContent).toBe('Launch ×4')
+  })
+
+  it('applies prefillNewTask payload to the prompt and mode', async () => {
+    const { store } = makeStore({ features: ['sessions-create'] })
+    render(<NewTaskBar store={store} />)
+
+    prefillNewTask({ prompt: 'fix the broken thing', mode: 'plan' })
+
+    await waitFor(() => {
+      const textarea = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
+      expect(textarea.value).toBe('fix the broken thing')
+    })
+    expect(screen.getByTestId('mode-plan').getAttribute('aria-checked')).toBe('true')
+    expect(newTaskPrefill.value).toBeNull()
+  })
+
+  it('expands the collapsed bar when prefillNewTask is called', async () => {
+    localStorage.setItem('minions-ui:newtaskbar-collapsed', 'true')
+    const { store } = makeStore({ features: ['sessions-create'] })
+    render(<NewTaskBar store={store} />)
+
+    expect(screen.getByTestId('new-task-bar').getAttribute('data-collapsed')).toBe('true')
+
+    prefillNewTask({ prompt: 'do the thing', mode: 'task' })
+
+    await waitFor(() => {
+      const bar = screen.getByTestId('new-task-bar')
+      expect(bar.getAttribute('data-collapsed')).toBeNull()
+    })
+    const textarea = screen.getByTestId('new-task-prompt') as HTMLTextAreaElement
+    expect(textarea.value).toBe('do the thing')
+    expect(localStorage.getItem('minions-ui:newtaskbar-collapsed')).toBe('false')
   })
 })


### PR DESCRIPTION
## Summary

- Replace the dead-end "Select a session" copy in `EmptyPane` with a small hero (icon + heading + subhead) and 3–4 chip starters: **Fix flaky test**, **Add /health endpoint**, **Refactor X to Y**, **Brainstorm an approach**.
- Chips pre-fill `NewTaskBar` (prompt + mode) via a new `prefillNewTask` helper backed by a module-level Preact signal in `src/chat/NewTaskBar.tsx`. The bar reacts to the signal, applies the payload, expands itself if collapsed, and focuses the textarea.
- No layout reshuffle; the bar stays where it is — the empty-state hero just gives users an entry point that lands directly in the existing input.

## Why

When a connection has no active session selected, the previous empty pane offered only "Select a session on the left, or start a new one with the task bar above" — useful instructions for an experienced user, useless for a first-timer staring at a blank canvas. The chips give a one-click path from "I just connected" to "I'm editing a real prompt."

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (1088 passing — adds 3 new cases: prefill payload application, expand-when-collapsed, EmptyPane chip integration)
- [ ] Manual: open the app with a fresh connection and zero sessions; click each chip and confirm the prompt + mode propagate to the task bar with focus.
