### PR TITLE
feat(chat): surface voice-to-text as primary mode chip

### DIFF
--- a/src/chat/MessageInput.tsx
+++ b/src/chat/MessageInput.tsx
@@ -170,11 +170,17 @@ export function MessageInput({ store, value, onValueChange, onSend }: MessageInp
           )}
         </div>
       )}
+      {micSupported && (
+        <ComposerModes
+          recording={recording}
+          sending={sending}
+          onToggleVoice={handleMicClick}
+        />
+      )}
       <ComposerToolbar
         charCount={charCount}
         isSlash={isSlash}
         sending={sending}
-        recording={recording}
       />
       {imagesSupported && attachmentsStrip}
       <div class="flex items-end gap-2">
@@ -237,12 +243,10 @@ function ComposerToolbar({
   charCount,
   isSlash,
   sending,
-  recording,
 }: {
   charCount: number
   isSlash: boolean
   sending: boolean
-  recording: boolean
 }) {
   return (
     <div
@@ -265,15 +269,6 @@ function ComposerToolbar({
         </span>
       )}
       <span class="ml-auto flex items-center gap-1.5">
-        {recording && (
-          <span
-            class="inline-flex items-center gap-1 text-red-600 dark:text-red-400"
-            data-testid="composer-recording-indicator"
-          >
-            <span class="inline-block h-1.5 w-1.5 rounded-full bg-red-500 animate-pulse" />
-            listening
-          </span>
-        )}
         {sending && (
           <span class="inline-flex items-center gap-1 text-indigo-600 dark:text-indigo-300">
             <span class="inline-block h-1.5 w-1.5 rounded-full bg-indigo-500 animate-pulse" />
@@ -295,6 +290,51 @@ function Kbd({ children }: { children: string }) {
     <kbd class="rounded border border-slate-300 dark:border-slate-600 bg-slate-100 dark:bg-slate-700 px-1.5 py-0.5 font-mono text-[10px] text-slate-600 dark:text-slate-300">
       {children}
     </kbd>
+  )
+}
+
+function ComposerModes({
+  recording,
+  sending,
+  onToggleVoice,
+}: {
+  recording: boolean
+  sending: boolean
+  onToggleVoice: () => void
+}) {
+  return (
+    <div
+      class="flex flex-wrap items-center gap-1.5"
+      data-testid="composer-modes"
+      role="toolbar"
+      aria-label="Input modes"
+    >
+      <button
+        type="button"
+        onClick={onToggleVoice}
+        disabled={sending}
+        aria-pressed={recording}
+        aria-label={recording ? 'Stop voice input' : 'Start voice input'}
+        class={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+          recording
+            ? 'bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300 border-red-300 dark:border-red-700 hover:bg-red-100 dark:hover:bg-red-900/40'
+            : 'bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600 hover:bg-slate-100 dark:hover:bg-slate-600'
+        }`}
+        data-testid="voice-mode-chip"
+      >
+        {recording ? (
+          <>
+            <span class="inline-block h-1.5 w-1.5 rounded-full bg-red-500 animate-pulse" />
+            <span>Listening…</span>
+          </>
+        ) : (
+          <>
+            <MicIcon recording={false} />
+            <span>Voice</span>
+          </>
+        )}
+      </button>
+    </div>
   )
 }
 

--- a/test/chat/MessageInput.test.tsx
+++ b/test/chat/MessageInput.test.tsx
@@ -241,16 +241,134 @@ describe('MessageInput · voice input', () => {
     delete w.webkitSpeechRecognition
     render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} />)
     const mic = screen.getByTestId('mic-btn') as HTMLButtonElement
+    const chip = screen.getByTestId('voice-mode-chip') as HTMLButtonElement
     expect(mic.getAttribute('aria-pressed')).toBe('false')
+    expect(chip.getAttribute('aria-pressed')).toBe('false')
+    expect(chip.textContent).toContain('Voice')
     act(() => {
       fireEvent.click(mic)
     })
     await waitFor(() => expect(mic.getAttribute('aria-pressed')).toBe('true'))
-    expect(screen.getByTestId('composer-recording-indicator')).toBeTruthy()
+    expect(chip.getAttribute('aria-pressed')).toBe('true')
+    expect(chip.textContent).toContain('Listening')
     act(() => {
       fireEvent.click(mic)
     })
     await waitFor(() => expect(mic.getAttribute('aria-pressed')).toBe('false'))
+    expect(chip.textContent).toContain('Voice')
+  })
+
+  it('hides voice mode chip when SpeechRecognition is unsupported', () => {
+    delete w.SpeechRecognition
+    delete w.webkitSpeechRecognition
+    render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} />)
+    expect(screen.queryByTestId('voice-mode-chip')).toBeNull()
+    expect(screen.queryByTestId('composer-modes')).toBeNull()
+  })
+
+  it('voice mode chip toggles recording state and stays in sync with inline mic button', async () => {
+    class FakeRec extends EventTarget implements SpeechRecognition {
+      continuous = false
+      interimResults = false
+      lang = ''
+      maxAlternatives = 1
+      onstart: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null = null
+      onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null = null
+      onend: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      start() {
+        this.onstart?.call(this, new Event('start'))
+      }
+      stop() {
+        this.onend?.call(this, new Event('end'))
+      }
+      abort() {
+        this.onend?.call(this, new Event('end'))
+      }
+    }
+    w.SpeechRecognition = FakeRec as unknown as SpeechRecognitionConstructor
+    delete w.webkitSpeechRecognition
+    render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} />)
+    const chip = screen.getByTestId('voice-mode-chip') as HTMLButtonElement
+    const mic = screen.getByTestId('mic-btn') as HTMLButtonElement
+    expect(chip.getAttribute('aria-label')).toBe('Start voice input')
+    act(() => {
+      fireEvent.click(chip)
+    })
+    await waitFor(() => expect(chip.getAttribute('aria-pressed')).toBe('true'))
+    expect(mic.getAttribute('aria-pressed')).toBe('true')
+    expect(chip.getAttribute('aria-label')).toBe('Stop voice input')
+    act(() => {
+      fireEvent.click(chip)
+    })
+    await waitFor(() => expect(chip.getAttribute('aria-pressed')).toBe('false'))
+    expect(mic.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('voice mode chip is the primary discoverability surface — labeled "Voice" when idle', () => {
+    class FakeRec extends EventTarget implements SpeechRecognition {
+      continuous = false
+      interimResults = false
+      lang = ''
+      maxAlternatives = 1
+      onstart: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null = null
+      onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null = null
+      onend: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      start() {
+        this.onstart?.call(this, new Event('start'))
+      }
+      stop() {
+        this.onend?.call(this, new Event('end'))
+      }
+      abort() {
+        this.onend?.call(this, new Event('end'))
+      }
+    }
+    w.SpeechRecognition = FakeRec as unknown as SpeechRecognitionConstructor
+    delete w.webkitSpeechRecognition
+    render(<Controlled onSend={vi.fn().mockResolvedValue(undefined)} />)
+    const chip = screen.getByTestId('voice-mode-chip') as HTMLButtonElement
+    expect(chip.textContent?.trim()).toContain('Voice')
+    const modes = screen.getByTestId('composer-modes')
+    expect(modes.getAttribute('role')).toBe('toolbar')
+    expect(modes.getAttribute('aria-label')).toBe('Input modes')
+  })
+
+  it('voice mode chip is disabled while sending', async () => {
+    class FakeRec extends EventTarget implements SpeechRecognition {
+      continuous = false
+      interimResults = false
+      lang = ''
+      maxAlternatives = 1
+      onstart: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null = null
+      onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null = null
+      onend: ((this: SpeechRecognition, ev: Event) => void) | null = null
+      start() {
+        this.onstart?.call(this, new Event('start'))
+      }
+      stop() {
+        this.onend?.call(this, new Event('end'))
+      }
+      abort() {
+        this.onend?.call(this, new Event('end'))
+      }
+    }
+    w.SpeechRecognition = FakeRec as unknown as SpeechRecognitionConstructor
+    delete w.webkitSpeechRecognition
+    let resolve: () => void
+    const onSend = vi.fn().mockReturnValue(new Promise<void>((r) => { resolve = r }))
+    render(<Controlled onSend={onSend} />)
+    fireEvent.input(getTextarea(), { target: { value: 'pending' } })
+    act(() => {
+      fireEvent.click(getSendBtn())
+    })
+    await waitFor(() => {
+      const chip = screen.getByTestId('voice-mode-chip') as HTMLButtonElement
+      expect(chip.hasAttribute('disabled')).toBe(true)
+    })
+    act(() => { resolve!() })
   })
 
   it('appends final transcript to existing input', async () => {


### PR DESCRIPTION
## Summary

Voice/speech-to-text already exists in the composer, but it was hidden as an icon-only mic button next to send — invisible until users went looking for it. This PR surfaces voice as a **primary mode chip** above the composer toolbar so the capability is discoverable at a glance.

- New `ComposerModes` row with a labeled "Voice" pill (mic icon + label)
- When recording: chip flips to red "Listening…" with pulsing dot
- Chip is `aria-pressed` toggle, syncs state with the existing inline mic button
- Inline mic button retained as the ergonomic shortcut next to send (especially important for mobile thumb-reach)
- Removed the now-redundant tiny "listening" subtext from the composer toolbar — the chip is now the primary recording-state surface

The chip is hidden when `SpeechRecognition` isn't supported by the browser, matching existing inline-mic behavior.

## Test plan

- [x] Unit: chip renders only when SpeechRecognition is supported
- [x] Unit: chip toggles recording, label flips Voice → Listening…
- [x] Unit: chip and inline mic-btn stay in sync (clicking either toggles both)
- [x] Unit: chip exposes `role="toolbar"` + `aria-label="Input modes"` for AT
- [x] Unit: chip is disabled while a send is pending
- [x] `npm run typecheck && npm run lint && npm run test` (1089 tests pass)
