### PR TITLE
feat(onboarding): first-run tour + surface help panel

### DIFF
--- a/e2e/helpers/connect.ts
+++ b/e2e/helpers/connect.ts
@@ -7,6 +7,9 @@ export async function connectToMinion(
   mock: MockMinion,
   label: string,
 ): Promise<void> {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('minions-ui:onboarding-tour:v1', 'completed') } catch { /* ignore */ }
+  })
   await page.goto('/')
 
   await expect(page.getByRole('button', { name: 'Add connection' })).toBeVisible()

--- a/e2e/tests/bad-token.spec.ts
+++ b/e2e/tests/bad-token.spec.ts
@@ -23,6 +23,9 @@ test.describe('bad token', () => {
     ])
 
     try {
+      await page.addInitScript(() => {
+        try { localStorage.setItem('minions-ui:onboarding-tour:v1', 'completed') } catch { /* ignore */ }
+      })
       await page.goto('/')
 
       await page.getByRole('button', { name: 'Add connection' }).click()

--- a/e2e/tests/connect.spec.ts
+++ b/e2e/tests/connect.spec.ts
@@ -10,6 +10,9 @@ test.describe('connection flow', () => {
     mock.setVersion({ features: ['messages', 'auth', 'cors-allowlist'] })
 
     try {
+      await page.addInitScript(() => {
+        try { localStorage.setItem('minions-ui:onboarding-tour:v1', 'completed') } catch { /* ignore */ }
+      })
       await page.goto('/')
 
       await expect(page.getByRole('heading', { name: 'Connect a minion' })).toBeVisible()
@@ -53,6 +56,9 @@ test.describe('connection flow', () => {
     ])
 
     try {
+      await page.addInitScript(() => {
+        try { localStorage.setItem('minions-ui:onboarding-tour:v1', 'completed') } catch { /* ignore */ }
+      })
       await page.goto('/')
       await page.getByRole('button', { name: 'Add connection' }).click()
       await page.getByPlaceholder('My minion').fill('Minion A')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,13 @@ import { InboxButton } from './components/InboxButton'
 import { InboxSheet } from './components/InboxPanel'
 import { NotificationsToggle } from './pwa/NotificationsToggle'
 import type { InboxEvent } from './state/inbox'
+import {
+  OnboardingTour,
+  markTourCompleted,
+  resetTour,
+  shouldShowFirstRunTour,
+} from './components/OnboardingTour'
+import { HelpPanel } from './components/HelpPanel'
 
 export type ViewMode = 'list' | 'canvas' | 'ship' | 'kanban' | 'timeline'
 
@@ -54,6 +61,8 @@ const showMemory = signal(false)
 const showPalette = signal(false)
 const showShortcutsHelp = signal(false)
 const showInboxSheet = signal(false)
+const showHelp = signal(false)
+const showTour = signal(false)
 export const viewMode = signal<ViewMode>('list')
 
 function ViewToggle({ mode, onChange, showKanban }: { mode: ViewMode; onChange: (m: ViewMode) => void; showKanban?: boolean }) {
@@ -394,6 +403,12 @@ function ActiveView() {
     document.documentElement.style.setProperty('--accent', color)
   }, [conn?.color])
 
+  useEffect(() => {
+    if (shouldShowFirstRunTour(connections.value.length > 0)) {
+      showTour.value = true
+    }
+  }, [])
+
   const runningCount = store ? countRunning(store.sessions.value) : 0
   useEffect(() => {
     const base = 'Minions UI'
@@ -677,6 +692,16 @@ function ActiveView() {
             >
               <span aria-hidden="true">🔄</span>
             </button>
+            <button
+              type="button"
+              onClick={() => { showHelp.value = true }}
+              class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 min-h-[44px] min-w-[44px] flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700"
+              title="Help and surface guide"
+              aria-label="Open help and surface guide"
+              data-testid="header-help-btn"
+            >
+              <span aria-hidden="true">❓</span>
+            </button>
           </div>
         ) : (
           <div class="ml-auto">
@@ -686,6 +711,7 @@ function ActiveView() {
               onClean={hasFeature(store, 'messages') ? handleClean : undefined}
               onRefresh={() => void store.refresh()}
               onInbox={() => { showInboxSheet.value = true }}
+              onHelp={() => { showHelp.value = true }}
               showMemory={hasFeature(store, 'memory')}
               memoryProposalsCount={store.memoryProposalsCount.value}
               showRuntimeConfig={hasFeature(store, 'runtime-config')}
@@ -953,6 +979,22 @@ function ActiveView() {
           />
         )
       })()}
+      <HelpPanel
+        open={showHelp.value}
+        onClose={() => { showHelp.value = false }}
+        onReplayTour={() => {
+          showHelp.value = false
+          resetTour()
+          showTour.value = true
+        }}
+      />
+      <OnboardingTour
+        open={showTour.value}
+        onClose={() => {
+          showTour.value = false
+          markTourCompleted()
+        }}
+      />
       </div>
     </div>
   )

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -17,6 +17,7 @@ export function HeaderMenu({
   onClean,
   onRefresh,
   onInbox,
+  onHelp,
   showMemory,
   memoryProposalsCount,
   showRuntimeConfig,
@@ -28,6 +29,7 @@ export function HeaderMenu({
   onClean?: () => void
   onRefresh: () => void
   onInbox?: () => void
+  onHelp?: () => void
   showMemory: boolean
   memoryProposalsCount?: number
   showRuntimeConfig: boolean
@@ -240,6 +242,20 @@ export function HeaderMenu({
             <span aria-hidden="true">🔄</span>
             <span>Refresh</span>
           </button>
+          {onHelp && (
+            <button
+              type="button"
+              onClick={() => {
+                onHelp()
+                closeMenu()
+              }}
+              class="w-full flex items-center gap-3 px-3 py-2 text-sm text-left text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+              data-testid="menu-help"
+            >
+              <span aria-hidden="true">❓</span>
+              <span>Help</span>
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/src/components/HelpPanel.tsx
+++ b/src/components/HelpPanel.tsx
@@ -1,0 +1,177 @@
+import { useEffect } from 'preact/hooks'
+
+export interface HelpSection {
+  id: string
+  icon: string
+  title: string
+  body: string
+}
+
+export const HELP_SECTIONS: HelpSection[] = [
+  {
+    id: 'new-task',
+    icon: '✨',
+    title: 'New task bar',
+    body: 'The bar at the top spawns a new minion. Type a task and press enter; the minion runs autonomously until it ships a PR or asks for input.',
+  },
+  {
+    id: 'sessions',
+    icon: '📋',
+    title: 'Sessions',
+    body: 'A session is one minion working on one task. The list (or strip on mobile) shows status, slug, and quick attention reasons.',
+  },
+  {
+    id: 'attention',
+    icon: '🔔',
+    title: 'Attention pills',
+    body: 'When sessions need you (failed, waiting for feedback, finished), pills appear above the list. Click a pill to filter to those sessions.',
+  },
+  {
+    id: 'list-view',
+    icon: '☰',
+    title: 'List view',
+    body: 'Sidebar of sessions plus a chat pane on the right. The default view — best for replying to a single minion.',
+  },
+  {
+    id: 'kanban-view',
+    icon: '📋',
+    title: 'Kanban view',
+    body: 'Group sessions by status (running, waiting, done, failed). Best for triaging many minions at once.',
+  },
+  {
+    id: 'canvas-view',
+    icon: '◎',
+    title: 'Canvas view',
+    body: 'Spatial DAG of sessions and their parents/children. Pan, zoom, and long-press / right-click any node for actions.',
+  },
+  {
+    id: 'ship-view',
+    icon: '🚀',
+    title: 'Ship view',
+    body: 'Pipeline grouping every DAG by stage: plan → implement → review → land. Failed nodes surface with a retry action.',
+  },
+  {
+    id: 'long-press',
+    icon: '🖐️',
+    title: 'Long-press / right-click menu',
+    body: 'On Canvas, long-press (mobile) or right-click (desktop) any node to stop, close, retry rebase, or jump straight to its chat.',
+  },
+  {
+    id: 'quick-actions',
+    icon: '⚡',
+    title: 'Quick actions',
+    body: 'Inside a session, the action bar surfaces the minion’s suggested next steps (e.g. approve plan, retry failed step, view PR).',
+  },
+  {
+    id: 'slash-commands',
+    icon: '/',
+    title: 'Slash commands',
+    body: 'In the message input, type / to see available commands like /clean, /memory, /restart, or any custom commands the minion advertises.',
+  },
+  {
+    id: 'pull-refresh',
+    icon: '⤓',
+    title: 'Pull-to-refresh (mobile)',
+    body: 'On mobile, drag down at the top of the list to refetch sessions and DAGs from the minion.',
+  },
+  {
+    id: 'connections',
+    icon: '🔌',
+    title: 'Connections',
+    body: 'Connect to multiple minion deployments and switch between them via the picker on the left of the header. Each gets its own accent color.',
+  },
+]
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onReplayTour: () => void
+}
+
+export function HelpPanel({ open, onClose, onReplayTour }: Props) {
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      class="fixed inset-0 z-[55] flex items-stretch justify-end"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="help-panel-title"
+      data-testid="help-panel"
+    >
+      <div
+        class="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        data-testid="help-panel-overlay"
+      />
+      <div class="relative w-full sm:max-w-md h-[100dvh] bg-white dark:bg-slate-800 border-l border-slate-200 dark:border-slate-700 shadow-2xl flex flex-col">
+        <div class="flex items-center gap-2 px-4 py-3 border-b border-slate-200 dark:border-slate-700 shrink-0">
+          <span aria-hidden="true" class="text-lg">❓</span>
+          <h2
+            id="help-panel-title"
+            class="text-base font-semibold text-slate-900 dark:text-slate-100"
+          >
+            Surface guide
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            class="ml-auto rounded-md text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 px-3 py-2 text-sm min-h-[44px]"
+            aria-label="Close help panel"
+            data-testid="help-panel-close"
+          >
+            Close
+          </button>
+        </div>
+        <div class="flex-1 overflow-y-auto px-4 py-3">
+          <p class="text-xs text-slate-500 dark:text-slate-400 mb-3">
+            Quick reference for every surface in this UI. Tap “Replay tour” for the
+            interactive walk-through.
+          </p>
+          <ul class="flex flex-col gap-3" data-testid="help-panel-sections">
+            {HELP_SECTIONS.map((section) => (
+              <li
+                key={section.id}
+                class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2.5"
+                data-testid={`help-section-${section.id}`}
+              >
+                <div class="flex items-start gap-2">
+                  <span class="text-lg leading-none mt-0.5" aria-hidden="true">
+                    {section.icon}
+                  </span>
+                  <div class="flex-1 min-w-0">
+                    <div class="text-sm font-medium text-slate-900 dark:text-slate-100">
+                      {section.title}
+                    </div>
+                    <div class="text-xs text-slate-600 dark:text-slate-300 mt-1 leading-relaxed">
+                      {section.body}
+                    </div>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div class="border-t border-slate-200 dark:border-slate-700 px-4 py-3 shrink-0">
+          <button
+            type="button"
+            onClick={onReplayTour}
+            class="w-full rounded-md bg-indigo-600 text-white px-4 py-2.5 text-sm font-medium hover:bg-indigo-700 min-h-[44px]"
+            data-testid="help-panel-replay-tour"
+          >
+            Replay tour
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useState } from 'preact/hooks'
+
+export const ONBOARDING_TOUR_KEY = 'minions-ui:onboarding-tour:v1'
+
+export interface TourStep {
+  id: string
+  icon: string
+  title: string
+  body: string
+  hint?: string
+}
+
+export const TOUR_STEPS: TourStep[] = [
+  {
+    id: 'welcome',
+    icon: '👋',
+    title: 'Welcome to minions',
+    body: 'Minions are autonomous agents you can spawn from this UI. Each session represents one minion working on a task. Let’s take a quick tour of the surfaces.',
+  },
+  {
+    id: 'new-task',
+    icon: '✨',
+    title: 'Start a new task',
+    body: 'Type a task into the bar at the top to spawn a new minion. It runs autonomously until it ships a PR or asks for feedback.',
+    hint: 'Try: "fix the failing CI test on main"',
+  },
+  {
+    id: 'sessions',
+    icon: '📋',
+    title: 'Sessions list',
+    body: 'Every running and recent minion shows up in the list on the left (or strip on top, on mobile). Tap a row to open its conversation.',
+  },
+  {
+    id: 'long-press',
+    icon: '🖐️',
+    title: 'Long-press for actions',
+    body: 'In Canvas view, long-press (mobile) or right-click (desktop) any node to open a context menu with stop, close, retry, and open-chat actions.',
+  },
+  {
+    id: 'views',
+    icon: '🎛️',
+    title: 'Switch views',
+    body: 'List shows a single session in detail. Canvas shows the full DAG of related minions. Ship walks each task through plan → implement → review → land stages.',
+  },
+  {
+    id: 'ship',
+    icon: '🚀',
+    title: 'Ship pipeline',
+    body: 'The Ship view groups your DAGs by stage so you can see what’s waiting on you, what’s in review, and what just landed. Failed nodes surface here first.',
+  },
+  {
+    id: 'help',
+    icon: '❓',
+    title: 'Need a refresher?',
+    body: 'Tap the ? button in the header any time to reopen this tour or browse the surface guide.',
+  },
+]
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export function OnboardingTour({ open, onClose }: Props) {
+  const [stepIndex, setStepIndex] = useState(0)
+
+  useEffect(() => {
+    if (open) setStepIndex(0)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+      } else if (e.key === 'ArrowRight') {
+        setStepIndex((i) => Math.min(i + 1, TOUR_STEPS.length - 1))
+      } else if (e.key === 'ArrowLeft') {
+        setStepIndex((i) => Math.max(i - 1, 0))
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const step = TOUR_STEPS[stepIndex]
+  const isFirst = stepIndex === 0
+  const isLast = stepIndex === TOUR_STEPS.length - 1
+
+  const handleNext = () => {
+    if (isLast) {
+      onClose()
+    } else {
+      setStepIndex(stepIndex + 1)
+    }
+  }
+
+  const handleBack = () => {
+    if (!isFirst) setStepIndex(stepIndex - 1)
+  }
+
+  return (
+    <div
+      class="fixed inset-0 z-[60] flex items-end sm:items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="onboarding-tour-title"
+      data-testid="onboarding-tour"
+    >
+      <div
+        class="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        data-testid="onboarding-tour-overlay"
+      />
+      <div
+        class="relative w-full sm:max-w-md mx-0 sm:mx-4 mb-0 sm:mb-0 rounded-t-2xl sm:rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-2xl flex flex-col max-h-[85dvh]"
+      >
+        <div class="flex items-center justify-between px-5 pt-5 pb-2">
+          <span
+            class="text-[10px] uppercase tracking-wider font-semibold text-slate-500 dark:text-slate-400"
+            data-testid="onboarding-tour-step-counter"
+          >
+            Step {stepIndex + 1} of {TOUR_STEPS.length}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            class="rounded-md text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 text-sm px-2 py-1"
+            aria-label="Skip tour"
+            data-testid="onboarding-tour-skip"
+          >
+            Skip
+          </button>
+        </div>
+        <div class="px-5 pb-2 flex flex-col items-center text-center gap-3">
+          <div
+            class="text-4xl"
+            aria-hidden="true"
+            data-testid="onboarding-tour-icon"
+          >
+            {step.icon}
+          </div>
+          <h2
+            id="onboarding-tour-title"
+            class="text-lg font-semibold text-slate-900 dark:text-slate-100"
+            data-testid="onboarding-tour-title"
+          >
+            {step.title}
+          </h2>
+          <p
+            class="text-sm text-slate-600 dark:text-slate-300 leading-relaxed"
+            data-testid="onboarding-tour-body"
+          >
+            {step.body}
+          </p>
+          {step.hint && (
+            <p
+              class="text-xs text-slate-500 dark:text-slate-400 italic"
+              data-testid="onboarding-tour-hint"
+            >
+              {step.hint}
+            </p>
+          )}
+        </div>
+        <div
+          class="flex items-center justify-center gap-1.5 px-5 py-3"
+          role="tablist"
+          aria-label="Tour progress"
+        >
+          {TOUR_STEPS.map((s, i) => (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => setStepIndex(i)}
+              role="tab"
+              aria-selected={i === stepIndex}
+              aria-label={`Go to step ${i + 1}: ${s.title}`}
+              class={`h-1.5 rounded-full transition-all ${
+                i === stepIndex
+                  ? 'w-6 bg-indigo-600 dark:bg-indigo-400'
+                  : 'w-1.5 bg-slate-300 dark:bg-slate-600 hover:bg-slate-400 dark:hover:bg-slate-500'
+              }`}
+              data-testid={`onboarding-tour-dot-${i}`}
+            />
+          ))}
+        </div>
+        <div class="flex items-center gap-2 px-5 pb-5 pt-1">
+          <button
+            type="button"
+            onClick={handleBack}
+            disabled={isFirst}
+            class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-3 py-2.5 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-40 disabled:cursor-not-allowed min-h-[44px]"
+            data-testid="onboarding-tour-back"
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={handleNext}
+            class="ml-auto rounded-md bg-indigo-600 text-white px-4 py-2.5 text-sm font-medium hover:bg-indigo-700 min-h-[44px]"
+            data-testid="onboarding-tour-next"
+          >
+            {isLast ? 'Got it' : 'Next'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function shouldShowFirstRunTour(hasConnections: boolean): boolean {
+  if (!hasConnections) return false
+  try {
+    return localStorage.getItem(ONBOARDING_TOUR_KEY) !== 'completed'
+  } catch {
+    return false
+  }
+}
+
+export function markTourCompleted(): void {
+  try {
+    localStorage.setItem(ONBOARDING_TOUR_KEY, 'completed')
+  } catch {
+    /* ignore */
+  }
+}
+
+export function resetTour(): void {
+  try {
+    localStorage.removeItem(ONBOARDING_TOUR_KEY)
+  } catch {
+    /* ignore */
+  }
+}

--- a/test/App.onboarding.test.tsx
+++ b/test/App.onboarding.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { installMockEventSource } from './sse-mock'
+import type { VersionInfo, ApiSession, ApiDagGraph } from '../src/api/types'
+
+vi.mock('virtual:pwa-register/preact', () => ({
+  useRegisterSW: vi.fn().mockReturnValue({}),
+}))
+
+const VERSION: VersionInfo = { apiVersion: '1', libraryVersion: '0.1.0', features: [] }
+
+function stubFetch(sessions: ApiSession[] = [], dags: ApiDagGraph[] = []) {
+  vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+    if (url.includes('/api/version')) {
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: VERSION }) })
+    }
+    if (url.includes('/api/sessions')) {
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: sessions }) })
+    }
+    if (url.includes('/api/dags')) {
+      return Promise.resolve({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ data: dags }) })
+    }
+    return Promise.resolve({ ok: false, status: 404, statusText: 'NF', json: () => Promise.resolve({ data: null }) })
+  }))
+}
+
+function session(over: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 's1',
+    slug: 'brave-fox',
+    status: 'running',
+    command: '/task foo',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...over,
+  }
+}
+
+function seedConnection() {
+  localStorage.setItem('minions-ui:connections:v1', JSON.stringify({
+    version: 1,
+    connections: [
+      { id: 'c1', label: 'My Minion', baseUrl: 'https://example.com', token: 'tok', color: '#3b82f6' },
+    ],
+    activeId: 'c1',
+  }))
+}
+
+function setDesktop(isDesktop: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn(() => ({
+      matches: isDesktop,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  })
+}
+
+describe('App onboarding tour and help panel', () => {
+  let mock: ReturnType<typeof installMockEventSource>
+
+  beforeEach(() => {
+    localStorage.clear()
+    mock = installMockEventSource()
+    vi.resetModules()
+    setDesktop(true)
+  })
+
+  afterEach(() => {
+    mock.restore()
+    vi.unstubAllGlobals()
+    localStorage.clear()
+  })
+
+  it('auto-shows the tour on first connection when no completion flag is set', { timeout: 15000 }, async () => {
+    seedConnection()
+    stubFetch([session()])
+    const App = (await import('../src/App')).default
+    render(<App />)
+    expect(await screen.findByTestId('onboarding-tour')).toBeTruthy()
+  })
+
+  it('does NOT auto-show the tour when completion flag is already set', { timeout: 15000 }, async () => {
+    localStorage.setItem('minions-ui:onboarding-tour:v1', 'completed')
+    seedConnection()
+    stubFetch([session()])
+    const App = (await import('../src/App')).default
+    render(<App />)
+    await screen.findByText('My Minion')
+    expect(screen.queryByTestId('onboarding-tour')).toBeNull()
+  })
+
+  it('does NOT auto-show the tour on the connection-empty welcome screen', { timeout: 15000 }, async () => {
+    stubFetch()
+    const App = (await import('../src/App')).default
+    render(<App />)
+    expect(screen.getByText('Connect a minion')).toBeTruthy()
+    expect(screen.queryByTestId('onboarding-tour')).toBeNull()
+  })
+
+  it('Skip persists the completion flag so the tour does not reappear', { timeout: 15000 }, async () => {
+    seedConnection()
+    stubFetch([session()])
+    const App = (await import('../src/App')).default
+    render(<App />)
+    fireEvent.click(await screen.findByTestId('onboarding-tour-skip'))
+    expect(screen.queryByTestId('onboarding-tour')).toBeNull()
+    expect(localStorage.getItem('minions-ui:onboarding-tour:v1')).toBe('completed')
+  })
+
+  it('header help button opens the HelpPanel on desktop', { timeout: 15000 }, async () => {
+    localStorage.setItem('minions-ui:onboarding-tour:v1', 'completed')
+    seedConnection()
+    stubFetch([session()])
+    const App = (await import('../src/App')).default
+    render(<App />)
+    fireEvent.click(await screen.findByTestId('header-help-btn'))
+    expect(await screen.findByTestId('help-panel')).toBeTruthy()
+  })
+
+  it('HelpPanel "Replay tour" closes the panel and reopens the tour', { timeout: 15000 }, async () => {
+    localStorage.setItem('minions-ui:onboarding-tour:v1', 'completed')
+    seedConnection()
+    stubFetch([session()])
+    const App = (await import('../src/App')).default
+    render(<App />)
+    fireEvent.click(await screen.findByTestId('header-help-btn'))
+    fireEvent.click(await screen.findByTestId('help-panel-replay-tour'))
+    expect(screen.queryByTestId('help-panel')).toBeNull()
+    expect(await screen.findByTestId('onboarding-tour')).toBeTruthy()
+    expect(localStorage.getItem('minions-ui:onboarding-tour:v1')).toBeNull()
+  })
+
+  it('mobile menu exposes a Help item that opens the HelpPanel', { timeout: 15000 }, async () => {
+    setDesktop(false)
+    localStorage.setItem('minions-ui:onboarding-tour:v1', 'completed')
+    seedConnection()
+    stubFetch([session()])
+    const App = (await import('../src/App')).default
+    render(<App />)
+    fireEvent.click(await screen.findByTestId('header-menu-btn'))
+    fireEvent.click(await screen.findByTestId('menu-help'))
+    expect(await screen.findByTestId('help-panel')).toBeTruthy()
+  })
+})

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -47,6 +47,7 @@ describe('App', () => {
 
   beforeEach(() => {
     localStorage.clear()
+    localStorage.setItem('minions-ui:onboarding-tour:v1', 'completed')
     mock = installMockEventSource()
     vi.resetModules()
   })

--- a/test/App.viewToggle.test.tsx
+++ b/test/App.viewToggle.test.tsx
@@ -154,6 +154,7 @@ describe('App view toggle', () => {
 
   beforeEach(() => {
     localStorage.clear()
+    localStorage.setItem('minions-ui:onboarding-tour:v1', 'completed')
     mock = installMockEventSource()
     vi.resetModules()
     setDesktop(true)

--- a/test/components/HelpPanel.test.tsx
+++ b/test/components/HelpPanel.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { HelpPanel, HELP_SECTIONS } from '../../src/components/HelpPanel'
+
+describe('HelpPanel', () => {
+  it('renders nothing when open=false', () => {
+    const { container } = render(
+      <HelpPanel open={false} onClose={() => {}} onReplayTour={() => {}} />,
+    )
+    expect(container.querySelector('[data-testid="help-panel"]')).toBeNull()
+  })
+
+  it('renders all help sections when open=true', () => {
+    render(<HelpPanel open={true} onClose={() => {}} onReplayTour={() => {}} />)
+    expect(screen.getByTestId('help-panel')).toBeTruthy()
+    for (const section of HELP_SECTIONS) {
+      const node = screen.getByTestId(`help-section-${section.id}`)
+      expect(node.textContent).toContain(section.title)
+      expect(node.textContent).toContain(section.body)
+    }
+  })
+
+  it('Close button calls onClose', () => {
+    const onClose = vi.fn()
+    render(<HelpPanel open={true} onClose={onClose} onReplayTour={() => {}} />)
+    fireEvent.click(screen.getByTestId('help-panel-close'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking the overlay calls onClose', () => {
+    const onClose = vi.fn()
+    render(<HelpPanel open={true} onClose={onClose} onReplayTour={() => {}} />)
+    fireEvent.click(screen.getByTestId('help-panel-overlay'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('Replay tour button calls onReplayTour', () => {
+    const onReplayTour = vi.fn()
+    render(<HelpPanel open={true} onClose={() => {}} onReplayTour={onReplayTour} />)
+    fireEvent.click(screen.getByTestId('help-panel-replay-tour'))
+    expect(onReplayTour).toHaveBeenCalledTimes(1)
+  })
+
+  it('Escape key calls onClose', () => {
+    const onClose = vi.fn()
+    render(<HelpPanel open={true} onClose={onClose} onReplayTour={() => {}} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('lists all surfaces (List, Kanban, Canvas, Ship, long-press)', () => {
+    render(<HelpPanel open={true} onClose={() => {}} onReplayTour={() => {}} />)
+    expect(screen.getByTestId('help-section-list-view')).toBeTruthy()
+    expect(screen.getByTestId('help-section-kanban-view')).toBeTruthy()
+    expect(screen.getByTestId('help-section-canvas-view')).toBeTruthy()
+    expect(screen.getByTestId('help-section-ship-view')).toBeTruthy()
+    expect(screen.getByTestId('help-section-long-press')).toBeTruthy()
+  })
+})

--- a/test/components/OnboardingTour.test.tsx
+++ b/test/components/OnboardingTour.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
+import {
+  OnboardingTour,
+  ONBOARDING_TOUR_KEY,
+  TOUR_STEPS,
+  shouldShowFirstRunTour,
+  markTourCompleted,
+  resetTour,
+} from '../../src/components/OnboardingTour'
+
+describe('OnboardingTour', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders nothing when open=false', () => {
+    const { container } = render(
+      <OnboardingTour open={false} onClose={() => {}} />,
+    )
+    expect(container.querySelector('[data-testid="onboarding-tour"]')).toBeNull()
+  })
+
+  it('renders the first step when open=true', () => {
+    render(<OnboardingTour open={true} onClose={() => {}} />)
+    expect(screen.getByTestId('onboarding-tour')).toBeTruthy()
+    expect(screen.getByTestId('onboarding-tour-title').textContent).toBe(
+      TOUR_STEPS[0].title,
+    )
+    expect(screen.getByTestId('onboarding-tour-step-counter').textContent).toBe(
+      `Step 1 of ${TOUR_STEPS.length}`,
+    )
+  })
+
+  it('Back button is disabled on the first step', () => {
+    render(<OnboardingTour open={true} onClose={() => {}} />)
+    const back = screen.getByTestId('onboarding-tour-back') as HTMLButtonElement
+    expect(back.disabled).toBe(true)
+  })
+
+  it('Next advances step by step and shows Got it on the last step', () => {
+    const onClose = vi.fn()
+    render(<OnboardingTour open={true} onClose={onClose} />)
+    const next = screen.getByTestId('onboarding-tour-next')
+    for (let i = 0; i < TOUR_STEPS.length - 1; i++) {
+      fireEvent.click(next)
+    }
+    expect(screen.getByTestId('onboarding-tour-title').textContent).toBe(
+      TOUR_STEPS[TOUR_STEPS.length - 1].title,
+    )
+    expect(screen.getByTestId('onboarding-tour-next').textContent).toBe('Got it')
+    fireEvent.click(screen.getByTestId('onboarding-tour-next'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('Back returns to the previous step', () => {
+    render(<OnboardingTour open={true} onClose={() => {}} />)
+    fireEvent.click(screen.getByTestId('onboarding-tour-next'))
+    expect(screen.getByTestId('onboarding-tour-title').textContent).toBe(
+      TOUR_STEPS[1].title,
+    )
+    fireEvent.click(screen.getByTestId('onboarding-tour-back'))
+    expect(screen.getByTestId('onboarding-tour-title').textContent).toBe(
+      TOUR_STEPS[0].title,
+    )
+  })
+
+  it('Skip button calls onClose', () => {
+    const onClose = vi.fn()
+    render(<OnboardingTour open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('onboarding-tour-skip'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking the overlay calls onClose', () => {
+    const onClose = vi.fn()
+    render(<OnboardingTour open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('onboarding-tour-overlay'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking a progress dot jumps directly to that step', () => {
+    render(<OnboardingTour open={true} onClose={() => {}} />)
+    fireEvent.click(screen.getByTestId('onboarding-tour-dot-3'))
+    expect(screen.getByTestId('onboarding-tour-title').textContent).toBe(
+      TOUR_STEPS[3].title,
+    )
+  })
+
+  it('Escape key calls onClose', () => {
+    const onClose = vi.fn()
+    render(<OnboardingTour open={true} onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('ArrowRight advances and ArrowLeft returns', () => {
+    render(<OnboardingTour open={true} onClose={() => {}} />)
+    fireEvent.keyDown(document, { key: 'ArrowRight' })
+    expect(screen.getByTestId('onboarding-tour-title').textContent).toBe(
+      TOUR_STEPS[1].title,
+    )
+    fireEvent.keyDown(document, { key: 'ArrowLeft' })
+    expect(screen.getByTestId('onboarding-tour-title').textContent).toBe(
+      TOUR_STEPS[0].title,
+    )
+  })
+
+  it('resets to step 0 when reopened', () => {
+    const { rerender } = render(<OnboardingTour open={true} onClose={() => {}} />)
+    fireEvent.click(screen.getByTestId('onboarding-tour-next'))
+    fireEvent.click(screen.getByTestId('onboarding-tour-next'))
+    rerender(<OnboardingTour open={false} onClose={() => {}} />)
+    rerender(<OnboardingTour open={true} onClose={() => {}} />)
+    expect(screen.getByTestId('onboarding-tour-title').textContent).toBe(
+      TOUR_STEPS[0].title,
+    )
+  })
+})
+
+describe('OnboardingTour storage helpers', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('shouldShowFirstRunTour returns false when no connections exist', () => {
+    expect(shouldShowFirstRunTour(false)).toBe(false)
+  })
+
+  it('shouldShowFirstRunTour returns true when connections exist and no completion flag', () => {
+    expect(shouldShowFirstRunTour(true)).toBe(true)
+  })
+
+  it('shouldShowFirstRunTour returns false once completed', () => {
+    markTourCompleted()
+    expect(shouldShowFirstRunTour(true)).toBe(false)
+    expect(localStorage.getItem(ONBOARDING_TOUR_KEY)).toBe('completed')
+  })
+
+  it('resetTour clears the completion flag so the tour is shown again', () => {
+    markTourCompleted()
+    expect(shouldShowFirstRunTour(true)).toBe(false)
+    resetTour()
+    expect(shouldShowFirstRunTour(true)).toBe(true)
+    expect(localStorage.getItem(ONBOARDING_TOUR_KEY)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a 7-step `OnboardingTour` overlay that auto-launches the first time a
  user opens a connection. Steps cover: welcome, the new-task bar, sessions
  list, long-press / right-click context menu, view modes, the Ship pipeline,
  and the help button. Gated by `localStorage` key
  `minions-ui:onboarding-tour:v1`.
- Adds a `HelpPanel` ("?") drawer reachable from a new header icon on desktop
  and a new menu item on mobile. Lists every surface (List, Kanban, Canvas,
  Ship, long-press, quick actions, slash commands, pull-to-refresh,
  connections) with a one-line explanation, plus a "Replay tour" button that
  clears the completion flag and reopens the tour.
- Existing `App.test.tsx` / `App.viewToggle.test.tsx` set the completion flag
  in `beforeEach` so the auto-trigger doesn't change their semantics.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (1114 / 1114 passing, including 29 new tests across
      `OnboardingTour`, `HelpPanel`, and `App.onboarding`)
- [ ] Manual smoke: clear `localStorage`, open a connection, confirm tour
      auto-shows; click ? in header; click "Replay tour"
- [ ] Mobile: confirm Help item appears in HeaderMenu and opens the panel
