### PR TITLE
feat(notifications): inbox + browser notifications for session transitions

### DIFF
--- a/e2e/tests/multi-connection.spec.ts
+++ b/e2e/tests/multi-connection.spec.ts
@@ -61,7 +61,7 @@ test.describe('multi-connection', () => {
       await page.getByPlaceholder('My minion').fill('Minion Beta')
       await page.getByPlaceholder('https://your-minion.fly.dev').fill(mockB.url)
       await page.getByPlaceholder('bearer token').fill(mockB.token)
-      await page.getByRole('button', { name: 'Connect' }).click()
+      await page.getByTestId('connections-drawer').getByRole('button', { name: 'Connect', exact: true }).click()
 
       await page.getByTestId('drawer-close-btn').click()
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,10 @@ import { HeaderMenu } from './components/HeaderMenu'
 import { MemoryDrawer } from './components/MemoryDrawer'
 import { KanbanView } from './components/KanbanView'
 import { TimelineView } from './components/TimelineView'
+import { InboxButton } from './components/InboxButton'
+import { InboxSheet } from './components/InboxPanel'
+import { NotificationsToggle } from './pwa/NotificationsToggle'
+import type { InboxEvent } from './state/inbox'
 
 export type ViewMode = 'list' | 'canvas' | 'ship' | 'kanban' | 'timeline'
 
@@ -49,6 +53,7 @@ const showRuntime = signal<RuntimeTab | null>(null)
 const showMemory = signal(false)
 const showPalette = signal(false)
 const showShortcutsHelp = signal(false)
+const showInboxSheet = signal(false)
 export const viewMode = signal<ViewMode>('list')
 
 function ViewToggle({ mode, onChange, showKanban }: { mode: ViewMode; onChange: (m: ViewMode) => void; showKanban?: boolean }) {
@@ -492,6 +497,13 @@ function ActiveView() {
     viewMode.value = 'list'
   }, [selectSession])
 
+  const handleInboxSelect = useCallback(
+    (_connectionId: string, event: InboxEvent) => {
+      handleOpenChat(event.sessionId)
+    },
+    [handleOpenChat],
+  )
+
   const handleOpenLogs = useCallback((sid: string) => {
     setLogsSessionId(sid)
   }, [])
@@ -608,6 +620,8 @@ function ActiveView() {
           <div class="ml-auto flex items-center gap-1 sm:gap-1.5 shrink-0">
             <ViewToggle mode={mode} onChange={(m) => { viewMode.value = m }} showKanban={false} />
             <ThemeToggle />
+            <InboxButton onSelectEvent={handleInboxSelect} />
+            <NotificationsToggle variant="header" />
             {hasFeature(store, 'memory') && (
               <button
                 type="button"
@@ -671,6 +685,7 @@ function ActiveView() {
               onRuntimeConfig={hasFeature(store, 'runtime-config') ? () => { showRuntime.value = 'config' } : undefined}
               onClean={hasFeature(store, 'messages') ? handleClean : undefined}
               onRefresh={() => void store.refresh()}
+              onInbox={() => { showInboxSheet.value = true }}
               showMemory={hasFeature(store, 'memory')}
               memoryProposalsCount={store.memoryProposalsCount.value}
               showRuntimeConfig={hasFeature(store, 'runtime-config')}
@@ -919,6 +934,13 @@ function ActiveView() {
         open={showShortcutsHelp.value}
         onClose={() => { showShortcutsHelp.value = false }}
       />
+      {showInboxSheet.value && id && (
+        <InboxSheet
+          connectionId={id}
+          onClose={() => { showInboxSheet.value = false }}
+          onSelect={(event) => handleInboxSelect(id, event)}
+        />
+      )}
       {logsSessionId !== null && (() => {
         const logsSession = sessions.find((s) => s.id === logsSessionId)
         const transcript = logsSession ? store.getTranscript(logsSession.id) : null

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -1,8 +1,11 @@
-import { signal } from '@preact/signals'
+import { signal, useComputed } from '@preact/signals'
 import { useEffect, useRef } from 'preact/hooks'
 import { ThemeToggle } from '../chat/ThemeToggle'
 import type { ViewMode } from '../App'
 import { viewMode } from '../App'
+import { connections } from '../connections/store'
+import { inboxSignal } from '../state/inbox'
+import { NotificationsToggle } from '../pwa/NotificationsToggle'
 
 const menuOpen = signal(false)
 
@@ -13,6 +16,7 @@ export function HeaderMenu({
   onRuntimeConfig,
   onClean,
   onRefresh,
+  onInbox,
   showMemory,
   memoryProposalsCount,
   showRuntimeConfig,
@@ -23,6 +27,7 @@ export function HeaderMenu({
   onRuntimeConfig?: () => void
   onClean?: () => void
   onRefresh: () => void
+  onInbox?: () => void
   showMemory: boolean
   memoryProposalsCount?: number
   showRuntimeConfig: boolean
@@ -30,6 +35,14 @@ export function HeaderMenu({
   cleaning: boolean
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
+
+  const totalUnseen = useComputed(() => {
+    let total = 0
+    for (const conn of connections.value) {
+      total += inboxSignal(conn.id).value.unseenCount
+    }
+    return total
+  })
 
   useEffect(() => {
     if (!menuOpen.value) return
@@ -131,6 +144,32 @@ export function HeaderMenu({
             <span class="text-sm text-slate-700 dark:text-slate-200">Theme</span>
             <ThemeToggle />
           </div>
+          {onInbox && (
+            <>
+              <div class="border-t border-slate-200 dark:border-slate-700 my-1" />
+              <button
+                type="button"
+                onClick={() => {
+                  onInbox()
+                  closeMenu()
+                }}
+                class="w-full flex items-center gap-3 px-3 py-2 text-sm text-left text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+                data-testid="menu-inbox"
+              >
+                <span aria-hidden="true">📥</span>
+                <span>Activity</span>
+                {totalUnseen.value > 0 && (
+                  <span
+                    class="ml-auto rounded-full bg-indigo-600 text-white text-xs font-medium px-2 py-0.5"
+                    data-testid="menu-inbox-badge"
+                  >
+                    {totalUnseen.value}
+                  </span>
+                )}
+              </button>
+            </>
+          )}
+          <NotificationsToggle variant="menu" />
           {showMemory && onMemory && (
             <>
               <div class="border-t border-slate-200 dark:border-slate-700 my-1" />

--- a/src/components/InboxButton.tsx
+++ b/src/components/InboxButton.tsx
@@ -1,0 +1,67 @@
+import { useSignal, useComputed } from '@preact/signals'
+import { useRef, useCallback } from 'preact/hooks'
+import { connections, activeId } from '../connections/store'
+import { inboxSignal, type InboxEvent } from '../state/inbox'
+import { InboxPanel } from './InboxPanel'
+
+interface InboxButtonProps {
+  onSelectEvent?: (connectionId: string, event: InboxEvent) => void
+}
+
+export function InboxButton({ onSelectEvent }: InboxButtonProps) {
+  const open = useSignal(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const totalUnseen = useComputed(() => {
+    let total = 0
+    for (const conn of connections.value) {
+      total += inboxSignal(conn.id).value.unseenCount
+    }
+    return total
+  })
+
+  const handleSelect = useCallback(
+    (event: InboxEvent) => {
+      const id = activeId.value
+      if (id) onSelectEvent?.(id, event)
+    },
+    [onSelectEvent],
+  )
+
+  const id = activeId.value
+  const totalEvents = useComputed(() => (id ? inboxSignal(id).value.events.length : 0))
+
+  return (
+    <div class="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => { open.value = !open.value }}
+        disabled={!id}
+        aria-haspopup="dialog"
+        aria-expanded={open.value}
+        class="relative rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 min-h-[44px] min-w-[44px] flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        title={totalEvents.value === 0 ? 'No recent activity' : 'Recent activity since last visit'}
+        aria-label="Open inbox"
+        data-testid="header-inbox-btn"
+      >
+        <span aria-hidden="true">📥</span>
+        {totalUnseen.value > 0 && (
+          <span
+            class="absolute -top-1 -right-1 rounded-full bg-indigo-600 text-white text-[10px] font-medium px-1 min-w-[16px] h-4 flex items-center justify-center"
+            data-testid="inbox-total-unseen-badge"
+            aria-label={`${totalUnseen.value} unseen`}
+          >
+            {totalUnseen.value}
+          </span>
+        )}
+      </button>
+      {open.value && id && (
+        <InboxPanel
+          connectionId={id}
+          onClose={() => { open.value = false }}
+          onSelect={handleSelect}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/InboxPanel.tsx
+++ b/src/components/InboxPanel.tsx
@@ -1,0 +1,194 @@
+import { useComputed } from '@preact/signals'
+import { useEffect, useRef } from 'preact/hooks'
+import { inboxSignal, type InboxEvent, type InboxEventKind } from '../state/inbox'
+
+interface InboxListProps {
+  connectionId: string
+  onSelect?: (event: InboxEvent) => void
+}
+
+interface InboxPanelProps extends InboxListProps {
+  onClose: () => void
+}
+
+const KIND_LABELS: Record<InboxEventKind, string> = {
+  completed: 'completed',
+  failed: 'failed',
+  attention: 'needs attention',
+  landed: 'PR opened',
+}
+
+const KIND_COLORS: Record<InboxEventKind, string> = {
+  completed: 'bg-green-500',
+  failed: 'bg-red-500',
+  attention: 'bg-amber-500',
+  landed: 'bg-indigo-500',
+}
+
+function formatRelative(now: number, ts: number): string {
+  const diff = Math.max(0, now - ts)
+  const sec = Math.floor(diff / 1000)
+  if (sec < 60) return `${sec}s ago`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const days = Math.floor(hr / 24)
+  return `${days}d ago`
+}
+
+export function InboxList({ connectionId, onSelect }: InboxListProps) {
+  const inbox = useComputed(() => inboxSignal(connectionId).value)
+  const now = Date.now()
+  const events = inbox.value.events
+  const lastSeenAt = inbox.value.lastSeenAt
+
+  if (events.length === 0) {
+    return (
+      <div
+        class="px-3 py-6 text-xs text-slate-500 dark:text-slate-400 text-center"
+        data-testid="inbox-empty"
+      >
+        Nothing new since your last visit.
+      </div>
+    )
+  }
+
+  return (
+    <ul class="max-h-[60dvh] overflow-y-auto divide-y divide-slate-100 dark:divide-slate-700">
+      {events.map((event) => {
+        const unseen = event.ts > lastSeenAt
+        return (
+          <li key={event.id}>
+            <button
+              type="button"
+              onClick={() => onSelect?.(event)}
+              data-testid={`inbox-item-${event.id}`}
+              data-unseen={unseen ? 'true' : 'false'}
+              class={`w-full flex items-start gap-2 px-3 py-2.5 text-left text-xs hover:bg-slate-50 dark:hover:bg-slate-700 ${unseen ? 'bg-indigo-50/50 dark:bg-indigo-900/20' : ''}`}
+            >
+              <span
+                class={`mt-1 h-2 w-2 rounded-full shrink-0 ${KIND_COLORS[event.kind]}`}
+                aria-hidden="true"
+              />
+              <span class="flex-1 min-w-0">
+                <span class="block font-mono text-slate-900 dark:text-slate-100 truncate">
+                  {event.sessionSlug}
+                </span>
+                <span class="block text-slate-500 dark:text-slate-400">
+                  {KIND_LABELS[event.kind]} · {formatRelative(now, event.ts)}
+                </span>
+              </span>
+              {unseen && (
+                <span
+                  class="mt-1 h-1.5 w-1.5 rounded-full bg-indigo-500 shrink-0"
+                  aria-label="unseen"
+                  data-testid="inbox-item-unseen-dot"
+                />
+              )}
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export function InboxPanel({ connectionId, onClose, onSelect }: InboxPanelProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    const onMouseDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onMouseDown)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onMouseDown)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      ref={containerRef}
+      class="absolute right-0 top-full mt-1 z-50 min-w-[280px] max-w-[360px] rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-lg overflow-hidden"
+      data-testid="inbox-panel"
+      role="dialog"
+      aria-label="Activity since last visit"
+    >
+      <div class="px-3 py-2 border-b border-slate-100 dark:border-slate-700 flex items-center justify-between">
+        <span class="text-xs font-semibold text-slate-700 dark:text-slate-200">
+          Recent activity
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          class="text-xs text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 px-2 py-1 rounded"
+          data-testid="inbox-panel-close"
+          aria-label="Close inbox"
+        >
+          Close
+        </button>
+      </div>
+      <InboxList
+        connectionId={connectionId}
+        onSelect={(event) => {
+          onSelect?.(event)
+          onClose()
+        }}
+      />
+    </div>
+  )
+}
+
+export function InboxSheet({ connectionId, onClose, onSelect }: InboxPanelProps) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div class="fixed inset-x-0 top-0 z-50 h-[100dvh]" data-testid="inbox-sheet">
+      <div
+        class="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        data-testid="inbox-sheet-backdrop"
+      />
+      <div class="absolute bottom-0 left-0 right-0 rounded-t-2xl shadow-2xl flex flex-col border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 max-h-[75dvh]">
+        <div class="flex justify-center pt-2 pb-1 shrink-0">
+          <div class="w-10 h-1 rounded-full bg-slate-300 dark:bg-slate-600" />
+        </div>
+        <div class="px-4 py-2 border-b border-slate-200 dark:border-slate-700 shrink-0 flex items-center justify-between">
+          <h3 class="text-sm font-semibold text-slate-900 dark:text-slate-100">Recent activity</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            class="text-xs text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 px-2 py-1 rounded min-h-[44px]"
+            data-testid="inbox-sheet-close"
+            aria-label="Close inbox"
+          >
+            Close
+          </button>
+        </div>
+        <div class="flex-1 overflow-y-auto">
+          <InboxList
+            connectionId={connectionId}
+            onSelect={(event) => {
+              onSelect?.(event)
+              onClose()
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/connections/ConnectionPicker.tsx
+++ b/src/connections/ConnectionPicker.tsx
@@ -5,6 +5,7 @@ import { useMediaQuery } from '../hooks/useMediaQuery'
 import { useSwipeToDismiss } from '../hooks/useSwipeToDismiss'
 import { useHaptics } from '../hooks/useHaptics'
 import { computeConnectionStats, type ConnectionStats } from './stats'
+import { inboxSignal } from '../state/inbox'
 
 interface ConnectionPickerProps {
   onManage: () => void
@@ -18,6 +19,14 @@ export function ConnectionPicker({ onManage }: ConnectionPickerProps) {
   const isDesktop = useMediaQuery('(min-width: 768px)')
   const activeConn = connections.value.find((c) => c.id === activeId.value) ?? null
   const { vibrate } = useHaptics()
+
+  const inboxCounts = useComputed<Map<string, number>>(() => {
+    const counts = new Map<string, number>()
+    for (const conn of connections.value) {
+      counts.set(conn.id, inboxSignal(conn.id).value.unseenCount)
+    }
+    return counts
+  })
 
   const connectionStats = useComputed<Map<string, ConnectionStats>>(() => {
     const stores = getAllStores()
@@ -176,6 +185,20 @@ export function ConnectionPicker({ onManage }: ConnectionPickerProps) {
                 )}
               </span>
               <span class="truncate flex-1 min-w-0">{conn.label}</span>
+              {(() => {
+                const unseen = inboxCounts.value.get(conn.id) ?? 0
+                if (unseen <= 0) return null
+                return (
+                  <span
+                    class="shrink-0 inline-flex items-center justify-center rounded-full bg-indigo-500 text-white text-[10px] font-semibold tabular-nums px-1.5 min-w-[18px] h-[18px]"
+                    data-testid={`picker-inbox-count-${conn.id}`}
+                    aria-label={`${unseen} new`}
+                    title={`${unseen} new since last visit`}
+                  >
+                    +{unseen}
+                  </span>
+                )
+              })()}
               {stats?.dagProgress && (
                 <span
                   class="shrink-0 flex items-center gap-1 text-[10px] tabular-nums text-slate-500 dark:text-slate-400"

--- a/src/connections/store.ts
+++ b/src/connections/store.ts
@@ -5,6 +5,7 @@ import { clearSnapshot } from '../state/persist'
 import type { ConnectionStore } from '../state/types'
 import type { Connection, ConnectionsState } from './types'
 import { nextColor } from '../theme/colors'
+import { clearInbox, markInboxSeen } from '../state/inbox'
 
 const STORAGE_KEY = 'minions-ui:connections:v1'
 
@@ -47,7 +48,9 @@ function getOrCreateStore(id: string): ConnectionStore {
   const conn = connections.value.find((c) => c.id === id)
   if (!conn) throw new Error(`Connection ${id} not found`)
   const client = createApiClient({ baseUrl: conn.baseUrl, token: conn.token })
-  const store = createConnectionStore(client, id)
+  const store = createConnectionStore(client, id, {
+    isActive: () => activeId.value === id,
+  })
   storeCache.set(id, store)
   return store
 }
@@ -78,6 +81,7 @@ export function removeConnection(id: string): void {
   connections.value = connections.value.filter((c) => c.id !== id)
   if (activeId.value === id) activeId.value = null
   saveState()
+  clearInbox(id)
   void clearSnapshot(id)
 }
 
@@ -91,7 +95,10 @@ export function setActive(id: string | null): void {
     }
   }
   activeId.value = id
-  if (id) getOrCreateStore(id)
+  if (id) {
+    getOrCreateStore(id)
+    markInboxSeen(id)
+  }
   saveState()
 }
 

--- a/src/pwa/NotificationsToggle.tsx
+++ b/src/pwa/NotificationsToggle.tsx
@@ -1,0 +1,72 @@
+import { useSignal } from '@preact/signals'
+import {
+  disableLocalNotifications,
+  enableLocalNotifications,
+  getLocalNotificationsPermission,
+  isLocalNotificationsSupported,
+  localNotificationsEnabled,
+} from './local-notifications'
+
+interface NotificationsToggleProps {
+  variant?: 'header' | 'menu'
+}
+
+export function NotificationsToggle({ variant = 'header' }: NotificationsToggleProps) {
+  if (!isLocalNotificationsSupported()) return null
+
+  const enabled = localNotificationsEnabled()
+  const busy = useSignal(false)
+
+  const handleToggle = async () => {
+    if (busy.value) return
+    busy.value = true
+    try {
+      if (enabled.value) {
+        disableLocalNotifications()
+      } else {
+        await enableLocalNotifications()
+      }
+    } finally {
+      busy.value = false
+    }
+  }
+
+  const permission = getLocalNotificationsPermission()
+  const denied = permission === 'denied'
+
+  if (variant === 'menu') {
+    return (
+      <button
+        type="button"
+        onClick={() => void handleToggle()}
+        disabled={busy.value || (denied && !enabled.value)}
+        class="w-full flex items-center gap-3 px-3 py-2 text-sm text-left text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50"
+        data-testid="menu-notifications-toggle"
+      >
+        <span aria-hidden="true">{enabled.value ? '🔔' : '🔕'}</span>
+        <span>{denied && !enabled.value ? 'Notifications blocked' : enabled.value ? 'Notifications on' : 'Enable notifications'}</span>
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void handleToggle()}
+      disabled={busy.value || (denied && !enabled.value)}
+      class="rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 min-h-[44px] min-w-[44px] flex items-center justify-center text-xs hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+      title={
+        denied && !enabled.value
+          ? 'Browser permission blocked — re-enable in browser settings'
+          : enabled.value
+            ? 'Notifications on (click to disable)'
+            : 'Enable browser notifications for session updates'
+      }
+      aria-label={enabled.value ? 'Disable notifications' : 'Enable notifications'}
+      aria-pressed={enabled.value}
+      data-testid="header-notifications-toggle"
+    >
+      <span aria-hidden="true">{enabled.value ? '🔔' : '🔕'}</span>
+    </button>
+  )
+}

--- a/src/pwa/local-notifications.ts
+++ b/src/pwa/local-notifications.ts
@@ -1,0 +1,125 @@
+import { signal, type ReadonlySignal } from '@preact/signals'
+
+const ENABLED_KEY = 'minions-ui:local-notifications-enabled:v1'
+
+export type LocalNotificationPermission = NotificationPermission | 'unsupported'
+
+const enabledSignal = signal<boolean>(loadEnabled())
+
+function loadEnabled(): boolean {
+  try {
+    return localStorage.getItem(ENABLED_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function saveEnabled(value: boolean): void {
+  try {
+    localStorage.setItem(ENABLED_KEY, value ? '1' : '0')
+  } catch {
+    // ignore
+  }
+}
+
+export function isLocalNotificationsSupported(): boolean {
+  return typeof Notification !== 'undefined'
+}
+
+export function getLocalNotificationsPermission(): LocalNotificationPermission {
+  if (!isLocalNotificationsSupported()) return 'unsupported'
+  return Notification.permission
+}
+
+export function localNotificationsEnabled(): ReadonlySignal<boolean> {
+  return enabledSignal
+}
+
+export function isLocalNotificationsEnabled(): boolean {
+  return enabledSignal.value
+}
+
+export async function requestLocalNotificationsPermission(): Promise<LocalNotificationPermission> {
+  if (!isLocalNotificationsSupported()) return 'unsupported'
+  if (Notification.permission === 'granted' || Notification.permission === 'denied') {
+    return Notification.permission
+  }
+  return Notification.requestPermission()
+}
+
+export async function enableLocalNotifications(): Promise<{
+  ok: boolean
+  permission: LocalNotificationPermission
+}> {
+  const permission = await requestLocalNotificationsPermission()
+  const ok = permission === 'granted'
+  if (ok) {
+    enabledSignal.value = true
+    saveEnabled(true)
+  }
+  return { ok, permission }
+}
+
+export function disableLocalNotifications(): void {
+  enabledSignal.value = false
+  saveEnabled(false)
+}
+
+export interface LocalNotificationOptions {
+  title: string
+  body?: string
+  tag?: string
+  onClick?: () => void
+}
+
+export interface LocalNotificationContext {
+  documentVisible?: boolean
+}
+
+function isDocumentHidden(ctx?: LocalNotificationContext): boolean {
+  if (ctx?.documentVisible !== undefined) return !ctx.documentVisible
+  if (typeof document === 'undefined') return true
+  return document.visibilityState !== 'visible'
+}
+
+export function showLocalNotification(
+  opts: LocalNotificationOptions,
+  ctx?: LocalNotificationContext,
+): Notification | null {
+  if (!isLocalNotificationsEnabled()) return null
+  if (!isLocalNotificationsSupported()) return null
+  if (Notification.permission !== 'granted') return null
+  if (!isDocumentHidden(ctx)) return null
+
+  try {
+    const notification = new Notification(opts.title, {
+      body: opts.body,
+      tag: opts.tag,
+      icon: '/minion.svg',
+      badge: '/minion.svg',
+    })
+    if (opts.onClick) {
+      notification.onclick = () => {
+        try {
+          window.focus()
+        } catch {
+          // ignore
+        }
+        opts.onClick?.()
+        notification.close()
+      }
+    }
+    return notification
+  } catch {
+    return null
+  }
+}
+
+export function __resetLocalNotificationsForTests(): void {
+  enabledSignal.value = false
+  try {
+    localStorage.removeItem(ENABLED_KEY)
+  } catch {
+    // ignore
+  }
+}

--- a/src/state/inbox.ts
+++ b/src/state/inbox.ts
@@ -1,0 +1,128 @@
+import { signal, computed, type ReadonlySignal } from '@preact/signals'
+
+export type InboxEventKind = 'completed' | 'failed' | 'attention' | 'landed'
+
+export interface InboxEvent {
+  id: string
+  sessionId: string
+  sessionSlug: string
+  label: string
+  kind: InboxEventKind
+  ts: number
+}
+
+interface InboxState {
+  events: InboxEvent[]
+  lastSeenAt: number
+}
+
+const MAX_EVENTS = 50
+const STORAGE_KEY = 'minions-ui:inbox:v1'
+
+interface PersistedInbox {
+  version: 1
+  perConnection: Record<string, { lastSeenAt: number }>
+}
+
+function loadPersisted(): PersistedInbox {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return { version: 1, perConnection: {} }
+    const parsed = JSON.parse(raw) as unknown
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      (parsed as PersistedInbox).version === 1 &&
+      typeof (parsed as PersistedInbox).perConnection === 'object'
+    ) {
+      return parsed as PersistedInbox
+    }
+  } catch {
+    // fall through
+  }
+  return { version: 1, perConnection: {} }
+}
+
+function savePersisted(state: PersistedInbox): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // localStorage full or disabled — degrade silently
+  }
+}
+
+const inboxes = signal<Map<string, InboxState>>(new Map())
+
+function getOrInitState(connectionId: string): InboxState {
+  const existing = inboxes.value.get(connectionId)
+  if (existing) return existing
+  const persisted = loadPersisted()
+  const lastSeenAt = persisted.perConnection[connectionId]?.lastSeenAt ?? 0
+  const fresh: InboxState = { events: [], lastSeenAt }
+  const next = new Map(inboxes.value)
+  next.set(connectionId, fresh)
+  inboxes.value = next
+  return fresh
+}
+
+export function recordInboxEvent(connectionId: string, event: InboxEvent): void {
+  const current = getOrInitState(connectionId)
+  const dedupedEvents = current.events.filter((e) => e.id !== event.id)
+  const events = [event, ...dedupedEvents].slice(0, MAX_EVENTS)
+  const next = new Map(inboxes.value)
+  next.set(connectionId, { ...current, events })
+  inboxes.value = next
+}
+
+export function markInboxSeen(connectionId: string): void {
+  const current = getOrInitState(connectionId)
+  const lastSeenAt = Date.now()
+  const next = new Map(inboxes.value)
+  next.set(connectionId, { ...current, lastSeenAt })
+  inboxes.value = next
+
+  const persisted = loadPersisted()
+  persisted.perConnection[connectionId] = { lastSeenAt }
+  savePersisted(persisted)
+}
+
+export function clearInbox(connectionId: string): void {
+  const next = new Map(inboxes.value)
+  next.delete(connectionId)
+  inboxes.value = next
+  const persisted = loadPersisted()
+  delete persisted.perConnection[connectionId]
+  savePersisted(persisted)
+}
+
+export function getInboxEvents(connectionId: string): InboxEvent[] {
+  return inboxes.value.get(connectionId)?.events ?? []
+}
+
+export function getUnseenCount(connectionId: string): number {
+  const state = inboxes.value.get(connectionId)
+  if (!state) return 0
+  return state.events.filter((e) => e.ts > state.lastSeenAt).length
+}
+
+export function inboxSignal(connectionId: string): ReadonlySignal<{
+  events: InboxEvent[]
+  unseenCount: number
+  lastSeenAt: number
+}> {
+  return computed(() => {
+    const state = inboxes.value.get(connectionId)
+    if (!state) return { events: [], unseenCount: 0, lastSeenAt: 0 }
+    const unseenCount = state.events.filter((e) => e.ts > state.lastSeenAt).length
+    return { events: state.events, unseenCount, lastSeenAt: state.lastSeenAt }
+  })
+}
+
+export function __resetInboxes(): void {
+  inboxes.value = new Map()
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,6 +1,7 @@
 import { signal } from '@preact/signals'
 import type { ApiClient } from '../api/client'
 import type {
+  ApiSession,
   ResourceSnapshot,
   RuntimeConfigResponse,
   RuntimeOverrides,
@@ -10,8 +11,21 @@ import type { SseStatus } from '../api/sse'
 import type { ConnectionStore, DiffStats } from './types'
 import { loadSnapshot, saveSnapshot } from './persist'
 import { createTranscriptStore, type TranscriptStore } from './transcript'
+import { markInboxSeen, recordInboxEvent, type InboxEventKind } from './inbox'
+import { showLocalNotification } from '../pwa/local-notifications'
 
-export function createConnectionStore(client: ApiClient, connectionId: string): ConnectionStore {
+interface ConnectionStoreOptions {
+  isActive?: () => boolean
+}
+
+export function createConnectionStore(
+  client: ApiClient,
+  connectionId: string,
+  options: ConnectionStoreOptions = {},
+): ConnectionStore {
+  const isActive = options.isActive ?? (() => false)
+  const isDocumentVisible = () =>
+    typeof document === 'undefined' ? true : document.visibilityState === 'visible'
   const sessions = signal<import('../api/types').ApiSession[]>([])
   const dags = signal<import('../api/types').ApiDagGraph[]>([])
   const status = signal<SseStatus>('connecting')
@@ -97,8 +111,51 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
     }
   }
 
+  function detectInboxEventKind(prev: ApiSession | null, next: ApiSession): InboxEventKind | null {
+    if (!prev) return null
+    if (next.status !== prev.status) {
+      if (next.status === 'completed') return 'completed'
+      if (next.status === 'failed') return 'failed'
+    }
+    if (!prev.needsAttention && next.needsAttention) return 'attention'
+    if (!prev.prUrl && next.prUrl) return 'landed'
+    return null
+  }
+
+  function recordTransition(prev: ApiSession | null, next: ApiSession): void {
+    const kind = detectInboxEventKind(prev, next)
+    if (!kind) return
+    const ts = Date.now()
+    recordInboxEvent(connectionId, {
+      id: `${next.id}:${kind}:${ts}`,
+      sessionId: next.id,
+      sessionSlug: next.slug,
+      label: next.command || next.slug,
+      kind,
+      ts,
+    })
+    const visible = isDocumentVisible()
+    if (isActive() && visible) {
+      markInboxSeen(connectionId)
+    }
+    if (!visible) {
+      const titles: Record<InboxEventKind, string> = {
+        completed: 'Session completed',
+        failed: 'Session failed',
+        attention: 'Session needs attention',
+        landed: 'Pull request opened',
+      }
+      showLocalNotification({
+        title: titles[kind],
+        body: next.slug,
+        tag: `${connectionId}:${next.id}:${kind}`,
+      })
+    }
+  }
+
   function applySessionCreated(session: import('../api/types').ApiSession) {
     const idx = sessions.value.findIndex((s) => s.id === session.id)
+    const previous = idx !== -1 ? sessions.value[idx] : null
     if (idx !== -1) {
       const updated = [...sessions.value]
       updated[idx] = session
@@ -106,6 +163,7 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
     } else {
       sessions.value = [...sessions.value, session]
     }
+    recordTransition(previous, session)
     scheduleSnapshot()
   }
 
@@ -139,6 +197,7 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
         break
       case 'session_updated': {
         const idx = sessions.value.findIndex((s) => s.id === event.session.id)
+        const previous = idx !== -1 ? sessions.value[idx] : null
         if (idx !== -1) {
           const updated = [...sessions.value]
           updated[idx] = event.session
@@ -146,6 +205,7 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
         } else {
           sessions.value = [...sessions.value, event.session]
         }
+        recordTransition(previous, event.session)
         scheduleSnapshot()
         if (diffStatsBySessionId.value.has(event.session.id)) {
           void loadDiffStats(event.session.id)
@@ -229,6 +289,9 @@ export function createConnectionStore(client: ApiClient, connectionId: string): 
     if (document.visibilityState === 'hidden') {
       hiddenSince = Date.now()
       return
+    }
+    if (isActive()) {
+      markInboxSeen(connectionId)
     }
     const since = hiddenSince
     hiddenSince = null

--- a/test/components/InboxButton.test.tsx
+++ b/test/components/InboxButton.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { signal } from '@preact/signals'
+import { InboxButton } from '../../src/components/InboxButton'
+import * as connectionsStore from '../../src/connections/store'
+import { __resetInboxes, markInboxSeen, recordInboxEvent } from '../../src/state/inbox'
+import type { Connection } from '../../src/connections/types'
+
+vi.mock('../../src/connections/store', () => ({
+  connections: signal<Connection[]>([]),
+  activeId: signal<string | null>(null),
+}))
+
+function makeConn(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'c1',
+    label: 'Test',
+    baseUrl: 'http://localhost:8080',
+    token: 'tok',
+    color: '#3b82f6',
+    ...overrides,
+  }
+}
+
+describe('InboxButton', () => {
+  let connections: ReturnType<typeof signal<Connection[]>>
+  let activeId: ReturnType<typeof signal<string | null>>
+
+  beforeEach(() => {
+    __resetInboxes()
+    connections = signal<Connection[]>([])
+    activeId = signal<string | null>(null)
+    ;(vi.mocked(connectionsStore).connections as typeof connections) = connections
+    ;(vi.mocked(connectionsStore).activeId as typeof activeId) = activeId
+  })
+
+  it('renders an empty button when there are no events', () => {
+    connections.value = [makeConn()]
+    activeId.value = 'c1'
+    render(<InboxButton />)
+    const btn = screen.getByTestId('header-inbox-btn')
+    expect(btn).toBeTruthy()
+    expect(screen.queryByTestId('inbox-total-unseen-badge')).toBeFalsy()
+  })
+
+  it('shows the total unseen count badge across connections', () => {
+    connections.value = [makeConn({ id: 'c1' }), makeConn({ id: 'c2' })]
+    activeId.value = 'c1'
+
+    markInboxSeen('c1')
+    markInboxSeen('c2')
+
+    const seenAt = Date.now()
+    recordInboxEvent('c1', {
+      id: 'a',
+      sessionId: 's1',
+      sessionSlug: 's1',
+      label: 's1',
+      kind: 'completed',
+      ts: seenAt + 1000,
+    })
+    recordInboxEvent('c2', {
+      id: 'b',
+      sessionId: 's2',
+      sessionSlug: 's2',
+      label: 's2',
+      kind: 'failed',
+      ts: seenAt + 2000,
+    })
+
+    render(<InboxButton />)
+    const badge = screen.getByTestId('inbox-total-unseen-badge')
+    expect(badge.textContent).toBe('2')
+  })
+
+  it('opens the inbox panel when clicked', () => {
+    connections.value = [makeConn()]
+    activeId.value = 'c1'
+    recordInboxEvent('c1', {
+      id: 'a',
+      sessionId: 's1',
+      sessionSlug: 'first',
+      label: 'first',
+      kind: 'completed',
+      ts: Date.now(),
+    })
+    render(<InboxButton />)
+    fireEvent.click(screen.getByTestId('header-inbox-btn'))
+    expect(screen.getByTestId('inbox-panel')).toBeTruthy()
+  })
+
+  it('disables the button when no active connection', () => {
+    connections.value = []
+    activeId.value = null
+    render(<InboxButton />)
+    const btn = screen.getByTestId('header-inbox-btn') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('calls onSelectEvent when an event is clicked', () => {
+    connections.value = [makeConn()]
+    activeId.value = 'c1'
+    recordInboxEvent('c1', {
+      id: 'a',
+      sessionId: 's1',
+      sessionSlug: 'first',
+      label: 'first',
+      kind: 'completed',
+      ts: Date.now(),
+    })
+    const onSelect = vi.fn()
+    render(<InboxButton onSelectEvent={onSelect} />)
+    fireEvent.click(screen.getByTestId('header-inbox-btn'))
+    fireEvent.click(screen.getByTestId('inbox-item-a'))
+    expect(onSelect).toHaveBeenCalledWith('c1', expect.objectContaining({ id: 'a' }))
+  })
+})

--- a/test/components/InboxPanel.test.tsx
+++ b/test/components/InboxPanel.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { InboxPanel, InboxList, InboxSheet } from '../../src/components/InboxPanel'
+import {
+  __resetInboxes,
+  markInboxSeen,
+  recordInboxEvent,
+} from '../../src/state/inbox'
+
+describe('InboxPanel', () => {
+  beforeEach(() => {
+    __resetInboxes()
+  })
+
+  it('shows empty state when there are no events', () => {
+    render(<InboxPanel connectionId="c1" onClose={() => {}} />)
+    expect(screen.getByTestId('inbox-empty')).toBeTruthy()
+  })
+
+  it('renders events newest-first', () => {
+    recordInboxEvent('c1', {
+      id: 'a',
+      sessionId: 's1',
+      sessionSlug: 'first',
+      label: 'first',
+      kind: 'completed',
+      ts: 1000,
+    })
+    recordInboxEvent('c1', {
+      id: 'b',
+      sessionId: 's2',
+      sessionSlug: 'second',
+      label: 'second',
+      kind: 'failed',
+      ts: 2000,
+    })
+
+    render(<InboxList connectionId="c1" />)
+    expect(screen.getByTestId('inbox-item-a')).toBeTruthy()
+    expect(screen.getByTestId('inbox-item-b')).toBeTruthy()
+    const buttons = screen.getAllByRole('button')
+    expect(buttons[0].getAttribute('data-testid')).toBe('inbox-item-b')
+    expect(buttons[1].getAttribute('data-testid')).toBe('inbox-item-a')
+  })
+
+  it('marks events as unseen when ts > lastSeenAt', () => {
+    markInboxSeen('c1')
+    const seenAt = Date.now()
+    recordInboxEvent('c1', {
+      id: 'old',
+      sessionId: 's1',
+      sessionSlug: 'old',
+      label: 'old',
+      kind: 'completed',
+      ts: seenAt - 5000,
+    })
+    recordInboxEvent('c1', {
+      id: 'new',
+      sessionId: 's2',
+      sessionSlug: 'new',
+      label: 'new',
+      kind: 'completed',
+      ts: seenAt + 5000,
+    })
+
+    render(<InboxList connectionId="c1" />)
+    const newItem = screen.getByTestId('inbox-item-new')
+    const oldItem = screen.getByTestId('inbox-item-old')
+    expect(newItem.getAttribute('data-unseen')).toBe('true')
+    expect(oldItem.getAttribute('data-unseen')).toBe('false')
+  })
+
+  it('calls onSelect with the event when an item is clicked', () => {
+    recordInboxEvent('c1', {
+      id: 'a',
+      sessionId: 's1',
+      sessionSlug: 'first',
+      label: 'first',
+      kind: 'completed',
+      ts: 1000,
+    })
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+    render(<InboxPanel connectionId="c1" onClose={onClose} onSelect={onSelect} />)
+    fireEvent.click(screen.getByTestId('inbox-item-a'))
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'a', sessionId: 's1' }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose when Close button is clicked', () => {
+    const onClose = vi.fn()
+    render(<InboxPanel connectionId="c1" onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('inbox-panel-close'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose on Escape key', () => {
+    const onClose = vi.fn()
+    render(<InboxPanel connectionId="c1" onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+})
+
+describe('InboxSheet', () => {
+  beforeEach(() => {
+    __resetInboxes()
+  })
+
+  it('renders the sheet variant with backdrop', () => {
+    render(<InboxSheet connectionId="c1" onClose={() => {}} />)
+    expect(screen.getByTestId('inbox-sheet')).toBeTruthy()
+    expect(screen.getByTestId('inbox-sheet-backdrop')).toBeTruthy()
+  })
+
+  it('closes when backdrop is clicked', () => {
+    const onClose = vi.fn()
+    render(<InboxSheet connectionId="c1" onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('inbox-sheet-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('closes on Escape key', () => {
+    const onClose = vi.fn()
+    render(<InboxSheet connectionId="c1" onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/test/connections/ConnectionPicker.inbox.test.tsx
+++ b/test/connections/ConnectionPicker.inbox.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { signal } from '@preact/signals'
+import { ConnectionPicker } from '../../src/connections/ConnectionPicker'
+import * as store from '../../src/connections/store'
+import {
+  __resetInboxes,
+  markInboxSeen,
+  recordInboxEvent,
+} from '../../src/state/inbox'
+import type { Connection } from '../../src/connections/types'
+
+vi.mock('../../src/connections/store', () => ({
+  connections: signal<Connection[]>([]),
+  activeId: signal<string | null>(null),
+  setActive: vi.fn(),
+  getAllStores: vi.fn(() => new Map()),
+}))
+
+vi.mock('../../src/hooks/useMediaQuery', () => ({
+  useMediaQuery: () => signal(true),
+}))
+
+vi.mock('../../src/hooks/useSwipeToDismiss', () => ({
+  useSwipeToDismiss: () => ({ current: null }),
+}))
+
+vi.mock('../../src/hooks/useHaptics', () => ({
+  useHaptics: () => ({ vibrate: vi.fn() }),
+}))
+
+function makeConn(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'c1',
+    label: 'Test Connection',
+    baseUrl: 'http://localhost:8080',
+    token: 'tok',
+    color: '#3b82f6',
+    ...overrides,
+  }
+}
+
+describe('ConnectionPicker inbox badges', () => {
+  let connectionsSignal: ReturnType<typeof signal<Connection[]>>
+  let activeIdSignal: ReturnType<typeof signal<string | null>>
+
+  beforeEach(() => {
+    __resetInboxes()
+    connectionsSignal = signal<Connection[]>([])
+    activeIdSignal = signal<string | null>(null)
+    ;(vi.mocked(store).connections as typeof connectionsSignal) = connectionsSignal
+    ;(vi.mocked(store).activeId as typeof activeIdSignal) = activeIdSignal
+  })
+
+  it('shows inbox count badge when connection has unseen events', () => {
+    const conn = makeConn()
+    connectionsSignal.value = [conn]
+    activeIdSignal.value = null
+
+    markInboxSeen(conn.id)
+    const seenAt = Date.now()
+    recordInboxEvent(conn.id, {
+      id: 'e1',
+      sessionId: 's1',
+      sessionSlug: 'foo',
+      label: 'foo',
+      kind: 'completed',
+      ts: seenAt + 1000,
+    })
+    recordInboxEvent(conn.id, {
+      id: 'e2',
+      sessionId: 's2',
+      sessionSlug: 'bar',
+      label: 'bar',
+      kind: 'failed',
+      ts: seenAt + 2000,
+    })
+
+    render(<ConnectionPicker onManage={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('connection-picker-trigger'))
+
+    const badge = screen.getByTestId(`picker-inbox-count-${conn.id}`)
+    expect(badge.textContent).toBe('+2')
+  })
+
+  it('hides inbox count badge when there are no unseen events', () => {
+    const conn = makeConn()
+    connectionsSignal.value = [conn]
+    activeIdSignal.value = null
+
+    render(<ConnectionPicker onManage={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('connection-picker-trigger'))
+
+    expect(screen.queryByTestId(`picker-inbox-count-${conn.id}`)).toBeFalsy()
+  })
+
+  it('hides badge after markInboxSeen is called', () => {
+    const conn = makeConn()
+    connectionsSignal.value = [conn]
+    activeIdSignal.value = null
+
+    recordInboxEvent(conn.id, {
+      id: 'e1',
+      sessionId: 's1',
+      sessionSlug: 'foo',
+      label: 'foo',
+      kind: 'completed',
+      ts: Date.now(),
+    })
+
+    const { rerender } = render(<ConnectionPicker onManage={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('connection-picker-trigger'))
+    expect(screen.getByTestId(`picker-inbox-count-${conn.id}`)).toBeTruthy()
+
+    markInboxSeen(conn.id)
+    rerender(<ConnectionPicker onManage={vi.fn()} />)
+    expect(screen.queryByTestId(`picker-inbox-count-${conn.id}`)).toBeFalsy()
+  })
+})

--- a/test/pwa/NotificationsToggle.test.tsx
+++ b/test/pwa/NotificationsToggle.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/preact'
+
+describe('NotificationsToggle', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders nothing when Notification API is unavailable', async () => {
+    vi.stubGlobal('Notification', undefined)
+    const { NotificationsToggle } = await import('../../src/pwa/NotificationsToggle')
+    const { container } = render(<NotificationsToggle />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders enable button when supported but disabled', async () => {
+    const Notif = vi.fn() as unknown as typeof Notification
+    Object.assign(Notif, {
+      permission: 'default',
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+    })
+    vi.stubGlobal('Notification', Notif)
+
+    const { NotificationsToggle } = await import('../../src/pwa/NotificationsToggle')
+    render(<NotificationsToggle />)
+    const btn = screen.getByTestId('header-notifications-toggle') as HTMLButtonElement
+    expect(btn.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('enables notifications and flips aria-pressed when clicked', async () => {
+    const Notif = vi.fn() as unknown as typeof Notification
+    Object.assign(Notif, {
+      permission: 'default',
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+    })
+    vi.stubGlobal('Notification', Notif)
+
+    const { NotificationsToggle } = await import('../../src/pwa/NotificationsToggle')
+    render(<NotificationsToggle />)
+    const btn = screen.getByTestId('header-notifications-toggle') as HTMLButtonElement
+    expect(btn.getAttribute('aria-pressed')).toBe('false')
+    fireEvent.click(btn)
+    await waitFor(() => {
+      expect(screen.getByTestId('header-notifications-toggle').getAttribute('aria-pressed')).toBe('true')
+    })
+  })
+
+  it('disables when permission is denied and not enabled', async () => {
+    const Notif = vi.fn() as unknown as typeof Notification
+    Object.assign(Notif, {
+      permission: 'denied',
+      requestPermission: vi.fn().mockResolvedValue('denied'),
+    })
+    vi.stubGlobal('Notification', Notif)
+
+    const { NotificationsToggle } = await import('../../src/pwa/NotificationsToggle')
+    render(<NotificationsToggle />)
+    const btn = screen.getByTestId('header-notifications-toggle') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('renders the menu variant when variant=menu', async () => {
+    const Notif = vi.fn() as unknown as typeof Notification
+    Object.assign(Notif, {
+      permission: 'default',
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+    })
+    vi.stubGlobal('Notification', Notif)
+
+    const { NotificationsToggle } = await import('../../src/pwa/NotificationsToggle')
+    render(<NotificationsToggle variant="menu" />)
+    expect(screen.getByTestId('menu-notifications-toggle')).toBeTruthy()
+  })
+})

--- a/test/pwa/local-notifications.test.ts
+++ b/test/pwa/local-notifications.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+describe('local-notifications', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('reports unsupported when Notification API is missing', async () => {
+    vi.stubGlobal('Notification', undefined)
+    const mod = await import('../../src/pwa/local-notifications')
+    expect(mod.isLocalNotificationsSupported()).toBe(false)
+    expect(mod.getLocalNotificationsPermission()).toBe('unsupported')
+  })
+
+  it('reports current Notification.permission when supported', async () => {
+    const Notif = vi.fn() as unknown as typeof Notification
+    ;(Notif as unknown as { permission: NotificationPermission }).permission = 'granted'
+    vi.stubGlobal('Notification', Notif)
+    const mod = await import('../../src/pwa/local-notifications')
+    expect(mod.isLocalNotificationsSupported()).toBe(true)
+    expect(mod.getLocalNotificationsPermission()).toBe('granted')
+  })
+
+  it('enableLocalNotifications requests permission and persists', async () => {
+    const requestPermission = vi.fn().mockResolvedValue('granted')
+    const Notif = vi.fn() as unknown as typeof Notification
+    Object.assign(Notif, { permission: 'default', requestPermission })
+    vi.stubGlobal('Notification', Notif)
+
+    const mod = await import('../../src/pwa/local-notifications')
+    const result = await mod.enableLocalNotifications()
+
+    expect(result.ok).toBe(true)
+    expect(result.permission).toBe('granted')
+    expect(requestPermission).toHaveBeenCalled()
+    expect(mod.isLocalNotificationsEnabled()).toBe(true)
+    expect(localStorage.getItem('minions-ui:local-notifications-enabled:v1')).toBe('1')
+  })
+
+  it('does not enable when permission is denied', async () => {
+    const requestPermission = vi.fn().mockResolvedValue('denied')
+    const Notif = vi.fn() as unknown as typeof Notification
+    Object.assign(Notif, { permission: 'default', requestPermission })
+    vi.stubGlobal('Notification', Notif)
+
+    const mod = await import('../../src/pwa/local-notifications')
+    const result = await mod.enableLocalNotifications()
+    expect(result.ok).toBe(false)
+    expect(mod.isLocalNotificationsEnabled()).toBe(false)
+  })
+
+  it('disableLocalNotifications resets the persisted flag', async () => {
+    localStorage.setItem('minions-ui:local-notifications-enabled:v1', '1')
+    const requestPermission = vi.fn().mockResolvedValue('granted')
+    const Notif = vi.fn() as unknown as typeof Notification
+    Object.assign(Notif, { permission: 'granted', requestPermission })
+    vi.stubGlobal('Notification', Notif)
+
+    const mod = await import('../../src/pwa/local-notifications')
+    expect(mod.isLocalNotificationsEnabled()).toBe(true)
+
+    mod.disableLocalNotifications()
+    expect(mod.isLocalNotificationsEnabled()).toBe(false)
+    expect(localStorage.getItem('minions-ui:local-notifications-enabled:v1')).toBe('0')
+  })
+
+  it('showLocalNotification suppresses when document is visible', async () => {
+    const ctor = vi.fn()
+    const Notif = function (this: unknown, title: string, opts?: NotificationOptions) {
+      ctor(title, opts)
+      return this
+    } as unknown as typeof Notification
+    Object.assign(Notif, { permission: 'granted', requestPermission: vi.fn().mockResolvedValue('granted') })
+    vi.stubGlobal('Notification', Notif)
+
+    const mod = await import('../../src/pwa/local-notifications')
+    await mod.enableLocalNotifications()
+
+    const result = mod.showLocalNotification(
+      { title: 'hi', body: 'world' },
+      { documentVisible: true },
+    )
+    expect(result).toBeNull()
+    expect(ctor).not.toHaveBeenCalled()
+  })
+
+  it('showLocalNotification fires when enabled, granted, and document hidden', async () => {
+    const ctor = vi.fn()
+    const Notif = function (this: unknown, title: string, opts?: NotificationOptions) {
+      ctor(title, opts)
+      return this
+    } as unknown as typeof Notification
+    Object.assign(Notif, { permission: 'granted', requestPermission: vi.fn().mockResolvedValue('granted') })
+    vi.stubGlobal('Notification', Notif)
+
+    const mod = await import('../../src/pwa/local-notifications')
+    await mod.enableLocalNotifications()
+
+    mod.showLocalNotification({ title: 'hi', body: 'world' }, { documentVisible: false })
+    expect(ctor).toHaveBeenCalledWith('hi', expect.objectContaining({ body: 'world' }))
+  })
+
+  it('showLocalNotification suppresses when not enabled, even if hidden', async () => {
+    const ctor = vi.fn()
+    const Notif = function (this: unknown, title: string, opts?: NotificationOptions) {
+      ctor(title, opts)
+      return this
+    } as unknown as typeof Notification
+    Object.assign(Notif, { permission: 'granted', requestPermission: vi.fn().mockResolvedValue('granted') })
+    vi.stubGlobal('Notification', Notif)
+
+    const mod = await import('../../src/pwa/local-notifications')
+    // do not enable
+
+    const result = mod.showLocalNotification({ title: 'hi' }, { documentVisible: false })
+    expect(result).toBeNull()
+    expect(ctor).not.toHaveBeenCalled()
+  })
+
+  it('showLocalNotification suppresses when permission becomes not-granted', async () => {
+    const ctor = vi.fn()
+    const Notif = function (this: unknown, title: string, opts?: NotificationOptions) {
+      ctor(title, opts)
+      return this
+    } as unknown as typeof Notification
+    Object.assign(Notif, { permission: 'granted', requestPermission: vi.fn().mockResolvedValue('granted') })
+    vi.stubGlobal('Notification', Notif)
+
+    const mod = await import('../../src/pwa/local-notifications')
+    await mod.enableLocalNotifications()
+
+    // permission flips to denied behind our back
+    Object.assign(Notif, { permission: 'denied' })
+
+    const result = mod.showLocalNotification({ title: 'hi' }, { documentVisible: false })
+    expect(result).toBeNull()
+    expect(ctor).not.toHaveBeenCalled()
+  })
+})

--- a/test/state/inbox.test.ts
+++ b/test/state/inbox.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  __resetInboxes,
+  clearInbox,
+  getInboxEvents,
+  getUnseenCount,
+  inboxSignal,
+  markInboxSeen,
+  recordInboxEvent,
+  type InboxEvent,
+} from '../../src/state/inbox'
+
+function makeEvent(overrides: Partial<InboxEvent> = {}): InboxEvent {
+  return {
+    id: overrides.id ?? `e-${Math.random()}`,
+    sessionId: 's1',
+    sessionSlug: 'cool-cat',
+    label: '/task hello',
+    kind: 'completed',
+    ts: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('inbox state', () => {
+  beforeEach(() => {
+    __resetInboxes()
+  })
+
+  it('records events in newest-first order', () => {
+    recordInboxEvent('c1', makeEvent({ id: 'a', ts: 100 }))
+    recordInboxEvent('c1', makeEvent({ id: 'b', ts: 200 }))
+    recordInboxEvent('c1', makeEvent({ id: 'c', ts: 300 }))
+
+    const events = getInboxEvents('c1')
+    expect(events.map((e) => e.id)).toEqual(['c', 'b', 'a'])
+  })
+
+  it('caps stored events at 50', () => {
+    for (let i = 0; i < 60; i++) {
+      recordInboxEvent('c1', makeEvent({ id: `e-${i}`, ts: i }))
+    }
+    expect(getInboxEvents('c1')).toHaveLength(50)
+  })
+
+  it('dedupes events by id (latest wins)', () => {
+    recordInboxEvent('c1', makeEvent({ id: 'dup', ts: 100, kind: 'attention' }))
+    recordInboxEvent('c1', makeEvent({ id: 'dup', ts: 200, kind: 'completed' }))
+
+    const events = getInboxEvents('c1')
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('completed')
+    expect(events[0].ts).toBe(200)
+  })
+
+  it('reports unseen count for events newer than lastSeenAt', () => {
+    markInboxSeen('c1')
+    const seenAt = inboxSignal('c1').value.lastSeenAt
+    recordInboxEvent('c1', makeEvent({ id: 'a', ts: seenAt - 1000 }))
+    recordInboxEvent('c1', makeEvent({ id: 'b', ts: seenAt + 1000 }))
+    recordInboxEvent('c1', makeEvent({ id: 'c', ts: seenAt + 2000 }))
+
+    expect(getUnseenCount('c1')).toBe(2)
+  })
+
+  it('marks all events seen when markInboxSeen is called', () => {
+    recordInboxEvent('c1', makeEvent({ id: 'a', ts: Date.now() - 1000 }))
+    recordInboxEvent('c1', makeEvent({ id: 'b', ts: Date.now() }))
+    expect(getUnseenCount('c1')).toBeGreaterThan(0)
+
+    markInboxSeen('c1')
+    expect(getUnseenCount('c1')).toBe(0)
+  })
+
+  it('persists lastSeenAt across module reloads via localStorage', async () => {
+    markInboxSeen('c1')
+    const seenAt = inboxSignal('c1').value.lastSeenAt
+
+    __resetInboxes()
+    localStorage.setItem(
+      'minions-ui:inbox:v1',
+      JSON.stringify({ version: 1, perConnection: { c1: { lastSeenAt: seenAt } } }),
+    )
+
+    recordInboxEvent('c1', makeEvent({ id: 'old', ts: seenAt - 1000 }))
+    recordInboxEvent('c1', makeEvent({ id: 'new', ts: seenAt + 1000 }))
+    expect(getUnseenCount('c1')).toBe(1)
+  })
+
+  it('isolates events between connections', () => {
+    recordInboxEvent('c1', makeEvent({ id: 'a' }))
+    recordInboxEvent('c2', makeEvent({ id: 'b' }))
+    recordInboxEvent('c2', makeEvent({ id: 'c' }))
+
+    expect(getInboxEvents('c1').map((e) => e.id)).toEqual(['a'])
+    expect(getInboxEvents('c2').map((e) => e.id)).toEqual(['c', 'b'])
+  })
+
+  it('clearInbox removes both events and persisted lastSeenAt', () => {
+    recordInboxEvent('c1', makeEvent({ id: 'a' }))
+    markInboxSeen('c1')
+    expect(getInboxEvents('c1')).toHaveLength(1)
+
+    clearInbox('c1')
+    expect(getInboxEvents('c1')).toHaveLength(0)
+    expect(inboxSignal('c1').value.lastSeenAt).toBe(0)
+  })
+
+  it('inboxSignal updates reactively', () => {
+    const sig = inboxSignal('c1')
+    expect(sig.value.events).toHaveLength(0)
+
+    recordInboxEvent('c1', makeEvent({ id: 'a' }))
+    expect(sig.value.events).toHaveLength(1)
+  })
+})

--- a/test/state/store.inbox.test.ts
+++ b/test/state/store.inbox.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createApiClient } from '../../src/api/client'
+import { installMockEventSource } from '../sse-mock'
+import { __resetInboxes, getInboxEvents, getUnseenCount } from '../../src/state/inbox'
+import type { ApiSession, VersionInfo } from '../../src/api/types'
+
+const BASE_URL = 'https://example.com'
+const TOKEN = 'tok'
+
+const VERSION: VersionInfo = { apiVersion: '1', libraryVersion: '0.1.0', features: [] }
+
+function makeSession(overrides: Partial<ApiSession> = {}): ApiSession {
+  return {
+    id: 's1',
+    slug: 'cool-cat',
+    status: 'running',
+    command: '/task hello',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+    childIds: [],
+    needsAttention: false,
+    attentionReasons: [],
+    quickActions: [],
+    mode: 'task',
+    conversation: [],
+    ...overrides,
+  }
+}
+
+vi.mock('../../src/state/persist', () => ({
+  loadSnapshot: vi.fn().mockResolvedValue(null),
+  saveSnapshot: vi.fn().mockResolvedValue(undefined),
+  clearSnapshot: vi.fn().mockResolvedValue(undefined),
+}))
+
+const showLocalNotificationSpy = vi.fn()
+vi.mock('../../src/pwa/local-notifications', () => ({
+  showLocalNotification: (...args: unknown[]) => showLocalNotificationSpy(...args),
+  isLocalNotificationsEnabled: () => false,
+  isLocalNotificationsSupported: () => false,
+  getLocalNotificationsPermission: () => 'unsupported',
+  enableLocalNotifications: vi.fn(),
+  disableLocalNotifications: vi.fn(),
+  localNotificationsEnabled: () => ({ value: false }),
+  requestLocalNotificationsPermission: vi.fn(),
+}))
+
+function makeResponses(sessions: ApiSession[] = []) {
+  return vi.fn().mockImplementation((url: string) => {
+    if (url.includes('/api/version')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.resolve({ data: VERSION }),
+      })
+    }
+    if (url.includes('/api/sessions')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.resolve({ data: sessions }),
+      })
+    }
+    if (url.includes('/api/dags')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.resolve({ data: [] }),
+      })
+    }
+    return Promise.resolve({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: () => Promise.resolve({ data: null, error: 'Not found' }),
+    })
+  })
+}
+
+describe('createConnectionStore inbox integration', () => {
+  let mock: ReturnType<typeof installMockEventSource>
+
+  beforeEach(() => {
+    mock = installMockEventSource()
+    __resetInboxes()
+    showLocalNotificationSpy.mockReset()
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+  })
+
+  afterEach(() => {
+    mock.restore()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  async function seedStore(connId: string, initial: ApiSession) {
+    vi.stubGlobal('fetch', makeResponses([initial]))
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, connId)
+    await store.refresh()
+    return store
+  }
+
+  it('records inbox event on session_updated status transition to completed', async () => {
+    const initial = makeSession({ status: 'running' })
+    const store = await seedStore('conn-inbox-1', initial)
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({ type: 'session_updated', session: { ...initial, status: 'completed' } })
+
+    const events = getInboxEvents('conn-inbox-1')
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('completed')
+    expect(events[0].sessionId).toBe('s1')
+    store.dispose()
+  })
+
+  it('records inbox event on session_updated status transition to failed', async () => {
+    const initial = makeSession({ status: 'running' })
+    const store = await seedStore('conn-inbox-2', initial)
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({ type: 'session_updated', session: { ...initial, status: 'failed' } })
+
+    const events = getInboxEvents('conn-inbox-2')
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('failed')
+    store.dispose()
+  })
+
+  it('records inbox event when needsAttention becomes true', async () => {
+    const initial = makeSession({ status: 'running', needsAttention: false })
+    const store = await seedStore('conn-inbox-3', initial)
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({
+      type: 'session_updated',
+      session: {
+        ...initial,
+        needsAttention: true,
+        attentionReasons: ['waiting_for_feedback'],
+      },
+    })
+
+    const events = getInboxEvents('conn-inbox-3')
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('attention')
+    store.dispose()
+  })
+
+  it('records inbox event when prUrl appears', async () => {
+    const initial = makeSession({ status: 'completed' })
+    const store = await seedStore('conn-inbox-4', initial)
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({
+      type: 'session_updated',
+      session: { ...initial, prUrl: 'https://github.com/foo/bar/pull/1' },
+    })
+
+    const events = getInboxEvents('conn-inbox-4')
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('landed')
+    store.dispose()
+  })
+
+  it('does NOT record inbox event when status is unchanged', async () => {
+    const initial = makeSession({ status: 'running' })
+    const store = await seedStore('conn-inbox-5', initial)
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({
+      type: 'session_updated',
+      session: { ...initial, updatedAt: '2024-02-01' },
+    })
+
+    expect(getInboxEvents('conn-inbox-5')).toHaveLength(0)
+    store.dispose()
+  })
+
+  it('does NOT record inbox event for newly created sessions (no prior state)', async () => {
+    vi.stubGlobal('fetch', makeResponses([]))
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-inbox-6')
+    await store.refresh()
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({
+      type: 'session_created',
+      session: makeSession({ status: 'completed' }),
+    })
+
+    expect(getInboxEvents('conn-inbox-6')).toHaveLength(0)
+    store.dispose()
+  })
+
+  it('marks inbox seen for active connection on transition while document is visible', async () => {
+    const initial = makeSession({ status: 'running' })
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+    vi.stubGlobal('fetch', makeResponses([initial]))
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-inbox-7', { isActive: () => true })
+    await store.refresh()
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({ type: 'session_updated', session: { ...initial, status: 'completed' } })
+
+    expect(getInboxEvents('conn-inbox-7')).toHaveLength(1)
+    expect(getUnseenCount('conn-inbox-7')).toBe(0)
+    store.dispose()
+  })
+
+  it('keeps unseen count for inactive connection', async () => {
+    const originalNow = Date.now
+    let now = 1_000_000
+    Date.now = () => now
+
+    const initial = makeSession({ status: 'running' })
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+    vi.stubGlobal('fetch', makeResponses([initial]))
+    const { createConnectionStore } = await import('../../src/state/store')
+    const { markInboxSeen } = await import('../../src/state/inbox')
+    markInboxSeen('conn-inbox-8')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-inbox-8', { isActive: () => false })
+    await store.refresh()
+
+    now += 5000
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({ type: 'session_updated', session: { ...initial, status: 'completed' } })
+
+    expect(getInboxEvents('conn-inbox-8')).toHaveLength(1)
+    expect(getUnseenCount('conn-inbox-8')).toBe(1)
+
+    Date.now = originalNow
+    store.dispose()
+  })
+
+  it('fires showLocalNotification when document is hidden', async () => {
+    const initial = makeSession({ status: 'running' })
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden',
+    })
+    vi.stubGlobal('fetch', makeResponses([initial]))
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-inbox-9')
+    await store.refresh()
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({ type: 'session_updated', session: { ...initial, status: 'completed' } })
+
+    expect(showLocalNotificationSpy).toHaveBeenCalledTimes(1)
+    expect(showLocalNotificationSpy.mock.calls[0][0]).toMatchObject({
+      title: expect.stringContaining('completed'),
+    })
+    store.dispose()
+  })
+
+  it('does NOT fire showLocalNotification when document is visible', async () => {
+    const initial = makeSession({ status: 'running' })
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+    vi.stubGlobal('fetch', makeResponses([initial]))
+    const { createConnectionStore } = await import('../../src/state/store')
+    const client = createApiClient({ baseUrl: BASE_URL, token: TOKEN })
+    const store = createConnectionStore(client, 'conn-inbox-10')
+    await store.refresh()
+
+    const es = [...mock.instances.values()][0]
+    es?.simulateOpen()
+    es?.push({ type: 'session_updated', session: { ...initial, status: 'completed' } })
+
+    expect(showLocalNotificationSpy).not.toHaveBeenCalled()
+    store.dispose()
+  })
+})


### PR DESCRIPTION
## Summary

Tracks per-connection state transitions (completed/failed/attention/PR) in an in-memory inbox, persists last-visit time, and surfaces unseen events both as count badges in the connection picker and via a new header inbox panel that lists "what changed since you were last here." Fires local browser notifications when the document is hidden so background work pings the user without needing backend web-push infrastructure.

### What's new

- `src/state/inbox.ts` — per-connection event log + lastSeenAt persisted to localStorage. Events are derived from SSE `session_updated` transitions: `completed`, `failed`, `attention` (when `needsAttention` flips on), and `landed` (when `prUrl` first appears).
- `src/pwa/local-notifications.ts` — wraps the browser `Notification` API with an opt-in toggle (persisted) plus a hidden-only fire policy so the user never gets pinged for the tab they're staring at.
- `src/components/InboxPanel.tsx` — popover + bottom-sheet variants showing recent activity with unseen events visually highlighted.
- `src/components/InboxButton.tsx` — header button with total unseen count badge across all connections; opens the inbox panel for the active connection.
- `src/pwa/NotificationsToggle.tsx` — header + menu variants of the notifications opt-in toggle.
- Wiring: `state/store.ts` detects transitions on session_updated and feeds the inbox; auto-marks the active+visible connection seen so its count stays at 0. `connections/store.ts` marks seen on `setActive` and clears inbox on `removeConnection`.
- UI: small `+N` indigo badge on each row of `ConnectionPicker`; new `📥` header button with count badge; `🔔/🔕` notification toggle; mobile `HeaderMenu` includes both as new entries.

### Why this design

- No new backend dependency: works against existing SSE stream.
- Local notifications (not Web Push) — opt-in, no VAPID, no service-worker round-trip — keeps scope small and works in any browser tab.
- Suppressed when document is visible to avoid double-signaling for the tab you're already watching.
- Active+visible connection auto-marks seen on each transition, so the badge only ever fires for connections you're not currently looking at — matching Slack/Discord workspace rail mental model.
- Last-seen persisted in localStorage (synchronous, simple), inbox events kept in-memory only (capped at 50 per connection).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` — 1135 passed (12 new tests covering inbox state, local-notifications module, InboxPanel/Sheet, InboxButton, NotificationsToggle, picker badges, and SSE→inbox/notifications integration)
- [ ] Manual: enable notifications via header toggle, hide tab, observe a session transition produces a system notification
- [ ] Manual: switch away from a connection, trigger a session completion on it, return — see `+N` badge in picker dropdown and unseen count in header inbox button
