### PR TITLE
feat(ui): per-DAG-node progress badges + Timeline tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,8 +39,9 @@ import type { ApiSession, AttentionReason, MinionCommand } from './api/types'
 import { HeaderMenu } from './components/HeaderMenu'
 import { MemoryDrawer } from './components/MemoryDrawer'
 import { KanbanView } from './components/KanbanView'
+import { TimelineView } from './components/TimelineView'
 
-export type ViewMode = 'list' | 'canvas' | 'ship' | 'kanban'
+export type ViewMode = 'list' | 'canvas' | 'ship' | 'kanban' | 'timeline'
 
 const showSettings = signal(false)
 const showDrawer = signal(false)
@@ -89,6 +90,18 @@ function ViewToggle({ mode, onChange, showKanban }: { mode: ViewMode; onChange: 
           <span class="hidden sm:inline">Kanban</span>
         </button>
       )}
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === 'timeline'}
+        aria-label="Timeline"
+        onClick={() => onChange('timeline')}
+        class={`${tabClass(mode === 'timeline')} border-l border-slate-300 dark:border-slate-600`}
+        data-testid="view-toggle-timeline"
+      >
+        <span class="sm:hidden" aria-hidden="true">≡</span>
+        <span class="hidden sm:inline">Timeline</span>
+      </button>
       <button
         type="button"
         role="tab"
@@ -693,6 +706,17 @@ function ActiveView() {
               onSessionSelect={handleOpenChat}
             />
           </div>
+        ) : mode === 'timeline' ? (
+          <div class="flex flex-1 min-h-0" data-testid="timeline-pane">
+            <TimelineView
+              store={store}
+              sessions={sessions}
+              dags={dags}
+              sessionId={sessionId}
+              onSelect={selectSession}
+              isDesktop
+            />
+          </div>
         ) : (
           <DesktopBody
             sessions={sessions}
@@ -803,6 +827,35 @@ function ActiveView() {
           </div>
           <div class="flex-1 min-h-0 flex flex-col">
             <ShipPipelineView dags={dags} onOpenChat={handleOpenChat} />
+          </div>
+        </div>
+      )}
+      {!isDesktop.value && mode === 'timeline' && (
+        <div
+          class="fixed inset-0 z-40 bg-slate-50 dark:bg-slate-900 flex flex-col"
+          data-testid="timeline-mobile-modal"
+        >
+          <div class="flex items-center gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0">
+            <span class="text-sm font-medium text-slate-900 dark:text-slate-100">Timeline</span>
+            <button
+              type="button"
+              onClick={() => { viewMode.value = 'list' }}
+              class="ml-auto rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 px-3 py-2.5 text-xs font-medium hover:bg-slate-100 dark:hover:bg-slate-700 min-h-[44px]"
+              data-testid="timeline-mobile-close"
+              aria-label="Close timeline"
+            >
+              Close
+            </button>
+          </div>
+          <div class="flex-1 min-h-0 flex flex-col">
+            <TimelineView
+              store={store}
+              sessions={sessions}
+              dags={dags}
+              sessionId={sessionId}
+              onSelect={selectSession}
+              isDesktop={false}
+            />
           </div>
         </div>
       )}

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -95,6 +95,17 @@ export function HeaderMenu({
           </button>
           <button
             type="button"
+            onClick={() => handleViewChange('timeline')}
+            class={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-slate-100 dark:hover:bg-slate-700 ${
+              viewMode.value === 'timeline' ? 'bg-indigo-50 dark:bg-indigo-950/30 text-indigo-700 dark:text-indigo-300 font-medium' : 'text-slate-700 dark:text-slate-200'
+            }`}
+            data-testid="menu-view-timeline"
+          >
+            <span aria-hidden="true">≡</span>
+            <span>Timeline</span>
+          </button>
+          <button
+            type="button"
             onClick={() => handleViewChange('canvas')}
             class={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-slate-100 dark:hover:bg-slate-700 ${
               viewMode.value === 'canvas' ? 'bg-indigo-50 dark:bg-indigo-950/30 text-indigo-700 dark:text-indigo-300 font-medium' : 'text-slate-700 dark:text-slate-200'

--- a/src/components/SessionLogsPopup.tsx
+++ b/src/components/SessionLogsPopup.tsx
@@ -1,19 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { useEffect } from 'preact/hooks'
 import type { TranscriptStore } from '../state/transcript'
-import type {
-  StatusSeverity,
-  ToolCallEvent,
-  ToolResultEvent,
-  TranscriptEvent,
-  TranscriptEventType,
-  UserMessageEvent,
-  AssistantTextEvent,
-  ThinkingEvent,
-  TurnStartedEvent,
-  TurnCompletedEvent,
-  StatusEvent,
-} from '../api/types'
 import { useTheme } from '../hooks/useTheme'
+import { TimelineLog } from './TimelineLog'
+
+export { formatLogTimestamp, summarizeLogEvent } from './TimelineLog'
 
 interface Props {
   sessionSlug: string
@@ -21,133 +11,9 @@ interface Props {
   onClose: () => void
 }
 
-type FilterSet = ReadonlySet<TranscriptEventType>
-
-const ALL_TYPES: TranscriptEventType[] = [
-  'user_message',
-  'turn_started',
-  'turn_completed',
-  'assistant_text',
-  'thinking',
-  'tool_call',
-  'tool_result',
-  'status',
-]
-
-const TYPE_LABEL: Record<TranscriptEventType, string> = {
-  user_message: 'user',
-  turn_started: 'turn·start',
-  turn_completed: 'turn·end',
-  assistant_text: 'assistant',
-  thinking: 'thinking',
-  tool_call: 'tool',
-  tool_result: 'result',
-  status: 'status',
-}
-
-const TYPE_TONE_LIGHT: Record<TranscriptEventType, string> = {
-  user_message: 'bg-blue-100 text-blue-800',
-  turn_started: 'bg-slate-100 text-slate-700',
-  turn_completed: 'bg-slate-100 text-slate-700',
-  assistant_text: 'bg-indigo-100 text-indigo-800',
-  thinking: 'bg-violet-100 text-violet-800',
-  tool_call: 'bg-amber-100 text-amber-800',
-  tool_result: 'bg-emerald-100 text-emerald-800',
-  status: 'bg-slate-200 text-slate-800',
-}
-
-const TYPE_TONE_DARK: Record<TranscriptEventType, string> = {
-  user_message: 'bg-blue-900/60 text-blue-200',
-  turn_started: 'bg-slate-700 text-slate-300',
-  turn_completed: 'bg-slate-700 text-slate-300',
-  assistant_text: 'bg-indigo-900/60 text-indigo-200',
-  thinking: 'bg-violet-900/60 text-violet-200',
-  tool_call: 'bg-amber-900/60 text-amber-200',
-  tool_result: 'bg-emerald-900/60 text-emerald-200',
-  status: 'bg-slate-600 text-slate-200',
-}
-
-const SEVERITY_TONE_LIGHT: Record<StatusSeverity, string> = {
-  info: 'text-slate-600',
-  warn: 'text-amber-700',
-  error: 'text-red-700',
-}
-
-const SEVERITY_TONE_DARK: Record<StatusSeverity, string> = {
-  info: 'text-slate-300',
-  warn: 'text-amber-300',
-  error: 'text-red-300',
-}
-
-export function formatLogTimestamp(ts: number): string {
-  const d = new Date(ts)
-  const h = String(d.getHours()).padStart(2, '0')
-  const m = String(d.getMinutes()).padStart(2, '0')
-  const s = String(d.getSeconds()).padStart(2, '0')
-  const ms = String(d.getMilliseconds()).padStart(3, '0')
-  return `${h}:${m}:${s}.${ms}`
-}
-
-export function summarizeLogEvent(event: TranscriptEvent): string {
-  switch (event.type) {
-    case 'user_message':
-      return oneLine((event as UserMessageEvent).text)
-    case 'turn_started':
-      return `turn ${event.turn} started (${(event as TurnStartedEvent).trigger})`
-    case 'turn_completed': {
-      const e = event as TurnCompletedEvent
-      const parts: string[] = [`turn ${event.turn} completed`]
-      if (e.errored) parts.push('errored')
-      if (typeof e.totalTokens === 'number') parts.push(`${e.totalTokens} tokens`)
-      if (typeof e.totalCostUsd === 'number') parts.push(`$${e.totalCostUsd.toFixed(4)}`)
-      if (typeof e.durationMs === 'number') parts.push(`${(e.durationMs / 1000).toFixed(1)}s`)
-      return parts.join(' · ')
-    }
-    case 'assistant_text': {
-      const e = event as AssistantTextEvent
-      return `${e.final ? '' : '…'}${oneLine(e.text)}`
-    }
-    case 'thinking': {
-      const e = event as ThinkingEvent
-      return `${e.final ? '' : '…'}${oneLine(e.text)}`
-    }
-    case 'tool_call': {
-      const e = event as ToolCallEvent
-      const name = e.call.name
-      const title = e.call.title ? ` — ${oneLine(e.call.title)}` : ''
-      return `${name}${title}`
-    }
-    case 'tool_result': {
-      const e = event as ToolResultEvent
-      const parts: string[] = [e.result.status]
-      if (e.result.error) parts.push(oneLine(e.result.error))
-      else if (e.result.text) parts.push(oneLine(e.result.text))
-      if (e.result.truncated) parts.push('(truncated)')
-      return parts.join(' · ')
-    }
-    case 'status': {
-      const e = event as StatusEvent
-      return `[${e.severity}] ${e.kind}: ${oneLine(e.message)}`
-    }
-  }
-}
-
-function oneLine(text: string, max = 240): string {
-  const collapsed = text.replace(/\s+/g, ' ').trim()
-  if (collapsed.length <= max) return collapsed
-  return collapsed.slice(0, max) + '…'
-}
-
 export function SessionLogsPopup({ sessionSlug, transcript, onClose }: Props) {
   const theme = useTheme()
   const isDark = theme.value === 'dark'
-  const events = transcript.events.value
-  const loading = transcript.loading.value
-  const error = transcript.error.value
-  const [filter, setFilter] = useState<FilterSet>(() => new Set(ALL_TYPES))
-  const [following, setFollowing] = useState(true)
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const prevCountRef = useRef(0)
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -157,71 +23,10 @@ export function SessionLogsPopup({ sessionSlug, transcript, onClose }: Props) {
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [onClose])
 
-  const filtered = useMemo(
-    () => events.filter((e) => filter.has(e.type)),
-    [events, filter],
-  )
-
-  useEffect(() => {
-    const el = scrollRef.current
-    if (!el) return
-    const prev = prevCountRef.current
-    prevCountRef.current = filtered.length
-    if (filtered.length <= prev) return
-    if (following) el.scrollTop = el.scrollHeight
-  }, [filtered.length, following])
-
-  function handleScroll() {
-    const el = scrollRef.current
-    if (!el) return
-    const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 40
-    if (nearBottom !== following) setFollowing(nearBottom)
-  }
-
-  function toggleType(type: TranscriptEventType) {
-    const next = new Set(filter)
-    if (next.has(type)) next.delete(type)
-    else next.add(type)
-    setFilter(next)
-  }
-
-  function selectAll() {
-    setFilter(new Set(ALL_TYPES))
-  }
-
-  function selectNone() {
-    setFilter(new Set<TranscriptEventType>())
-  }
-
-  async function copyJson() {
-    const payload = JSON.stringify(filtered, null, 2)
-    try {
-      if (typeof navigator !== 'undefined' && navigator.clipboard) {
-        await navigator.clipboard.writeText(payload)
-      }
-    } catch {
-      // clipboard may be unavailable in non-secure contexts; silent no-op
-    }
-  }
-
   const overlayBg = isDark ? 'bg-black/70' : 'bg-black/50'
   const dialogBg = isDark ? 'bg-slate-900' : 'bg-white'
   const borderColor = isDark ? 'border-slate-700' : 'border-slate-200'
   const titleColor = isDark ? 'text-slate-100' : 'text-slate-900'
-  const mutedText = isDark ? 'text-slate-400' : 'text-slate-500'
-  const typeTone = isDark ? TYPE_TONE_DARK : TYPE_TONE_LIGHT
-  const severityTone = isDark ? SEVERITY_TONE_DARK : SEVERITY_TONE_LIGHT
-  const rowHover = isDark ? 'hover:bg-slate-800' : 'hover:bg-slate-50'
-  const pillBase = 'text-[11px] font-medium px-2 py-0.5 rounded-full border transition-colors'
-  const pillOn = isDark
-    ? 'border-indigo-400 bg-indigo-500/20 text-indigo-200'
-    : 'border-indigo-300 bg-indigo-50 text-indigo-700'
-  const pillOff = isDark
-    ? 'border-slate-700 bg-slate-800 text-slate-400 hover:bg-slate-700'
-    : 'border-slate-200 bg-white text-slate-500 hover:bg-slate-100'
-
-  const noneMatching = events.length > 0 && filtered.length === 0
-  const showEmpty = events.length === 0 && !loading && !error
 
   return (
     <div
@@ -241,24 +46,7 @@ export function SessionLogsPopup({ sessionSlug, transcript, onClose }: Props) {
             <h3 id="session-logs-title" class={`text-base font-semibold ${titleColor} truncate`}>
               Logs · {sessionSlug}
             </h3>
-            <div class={`text-[11px] ${mutedText} mt-0.5`} data-testid="session-logs-count">
-              {filtered.length} of {events.length} event{events.length === 1 ? '' : 's'}
-            </div>
           </div>
-          <button
-            type="button"
-            onClick={() => void copyJson()}
-            class={`shrink-0 text-xs font-medium rounded-md border px-2.5 py-1 transition-colors ${
-              isDark
-                ? 'border-slate-600 text-slate-200 hover:bg-slate-700'
-                : 'border-slate-300 text-slate-700 hover:bg-slate-100'
-            }`}
-            data-testid="session-logs-copy"
-            title="Copy filtered events as JSON"
-            disabled={filtered.length === 0}
-          >
-            Copy JSON
-          </button>
           <button
             type="button"
             onClick={onClose}
@@ -271,131 +59,7 @@ export function SessionLogsPopup({ sessionSlug, transcript, onClose }: Props) {
             <span class="text-lg leading-none">&times;</span>
           </button>
         </div>
-
-        <div class={`flex flex-wrap items-center gap-1.5 px-4 py-2 border-b ${borderColor}`}>
-          {ALL_TYPES.map((t) => (
-            <button
-              key={t}
-              type="button"
-              onClick={() => toggleType(t)}
-              class={`${pillBase} ${filter.has(t) ? pillOn : pillOff}`}
-              data-testid={`session-logs-filter-${t}`}
-              aria-pressed={filter.has(t)}
-            >
-              {TYPE_LABEL[t]}
-            </button>
-          ))}
-          <div class="ml-auto flex items-center gap-1">
-            <button
-              type="button"
-              onClick={selectAll}
-              class={`text-[11px] font-medium ${mutedText} hover:underline`}
-              data-testid="session-logs-filter-all"
-            >
-              All
-            </button>
-            <span class={mutedText}>·</span>
-            <button
-              type="button"
-              onClick={selectNone}
-              class={`text-[11px] font-medium ${mutedText} hover:underline`}
-              data-testid="session-logs-filter-none"
-            >
-              None
-            </button>
-          </div>
-        </div>
-
-        <div
-          ref={scrollRef}
-          onScroll={handleScroll}
-          class={`flex-1 min-h-0 overflow-y-auto font-mono text-[11px] leading-relaxed ${
-            isDark ? 'bg-slate-950' : 'bg-slate-50'
-          }`}
-          data-testid="session-logs-body"
-        >
-          {error && (
-            <div
-              class={`px-4 py-3 text-xs ${isDark ? 'text-red-300' : 'text-red-700'}`}
-              data-testid="session-logs-error"
-            >
-              <div class="font-semibold mb-1">Couldn’t load logs</div>
-              <div class="whitespace-pre-wrap break-words">{error}</div>
-              <button
-                type="button"
-                onClick={() => void transcript.reconcile()}
-                class="mt-1.5 text-xs font-medium underline"
-              >
-                Retry
-              </button>
-            </div>
-          )}
-          {loading && events.length === 0 && !error && (
-            <div
-              class={`text-xs italic text-center py-8 ${mutedText}`}
-              data-testid="session-logs-loading"
-            >
-              Loading logs…
-            </div>
-          )}
-          {showEmpty && (
-            <div
-              class={`text-xs italic text-center py-8 ${mutedText}`}
-              data-testid="session-logs-empty"
-            >
-              No events yet.
-            </div>
-          )}
-          {noneMatching && (
-            <div
-              class={`text-xs italic text-center py-8 ${mutedText}`}
-              data-testid="session-logs-no-match"
-            >
-              No events match the current filter.
-            </div>
-          )}
-          {filtered.length > 0 && (
-            <ul class="py-1" data-testid="session-logs-list">
-              {filtered.map((e) => {
-                const severityClass =
-                  e.type === 'status' ? severityTone[(e as StatusEvent).severity] : ''
-                return (
-                  <li
-                    key={e.seq}
-                    class={`flex items-start gap-2 px-4 py-1 ${rowHover}`}
-                    data-testid="session-logs-row"
-                    data-event-type={e.type}
-                    data-event-seq={e.seq}
-                  >
-                    <span
-                      class={`shrink-0 tabular-nums ${mutedText}`}
-                      data-testid="session-logs-row-timestamp"
-                    >
-                      {formatLogTimestamp(e.timestamp)}
-                    </span>
-                    <span
-                      class={`shrink-0 w-14 text-[10px] tabular-nums text-right ${mutedText}`}
-                      title={`turn ${e.turn}`}
-                    >
-                      t{e.turn}#{e.seq}
-                    </span>
-                    <span
-                      class={`shrink-0 text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${typeTone[e.type]}`}
-                    >
-                      {TYPE_LABEL[e.type]}
-                    </span>
-                    <span
-                      class={`flex-1 min-w-0 whitespace-pre-wrap break-words ${severityClass || (isDark ? 'text-slate-200' : 'text-slate-800')}`}
-                      data-testid="session-logs-row-summary"
-                    >
-                      {summarizeLogEvent(e)}
-                    </span>
-                  </li>
-                )
-              })}
-            </ul>
-          )}
-        </div>
+        <TimelineLog transcript={transcript} testIdPrefix="session-logs" />
       </div>
     </div>
   )

--- a/src/components/TimelineLog.tsx
+++ b/src/components/TimelineLog.tsx
@@ -1,0 +1,360 @@
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import type { TranscriptStore } from '../state/transcript'
+import type {
+  StatusSeverity,
+  ToolCallEvent,
+  ToolResultEvent,
+  TranscriptEvent,
+  TranscriptEventType,
+  UserMessageEvent,
+  AssistantTextEvent,
+  ThinkingEvent,
+  TurnStartedEvent,
+  TurnCompletedEvent,
+  StatusEvent,
+} from '../api/types'
+import { useTheme } from '../hooks/useTheme'
+
+const ALL_TYPES: TranscriptEventType[] = [
+  'user_message',
+  'turn_started',
+  'turn_completed',
+  'assistant_text',
+  'thinking',
+  'tool_call',
+  'tool_result',
+  'status',
+]
+
+const TYPE_LABEL: Record<TranscriptEventType, string> = {
+  user_message: 'user',
+  turn_started: 'turn·start',
+  turn_completed: 'turn·end',
+  assistant_text: 'assistant',
+  thinking: 'thinking',
+  tool_call: 'tool',
+  tool_result: 'result',
+  status: 'status',
+}
+
+const TYPE_TONE_LIGHT: Record<TranscriptEventType, string> = {
+  user_message: 'bg-blue-100 text-blue-800',
+  turn_started: 'bg-slate-100 text-slate-700',
+  turn_completed: 'bg-slate-100 text-slate-700',
+  assistant_text: 'bg-indigo-100 text-indigo-800',
+  thinking: 'bg-violet-100 text-violet-800',
+  tool_call: 'bg-amber-100 text-amber-800',
+  tool_result: 'bg-emerald-100 text-emerald-800',
+  status: 'bg-slate-200 text-slate-800',
+}
+
+const TYPE_TONE_DARK: Record<TranscriptEventType, string> = {
+  user_message: 'bg-blue-900/60 text-blue-200',
+  turn_started: 'bg-slate-700 text-slate-300',
+  turn_completed: 'bg-slate-700 text-slate-300',
+  assistant_text: 'bg-indigo-900/60 text-indigo-200',
+  thinking: 'bg-violet-900/60 text-violet-200',
+  tool_call: 'bg-amber-900/60 text-amber-200',
+  tool_result: 'bg-emerald-900/60 text-emerald-200',
+  status: 'bg-slate-600 text-slate-200',
+}
+
+const SEVERITY_TONE_LIGHT: Record<StatusSeverity, string> = {
+  info: 'text-slate-600',
+  warn: 'text-amber-700',
+  error: 'text-red-700',
+}
+
+const SEVERITY_TONE_DARK: Record<StatusSeverity, string> = {
+  info: 'text-slate-300',
+  warn: 'text-amber-300',
+  error: 'text-red-300',
+}
+
+export function formatLogTimestamp(ts: number): string {
+  const d = new Date(ts)
+  const h = String(d.getHours()).padStart(2, '0')
+  const m = String(d.getMinutes()).padStart(2, '0')
+  const s = String(d.getSeconds()).padStart(2, '0')
+  const ms = String(d.getMilliseconds()).padStart(3, '0')
+  return `${h}:${m}:${s}.${ms}`
+}
+
+export function summarizeLogEvent(event: TranscriptEvent): string {
+  switch (event.type) {
+    case 'user_message':
+      return oneLine((event as UserMessageEvent).text)
+    case 'turn_started':
+      return `turn ${event.turn} started (${(event as TurnStartedEvent).trigger})`
+    case 'turn_completed': {
+      const e = event as TurnCompletedEvent
+      const parts: string[] = [`turn ${event.turn} completed`]
+      if (e.errored) parts.push('errored')
+      if (typeof e.totalTokens === 'number') parts.push(`${e.totalTokens} tokens`)
+      if (typeof e.totalCostUsd === 'number') parts.push(`$${e.totalCostUsd.toFixed(4)}`)
+      if (typeof e.durationMs === 'number') parts.push(`${(e.durationMs / 1000).toFixed(1)}s`)
+      return parts.join(' · ')
+    }
+    case 'assistant_text': {
+      const e = event as AssistantTextEvent
+      return `${e.final ? '' : '…'}${oneLine(e.text)}`
+    }
+    case 'thinking': {
+      const e = event as ThinkingEvent
+      return `${e.final ? '' : '…'}${oneLine(e.text)}`
+    }
+    case 'tool_call': {
+      const e = event as ToolCallEvent
+      const name = e.call.name
+      const title = e.call.title ? ` — ${oneLine(e.call.title)}` : ''
+      return `${name}${title}`
+    }
+    case 'tool_result': {
+      const e = event as ToolResultEvent
+      const parts: string[] = [e.result.status]
+      if (e.result.error) parts.push(oneLine(e.result.error))
+      else if (e.result.text) parts.push(oneLine(e.result.text))
+      if (e.result.truncated) parts.push('(truncated)')
+      return parts.join(' · ')
+    }
+    case 'status': {
+      const e = event as StatusEvent
+      return `[${e.severity}] ${e.kind}: ${oneLine(e.message)}`
+    }
+  }
+}
+
+function oneLine(text: string, max = 240): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim()
+  if (collapsed.length <= max) return collapsed
+  return collapsed.slice(0, max) + '…'
+}
+
+type FilterSet = ReadonlySet<TranscriptEventType>
+
+export interface TimelineLogProps {
+  transcript: TranscriptStore
+  testIdPrefix?: string
+}
+
+export function TimelineLog({ transcript, testIdPrefix = 'session-logs' }: TimelineLogProps) {
+  const theme = useTheme()
+  const isDark = theme.value === 'dark'
+  const events = transcript.events.value
+  const loading = transcript.loading.value
+  const error = transcript.error.value
+  const [filter, setFilter] = useState<FilterSet>(() => new Set(ALL_TYPES))
+  const [following, setFollowing] = useState(true)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const prevCountRef = useRef(0)
+
+  const filtered = useMemo(
+    () => events.filter((e) => filter.has(e.type)),
+    [events, filter],
+  )
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const prev = prevCountRef.current
+    prevCountRef.current = filtered.length
+    if (filtered.length <= prev) return
+    if (following) el.scrollTop = el.scrollHeight
+  }, [filtered.length, following])
+
+  function handleScroll() {
+    const el = scrollRef.current
+    if (!el) return
+    const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 40
+    if (nearBottom !== following) setFollowing(nearBottom)
+  }
+
+  function toggleType(type: TranscriptEventType) {
+    const next = new Set(filter)
+    if (next.has(type)) next.delete(type)
+    else next.add(type)
+    setFilter(next)
+  }
+
+  function selectAll() {
+    setFilter(new Set(ALL_TYPES))
+  }
+
+  function selectNone() {
+    setFilter(new Set<TranscriptEventType>())
+  }
+
+  async function copyJson() {
+    const payload = JSON.stringify(filtered, null, 2)
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        await navigator.clipboard.writeText(payload)
+      }
+    } catch {
+      // clipboard may be unavailable in non-secure contexts; silent no-op
+    }
+  }
+
+  const borderColor = isDark ? 'border-slate-700' : 'border-slate-200'
+  const mutedText = isDark ? 'text-slate-400' : 'text-slate-500'
+  const typeTone = isDark ? TYPE_TONE_DARK : TYPE_TONE_LIGHT
+  const severityTone = isDark ? SEVERITY_TONE_DARK : SEVERITY_TONE_LIGHT
+  const rowHover = isDark ? 'hover:bg-slate-800' : 'hover:bg-slate-50'
+  const pillBase = 'text-[11px] font-medium px-2 py-0.5 rounded-full border transition-colors'
+  const pillOn = isDark
+    ? 'border-indigo-400 bg-indigo-500/20 text-indigo-200'
+    : 'border-indigo-300 bg-indigo-50 text-indigo-700'
+  const pillOff = isDark
+    ? 'border-slate-700 bg-slate-800 text-slate-400 hover:bg-slate-700'
+    : 'border-slate-200 bg-white text-slate-500 hover:bg-slate-100'
+
+  const noneMatching = events.length > 0 && filtered.length === 0
+  const showEmpty = events.length === 0 && !loading && !error
+
+  return (
+    <div class="flex flex-col flex-1 min-h-0" data-testid={`${testIdPrefix}-log`}>
+      <div class={`flex flex-wrap items-center gap-1.5 px-4 py-2 border-b ${borderColor}`}>
+        <span
+          class={`text-[11px] tabular-nums ${mutedText}`}
+          data-testid={`${testIdPrefix}-count`}
+        >
+          {filtered.length} of {events.length} event{events.length === 1 ? '' : 's'}
+        </span>
+        <span class={`${mutedText} mx-1`}>·</span>
+        {ALL_TYPES.map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => toggleType(t)}
+            class={`${pillBase} ${filter.has(t) ? pillOn : pillOff}`}
+            data-testid={`${testIdPrefix}-filter-${t}`}
+            aria-pressed={filter.has(t)}
+          >
+            {TYPE_LABEL[t]}
+          </button>
+        ))}
+        <div class="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={selectAll}
+            class={`text-[11px] font-medium ${mutedText} hover:underline`}
+            data-testid={`${testIdPrefix}-filter-all`}
+          >
+            All
+          </button>
+          <span class={mutedText}>·</span>
+          <button
+            type="button"
+            onClick={selectNone}
+            class={`text-[11px] font-medium ${mutedText} hover:underline`}
+            data-testid={`${testIdPrefix}-filter-none`}
+          >
+            None
+          </button>
+          <span class={mutedText}>·</span>
+          <button
+            type="button"
+            onClick={() => void copyJson()}
+            class={`text-[11px] font-medium ${mutedText} hover:underline disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline`}
+            data-testid={`${testIdPrefix}-copy`}
+            title="Copy filtered events as JSON"
+            disabled={filtered.length === 0}
+          >
+            Copy JSON
+          </button>
+        </div>
+      </div>
+
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        class={`flex-1 min-h-0 overflow-y-auto font-mono text-[11px] leading-relaxed ${
+          isDark ? 'bg-slate-950' : 'bg-slate-50'
+        }`}
+        data-testid={`${testIdPrefix}-body`}
+      >
+        {error && (
+          <div
+            class={`px-4 py-3 text-xs ${isDark ? 'text-red-300' : 'text-red-700'}`}
+            data-testid={`${testIdPrefix}-error`}
+          >
+            <div class="font-semibold mb-1">Couldn’t load logs</div>
+            <div class="whitespace-pre-wrap break-words">{error}</div>
+            <button
+              type="button"
+              onClick={() => void transcript.reconcile()}
+              class="mt-1.5 text-xs font-medium underline"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {loading && events.length === 0 && !error && (
+          <div
+            class={`text-xs italic text-center py-8 ${mutedText}`}
+            data-testid={`${testIdPrefix}-loading`}
+          >
+            Loading logs…
+          </div>
+        )}
+        {showEmpty && (
+          <div
+            class={`text-xs italic text-center py-8 ${mutedText}`}
+            data-testid={`${testIdPrefix}-empty`}
+          >
+            No events yet.
+          </div>
+        )}
+        {noneMatching && (
+          <div
+            class={`text-xs italic text-center py-8 ${mutedText}`}
+            data-testid={`${testIdPrefix}-no-match`}
+          >
+            No events match the current filter.
+          </div>
+        )}
+        {filtered.length > 0 && (
+          <ul class="py-1" data-testid={`${testIdPrefix}-list`}>
+            {filtered.map((e) => {
+              const severityClass =
+                e.type === 'status' ? severityTone[(e as StatusEvent).severity] : ''
+              return (
+                <li
+                  key={e.seq}
+                  class={`flex items-start gap-2 px-4 py-1 ${rowHover}`}
+                  data-testid={`${testIdPrefix}-row`}
+                  data-event-type={e.type}
+                  data-event-seq={e.seq}
+                >
+                  <span
+                    class={`shrink-0 tabular-nums ${mutedText}`}
+                    data-testid={`${testIdPrefix}-row-timestamp`}
+                  >
+                    {formatLogTimestamp(e.timestamp)}
+                  </span>
+                  <span
+                    class={`shrink-0 w-14 text-[10px] tabular-nums text-right ${mutedText}`}
+                    title={`turn ${e.turn}`}
+                  >
+                    t{e.turn}#{e.seq}
+                  </span>
+                  <span
+                    class={`shrink-0 text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${typeTone[e.type]}`}
+                  >
+                    {TYPE_LABEL[e.type]}
+                  </span>
+                  <span
+                    class={`flex-1 min-w-0 whitespace-pre-wrap break-words ${severityClass || (isDark ? 'text-slate-200' : 'text-slate-800')}`}
+                    data-testid={`${testIdPrefix}-row-summary`}
+                  >
+                    {summarizeLogEvent(e)}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -1,0 +1,97 @@
+import { useEffect } from 'preact/hooks'
+import type { ApiDagGraph, ApiSession } from '../api/types'
+import type { ConnectionStore } from '../state/types'
+import { SessionList } from './SessionList'
+import { TimelineLog } from './TimelineLog'
+
+export interface TimelineViewProps {
+  store: ConnectionStore
+  sessions: ApiSession[]
+  dags: ApiDagGraph[]
+  sessionId: string | null
+  onSelect: (id: string) => void
+  isDesktop: boolean
+}
+
+export function TimelineView({
+  store,
+  sessions,
+  dags,
+  sessionId,
+  onSelect,
+  isDesktop,
+}: TimelineViewProps) {
+  const selected = sessionId ? sessions.find((s) => s.id === sessionId) ?? null : null
+  const transcript = selected ? store.getTranscript(selected.id) : null
+
+  useEffect(() => {
+    if (!transcript) return
+    void transcript.reconcile()
+  }, [transcript])
+
+  return (
+    <div
+      class="flex flex-1 min-h-0"
+      data-testid="timeline-view"
+      style={{ flexDirection: isDesktop ? 'row' : 'column' }}
+    >
+      {isDesktop ? (
+        <aside
+          class="border-r border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 overflow-y-auto shrink-0 w-72"
+          data-testid="timeline-sidebar"
+        >
+          <SessionList
+            sessions={sessions}
+            dags={dags}
+            activeSessionId={sessionId}
+            onSelect={onSelect}
+            orientation="vertical"
+          />
+        </aside>
+      ) : (
+        sessions.length > 0 && (
+          <div data-testid="timeline-strip" class="shrink-0">
+            <SessionList
+              sessions={sessions}
+              dags={dags}
+              activeSessionId={sessionId}
+              onSelect={onSelect}
+              orientation="horizontal"
+            />
+          </div>
+        )
+      )}
+      <div class="flex flex-col flex-1 min-h-0">
+        {selected && transcript ? (
+          <>
+            <div
+              class="flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shrink-0"
+              data-testid="timeline-session-header"
+            >
+              <span class="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">
+                {selected.slug}
+              </span>
+              {selected.command && (
+                <span class="text-xs text-slate-500 dark:text-slate-400 truncate">
+                  · {selected.command}
+                </span>
+              )}
+            </div>
+            <TimelineLog transcript={transcript} testIdPrefix="timeline" />
+          </>
+        ) : (
+          <div
+            class="flex-1 flex items-center justify-center p-8 bg-slate-50 dark:bg-slate-900"
+            data-testid="timeline-empty"
+          >
+            <div class="text-sm text-slate-500 dark:text-slate-400 text-center">
+              {sessions.length === 0
+                ? 'No sessions yet — start one to see its timeline.'
+                : 'Select a session to view its timeline.'}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/UniverseCanvas.tsx
+++ b/src/components/UniverseCanvas.tsx
@@ -17,7 +17,8 @@ import '@reactflow/core/dist/base.css'
 import '@reactflow/controls/dist/style.css'
 import '@reactflow/minimap/dist/style.css'
 import type { ApiSession, ApiDagGraph, FeedbackMetadata } from '../api/types'
-import { StatusBadge, AttentionIconStack, getStatusColors, getAttentionBorder, formatRelativeTime } from './shared'
+import { StatusBadge, AttentionIconStack, STATUS_CONFIG, getStatusColors, getAttentionBorder, formatRelativeTime } from './shared'
+import type { StatusType } from './shared'
 import { PrLink } from './PrLink'
 import { ContextMenu, useLongPress, useContextMenu } from './ContextMenu'
 import type { ContextMenuActions, DagContext } from './ContextMenu'
@@ -49,10 +50,22 @@ interface UniverseNodeData {
   nodeType: 'dag' | 'parent-child' | 'standalone' | 'ship'
   isDark: boolean
   scale: number
+  dagProgressIndex?: number
+  dagProgressTotal?: number
   onContextMenu: (session: ApiSession, position: { x: number; y: number }) => void
   onNodeClick: (session: ApiSession) => void
   onRetryNode?: (session: ApiSession) => void
   onViewNodeLogs?: (sessionId: string) => void
+}
+
+export function formatDagProgressBadge(
+  index: number,
+  total: number,
+  status: string,
+): string {
+  const config = STATUS_CONFIG[status as StatusType]
+  const label = config?.label ?? status
+  return `${index}/${total} · ${label}`
 }
 
 function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
@@ -182,7 +195,7 @@ function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
           </div>
         </div>
 
-        <div class="flex items-center gap-2 mt-1">
+        <div class="flex items-center gap-2 mt-1 flex-wrap">
           {isRebasing && (
             <span class="inline-flex items-center gap-1.5 text-xs" data-testid="rebasing-indicator">
               <span
@@ -192,6 +205,21 @@ function UniverseNodeComponent({ data }: { data: UniverseNodeData }) {
             </span>
           )}
           <StatusBadge status={status} />
+          {data.dagProgressIndex !== undefined &&
+            data.dagProgressTotal !== undefined &&
+            data.dagProgressTotal > 1 && (
+              <span
+                class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold tabular-nums"
+                style={{
+                  backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.05)',
+                  color: isDark ? 'rgba(229,231,235,0.85)' : 'rgba(31,41,55,0.75)',
+                }}
+                data-testid="dag-progress-badge"
+                title={`Step ${data.dagProgressIndex} of ${data.dagProgressTotal}`}
+              >
+                {formatDagProgressBadge(data.dagProgressIndex, data.dagProgressTotal, data.status)}
+              </span>
+            )}
           {session?.needsAttention && session.attentionReasons.length > 0 && (
             <AttentionIconStack reasons={session.attentionReasons} darkMode={isDark} />
           )}

--- a/src/components/universe-layout.ts
+++ b/src/components/universe-layout.ts
@@ -20,11 +20,34 @@ export type UniverseNode = Node<{
   status: string
   groupId: string
   nodeType: 'dag' | 'parent-child' | 'standalone' | 'ship'
+  dagProgressIndex?: number
+  dagProgressTotal?: number
 }>
 
 export type UniverseEdge = Edge<{
   relationship: EdgeRelationship
 }>
+
+export function topologicalDagOrder(dagNodes: ApiDagNode[]): Map<string, number> {
+  const byId = new Map<string, ApiDagNode>(dagNodes.map((n) => [n.id, n]))
+  const visited = new Set<string>()
+  const order: string[] = []
+
+  function visit(id: string): void {
+    if (visited.has(id)) return
+    const node = byId.get(id)
+    if (!node) return
+    visited.add(id)
+    for (const dep of node.dependencies) visit(dep)
+    order.push(id)
+  }
+
+  for (const node of dagNodes) visit(node.id)
+
+  const result = new Map<string, number>()
+  order.forEach((id, idx) => result.set(id, idx + 1))
+  return result
+}
 
 interface LayoutGroup {
   id: string
@@ -69,6 +92,9 @@ function layoutDagGroup(dag: ApiDagGraph, isDark: boolean): LayoutGroup {
 
   dagre.layout(g)
 
+  const order = topologicalDagOrder(dagNodes)
+  const total = dagNodes.length
+
   const nodes: Node[] = dagNodes.map((dagNode) => {
     const pos = g.node(dagNode.id)
     return {
@@ -85,6 +111,8 @@ function layoutDagGroup(dag: ApiDagGraph, isDark: boolean): LayoutGroup {
         status: dagNode.status,
         groupId: `dag-${dag.id}`,
         nodeType: 'dag' as const,
+        dagProgressIndex: order.get(dagNode.id),
+        dagProgressTotal: total,
       },
     }
   })

--- a/test/components/TimelineView.test.tsx
+++ b/test/components/TimelineView.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/preact'
+import { signal } from '@preact/signals'
+import { TimelineView } from '../../src/components/TimelineView'
+import { createTranscriptStore } from '../../src/state/transcript'
+import type { ApiClient } from '../../src/api/client'
+import type { ApiSession, TranscriptEvent, TranscriptSnapshot } from '../../src/api/types'
+import type { ConnectionStore } from '../../src/state/types'
+
+function makeSession(over: Partial<ApiSession> & { id: string; slug: string }): ApiSession {
+  return {
+    status: 'running',
+    command: '/task test',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...over,
+  }
+}
+
+function makeStore(opts: {
+  sessions: ApiSession[]
+  transcriptForSession?: (id: string) => TranscriptSnapshot | null
+}): ConnectionStore {
+  const transcripts = new Map<
+    string,
+    ReturnType<typeof createTranscriptStore>
+  >()
+  const client: ApiClient = {
+    getTranscript: (slug: string) => {
+      const session = opts.sessions.find((s) => s.slug === slug)
+      const snap = session && opts.transcriptForSession
+        ? opts.transcriptForSession(session.id)
+        : null
+      if (!snap) return new Promise<TranscriptSnapshot>(() => {})
+      return Promise.resolve(snap)
+    },
+  } as unknown as ApiClient
+  return {
+    sessions: signal(opts.sessions),
+    getTranscript: (sessionId: string) => {
+      const existing = transcripts.get(sessionId)
+      if (existing) return existing
+      const sess = opts.sessions.find((s) => s.id === sessionId)
+      if (!sess) return null
+      const store = createTranscriptStore({ client, slug: sess.slug })
+      transcripts.set(sessionId, store)
+      return store
+    },
+  } as unknown as ConnectionStore
+}
+
+const baseEvent = (seq: number, turn = 1) => ({
+  seq,
+  id: `e${seq}`,
+  sessionId: 's1',
+  turn,
+  timestamp: 1_700_000_000_000 + seq,
+})
+
+async function flush() {
+  for (let i = 0; i < 6; i++) await Promise.resolve()
+}
+
+describe('TimelineView', () => {
+  beforeEach(() => {
+    if (!window.matchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn(() => ({
+          matches: false,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        })),
+      })
+    }
+  })
+
+  afterEach(() => cleanup())
+
+  it('shows the empty state when no session is selected', () => {
+    const store = makeStore({ sessions: [makeSession({ id: 's1', slug: 'a' })] })
+    render(
+      <TimelineView
+        store={store}
+        sessions={[makeSession({ id: 's1', slug: 'a' })]}
+        dags={[]}
+        sessionId={null}
+        onSelect={vi.fn()}
+        isDesktop
+      />,
+    )
+    const empty = screen.getByTestId('timeline-empty')
+    expect(empty.textContent).toContain('Select a session')
+  })
+
+  it('shows a no-sessions state when there are no sessions at all', () => {
+    const store = makeStore({ sessions: [] })
+    render(
+      <TimelineView
+        store={store}
+        sessions={[]}
+        dags={[]}
+        sessionId={null}
+        onSelect={vi.fn()}
+        isDesktop
+      />,
+    )
+    const empty = screen.getByTestId('timeline-empty')
+    expect(empty.textContent).toContain('No sessions yet')
+  })
+
+  it('renders the session header and timeline log when a session is selected', async () => {
+    const session = makeSession({ id: 's1', slug: 'brave-fox', command: '/task hello' })
+    const events: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'hi there' },
+    ]
+    const store = makeStore({
+      sessions: [session],
+      transcriptForSession: () => ({
+        session: { sessionId: 's1', startedAt: 1_700_000_000_000, active: true },
+        events,
+        highWaterMark: 1,
+      }),
+    })
+
+    render(
+      <TimelineView
+        store={store}
+        sessions={[session]}
+        dags={[]}
+        sessionId="s1"
+        onSelect={vi.fn()}
+        isDesktop
+      />,
+    )
+
+    expect(screen.getByTestId('timeline-session-header').textContent).toContain('brave-fox')
+
+    await flush()
+    await waitFor(() => {
+      expect(screen.getAllByTestId('timeline-row')).toHaveLength(1)
+    })
+    const row = screen.getByTestId('timeline-row')
+    expect(row.getAttribute('data-event-type')).toBe('user_message')
+  })
+
+  it('renders the desktop sidebar with the session list', () => {
+    const session = makeSession({ id: 's1', slug: 'in-sidebar' })
+    const store = makeStore({ sessions: [session] })
+    render(
+      <TimelineView
+        store={store}
+        sessions={[session]}
+        dags={[]}
+        sessionId={null}
+        onSelect={vi.fn()}
+        isDesktop
+      />,
+    )
+    expect(screen.getByTestId('timeline-sidebar')).toBeTruthy()
+  })
+
+  it('does not render the desktop sidebar on mobile', () => {
+    const session = makeSession({ id: 's1', slug: 'mobile-row' })
+    const store = makeStore({ sessions: [session] })
+    render(
+      <TimelineView
+        store={store}
+        sessions={[session]}
+        dags={[]}
+        sessionId={null}
+        onSelect={vi.fn()}
+        isDesktop={false}
+      />,
+    )
+    expect(screen.queryByTestId('timeline-sidebar')).toBeNull()
+    expect(screen.getByTestId('timeline-strip')).toBeTruthy()
+  })
+
+  it('toggling a filter pill hides matching events', async () => {
+    const session = makeSession({ id: 's1', slug: 'brave-fox' })
+    const events: TranscriptEvent[] = [
+      { ...baseEvent(1), type: 'user_message', text: 'hi' },
+      { ...baseEvent(2), type: 'thinking', blockId: 'b', text: 'pondering', final: true },
+    ]
+    const store = makeStore({
+      sessions: [session],
+      transcriptForSession: () => ({
+        session: { sessionId: 's1', startedAt: 1_700_000_000_000, active: true },
+        events,
+        highWaterMark: 2,
+      }),
+    })
+
+    render(
+      <TimelineView
+        store={store}
+        sessions={[session]}
+        dags={[]}
+        sessionId="s1"
+        onSelect={vi.fn()}
+        isDesktop
+      />,
+    )
+
+    await flush()
+    await waitFor(() => expect(screen.getAllByTestId('timeline-row')).toHaveLength(2))
+    fireEvent.click(screen.getByTestId('timeline-filter-thinking'))
+    await waitFor(() => expect(screen.getAllByTestId('timeline-row')).toHaveLength(1))
+    expect(screen.getByTestId('timeline-row').getAttribute('data-event-type')).toBe('user_message')
+  })
+})

--- a/test/components/UniverseCanvas.test.tsx
+++ b/test/components/UniverseCanvas.test.tsx
@@ -767,4 +767,64 @@ describe('loadPersistedViewport / savePersistedViewport', () => {
     expect(document.body.innerHTML).toContain('Tree')
     expect(document.body.innerHTML).toContain('Feedback')
   })
+
+  it('renders DAG progress badge on multi-node DAG nodes', () => {
+    const dag = createDag({
+      nodes: {
+        a: {
+          id: 'a',
+          slug: 'first',
+          status: 'completed',
+          dependencies: [],
+          dependents: ['b'],
+          session: createSession({ id: 'sess-a', slug: 'first' }),
+        },
+        b: {
+          id: 'b',
+          slug: 'second',
+          status: 'running',
+          dependencies: ['a'],
+          dependents: ['c'],
+          session: createSession({ id: 'sess-b', slug: 'second', status: 'running' }),
+        },
+        c: {
+          id: 'c',
+          slug: 'third',
+          status: 'pending',
+          dependencies: ['b'],
+          dependents: [],
+          session: createSession({ id: 'sess-c', slug: 'third', status: 'pending' }),
+        },
+      },
+    })
+    render(<UniverseCanvas {...defaultProps} dags={[dag]} />)
+    const badges = document.querySelectorAll('[data-testid="dag-progress-badge"]')
+    expect(badges).toHaveLength(3)
+    const labels = Array.from(badges).map((b) => b.textContent)
+    expect(labels).toContain('1/3 · Done')
+    expect(labels).toContain('2/3 · Running')
+    expect(labels).toContain('3/3 · Idle')
+  })
+
+  it('omits the DAG progress badge on single-node DAGs', () => {
+    const dag = createDag({
+      nodes: {
+        only: {
+          id: 'only',
+          slug: 'only',
+          status: 'running',
+          dependencies: [],
+          dependents: [],
+          session: createSession({ id: 'sess-only', slug: 'only' }),
+        },
+      },
+    })
+    render(<UniverseCanvas {...defaultProps} dags={[dag]} />)
+    expect(document.querySelector('[data-testid="dag-progress-badge"]')).toBeFalsy()
+  })
+
+  it('omits the DAG progress badge on standalone (non-DAG) sessions', () => {
+    render(<UniverseCanvas {...defaultProps} sessions={[createSession()]} />)
+    expect(document.querySelector('[data-testid="dag-progress-badge"]')).toBeFalsy()
+  })
 })

--- a/test/components/dag-progress.test.ts
+++ b/test/components/dag-progress.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest'
+import { topologicalDagOrder } from '../../src/components/universe-layout'
+import { formatDagProgressBadge } from '../../src/components/UniverseCanvas'
+import type { ApiDagNode } from '../../src/api/types'
+
+vi.mock('@reactflow/core', () => ({
+  MarkerType: { ArrowClosed: 'arrowClosed' },
+  ReactFlow: () => null,
+  ReactFlowProvider: ({ children }: { children: unknown }) => children,
+  useReactFlow: () => ({ setCenter: vi.fn(), fitBounds: vi.fn(), fitView: vi.fn() }),
+  useNodesState: (init: unknown) => [init, vi.fn(), vi.fn()],
+  useEdgesState: (init: unknown) => [init, vi.fn(), vi.fn()],
+  Handle: () => null,
+  Position: { Top: 'top', Bottom: 'bottom' },
+}))
+
+vi.mock('@reactflow/background', () => ({ Background: () => null }))
+vi.mock('@reactflow/controls', () => ({ Controls: () => null }))
+vi.mock('@reactflow/minimap', () => ({ MiniMap: () => null }))
+
+function node(
+  id: string,
+  deps: string[] = [],
+  status: ApiDagNode['status'] = 'pending',
+): ApiDagNode {
+  return { id, slug: id, status, dependencies: deps, dependents: [] }
+}
+
+describe('topologicalDagOrder', () => {
+  it('returns 1-based order for a linear chain', () => {
+    const order = topologicalDagOrder([node('c', ['b']), node('b', ['a']), node('a')])
+    expect(order.get('a')).toBe(1)
+    expect(order.get('b')).toBe(2)
+    expect(order.get('c')).toBe(3)
+  })
+
+  it('handles diamond dependencies (a -> b,c -> d)', () => {
+    const order = topologicalDagOrder([
+      node('a'),
+      node('b', ['a']),
+      node('c', ['a']),
+      node('d', ['b', 'c']),
+    ])
+    expect(order.get('a')).toBe(1)
+    expect(order.get('d')).toBe(4)
+    expect(order.get('b')).toBeLessThan(order.get('d')!)
+    expect(order.get('c')).toBeLessThan(order.get('d')!)
+  })
+
+  it('handles independent nodes (preserves input order on ties)', () => {
+    const order = topologicalDagOrder([node('x'), node('y'), node('z')])
+    expect(order.size).toBe(3)
+    expect(new Set([order.get('x'), order.get('y'), order.get('z')])).toEqual(new Set([1, 2, 3]))
+  })
+
+  it('skips dangling dependencies that point to missing nodes', () => {
+    const order = topologicalDagOrder([node('only', ['ghost'])])
+    expect(order.get('only')).toBe(1)
+    expect(order.size).toBe(1)
+  })
+
+  it('returns an empty map for an empty input', () => {
+    expect(topologicalDagOrder([]).size).toBe(0)
+  })
+})
+
+describe('formatDagProgressBadge', () => {
+  it('formats with the human-readable status label', () => {
+    expect(formatDagProgressBadge(3, 7, 'running')).toBe('3/7 · Running')
+    expect(formatDagProgressBadge(1, 2, 'completed')).toBe('1/2 · Done')
+    expect(formatDagProgressBadge(2, 4, 'ci-pending')).toBe('2/4 · CI Pending')
+  })
+
+  it('falls back to the raw status when not in STATUS_CONFIG', () => {
+    expect(formatDagProgressBadge(1, 1, 'unknown-status')).toBe('1/1 · unknown-status')
+  })
+})

--- a/test/components/universe-layout.test.ts
+++ b/test/components/universe-layout.test.ts
@@ -720,6 +720,47 @@ describe('universe-layout', () => {
     expect(cross?.animated).toBe(false)
   })
 
+  it('attaches dagProgressIndex and dagProgressTotal to DAG nodes', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const dag = makeDag({
+      id: 'dag-1',
+      nodes: {
+        a: { id: 'a', slug: 'first', status: 'completed', dependencies: [], dependents: ['b'] },
+        b: { id: 'b', slug: 'second', status: 'running', dependencies: ['a'], dependents: ['c'] },
+        c: { id: 'c', slug: 'third', status: 'pending', dependencies: ['b'], dependents: [] },
+      },
+    })
+
+    const result = layoutUniverse([], [dag], false)
+
+    expect(result.nodes).toHaveLength(3)
+    for (const n of result.nodes) {
+      expect(n.data.dagProgressTotal).toBe(3)
+    }
+    const a = result.nodes.find((n) => n.id === 'a')!
+    const b = result.nodes.find((n) => n.id === 'b')!
+    const c = result.nodes.find((n) => n.id === 'c')!
+    expect(a.data.dagProgressIndex).toBe(1)
+    expect(b.data.dagProgressIndex).toBe(2)
+    expect(c.data.dagProgressIndex).toBe(3)
+  })
+
+  it('does not attach DAG progress fields to standalone or parent-child nodes', async () => {
+    const { layoutUniverse } = await import('../../src/components/universe-layout')
+    const sessions = [
+      makeSession({ id: 'p', slug: 'parent', childIds: ['c'] }),
+      makeSession({ id: 'c', slug: 'child', parentId: 'p' }),
+      makeSession({ id: 'solo', slug: 'solo' }),
+    ]
+
+    const result = layoutUniverse(sessions, [], false)
+
+    for (const n of result.nodes) {
+      expect(n.data.dagProgressIndex).toBeUndefined()
+      expect(n.data.dagProgressTotal).toBeUndefined()
+    }
+  })
+
   it('renders ship coordinator (mode=ship) with stage in ship group', async () => {
     const { layoutUniverse } = await import('../../src/components/universe-layout')
     const coordinator = makeSession({


### PR DESCRIPTION
## Summary

Two new UI affordances aimed at making long-running DAG/agent work easier to follow:

- **Progress badges on DAG nodes (Canvas).** Each DAG node now carries a 1-based topological index plus the DAG's total node count and renders a small pill: e.g. `3/7 · Running`, `2/7 · CI Pending`. Single-node DAGs and standalone sessions are unchanged.
- **Timeline tab.** A new tab (`☰ Timeline`) sits next to List / Kanban / Canvas / Ship and shows a vertical, scrollable transcript event log per session — turn boundaries, tool calls, status events, etc. — with the same filter pills, follow-tail, and copy-JSON affordances as the existing logs popup.

To avoid duplication, the existing `SessionLogsPopup` was refactored to wrap a new shared `TimelineLog` component. Same `data-testid` surface, same behavior.

### Files

- `src/components/universe-layout.ts` — exports `topologicalDagOrder()`; DAG groups attach `dagProgressIndex` / `dagProgressTotal` to each node's data.
- `src/components/UniverseCanvas.tsx` — renders the new `dag-progress-badge` pill; exports `formatDagProgressBadge()`.
- `src/components/TimelineLog.tsx` (new) — extracted, parameterized `testIdPrefix` so the popup keeps its `session-logs-*` ids and the new tab uses `timeline-*`.
- `src/components/TimelineView.tsx` (new) — sidebar (desktop) / strip (mobile) + `TimelineLog` for the selected session.
- `src/components/SessionLogsPopup.tsx` — now a thin modal shell over `TimelineLog`.
- `src/App.tsx` — `'timeline'` added to `ViewMode`; tab button + desktop `timeline-pane` + mobile `timeline-mobile-modal`.
- `src/components/HeaderMenu.tsx` — adds `menu-view-timeline` for the mobile burger menu.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 1103 passed, 0 failed (existing `SessionLogsPopup` tests still pass after the refactor; new tests cover `topologicalDagOrder`, `formatDagProgressBadge`, badge rendering on multi-node / single-node / standalone, and `TimelineView` empty / populated / mobile / filter behavior).
- [ ] Spot-check on a live minion: open the Timeline tab on a running session, verify events stream in; open the Canvas on a multi-node DAG, verify progress pills appear and update as nodes transition.

