### PR TITLE
feat(ui): inline retry/logs chips on failed nodes + recovery strip

### DIFF
--- a/src/chat/ChatPane.tsx
+++ b/src/chat/ChatPane.tsx
@@ -49,6 +49,7 @@ export function ChatPane({
 }: ChatPaneProps) {
   const [text, setText] = useState('')
   const [pending, setPending] = useState<'stop' | 'close' | null>(null)
+  const [recoveryPending, setRecoveryPending] = useState<'retry' | 'resume' | 'abort' | null>(null)
   const [activeTab, setActiveTab] = useState<SessionTabId>('chat')
   const isDesktopPane = useMediaQuery('(min-width: 768px)')
   const [fullscreen, setFullscreen] = useState<boolean>(() =>
@@ -116,6 +117,40 @@ export function ChatPane({
       await onCommand({ action: 'close', sessionId: session.id })
     } finally {
       setPending(null)
+    }
+  }
+
+  const handleFailureRetry = async () => {
+    setRecoveryPending('retry')
+    try {
+      await onSend('/retry', session.id)
+    } finally {
+      setRecoveryPending(null)
+    }
+  }
+
+  const handleFailureResume = async () => {
+    setRecoveryPending('resume')
+    try {
+      await onSend('/resume', session.id)
+    } finally {
+      setRecoveryPending(null)
+    }
+  }
+
+  const handleFailureAbort = async () => {
+    const ok = await confirm({
+      title: `Abort ${session.slug}?`,
+      message: 'Closes this failed session permanently. Conversation history stays, but you cannot resume it.',
+      destructive: true,
+      confirmLabel: 'Abort',
+    })
+    if (!ok) return
+    setRecoveryPending('abort')
+    try {
+      await onCommand({ action: 'close', sessionId: session.id })
+    } finally {
+      setRecoveryPending(null)
     }
   }
 
@@ -289,6 +324,43 @@ export function ChatPane({
       >
         {activeTab === 'chat' && (
           <>
+            {session.status === 'failed' && (
+              <div
+                class="shrink-0 flex flex-wrap items-center gap-2 px-4 py-2.5 border-b border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/40"
+                data-testid="failure-recovery-strip"
+              >
+                <span class="text-xs font-semibold text-red-800 dark:text-red-200 mr-1" aria-hidden="true">
+                  ⚠ Session failed
+                </span>
+                <button
+                  type="button"
+                  onClick={() => void handleFailureRetry()}
+                  disabled={recoveryPending !== null}
+                  class="rounded-md border border-red-300 dark:border-red-700 text-red-800 dark:text-red-200 bg-white dark:bg-slate-800 px-3 py-2 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-900/40 disabled:opacity-50 disabled:cursor-not-allowed min-h-[36px]"
+                  data-testid="failure-retry-btn"
+                >
+                  {recoveryPending === 'retry' ? 'Retrying…' : '↻ Retry'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleFailureResume()}
+                  disabled={recoveryPending !== null}
+                  class="rounded-md border border-red-300 dark:border-red-700 text-red-800 dark:text-red-200 bg-white dark:bg-slate-800 px-3 py-2 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-900/40 disabled:opacity-50 disabled:cursor-not-allowed min-h-[36px]"
+                  data-testid="failure-resume-btn"
+                >
+                  {recoveryPending === 'resume' ? 'Resuming…' : '▶ Resume'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleFailureAbort()}
+                  disabled={recoveryPending !== null}
+                  class="ml-auto rounded-md border border-red-400 dark:border-red-700 text-white bg-red-600 hover:bg-red-700 px-3 py-2 text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed min-h-[36px]"
+                  data-testid="failure-abort-btn"
+                >
+                  {recoveryPending === 'abort' ? 'Aborting…' : '✕ Abort'}
+                </button>
+              </div>
+            )}
             {session.prUrl && hasFeature(store, 'pr-preview') && (
               <PrPreviewCard
                 sessionId={session.id}

--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -51,6 +51,8 @@ interface UniverseNodeData {
   scale: number
   onContextMenu: (session: ApiSession, position: { x: number; y: number }) => void
   onNodeClick: (session: ApiSession) => void
+  onRetryNode?: (session: ApiSession) => void
+  onViewNodeLogs?: (sessionId: string) => void
 }
 
 function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
@@ -89,8 +91,33 @@ function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
   const nodeTypeLabel = data.nodeType === 'dag' ? 'DAG' : data.nodeType === 'parent-child' ? 'Tree' : null
   const isFeedback = isFeedbackSession(session)
 
+  const isFailed = data.status === 'failed' || data.status === 'ci-failed'
+  const showFailureChips = isFailed && Boolean(session) && (Boolean(data.onRetryNode) || Boolean(data.onViewNodeLogs))
+
+  const handleRetryClick = useCallback(
+    (e: Event) => {
+      e.stopPropagation()
+      if (session && data.onRetryNode) {
+        vibrate('light')
+        data.onRetryNode(session)
+      }
+    },
+    [session, data, vibrate]
+  )
+
+  const handleLogsClick = useCallback(
+    (e: Event) => {
+      e.stopPropagation()
+      if (session && data.onViewNodeLogs) {
+        vibrate('light')
+        data.onViewNodeLogs(session.id)
+      }
+    },
+    [session, data, vibrate]
+  )
+
   const baseWidth = isCoordinator ? 300 : 240
-  const baseHeight = isCoordinator ? 120 : 100
+  const baseHeight = isCoordinator ? (showFailureChips ? 152 : 120) : (showFailureChips ? 132 : 100)
   const nodeWidth = Math.round(baseWidth * data.scale)
   const nodeHeight = Math.round(baseHeight * data.scale)
 
@@ -200,6 +227,45 @@ function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
             <span class="text-[10px] opacity-40 shrink-0">{formatRelativeTime(session.updatedAt)}</span>
           )}
         </div>
+
+        {showFailureChips && (
+          <div class="flex items-center gap-1.5 mt-1.5" data-testid={`failure-chips-${session!.id}`}>
+            {data.onRetryNode && (
+              <button
+                type="button"
+                onClick={handleRetryClick}
+                class="inline-flex items-center gap-1 rounded-full text-[10px] font-semibold px-2 py-1 border transition-colors"
+                style={{
+                  backgroundColor: isDark ? 'rgba(239,68,68,0.15)' : '#fff',
+                  borderColor: colors.border,
+                  color: colors.border,
+                }}
+                title="Retry this node"
+                data-testid={`node-retry-chip-${session!.id}`}
+              >
+                <span aria-hidden="true">↻</span>
+                <span>Retry</span>
+              </button>
+            )}
+            {data.onViewNodeLogs && (
+              <button
+                type="button"
+                onClick={handleLogsClick}
+                class="inline-flex items-center gap-1 rounded-full text-[10px] font-semibold px-2 py-1 border transition-colors"
+                style={{
+                  backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : '#fff',
+                  borderColor: isDark ? 'rgba(255,255,255,0.25)' : 'rgba(0,0,0,0.2)',
+                  color: isDark ? '#e5e7eb' : '#374151',
+                }}
+                title="View logs for this node"
+                data-testid={`node-logs-chip-${session!.id}`}
+              >
+                <span aria-hidden="true">📋</span>
+                <span>Logs</span>
+              </button>
+            )}
+          </div>
+        )}
       </div>
       <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
     </div>
@@ -413,6 +479,10 @@ function UniverseCanvasInner({
     onNodeSelect?.(session)
   }, [onNodeSelect])
 
+  const handleRetryNode = useCallback((session: ApiSession) => {
+    void onSendReply(session.id, '/retry')
+  }, [onSendReply])
+
   const { nodes: layoutNodes, edges: layoutEdges } = useMemo(() => {
     if (sessions.length === 0 && dags.length === 0) {
       return { nodes: [] as Node[], edges: [] as UniverseEdge[] }
@@ -430,9 +500,11 @@ function UniverseCanvasInner({
         scale: nodeScale,
         onContextMenu: handleNodeContextMenu,
         onNodeClick: handleNodeClick,
+        onRetryNode: handleRetryNode,
+        onViewNodeLogs: onViewLogs,
       },
     }))
-  }, [layoutNodes, isDark, nodeScale, handleNodeContextMenu, handleNodeClick])
+  }, [layoutNodes, isDark, nodeScale, handleNodeContextMenu, handleNodeClick, handleRetryNode, onViewLogs])
 
   const [nodes, setNodes, onNodesChange] = useNodesState(nodesWithHandlers)
   const [edges, setEdges, onEdgesChange] = useEdgesState(layoutEdges)

--- a/test/chat/ChatPane.test.tsx
+++ b/test/chat/ChatPane.test.tsx
@@ -265,6 +265,88 @@ describe('ChatPane', () => {
     expect(stopBtn.hasAttribute('disabled')).toBe(true)
   })
 
+  it('does not render the failure-recovery strip when session is running', () => {
+    render(
+      <ChatPane
+        session={mockSession}
+        store={mockStore}
+        onSend={mockOnSend}
+        onCommand={mockOnCommand}
+      />,
+    )
+    expect(screen.queryByTestId('failure-recovery-strip')).toBeNull()
+  })
+
+  it('renders the failure-recovery strip when session is failed', () => {
+    const failedSession = { ...mockSession, status: 'failed' as const }
+    render(
+      <ChatPane
+        session={failedSession}
+        store={mockStore}
+        onSend={mockOnSend}
+        onCommand={mockOnCommand}
+      />,
+    )
+    expect(screen.getByTestId('failure-recovery-strip')).toBeTruthy()
+    expect(screen.getByTestId('failure-retry-btn')).toBeTruthy()
+    expect(screen.getByTestId('failure-resume-btn')).toBeTruthy()
+    expect(screen.getByTestId('failure-abort-btn')).toBeTruthy()
+  })
+
+  it('clicking failure retry calls onSend with /retry', async () => {
+    mockOnSend.mockResolvedValue(undefined)
+    const failedSession = { ...mockSession, status: 'failed' as const }
+    render(
+      <ChatPane
+        session={failedSession}
+        store={mockStore}
+        onSend={mockOnSend}
+        onCommand={mockOnCommand}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('failure-retry-btn'))
+    await waitFor(() => {
+      expect(mockOnSend).toHaveBeenCalledWith('/retry', failedSession.id)
+    })
+  })
+
+  it('clicking failure resume calls onSend with /resume', async () => {
+    mockOnSend.mockResolvedValue(undefined)
+    const failedSession = { ...mockSession, status: 'failed' as const }
+    render(
+      <ChatPane
+        session={failedSession}
+        store={mockStore}
+        onSend={mockOnSend}
+        onCommand={mockOnCommand}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('failure-resume-btn'))
+    await waitFor(() => {
+      expect(mockOnSend).toHaveBeenCalledWith('/resume', failedSession.id)
+    })
+  })
+
+  it('clicking failure abort calls onCommand with close after confirm', async () => {
+    mockOnCommand.mockResolvedValue({ success: true })
+    const failedSession = { ...mockSession, status: 'failed' as const }
+    render(
+      <ChatPane
+        session={failedSession}
+        store={mockStore}
+        onSend={mockOnSend}
+        onCommand={mockOnCommand}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('failure-abort-btn'))
+    await waitFor(() => {
+      expect(mockOnCommand).toHaveBeenCalledWith({
+        action: 'close',
+        sessionId: failedSession.id,
+      })
+    })
+  })
+
   it('shows PR link when prUrl is present', () => {
     const sessionWithPr = { ...mockSession, prUrl: 'https://github.com/owner/repo/pull/123' }
 

--- a/test/components/UniverseCanvas.test.tsx
+++ b/test/components/UniverseCanvas.test.tsx
@@ -665,6 +665,84 @@ describe('loadPersistedViewport / savePersistedViewport', () => {
     expect(document.querySelector('[data-testid="feedback-canvas-badge"]')).toBeFalsy()
   })
 
+  it('renders Retry and Logs chips on a failed standalone node', () => {
+    const sessions = [createSession({ id: 's-fail', slug: 'failed-one', status: 'failed' })]
+    const onViewLogs = vi.fn()
+    render(
+      <UniverseCanvas {...defaultProps} sessions={sessions} onViewLogs={onViewLogs} />,
+    )
+    expect(document.querySelector('[data-testid="node-retry-chip-s-fail"]')).toBeTruthy()
+    expect(document.querySelector('[data-testid="node-logs-chip-s-fail"]')).toBeTruthy()
+  })
+
+  it('does not render failure chips on running nodes', () => {
+    const sessions = [createSession({ id: 's-ok', slug: 'ok', status: 'running' })]
+    render(<UniverseCanvas {...defaultProps} sessions={sessions} onViewLogs={vi.fn()} />)
+    expect(document.querySelector('[data-testid="node-retry-chip-s-ok"]')).toBeFalsy()
+    expect(document.querySelector('[data-testid="node-logs-chip-s-ok"]')).toBeFalsy()
+  })
+
+  it('renders Retry chip on a ci-failed DAG node and clicking it sends /retry', () => {
+    const onSendReply = vi.fn().mockResolvedValue(undefined)
+    const dag = createDag({
+      nodes: {
+        'node-1': {
+          id: 'node-1',
+          slug: 'dag-root',
+          status: 'ci-failed',
+          dependencies: [],
+          dependents: [],
+          session: createSession({ id: 'dag-session-1', slug: 'dag-root', status: 'running' }),
+        },
+      },
+    })
+    render(<UniverseCanvas {...defaultProps} dags={[dag]} onSendReply={onSendReply} onViewLogs={vi.fn()} />)
+    const retryChip = document.querySelector('[data-testid="node-retry-chip-dag-session-1"]') as HTMLButtonElement | null
+    expect(retryChip).toBeTruthy()
+    if (retryChip) {
+      fireEvent.click(retryChip)
+      expect(onSendReply).toHaveBeenCalledWith('dag-session-1', '/retry')
+    }
+  })
+
+  it('clicking Logs chip on a failed node calls onViewLogs with the session id', () => {
+    const onViewLogs = vi.fn()
+    const sessions = [createSession({ id: 's-fail-2', slug: 'failed-two', status: 'failed' })]
+    render(<UniverseCanvas {...defaultProps} sessions={sessions} onViewLogs={onViewLogs} />)
+    const logsChip = document.querySelector('[data-testid="node-logs-chip-s-fail-2"]') as HTMLButtonElement | null
+    expect(logsChip).toBeTruthy()
+    if (logsChip) {
+      fireEvent.click(logsChip)
+      expect(onViewLogs).toHaveBeenCalledWith('s-fail-2')
+    }
+  })
+
+  it('clicking a failure chip does not also trigger node selection', () => {
+    const onNodeSelect = vi.fn()
+    const onViewLogs = vi.fn()
+    const sessions = [createSession({ id: 's-fail-3', slug: 'failed-three', status: 'failed' })]
+    render(
+      <UniverseCanvas
+        {...defaultProps}
+        sessions={sessions}
+        onNodeSelect={onNodeSelect}
+        onViewLogs={onViewLogs}
+      />,
+    )
+    const logsChip = document.querySelector('[data-testid="node-logs-chip-s-fail-3"]') as HTMLButtonElement | null
+    if (logsChip) {
+      fireEvent.click(logsChip)
+      expect(onNodeSelect).not.toHaveBeenCalled()
+    }
+  })
+
+  it('omits the Logs chip when no onViewLogs handler is provided', () => {
+    const sessions = [createSession({ id: 's-fail-4', slug: 'failed-four', status: 'failed' })]
+    render(<UniverseCanvas {...defaultProps} sessions={sessions} />)
+    expect(document.querySelector('[data-testid="node-retry-chip-s-fail-4"]')).toBeTruthy()
+    expect(document.querySelector('[data-testid="node-logs-chip-s-fail-4"]')).toBeFalsy()
+  })
+
   it('renders both feedback badge and node type label on canvas node', () => {
     const feedbackMeta: FeedbackMetadata = {
       kind: 'feedback',


### PR DESCRIPTION
## Summary

- Failed and CI-failed nodes in the universe canvas now show inline `↻ Retry` and `📋 Logs` chips so common recovery actions don't require opening the long-press context menu.
- The chat pane gains a dedicated failure-recovery strip (`Retry` / `Resume` / `Abort`) that appears when a session ends in a failed state, surfacing the three most common recovery flows above the transcript.
- Retry chip sends `/retry` via `onSendReply`; Logs chip reuses the existing `onViewLogs` plumbing already wired through `App.tsx`. Recovery strip uses `onSend` for `/retry` and `/resume`, and the existing `onCommand({ action: 'close' })` for Abort (with a confirm dialog).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (1096 passed, including 5 new `UniverseCanvas` chip tests and 5 new `ChatPane` recovery-strip tests)
